### PR TITLE
Use deterministic CREATE2 factory for canonical deployment addresses

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -62,13 +62,22 @@ contract Deploy is Script {
         address accountConfig = _addr(type(AccountConfiguration).creationCode);
 
         console.log("AccountConfiguration:  ", accountConfig);
-        console.log("DefaultAccount:        ", _addr(abi.encodePacked(type(DefaultAccount).creationCode, abi.encode(accountConfig))));
-        console.log("DefaultHighRateAccount:", _addr(abi.encodePacked(type(DefaultHighRateAccount).creationCode, abi.encode(accountConfig))));
+        console.log(
+            "DefaultAccount:        ",
+            _addr(abi.encodePacked(type(DefaultAccount).creationCode, abi.encode(accountConfig)))
+        );
+        console.log(
+            "DefaultHighRateAccount:",
+            _addr(abi.encodePacked(type(DefaultHighRateAccount).creationCode, abi.encode(accountConfig)))
+        );
         console.log("");
         console.log("K1Verifier:            ", _addr(type(K1Verifier).creationCode));
         console.log("P256Verifier:          ", _addr(type(P256Verifier).creationCode));
         console.log("WebAuthnVerifier:      ", _addr(type(WebAuthnVerifier).creationCode));
-        console.log("DelegateVerifier:      ", _addr(abi.encodePacked(type(DelegateVerifier).creationCode, abi.encode(accountConfig))));
+        console.log(
+            "DelegateVerifier:      ",
+            _addr(abi.encodePacked(type(DelegateVerifier).creationCode, abi.encode(accountConfig)))
+        );
         console.log("BLSVerifier:           ", _addr(type(BLSVerifier).creationCode));
         console.log("SchnorrVerifier:       ", _addr(type(SchnorrVerifier).creationCode));
         console.log("MultisigVerifier:      ", _addr(type(MultisigVerifier).creationCode));
@@ -85,20 +94,22 @@ contract Deploy is Script {
 
         // ── Core ──
 
-        address accountConfig  = _create2(type(AccountConfiguration).creationCode);
-        address defaultAccount = _create2(abi.encodePacked(type(DefaultAccount).creationCode, abi.encode(accountConfig)));
-        address defaultHighRate = _create2(abi.encodePacked(type(DefaultHighRateAccount).creationCode, abi.encode(accountConfig)));
+        address accountConfig = _create2(type(AccountConfiguration).creationCode);
+        address defaultAccount =
+            _create2(abi.encodePacked(type(DefaultAccount).creationCode, abi.encode(accountConfig)));
+        address defaultHighRate =
+            _create2(abi.encodePacked(type(DefaultHighRateAccount).creationCode, abi.encode(accountConfig)));
 
         // ── Verifiers ──
 
-        address k1          = _create2(type(K1Verifier).creationCode);
-        address p256        = _create2(type(P256Verifier).creationCode);
-        address webAuthn    = _create2(type(WebAuthnVerifier).creationCode);
-        address delegate    = _create2(abi.encodePacked(type(DelegateVerifier).creationCode, abi.encode(accountConfig)));
-        address bls         = _create2(type(BLSVerifier).creationCode);
-        address schnorr     = _create2(type(SchnorrVerifier).creationCode);
-        address multisig    = _create2(type(MultisigVerifier).creationCode);
-        address groth16     = _create2(type(Groth16Verifier).creationCode);
+        address k1 = _create2(type(K1Verifier).creationCode);
+        address p256 = _create2(type(P256Verifier).creationCode);
+        address webAuthn = _create2(type(WebAuthnVerifier).creationCode);
+        address delegate = _create2(abi.encodePacked(type(DelegateVerifier).creationCode, abi.encode(accountConfig)));
+        address bls = _create2(type(BLSVerifier).creationCode);
+        address schnorr = _create2(type(SchnorrVerifier).creationCode);
+        address multisig = _create2(type(MultisigVerifier).creationCode);
+        address groth16 = _create2(type(Groth16Verifier).creationCode);
         address alwaysValid = _create2(type(AlwaysValidVerifier).creationCode);
 
         console.log("AccountConfiguration:  ", accountConfig);

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -16,44 +16,104 @@ import {MultisigVerifier} from "../src/verifiers/MultisigVerifier.sol";
 import {Groth16Verifier} from "../src/verifiers/Groth16Verifier.sol";
 import {AlwaysValidVerifier} from "../src/verifiers/AlwaysValidVerifier.sol";
 
+/// @dev Nick's deterministic deployment proxy — same address on every EVM chain.
+///      Receives (salt ++ initCode) as calldata and deploys via CREATE2.
+///      https://github.com/Arachnid/deterministic-deployment-proxy
+address constant CREATE2_FACTORY = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
+
+bytes32 constant SALT = bytes32(0);
+
 /// @notice Deploys the full EIP-8130 system.
+///         All addresses are canonical: determined solely by salt + bytecode,
+///         independent of the deployer's address or nonce.
+///
+/// @dev Preview all addresses without deploying:
+///      forge script script/Deploy.s.sol --sig "addresses()"
 contract Deploy is Script {
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// @dev Computes the canonical CREATE2 address for the given init code.
+    function _addr(bytes memory initCode) internal pure returns (address) {
+        return address(
+            uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), CREATE2_FACTORY, SALT, keccak256(initCode)))))
+        );
+    }
+
+    /// @dev Deploys initCode through the singleton CREATE2 factory.
+    ///      Idempotent: if the contract is already deployed the call is skipped
+    ///      and the pre-existing address is returned.
+    function _create2(bytes memory initCode) internal returns (address addr) {
+        addr = _addr(initCode);
+        if (addr.code.length > 0) return addr;
+        (bool ok,) = CREATE2_FACTORY.call(abi.encodePacked(SALT, initCode));
+        require(ok && addr.code.length > 0, "create2 deployment failed");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Address preview  (no deployment)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// @notice Logs the canonical address of every contract in the system.
+    ///         Addresses depend only on the compiler output and SALT — they are
+    ///         the same on every chain and are known before deployment.
+    function addresses() public {
+        address accountConfig = _addr(type(AccountConfiguration).creationCode);
+
+        console.log("AccountConfiguration:  ", accountConfig);
+        console.log("DefaultAccount:        ", _addr(abi.encodePacked(type(DefaultAccount).creationCode, abi.encode(accountConfig))));
+        console.log("DefaultHighRateAccount:", _addr(abi.encodePacked(type(DefaultHighRateAccount).creationCode, abi.encode(accountConfig))));
+        console.log("");
+        console.log("K1Verifier:            ", _addr(type(K1Verifier).creationCode));
+        console.log("P256Verifier:          ", _addr(type(P256Verifier).creationCode));
+        console.log("WebAuthnVerifier:      ", _addr(type(WebAuthnVerifier).creationCode));
+        console.log("DelegateVerifier:      ", _addr(abi.encodePacked(type(DelegateVerifier).creationCode, abi.encode(accountConfig))));
+        console.log("BLSVerifier:           ", _addr(type(BLSVerifier).creationCode));
+        console.log("SchnorrVerifier:       ", _addr(type(SchnorrVerifier).creationCode));
+        console.log("MultisigVerifier:      ", _addr(type(MultisigVerifier).creationCode));
+        console.log("Groth16Verifier:       ", _addr(type(Groth16Verifier).creationCode));
+        console.log("AlwaysValidVerifier:   ", _addr(type(AlwaysValidVerifier).creationCode));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Deployment
+    // ─────────────────────────────────────────────────────────────────────────
+
     function run() public {
         vm.startBroadcast();
 
-        // ── Reference verifiers (deployed first — addresses needed by AccountConfiguration) ──
+        // ── Core ──
 
-        address k1 = address(new K1Verifier{salt: 0}());
-        address p256Raw = address(new P256Verifier{salt: 0}());
-        address p256WebAuthn = address(new WebAuthnVerifier{salt: 0}());
+        address accountConfig  = _create2(type(AccountConfiguration).creationCode);
+        address defaultAccount = _create2(abi.encodePacked(type(DefaultAccount).creationCode, abi.encode(accountConfig)));
+        address defaultHighRate = _create2(abi.encodePacked(type(DefaultHighRateAccount).creationCode, abi.encode(accountConfig)));
 
-        // DelegateVerifier needs AccountConfiguration — use address(0) placeholder,
-        // deploy AccountConfiguration, then deploy DelegateVerifier
-        AccountConfiguration accountConfig = new AccountConfiguration{salt: 0}();
-        console.log("AccountConfiguration:", address(accountConfig));
+        // ── Verifiers ──
 
-        address delegateAddr = address(new DelegateVerifier{salt: 0}(address(accountConfig)));
+        address k1          = _create2(type(K1Verifier).creationCode);
+        address p256        = _create2(type(P256Verifier).creationCode);
+        address webAuthn    = _create2(type(WebAuthnVerifier).creationCode);
+        address delegate    = _create2(abi.encodePacked(type(DelegateVerifier).creationCode, abi.encode(accountConfig)));
+        address bls         = _create2(type(BLSVerifier).creationCode);
+        address schnorr     = _create2(type(SchnorrVerifier).creationCode);
+        address multisig    = _create2(type(MultisigVerifier).creationCode);
+        address groth16     = _create2(type(Groth16Verifier).creationCode);
+        address alwaysValid = _create2(type(AlwaysValidVerifier).creationCode);
 
-        address defaultAccount = address(new DefaultAccount{salt: 0}(address(accountConfig)));
-        address defaultHighRate = address(new DefaultHighRateAccount{salt: 0}(address(accountConfig)));
-
-        console.log("DefaultAccount:       ", defaultAccount);
+        console.log("AccountConfiguration:  ", accountConfig);
+        console.log("DefaultAccount:        ", defaultAccount);
         console.log("DefaultHighRateAccount:", defaultHighRate);
-
-        // ── Reference verifiers ──
-
-        console.log("K1Verifier:          ", k1);
-        console.log("P256Verifier:        ", p256Raw);
-        console.log("WebAuthnVerifier:    ", p256WebAuthn);
-        console.log("DelegateVerifier:    ", delegateAddr);
-
-        // ── Additional verifiers ──
-
-        console.log("BLSVerifier:         ", address(new BLSVerifier{salt: 0}()));
-        console.log("SchnorrVerifier:     ", address(new SchnorrVerifier{salt: 0}()));
-        console.log("MultisigVerifier:    ", address(new MultisigVerifier{salt: 0}()));
-        console.log("Groth16Verifier:     ", address(new Groth16Verifier{salt: 0}()));
-        console.log("AlwaysValidVerifier: ", address(new AlwaysValidVerifier{salt: 0}()));
+        console.log("");
+        console.log("K1Verifier:            ", k1);
+        console.log("P256Verifier:          ", p256);
+        console.log("WebAuthnVerifier:      ", webAuthn);
+        console.log("DelegateVerifier:      ", delegate);
+        console.log("BLSVerifier:           ", bls);
+        console.log("SchnorrVerifier:       ", schnorr);
+        console.log("MultisigVerifier:      ", multisig);
+        console.log("Groth16Verifier:       ", groth16);
+        console.log("AlwaysValidVerifier:   ", alwaysValid);
 
         vm.stopBroadcast();
     }

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -63,8 +63,12 @@ contract AccountConfiguration is IAccountConfiguration {
     /// @notice Owner can change account owners
     uint8 public constant SCOPE_CHANGE_OWNERS = 0x08;
 
+    /// @dev Verifier namespace: 0=implicit EOA, 1=ecrecover EOA, 2..max-1=custom, max=revoked.
+    /// @notice Explicit verifier for native EOA signatures via ecrecover.
+    address public constant ECRECOVER_VERIFIER = address(1);
+
     /// @notice Sentinel verifier written on self-ownerId revocation to block implicit re-authorization.
-    address public constant REVOKED_VERIFIER = address(1);
+    address public constant REVOKED_VERIFIER = address(type(uint160).max);
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // STORAGE
@@ -163,7 +167,6 @@ contract AccountConfiguration is IAccountConfiguration {
                 revert();
             }
         }
-        emit AppliedSignedOwnerChanges(account, sequence);
     }
 
     // ----------------------------------------------------------------------------------------------------------------
@@ -240,7 +243,7 @@ contract AccountConfiguration is IAccountConfiguration {
 
     function isOwner(address account, bytes32 ownerId) public view returns (bool) {
         address verifier = _ownerConfig[ownerId][account].verifier;
-        if (verifier > REVOKED_VERIFIER) return true;
+        if (verifier >= ECRECOVER_VERIFIER && verifier != REVOKED_VERIFIER) return true;
         // Implicit EOA: self-ownerId with truly empty slot
         return verifier == address(0) && ownerId == bytes32(bytes20(account));
     }
@@ -307,7 +310,7 @@ contract AccountConfiguration is IAccountConfiguration {
     }
 
     function _authorizeOwner(address account, bytes32 ownerId, OwnerConfig memory config) internal nonZero(account) {
-        require(config.verifier > REVOKED_VERIFIER);
+        require(config.verifier >= ECRECOVER_VERIFIER && config.verifier != REVOKED_VERIFIER);
         address existing = _ownerConfig[ownerId][account].verifier;
         require(existing == address(0) || existing == REVOKED_VERIFIER);
 
@@ -373,6 +376,8 @@ contract AccountConfiguration is IAccountConfiguration {
         returns (uint8 scopes)
     {
         if (verifier == address(0)) return _verifyImplicitEOA(account, hash, data);
+        if (verifier == ECRECOVER_VERIFIER) return _verifyEcrecover(account, hash, data);
+        require(verifier != REVOKED_VERIFIER);
 
         bytes32 ownerId = IVerifier(verifier).verify(hash, data);
         require(ownerId != bytes32(0));
@@ -382,15 +387,30 @@ contract AccountConfiguration is IAccountConfiguration {
         return config.scopes;
     }
 
-    /// @dev Implicit EOA: native ecrecover, requires self-ownerId slot is empty (not REVOKED_VERIFIER).
+    /// @dev Implicit EOA: native ecrecover, requires self-ownerId slot to be empty.
     function _verifyImplicitEOA(address account, bytes32 hash, bytes calldata data) internal view returns (uint8) {
         require(_ownerConfig[bytes32(bytes20(account))][account].verifier == address(0));
+        address recovered = _recoverSigner(hash, data);
+        require(recovered == account);
+        return 0;
+    }
+
+    /// @dev Explicit EOA owner via native ecrecover verifier (address(1)).
+    function _verifyEcrecover(address account, bytes32 hash, bytes calldata data) internal view returns (uint8) {
+        address recovered = _recoverSigner(hash, data);
+        require(recovered != address(0));
+
+        bytes32 ownerId = bytes32(bytes20(recovered));
+        OwnerConfig memory config = _ownerConfig[ownerId][account];
+        require(config.verifier == ECRECOVER_VERIFIER);
+        return config.scopes;
+    }
+
+    function _recoverSigner(bytes32 hash, bytes calldata data) internal pure returns (address recovered) {
         require(data.length == 65);
         bytes32 r = bytes32(data[:32]);
         bytes32 s = bytes32(data[32:64]);
-        address recovered = ecrecover(hash, uint8(data[64]), r, s);
-        require(recovered == account);
-        return 0;
+        return ecrecover(hash, uint8(data[64]), r, s);
     }
 
     // ----------------------------------------------------------------------------------------------------------------

--- a/src/interfaces/IAccountConfiguration.sol
+++ b/src/interfaces/IAccountConfiguration.sol
@@ -40,7 +40,8 @@ interface IAccountConfiguration {
 
     event AccountImported(address indexed account);
 
-    event AppliedSignedOwnerChanges(address indexed account, uint64 sequence);
+    /// @notice Protocol-injected receipt log for successful EIP-8130 delegation updates (not emitted in EVM).
+    event DelegationApplied(address indexed account, address target);
 
     event AccountLocked(address indexed account, uint16 unlockDelay);
 

--- a/test/lib/AccountConfigurationTest.sol
+++ b/test/lib/AccountConfigurationTest.sol
@@ -84,6 +84,12 @@ contract AccountConfigurationTest is Test {
         return abi.encodePacked(address(0), r, s, v);
     }
 
+    /// @dev Build auth bytes for explicit EOA path: address(1) || ecdsa signature.
+    function _buildExplicitEOAAuth(uint256 pk, bytes32 digest) internal pure returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);
+        return abi.encodePacked(address(1), r, s, v);
+    }
+
     // ── Canonical digest computation ──
 
     function _computeOwnerChangeBatchDigest(

--- a/test/unit/AccountConfiguration/applyKeyChange.t.sol
+++ b/test/unit/AccountConfiguration/applyKeyChange.t.sol
@@ -346,7 +346,7 @@ contract ApplyConfigChangeOwnerTest is AccountConfigurationTest {
     // ── EOA self-ownerId revoke/add with explicit registration ──
     //
     // The self-ownerId for an account is bytes32(bytes20(account)).
-    // Revoking this ownerId sets a sentinel (verifier=0, scopes=0xff)
+    // Revoking this ownerId sets a sentinel (verifier=REVOKED_VERIFIER, scopes=0)
     // instead of deleting, to block the implicit authorization.
 
     function test_selfOwnerId_addKey() public {
@@ -381,7 +381,7 @@ contract ApplyConfigChangeOwnerTest is AccountConfigurationTest {
         _revokeOwner(account, OWNER_PK, selfOwnerId);
         assertFalse(accountConfiguration.isOwner(account, selfOwnerId));
 
-        // Sentinel has verifier=0, so _authorizeOwner's `require(verifier == 0)` passes
+        // Re-authorization is allowed from the revoked sentinel state.
         _authorizeOwner(account, OWNER_PK, selfOwnerId, address(k1Verifier));
         assertTrue(accountConfiguration.isOwner(account, selfOwnerId));
     }

--- a/test/unit/AccountConfiguration/verify.t.sol
+++ b/test/unit/AccountConfiguration/verify.t.sol
@@ -165,6 +165,55 @@ contract VerifyTest is AccountConfigurationTest {
         accountConfiguration.verify(eoa, hash, _buildImplicitEOAAuth(eoaPk, hash));
     }
 
+    function test_verify_explicitEOA_selfOwner() public {
+        uint256 eoaPk = 500;
+        address eoa = vm.addr(eoaPk);
+        bytes32 selfOwnerId = bytes32(bytes20(eoa));
+
+        _implicitAuthorizeOwner(eoa, eoaPk, selfOwnerId, accountConfiguration.ECRECOVER_VERIFIER());
+
+        bytes32 hash = keccak256("explicit self-owner");
+        uint8 scopes = accountConfiguration.verify(eoa, hash, _buildExplicitEOAAuth(eoaPk, hash));
+        assertEq(scopes, 0);
+
+        // Explicit self-owner registration disables implicit auth path.
+        vm.expectRevert();
+        accountConfiguration.verify(eoa, hash, _buildImplicitEOAAuth(eoaPk, hash));
+    }
+
+    function test_verify_explicitEOA_nonSelfOwner() public {
+        uint256 eoaPk = 500;
+        address eoa = vm.addr(eoaPk);
+
+        uint256 bobPk = 501;
+        bytes32 bobOwnerId = bytes32(bytes20(vm.addr(bobPk)));
+        _implicitAuthorizeOwner(eoa, eoaPk, bobOwnerId, accountConfiguration.ECRECOVER_VERIFIER());
+
+        bytes32 hash = keccak256("explicit non-self owner");
+        uint8 scopes = accountConfiguration.verify(eoa, hash, _buildExplicitEOAAuth(bobPk, hash));
+        assertEq(scopes, 0);
+    }
+
+    function test_verify_explicitEOA_unregisteredFails() public {
+        uint256 eoaPk = 500;
+        address eoa = vm.addr(eoaPk);
+
+        bytes32 hash = keccak256("explicit unregistered");
+        vm.expectRevert();
+        accountConfiguration.verify(eoa, hash, _buildExplicitEOAAuth(eoaPk, hash));
+    }
+
+    function test_verify_revokedVerifierPrefixReverts() public {
+        uint256 eoaPk = 500;
+        address eoa = vm.addr(eoaPk);
+
+        bytes32 hash = keccak256("revoked verifier prefix");
+        bytes memory auth = abi.encodePacked(accountConfiguration.REVOKED_VERIFIER());
+
+        vm.expectRevert();
+        accountConfiguration.verify(eoa, hash, auth);
+    }
+
     // ── Helpers ──
 
     function _authorizeOwner(address account, uint256 pk, bytes32 newOwnerId, address verifier) internal {


### PR DESCRIPTION
Routes all deployments through Nick's singleton factory (0x4e59b44847b379578588920cA78FbF26c0B4956C) so addresses depend only on salt + bytecode, not the broadcaster's address or nonce.

Adds an addresses() function for previewing canonical addresses without broadcasting, and makes _create2 idempotent via code.length guard.

Fixes sentinels 