### PR TITLE
fix: enforce SIGNATURE scope on delegate nested signer

### DIFF
--- a/src/authenticators/DelegateAuthenticator.sol
+++ b/src/authenticators/DelegateAuthenticator.sol
@@ -11,7 +11,7 @@ import {AccountConfiguration} from "../AccountConfiguration.sol";
 ///         in normal EVM. On 8130 chains, the protocol handles DELEGATE directly
 ///         at the protocol level.
 ///
-///         Data layout: delegate_address (20) || nested_authenticator_type (1) || nested_data
+///         Data layout: delegate_address (20) || nested_authenticator (20) || nested_data
 contract DelegateAuthenticator is IAuthenticator {
     AccountConfiguration public immutable ACCOUNT_CONFIGURATION;
 
@@ -30,6 +30,7 @@ contract DelegateAuthenticator is IAuthenticator {
         address nestedAuthenticator = address(bytes20(nestedAuth[:20]));
         require(nestedAuthenticator != address(this));
 
-        ACCOUNT_CONFIGURATION.authenticateActor(delegate, hash, nestedAuth);
+        // Nested signer must have SIGNATURE scope on the delegate account.
+        require(ACCOUNT_CONFIGURATION.verifySignature(delegate, hash, nestedAuth));
     }
 }

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -93,4 +93,53 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
         vm.expectRevert();
         delegateAuthenticator.authenticate(hash, doubleHopData);
     }
+
+    function test_authenticate_revertsWhenNestedSignerLacksSignatureScope() public {
+        // Account B: unrestricted owner (DELEGATE_PK) plus a second key scoped to PAYER only.
+        (address delegateAccount,) = _createK1Account(DELEGATE_PK);
+        _authorizeScopedK1Actor(delegateAccount, DELEGATE_PK, DELEGATOR_PK, SCOPE_PAYER);
+
+        bytes32 hash = keccak256("scoped delegate test");
+        // The PAYER-only key is a valid, bound actor on B, but lacks SIGNATURE scope.
+        bytes memory nestedAuth = abi.encodePacked(address(k1Authenticator), _signDigest(DELEGATOR_PK, hash));
+        bytes memory data = abi.encodePacked(delegateAccount, nestedAuth);
+
+        // Delegation now gates SCOPE_SIGNER (verifySignature), so a non-SIGNATURE key must revert.
+        vm.expectRevert();
+        delegateAuthenticator.authenticate(hash, data);
+    }
+
+    function test_authenticate_succeedsWhenNestedSignerHasSignatureScope() public {
+        (address delegateAccount,) = _createK1Account(DELEGATE_PK);
+        _authorizeScopedK1Actor(delegateAccount, DELEGATE_PK, DELEGATOR_PK, SCOPE_SIGNER);
+
+        bytes32 hash = keccak256("scoped delegate test");
+        bytes memory nestedAuth = abi.encodePacked(address(k1Authenticator), _signDigest(DELEGATOR_PK, hash));
+        bytes memory data = abi.encodePacked(delegateAccount, nestedAuth);
+
+        bytes32 actorId = delegateAuthenticator.authenticate(hash, data);
+        assertEq(actorId, bytes32(bytes20(delegateAccount)));
+    }
+
+    uint8 constant SCOPE_SIGNER = 0x01;
+    uint8 constant SCOPE_PAYER = 0x04;
+    uint8 constant AUTHORIZE_ACTOR = 0x01;
+
+    /// @dev Authorizes a new K1 actor (`newPk`) with `scope` on `account`, signed by the
+    ///      unrestricted owner (`ownerPk`) via applySignedActorChanges on the local chain.
+    function _authorizeScopedK1Actor(address account, uint256 ownerPk, uint256 newPk, uint8 scope) internal {
+        IAccountConfiguration.ActorConfig memory config = IAccountConfiguration.ActorConfig({
+            authenticator: address(k1Authenticator), scope: scope, expiry: 0, policyType: 0
+        });
+
+        IAccountConfiguration.ActorChange[] memory changes = new IAccountConfiguration.ActorChange[](1);
+        changes[0] = IAccountConfiguration.ActorChange({
+            changeType: AUTHORIZE_ACTOR, actorId: bytes32(bytes20(vm.addr(newPk))), data: abi.encode(config, bytes(""))
+        });
+
+        uint64 chainId = uint64(block.chainid);
+        uint64 sequence = accountConfiguration.getChangeSequences(account).local;
+        bytes32 digest = _computeActorChangeBatchDigest(account, chainId, sequence, changes);
+        accountConfiguration.applySignedActorChanges(account, chainId, changes, _buildK1Auth(ownerPk, digest));
+    }
 }


### PR DESCRIPTION
`DelegateAuthenticator` called `authenticateActor`, which authenticates the nested signer but does not check its scope. Per the EIP, a key may only sign on behalf of another account via delegation if it has SIGNATURE scope on that account.

Switched to `verifySignature` (gates `SCOPE_SIGNER`). The capability granted to the delegating account remains carried by its own delegate-entry scope.

Added regression tests: a non-SIGNATURE nested key now reverts; a SIGNATURE-scoped key passes. Full suite green (159 tests).