### PR TITLE
Add SETDELEGATE factory example

### DIFF
--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -193,7 +193,13 @@ contract AccountConfiguration is IAccountConfiguration {
     }
 
     /// @notice Import an existing account to AccountConfiguration management.
-    /// @dev Verifies via ERC-1271. Accounts must have bytecode.
+    /// @dev Verifies via ERC-1271. The callback is the sole binding between `account` and `initialActors`, so any
+    ///      address whose code answers `isValidSignature` honestly may be imported — already-deployed contract
+    ///      accounts, EIP-7702 delegated EOAs (whose delegate's ERC-1271 vouches), and accounts deployed via an
+    ///      EIP-7819 SETDELEGATE factory (whose delegate runs a bootstrap-aware ERC-1271 that validates
+    ///      `initialActors` against state primed by the factory in the same tx frame — see examples/factory).
+    ///      Codeless addresses cannot be imported (a no-code staticcall returns empty data, failing the magic
+    ///      check below), which prevents squatting on counterfactual addresses.
     /// @dev Custom hash used to partially mitigate phishing attacks on eth_signTypedData.
     function importAccount(address account, InitialActor[] calldata initialActors, bytes calldata signature)
         external
@@ -201,18 +207,22 @@ contract AccountConfiguration is IAccountConfiguration {
     {
         // Import is a one-time bootstrap for accounts with no 8130 state yet
         require(_accountState[account].localSequence == 0 && _accountState[account].multichainSequence == 0);
-        _accountState[account].localSequence = 1;
 
         bytes32 digest = _computeImportDigest(account, initialActors);
+        // STATICCALL — a view callback cannot write state, so no reentrancy is possible and the localSequence
+        // write can be deferred until after the check. Deferring it keeps `getChangeSequences(this).local == 0`
+        // observable during the callback, which a bootstrap-aware delegate (see examples/factory) branches on.
         (bool success, bytes memory result) =
             account.staticcall(abi.encodeWithSelector(ERC1271_SELECTOR, digest, signature));
         require(success && result.length == 32 && abi.decode(result, (bytes4)) == ERC1271_SELECTOR);
 
-        // Disable the implicit default-EOA path (parity with createAccount). Set *after* the ERC-1271 check: for an
-        // EIP-7702 delegated EOA its own k1 signature (the implicit full owner) is the only authenticator available
-        // at import time, so it must stay live for that check. An owner who wants to keep using the key can include
-        // the self-actorId as an explicit k1 actor in initialActors (still a full owner, now via its config), or
-        // re-enable it later. Folds into the same slot as localSequence.
+        // Mark initialized (localSequence doubles as the initialized flag) and disable the implicit default-EOA path
+        // (parity with createAccount). Both writes land after the ERC-1271 check: for an EIP-7702 delegated EOA its
+        // own k1 signature (the implicit full owner) is the only authenticator available at import time, so it must
+        // stay live for that check. An owner who wants to keep using the key can include the self-actorId as an
+        // explicit k1 actor in initialActors (still a full owner, now via its config), or re-enable it later. Both
+        // fold into the same packed AccountState slot.
+        _accountState[account].localSequence = 1;
         _accountState[account].flags = FLAG_REVOKE_DEFAULT_EOA;
 
         _initializeAccount(account, initialActors);

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -193,13 +193,7 @@ contract AccountConfiguration is IAccountConfiguration {
     }
 
     /// @notice Import an existing account to AccountConfiguration management.
-    /// @dev Verifies via ERC-1271. The callback is the sole binding between `account` and `initialActors`, so any
-    ///      address whose code answers `isValidSignature` honestly may be imported — already-deployed contract
-    ///      accounts, EIP-7702 delegated EOAs (whose delegate's ERC-1271 vouches), and accounts deployed via an
-    ///      EIP-7819 SETDELEGATE factory (whose delegate runs a bootstrap-aware ERC-1271 that validates
-    ///      `initialActors` against state primed by the factory in the same tx frame — see examples/factory).
-    ///      Codeless addresses cannot be imported (a no-code staticcall returns empty data, failing the magic
-    ///      check below), which prevents squatting on counterfactual addresses.
+    /// @dev Verifies via ERC-1271. Accounts must have bytecode.
     /// @dev Custom hash used to partially mitigate phishing attacks on eth_signTypedData.
     function importAccount(address account, InitialActor[] calldata initialActors, bytes calldata signature)
         external
@@ -207,22 +201,18 @@ contract AccountConfiguration is IAccountConfiguration {
     {
         // Import is a one-time bootstrap for accounts with no 8130 state yet
         require(_accountState[account].localSequence == 0 && _accountState[account].multichainSequence == 0);
+        _accountState[account].localSequence = 1;
 
         bytes32 digest = _computeImportDigest(account, initialActors);
-        // STATICCALL — a view callback cannot write state, so no reentrancy is possible and the localSequence
-        // write can be deferred until after the check. Deferring it keeps `getChangeSequences(this).local == 0`
-        // observable during the callback, which a bootstrap-aware delegate (see examples/factory) branches on.
         (bool success, bytes memory result) =
             account.staticcall(abi.encodeWithSelector(ERC1271_SELECTOR, digest, signature));
         require(success && result.length == 32 && abi.decode(result, (bytes4)) == ERC1271_SELECTOR);
 
-        // Mark initialized (localSequence doubles as the initialized flag) and disable the implicit default-EOA path
-        // (parity with createAccount). Both writes land after the ERC-1271 check: for an EIP-7702 delegated EOA its
-        // own k1 signature (the implicit full owner) is the only authenticator available at import time, so it must
-        // stay live for that check. An owner who wants to keep using the key can include the self-actorId as an
-        // explicit k1 actor in initialActors (still a full owner, now via its config), or re-enable it later. Both
-        // fold into the same packed AccountState slot.
-        _accountState[account].localSequence = 1;
+        // Disable the implicit default-EOA path (parity with createAccount). Set *after* the ERC-1271 check: for an
+        // EIP-7702 delegated EOA its own k1 signature (the implicit full owner) is the only authenticator available
+        // at import time, so it must stay live for that check. An owner who wants to keep using the key can include
+        // the self-actorId as an explicit k1 actor in initialActors (still a full owner, now via its config), or
+        // re-enable it later. Folds into the same slot as localSequence.
         _accountState[account].flags = FLAG_REVOKE_DEFAULT_EOA;
 
         _initializeAccount(account, initialActors);

--- a/src/examples/factory/BootstrapAccount.sol
+++ b/src/examples/factory/BootstrapAccount.sol
@@ -8,17 +8,21 @@ import {IBootstrap} from "./IBootstrap.sol";
 
 /// @notice Reference implementation for accounts deployed via `SetDelegateFactory`.
 ///
-///         Bootstrap-aware ERC-1271:
-///           - While `getChangeSequences(this).local == 0`, the implementation is in BOOTSTRAP mode and validates
-///             the presented digest against the typed actors hash primed by the factory in the same tx frame.
-///           - After `AccountConfiguration.importAccount` succeeds (local sequence becomes 1), the implementation
-///             defers `isValidSignature` to `AccountConfiguration.authenticateActor` for normal operation.
+///         Self-contained bootstrap (no changes to AccountConfiguration required):
+///           - `bootstrap` is the account's own entrypoint. It sets a transient (EIP-1153) latch, drives
+///             `AccountConfiguration.importAccount` on itself, then clears the latch — all in one call frame.
+///           - While the latch is set (i.e. only during that nested `importAccount`), the ERC-1271 callback is in
+///             BOOTSTRAP mode and validates the presented digest against the typed actors hash the factory passed
+///             in. The latch lives in transient storage, so it is scoped to the bootstrap transaction and cannot
+///             leak into normal operation; it is also cleared explicitly once import returns.
+///           - In every other context (latch unset) the implementation defers `isValidSignature` to
+///             `AccountConfiguration.authenticateActor` for normal operation.
 ///
-///         Bootstrap mode is the only window in which the "signature" need not be checked: the factory's atomic
-///         `SETDELEGATE → bootstrap → importAccount` sequence makes front-running impossible, and the SETDELEGATE
-///         address derivation binds the address to `(factory, salt)` where `salt` already commits to the actor
-///         set. The implementation just confirms the import digest AccountConfiguration computed matches the
-///         actors the factory primed.
+///         Why the signature need not be checked in BOOTSTRAP mode: the account has no key. The factory's atomic
+///         `SETDELEGATE → bootstrap` sequence makes front-running impossible, and the SETDELEGATE address
+///         derivation binds the address to `(factory, salt)` where `salt` already commits to the actor set. The
+///         implementation just confirms the import digest AccountConfiguration computed matches the actors the
+///         factory primed.
 ///
 ///         Minimal reference; production accounts add execution, caller authorization, asset receive hooks, etc.
 contract BootstrapAccount is IBootstrap, Receiver {
@@ -32,12 +36,11 @@ contract BootstrapAccount is IBootstrap, Receiver {
     bytes4 internal constant _ERC1271_MAGIC = 0x1626ba7e;
     bytes4 internal constant _ERC1271_INVALID = 0xffffffff;
 
-    /// @notice Typed actors hash primed by the factory at bootstrap. Combined with `address(this)` it
-    ///         reconstructs the expected `ActorInitialization` digest used by `importAccount`.
-    bytes32 public bootstrappedActorsHash;
-
-    /// @notice True once `bootstrap` has been called; prevents re-bootstrap.
-    bool public bootstrapped;
+    /// @notice Transient (EIP-1153) bootstrap latch. Non-zero ONLY for the duration of the `bootstrap` call frame
+    ///         (i.e. across the nested `importAccount`). When set, it is the typed actors hash that, combined with
+    ///         `address(this)`, reconstructs the expected `ActorInitialization` digest. Auto-clears at end of tx and
+    ///         is cleared explicitly after import, so the BOOTSTRAP branch is reachable exactly once.
+    bytes32 internal transient _bootstrapActorsHash;
 
     constructor(address accountConfiguration) {
         ACCOUNT_CONFIGURATION = IAccountConfiguration(accountConfiguration);
@@ -47,15 +50,18 @@ contract BootstrapAccount is IBootstrap, Receiver {
     //  BOOTSTRAP
     // ══════════════════════════════════════════════
 
-    /// @notice Prime the implementation with the typed `actorsHash`. Single-use; the factory calls this in
-    ///         the same tx frame as `importAccount`. After `importAccount` succeeds, the bootstrap branch is
-    ///         no longer taken (AccountConfiguration sequence is non-zero), and re-bootstrap is also blocked.
-    /// @param  actorsHash `keccak256(actorHash_0 || actorHash_1 || ... )`, matching the inner hash of the
-    ///                    `ActorInitialization` digest AccountConfiguration computes for the same actor set.
-    function bootstrap(bytes32 actorsHash) external {
-        require(!bootstrapped, "bootstrapped");
-        bootstrappedActorsHash = actorsHash;
-        bootstrapped = true;
+    /// @notice Atomically prime + self-import. Called by the factory in the same tx frame as `SETDELEGATE`.
+    ///         Sets the transient latch, has AccountConfiguration register the actors (whose ERC-1271 callback
+    ///         lands on the BOOTSTRAP branch below), then clears the latch. After `importAccount` succeeds the
+    ///         account is initialized, so a second call reverts inside `importAccount` and the BOOTSTRAP branch
+    ///         is never reachable again.
+    /// @param  actorsHash    `keccak256(actorHash_0 || actorHash_1 || ... )`, matching the inner hash of the
+    ///                        `ActorInitialization` digest AccountConfiguration computes for the same actor set.
+    /// @param  initialActors The actor set to import. MUST match `actorsHash`.
+    function bootstrap(bytes32 actorsHash, IAccountConfiguration.InitialActor[] calldata initialActors) external {
+        _bootstrapActorsHash = actorsHash;
+        ACCOUNT_CONFIGURATION.importAccount(address(this), initialActors, "");
+        _bootstrapActorsHash = bytes32(0);
     }
 
     // ══════════════════════════════════════════════
@@ -63,13 +69,14 @@ contract BootstrapAccount is IBootstrap, Receiver {
     // ══════════════════════════════════════════════
 
     /// @notice Signature validation.
-    ///         BOOTSTRAP mode (sequence == 0): the presented `hash` must equal the canonical
-    ///         `ActorInitialization` digest reconstructed from the primed `bootstrappedActorsHash`.
-    ///         The `signature` argument is ignored; binding comes from the factory's atomic sequence.
-    ///         NORMAL mode (sequence > 0): defer to AccountConfiguration.
+    ///         BOOTSTRAP mode (transient latch set): the presented `hash` must equal the canonical
+    ///         `ActorInitialization` digest reconstructed from the latched actors hash. The `signature` argument
+    ///         is ignored; binding comes from the factory's atomic sequence and the address derivation.
+    ///         NORMAL mode (latch unset): defer to AccountConfiguration.
     function isValidSignature(bytes32 hash, bytes calldata signature) external view virtual returns (bytes4) {
-        if (bootstrapped && ACCOUNT_CONFIGURATION.getChangeSequences(address(this)).local == 0) {
-            return hash == _expectedImportDigest() ? _ERC1271_MAGIC : _ERC1271_INVALID;
+        bytes32 actorsHash = _bootstrapActorsHash;
+        if (actorsHash != bytes32(0)) {
+            return hash == _expectedImportDigest(actorsHash) ? _ERC1271_MAGIC : _ERC1271_INVALID;
         }
         // signature is `authenticator(20) || data` per EIP-8130 for the canonical path.
         try ACCOUNT_CONFIGURATION.authenticateActor(address(this), hash, signature) returns (uint8, uint8, address) {
@@ -79,19 +86,17 @@ contract BootstrapAccount is IBootstrap, Receiver {
         }
     }
 
-    /// @notice The digest this account expects in BOOTSTRAP mode. Exposed for off-chain tooling.
-    function expectedImportDigest() external view returns (bytes32) {
-        return _expectedImportDigest();
+    /// @notice The digest this account expects in BOOTSTRAP mode for a given actor set. Exposed for off-chain
+    ///         tooling; the on-chain check uses the transient latch primed by `bootstrap`.
+    function expectedImportDigest(bytes32 actorsHash) external view returns (bytes32) {
+        return _expectedImportDigest(actorsHash);
     }
 
     // ══════════════════════════════════════════════
     //  INTERNALS
     // ══════════════════════════════════════════════
 
-    function _expectedImportDigest() internal view returns (bytes32) {
-        return
-            keccak256(
-                abi.encode(_ACTOR_INITIALIZATION_TYPEHASH, bytes32(bytes20(address(this))), bootstrappedActorsHash)
-            );
+    function _expectedImportDigest(bytes32 actorsHash) internal view returns (bytes32) {
+        return keccak256(abi.encode(_ACTOR_INITIALIZATION_TYPEHASH, bytes32(bytes20(address(this))), actorsHash));
     }
 }

--- a/src/examples/factory/BootstrapAccount.sol
+++ b/src/examples/factory/BootstrapAccount.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Receiver} from "solady/accounts/Receiver.sol";
+
+import {IAccountConfiguration} from "../../interfaces/IAccountConfiguration.sol";
+import {IBootstrap} from "./IBootstrap.sol";
+
+/// @notice Reference implementation for accounts deployed via `SetDelegateFactory`.
+///
+///         Bootstrap-aware ERC-1271:
+///           - While `getChangeSequences(this).local == 0`, the implementation is in BOOTSTRAP mode and validates
+///             the presented digest against the typed actors hash primed by the factory in the same tx frame.
+///           - After `AccountConfiguration.importAccount` succeeds (local sequence becomes 1), the implementation
+///             defers `isValidSignature` to `AccountConfiguration.authenticateActor` for normal operation.
+///
+///         Bootstrap mode is the only window in which the "signature" need not be checked: the factory's atomic
+///         `SETDELEGATE → bootstrap → importAccount` sequence makes front-running impossible, and the SETDELEGATE
+///         address derivation binds the address to `(factory, salt)` where `salt` already commits to the actor
+///         set. The implementation just confirms the import digest AccountConfiguration computed matches the
+///         actors the factory primed.
+///
+///         Minimal reference; production accounts add execution, caller authorization, asset receive hooks, etc.
+contract BootstrapAccount is IBootstrap, Receiver {
+    IAccountConfiguration public immutable ACCOUNT_CONFIGURATION;
+
+    /// @dev Matches `AccountConfiguration.ACTOR_INITIALIZATION_TYPEHASH`.
+    bytes32 internal constant _ACTOR_INITIALIZATION_TYPEHASH = keccak256(
+        "ActorInitialization(bytes32 salt,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint8 policyType)"
+    );
+
+    bytes4 internal constant _ERC1271_MAGIC = 0x1626ba7e;
+    bytes4 internal constant _ERC1271_INVALID = 0xffffffff;
+
+    /// @notice Typed actors hash primed by the factory at bootstrap. Combined with `address(this)` it
+    ///         reconstructs the expected `ActorInitialization` digest used by `importAccount`.
+    bytes32 public bootstrappedActorsHash;
+
+    /// @notice True once `bootstrap` has been called; prevents re-bootstrap.
+    bool public bootstrapped;
+
+    constructor(address accountConfiguration) {
+        ACCOUNT_CONFIGURATION = IAccountConfiguration(accountConfiguration);
+    }
+
+    // ══════════════════════════════════════════════
+    //  BOOTSTRAP
+    // ══════════════════════════════════════════════
+
+    /// @notice Prime the implementation with the typed `actorsHash`. Single-use; the factory calls this in
+    ///         the same tx frame as `importAccount`. After `importAccount` succeeds, the bootstrap branch is
+    ///         no longer taken (AccountConfiguration sequence is non-zero), and re-bootstrap is also blocked.
+    /// @param  actorsHash `keccak256(actorHash_0 || actorHash_1 || ... )`, matching the inner hash of the
+    ///                    `ActorInitialization` digest AccountConfiguration computes for the same actor set.
+    function bootstrap(bytes32 actorsHash) external {
+        require(!bootstrapped, "bootstrapped");
+        bootstrappedActorsHash = actorsHash;
+        bootstrapped = true;
+    }
+
+    // ══════════════════════════════════════════════
+    //  ERC-1271
+    // ══════════════════════════════════════════════
+
+    /// @notice Signature validation.
+    ///         BOOTSTRAP mode (sequence == 0): the presented `hash` must equal the canonical
+    ///         `ActorInitialization` digest reconstructed from the primed `bootstrappedActorsHash`.
+    ///         The `signature` argument is ignored; binding comes from the factory's atomic sequence.
+    ///         NORMAL mode (sequence > 0): defer to AccountConfiguration.
+    function isValidSignature(bytes32 hash, bytes calldata signature) external view virtual returns (bytes4) {
+        if (bootstrapped && ACCOUNT_CONFIGURATION.getChangeSequences(address(this)).local == 0) {
+            return hash == _expectedImportDigest() ? _ERC1271_MAGIC : _ERC1271_INVALID;
+        }
+        // signature is `authenticator(20) || data` per EIP-8130 for the canonical path.
+        try ACCOUNT_CONFIGURATION.authenticateActor(address(this), hash, signature) returns (uint8, uint8, address) {
+            return _ERC1271_MAGIC;
+        } catch {
+            return _ERC1271_INVALID;
+        }
+    }
+
+    /// @notice The digest this account expects in BOOTSTRAP mode. Exposed for off-chain tooling.
+    function expectedImportDigest() external view returns (bytes32) {
+        return _expectedImportDigest();
+    }
+
+    // ══════════════════════════════════════════════
+    //  INTERNALS
+    // ══════════════════════════════════════════════
+
+    function _expectedImportDigest() internal view returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(_ACTOR_INITIALIZATION_TYPEHASH, bytes32(bytes20(address(this))), bootstrappedActorsHash)
+            );
+    }
+}

--- a/src/examples/factory/IBootstrap.sol
+++ b/src/examples/factory/IBootstrap.sol
@@ -1,18 +1,24 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {IAccountConfiguration} from "../../interfaces/IAccountConfiguration.sol";
+
 /// @notice Minimal interface a SETDELEGATE-factory implementation must expose for atomic bootstrap.
 ///
 ///         A bootstrap-aware implementation:
-///           - Accepts a single `bootstrap(actorsHash)` call from the factory before `importAccount` runs.
-///           - In its ERC-1271 `isValidSignature`, while `AccountConfiguration.getChangeSequences(this).local == 0`,
-///             validates that the presented digest equals the canonical EIP-8130 `ActorInitialization` digest
-///             reconstructed from the stored `actorsHash`.
-///           - After bootstrap (once AccountConfiguration records the local sequence as 1), permanently switches
-///             to deferring `isValidSignature` to `AccountConfiguration`.
+///           - Exposes a single `bootstrap(actorsHash, initialActors)` entrypoint that the factory calls in the
+///             same tx frame as `SETDELEGATE`. It primes a transient latch, drives `importAccount` on itself, then
+///             clears the latch.
+///           - In its ERC-1271 `isValidSignature`, while that transient latch is set, validates that the presented
+///             digest equals the canonical EIP-8130 `ActorInitialization` digest reconstructed from `actorsHash`.
+///           - In every other context permanently defers `isValidSignature` to `AccountConfiguration`.
+///
+///         This requires no changes to AccountConfiguration: the bootstrap window is tracked entirely by the
+///         account's own transient state rather than by reading AccountConfiguration's local sequence.
 interface IBootstrap {
-    /// @notice Prime the implementation's bootstrap state with the typed actors hash.
-    /// @param actorsHash The inner hash of the EIP-8130 `ActorInitialization` digest for the initial actor set:
-    ///                   `keccak256(actorHash_0 || ... || actorHash_n)`.
-    function bootstrap(bytes32 actorsHash) external;
+    /// @notice Prime the bootstrap latch and atomically import the actor set.
+    /// @param actorsHash    The inner hash of the EIP-8130 `ActorInitialization` digest for the initial actor set:
+    ///                       `keccak256(actorHash_0 || ... || actorHash_n)`.
+    /// @param initialActors The actor set to import. MUST correspond to `actorsHash`.
+    function bootstrap(bytes32 actorsHash, IAccountConfiguration.InitialActor[] calldata initialActors) external;
 }

--- a/src/examples/factory/IBootstrap.sol
+++ b/src/examples/factory/IBootstrap.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @notice Minimal interface a SETDELEGATE-factory implementation must expose for atomic bootstrap.
+///
+///         A bootstrap-aware implementation:
+///           - Accepts a single `bootstrap(actorsHash)` call from the factory before `importAccount` runs.
+///           - In its ERC-1271 `isValidSignature`, while `AccountConfiguration.getChangeSequences(this).local == 0`,
+///             validates that the presented digest equals the canonical EIP-8130 `ActorInitialization` digest
+///             reconstructed from the stored `actorsHash`.
+///           - After bootstrap (once AccountConfiguration records the local sequence as 1), permanently switches
+///             to deferring `isValidSignature` to `AccountConfiguration`.
+interface IBootstrap {
+    /// @notice Prime the implementation's bootstrap state with the typed actors hash.
+    /// @param actorsHash The inner hash of the EIP-8130 `ActorInitialization` digest for the initial actor set:
+    ///                   `keccak256(actorHash_0 || ... || actorHash_n)`.
+    function bootstrap(bytes32 actorsHash) external;
+}

--- a/src/examples/factory/README.md
+++ b/src/examples/factory/README.md
@@ -14,8 +14,24 @@ repeated per account) and forecloses on-chain upgradeability.
 
 `SETDELEGATE` (opcode `0xf6`, EIP-7819) lets a contract place a 23-byte delegation indicator
 (`0xef0100 || target`) at a deterministic address. Combining it with EIP-8130's `importAccount` gives a
-fourth, off-spec path with state and gas savings plus factory-mediated upgradeability — without
-AccountConfiguration ever knowing the factory exists.
+fourth, off-spec path with state and gas savings plus factory-mediated upgradeability — **without any changes
+to AccountConfiguration** and without AccountConfiguration ever knowing the factory exists.
+
+## How the bootstrap window is tracked
+
+The account has no key, so at import time there is no signature anyone can produce — authorization is purely
+structural (the address commits to the actor set). The only question the account's ERC-1271 must answer during
+its own import is *"am I in the one-time bootstrap window?"*.
+
+The account answers that from **its own transient state**, not from AccountConfiguration's sequence counter:
+
+- `BootstrapAccount.bootstrap` sets a transient (EIP-1153) latch, calls `importAccount` **on itself**, then
+  clears the latch — all in one call frame.
+- While the latch is set (only across that nested `importAccount`), `isValidSignature` validates the presented
+  digest against the primed actors hash. Otherwise it defers to `AccountConfiguration.authenticateActor`.
+
+Because the latch lives in the account, AccountConfiguration's `importAccount` is used exactly as it ships on
+`main` — no reordering of its `localSequence` write, no awareness of the factory.
 
 ## Flow
 
@@ -29,19 +45,18 @@ Phase B (one tx)      invokes factory.deploy(initialActors, implementation, user
   B.1  SETDELEGATE(salt, implementation)
        → code(account) = 0xef0100 || implementation                 (23 bytes)
        → nonce(account) = 1                                         (EIP-7819 step 9)
-  B.2  account.bootstrap(actorsHash)
-       → implementation stores expected actors hash in account's storage
-  B.3  ACCOUNT_CONFIG.importAccount(account, initialActors, "")
-       → AccountConfig computes ActorInitialization digest
-       → STATICCALL account.isValidSignature(digest, "")
-         → Implementation's bootstrap branch (getChangeSequences(account).local == 0):
-           digest matches expected → MAGIC
-       → AccountConfig writes actor_config, bumps local sequence to 1
+  B.2  account.bootstrap(actorsHash, initialActors)                 (runs in account's storage)
+       → transient latch := actorsHash
+       → ACCOUNT_CONFIG.importAccount(account, initialActors, "")
+         → AccountConfig computes ActorInitialization digest, bumps local sequence to 1
+         → STATICCALL account.isValidSignature(digest, "")
+           → latch set → digest matches expected → MAGIC
+         → AccountConfig writes actor_config
+       → transient latch := 0                                       (bootstrap window closed)
 
 Phase C (optional)    close the implicit-EOA path
   Send a Config Change Entry (or applySignedActorChanges) with
     actor_change = revokeActor(bytes32(bytes20(account)))
-  → AccountState.flags |= FLAG_REVOKE_DEFAULT_EOA for the account
   (importAccount already disables the implicit default-EOA path on the account itself; this revokes the
    self-actorId at the actor level if it was re-enabled via an explicit self actor.)
 
@@ -56,11 +71,12 @@ Phase D (later)       upgrade implementation
 - `SETDELEGATE` address derivation includes `msg.sender`, so a different factory yields a different address.
 - The salt commits to the actor set (`actorsHash`), so a different actor set yields a different salt and
   therefore a different address. Trying to put unintended actors at the same address is a hash collision.
-- `SETDELEGATE → bootstrap → importAccount` runs in one transaction frame; no intermediate window exists for
-  a different transaction to interpose state changes.
-- After `importAccount` succeeds, `getChangeSequences(account).local == 1`, so the bootstrap branch in
-  `isValidSignature` is permanently disabled. The implementation is in normal-ERC-1271-via-AccountConfig
-  mode forever after.
+- `SETDELEGATE → bootstrap` runs in one transaction frame; no intermediate window exists for a different
+  transaction to interpose state changes.
+- The bootstrap branch is reachable only while the transient latch is set, which is only across the nested
+  `importAccount` inside `bootstrap`. The latch is cleared before `bootstrap` returns and, being transient,
+  cannot persist past the transaction. After import, `importAccount`'s one-time guard
+  (`localSequence == 0`) also prevents any second import. The branch is therefore reachable exactly once.
 - A codeless counterfactual address cannot be imported: a no-code STATICCALL returns empty data, the magic
   check fails, `importAccount` reverts. Squatting on counterfactual EOAs is impossible.
 
@@ -68,29 +84,30 @@ Phase D (later)       upgrade implementation
 
 | Contract | Role |
 |----------|------|
-| `SetDelegateFactory` | Deploys via `SETDELEGATE`, primes implementation bootstrap, calls `importAccount`. Owns the address-derivation logic and the optional `upgrade` path. |
-| `IBootstrap` | Minimal interface the implementation must expose for atomic priming. |
-| `BootstrapAccount` | Minimal bootstrap-aware reference implementation. ERC-1271 has a BOOTSTRAP branch that validates the import digest against the primed `actorsHash`, and otherwise defers to `AccountConfiguration.authenticateActor`. |
+| `SetDelegateFactory` | Deploys via `SETDELEGATE`, then calls the account's `bootstrap`. Owns the address-derivation logic and the optional `upgrade` path. Holds no reference to AccountConfiguration. |
+| `IBootstrap` | Minimal interface the implementation must expose for atomic priming + self-import. |
+| `BootstrapAccount` | Minimal bootstrap-aware reference implementation. ERC-1271 has a BOOTSTRAP branch (gated by a transient latch) that validates the import digest against the primed `actorsHash`, and otherwise defers to `AccountConfiguration.authenticateActor`. |
 
 ## Spec-side prerequisite
 
-This pattern relies on two `AccountConfiguration.importAccount` properties, both already in place on `main`:
+This pattern relies on one `AccountConfiguration.importAccount` property, already in place on `main`:
 
-1. **No delegation-indicator reject.** `importAccount` does not reject accounts whose code begins with the
-   delegation indicator (`0xef0100`). An earlier draft rejected them, but that rule never closed an attack
-   surface — a compromised k1 key already drains a delegated EOA via standard 7702 / 1559 transactions — while
-   it did block the entire SETDELEGATE factory pattern. The ERC-1271 callback is the sole binding between the
-   account and its initial actor set, which naturally rejects code-less addresses and dishonest implementations.
-2. **`localSequence` written after the ERC-1271 callback.** `importAccount` defers its `localSequence = 1`
-   write until after the STATICCALL, so the bootstrap-aware implementation can observe
-   `getChangeSequences(this).local == 0` during the callback and take its bootstrap branch. The STATICCALL
-   cannot write state, so deferring the write introduces no reentrancy risk.
+- **No delegation-indicator reject.** `importAccount` does not reject accounts whose code begins with the
+  delegation indicator (`0xef0100`). An earlier draft rejected them, but that rule never closed an attack
+  surface — a compromised k1 key already drains a delegated EOA via standard 7702 / 1559 transactions — while
+  it did block the entire SETDELEGATE factory pattern. The ERC-1271 callback is the sole binding between the
+  account and its initial actor set, which naturally rejects code-less addresses and dishonest implementations.
+
+No other change to AccountConfiguration is required: the account tracks its own bootstrap window in transient
+storage, so `importAccount` is used exactly as shipped.
 
 ## Caveats
 
 - **EIP-7819 is Draft** and `SETDELEGATE` (opcode `0xf6`) is not yet executable on most chains. In tests,
   `SetDelegateFactory._setDelegate` is overridden by `TestableSetDelegateFactory` to simulate the opcode
   via `vm.etch`. Production uses the real opcode.
+- **EIP-1153 transient storage** is used for the bootstrap latch; it is scoped to the bootstrap transaction
+  and so cannot leak into normal operation.
 - The reference `BootstrapAccount` is intentionally minimal: no execution, caller-authorization, or
   receive-hook plumbing beyond Solady's `Receiver`. Combine with `DefaultAccount` (or equivalent) for a
   full account.
@@ -111,5 +128,5 @@ These are forward-looking notes; nothing in this directory depends on them.
    indexers honor the set off-chain; AccountConfiguration remains unaware.
 2. **`account_changes` entry type `0x03 SetDelegateCreate`.** For atomic single-tx deploys via canonical
    factories within an 8130 transaction.
-3. **Do nothing protocol-side.** Factories live entirely in user space; both spec prerequisites above are
-   already satisfied on `main`.
+3. **Do nothing protocol-side.** Factories live entirely in user space; the pattern works against
+   AccountConfiguration as it ships on `main`.

--- a/src/examples/factory/README.md
+++ b/src/examples/factory/README.md
@@ -1,0 +1,115 @@
+# Example external factory (`SETDELEGATE` + EIP-8130)
+
+Reference, **unaudited** example of an external account factory that combines
+[EIP-7819](https://eips.ethereum.org/EIPS/eip-7819) (`SETDELEGATE`) with
+[EIP-8130](https://eips.ethereum.org/EIPS/eip-8130) (Account Configuration).
+
+EIP-8130 supports three first-class account-creation paths today: EOAs (auto-delegated to
+`DEFAULT_ACCOUNT_ADDRESS`), already-deployed contract accounts (`importAccount`), and new accounts via the
+`Create Entry` in `account_changes` (places runtime bytecode at a CREATE2 address).
+
+Path 3 places the wallet's full runtime bytecode at every account address. For wallets that share a common
+implementation across many accounts, this is wasteful (up to ~4.9M gas to deposit a 24 KB implementation,
+repeated per account) and forecloses on-chain upgradeability.
+
+`SETDELEGATE` (opcode `0xf6`, EIP-7819) lets a contract place a 23-byte delegation indicator
+(`0xef0100 || target`) at a deterministic address. Combining it with EIP-8130's `importAccount` gives a
+fourth, off-spec path with state and gas savings plus factory-mediated upgradeability — without
+AccountConfiguration ever knowing the factory exists.
+
+## Flow
+
+```
+Phase A (off-chain)   wallet computes counterfactual address
+  actorsHash = keccak256(actorHash_0 || ... || actorHash_n)         // typed actor hashes
+  salt       = keccak256(userSalt || actorsHash)
+  account    = keccak256(0xef0100 || factory || salt)[12:]          // EIP-7819 derivation
+
+Phase B (one tx)      invokes factory.deploy(initialActors, implementation, userSalt)
+  B.1  SETDELEGATE(salt, implementation)
+       → code(account) = 0xef0100 || implementation                 (23 bytes)
+       → nonce(account) = 1                                         (EIP-7819 step 9)
+  B.2  account.bootstrap(actorsHash)
+       → implementation stores expected actors hash in account's storage
+  B.3  ACCOUNT_CONFIG.importAccount(account, initialActors, "")
+       → AccountConfig computes ActorInitialization digest
+       → STATICCALL account.isValidSignature(digest, "")
+         → Implementation's bootstrap branch (getChangeSequences(account).local == 0):
+           digest matches expected → MAGIC
+       → AccountConfig writes actor_config, bumps local sequence to 1
+
+Phase C (optional)    close the implicit-EOA path
+  Send a Config Change Entry (or applySignedActorChanges) with
+    actor_change = revokeActor(bytes32(bytes20(account)))
+  → AccountState.flags |= FLAG_REVOKE_DEFAULT_EOA for the account
+  (importAccount already disables the implicit default-EOA path on the account itself; this revokes the
+   self-actorId at the actor level if it was re-enabled via an explicit self actor.)
+
+Phase D (later)       upgrade implementation
+  account submits 8130 tx (authed by an actor) with calls = [[ factory.upgrade(...) ]]
+  → msg.sender = account in factory.upgrade, factory runs SETDELEGATE(salt, newImpl)
+  → code(account) = 0xef0100 || newImpl
+```
+
+## Squatting / front-running defenses
+
+- `SETDELEGATE` address derivation includes `msg.sender`, so a different factory yields a different address.
+- The salt commits to the actor set (`actorsHash`), so a different actor set yields a different salt and
+  therefore a different address. Trying to put unintended actors at the same address is a hash collision.
+- `SETDELEGATE → bootstrap → importAccount` runs in one transaction frame; no intermediate window exists for
+  a different transaction to interpose state changes.
+- After `importAccount` succeeds, `getChangeSequences(account).local == 1`, so the bootstrap branch in
+  `isValidSignature` is permanently disabled. The implementation is in normal-ERC-1271-via-AccountConfig
+  mode forever after.
+- A codeless counterfactual address cannot be imported: a no-code STATICCALL returns empty data, the magic
+  check fails, `importAccount` reverts. Squatting on counterfactual EOAs is impossible.
+
+## Contracts
+
+| Contract | Role |
+|----------|------|
+| `SetDelegateFactory` | Deploys via `SETDELEGATE`, primes implementation bootstrap, calls `importAccount`. Owns the address-derivation logic and the optional `upgrade` path. |
+| `IBootstrap` | Minimal interface the implementation must expose for atomic priming. |
+| `BootstrapAccount` | Minimal bootstrap-aware reference implementation. ERC-1271 has a BOOTSTRAP branch that validates the import digest against the primed `actorsHash`, and otherwise defers to `AccountConfiguration.authenticateActor`. |
+
+## Spec-side prerequisite
+
+This pattern relies on two `AccountConfiguration.importAccount` properties, both already in place on `main`:
+
+1. **No delegation-indicator reject.** `importAccount` does not reject accounts whose code begins with the
+   delegation indicator (`0xef0100`). An earlier draft rejected them, but that rule never closed an attack
+   surface — a compromised k1 key already drains a delegated EOA via standard 7702 / 1559 transactions — while
+   it did block the entire SETDELEGATE factory pattern. The ERC-1271 callback is the sole binding between the
+   account and its initial actor set, which naturally rejects code-less addresses and dishonest implementations.
+2. **`localSequence` written after the ERC-1271 callback.** `importAccount` defers its `localSequence = 1`
+   write until after the STATICCALL, so the bootstrap-aware implementation can observe
+   `getChangeSequences(this).local == 0` during the callback and take its bootstrap branch. The STATICCALL
+   cannot write state, so deferring the write introduces no reentrancy risk.
+
+## Caveats
+
+- **EIP-7819 is Draft** and `SETDELEGATE` (opcode `0xf6`) is not yet executable on most chains. In tests,
+  `SetDelegateFactory._setDelegate` is overridden by `TestableSetDelegateFactory` to simulate the opcode
+  via `vm.etch`. Production uses the real opcode.
+- The reference `BootstrapAccount` is intentionally minimal: no execution, caller-authorization, or
+  receive-hook plumbing beyond Solady's `Receiver`. Combine with `DefaultAccount` (or equivalent) for a
+  full account.
+- `importAccount` disables the implicit default-EOA path on the imported account itself (parity with
+  `createAccount`). The factory revokes nothing further automatically; if an explicit self k1 actor was
+  included to keep the key live, close it later with an `applySignedActorChanges` that `revokeActor`s
+  `bytes32(bytes20(account))` — or stack a Config Change Entry in the same 8130 tx.
+- The `actorsHash` here is the **typed** hash (matching EIP-8130's `ActorInitialization` digest). If you
+  also want addresses to match the Create Entry path, switch to the **packed** commitment
+  `keccak256(actorId_0 || authenticator_0 || ...)` and reconstruct the typed digest in the implementation.
+
+## Future protocol integration (optional)
+
+These are forward-looking notes; nothing in this directory depends on them.
+
+1. **Canonical factory set (off-chain, by analogy to canonical authenticators).** A companion spec could
+   standardize the factory + implementation pair and a deterministic CREATE2 deployment address. Wallets and
+   indexers honor the set off-chain; AccountConfiguration remains unaware.
+2. **`account_changes` entry type `0x03 SetDelegateCreate`.** For atomic single-tx deploys via canonical
+   factories within an 8130 transaction.
+3. **Do nothing protocol-side.** Factories live entirely in user space; both spec prerequisites above are
+   already satisfied on `main`.

--- a/src/examples/factory/SetDelegateFactory.sol
+++ b/src/examples/factory/SetDelegateFactory.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccountConfiguration} from "../../interfaces/IAccountConfiguration.sol";
+import {IBootstrap} from "./IBootstrap.sol";
+
+/// @notice Reference factory that deploys EIP-8130 accounts via the EIP-7819 `SETDELEGATE` opcode.
+///
+///         Flow (atomic, one tx frame):
+///           1. `SETDELEGATE(salt, implementation)` places `0xef0100 || implementation` at a deterministic
+///              address `keccak256(0xef0100 || factory || salt)[12:]`.
+///           2. `bootstrap(actorsHash)` primes the implementation's bootstrap state in the account's storage.
+///              `actorsHash` is the inner hash of EIP-8130's `ActorInitialization` digest and also feeds the
+///              SETDELEGATE salt, so the address binds to the actor set.
+///           3. `AccountConfiguration.importAccount(account, initialActors, "")` registers the actors.
+///              The ERC-1271 callback lands at the implementation's bootstrap branch, which validates the
+///              presented `ActorInitialization` digest against the primed `actorsHash`.
+///
+///         Squatting / front-running defenses:
+///           - `SETDELEGATE` address derivation includes `msg.sender`, so a different factory yields a
+///             different address.
+///           - The salt includes a commitment to the actor set, so a different actor set yields a different
+///             salt and therefore a different address.
+///           - The full sequence runs in one transaction frame; no intermediate window exists.
+///
+///         AccountConfiguration is not aware of this factory. No registry, no privileged call path.
+///
+///         Requires: EIP-7819 (`SETDELEGATE`, opcode 0xf6). Not yet executable on most chains; `_setDelegate`
+///         is `virtual` so a test subclass can simulate the opcode via `vm.etch`.
+contract SetDelegateFactory {
+    IAccountConfiguration public immutable ACCOUNT_CONFIGURATION;
+
+    /// @dev EIP-7702 delegation indicator prefix used in SETDELEGATE address derivation.
+    bytes3 internal constant DELEGATION_INDICATOR = 0xef0100;
+
+    /// @dev Mirrors `AccountConfiguration.ACTOR_INITIALIZATION_TYPEHASH`.
+    bytes32 internal constant _ACTOR_INITIALIZATION_TYPEHASH = keccak256(
+        "ActorInitialization(bytes32 salt,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint8 policyType)"
+    );
+
+    /// @dev Mirrors `AccountConfiguration.ACTOR_TYPEHASH`.
+    bytes32 internal constant _ACTOR_TYPEHASH = keccak256(
+        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint8 policyType)"
+    );
+
+    /// @dev Mirrors `AccountConfiguration.ACTORCONFIG_TYPEHASH`.
+    bytes32 internal constant _ACTORCONFIG_TYPEHASH =
+        keccak256("ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint8 policyType)");
+
+    /// @dev `keccak256("")` — cached because every imported (always-unrestricted) actor has empty `policyData`.
+    bytes32 internal constant _EMPTY_HASH = keccak256("");
+
+    constructor(address accountConfiguration) {
+        ACCOUNT_CONFIGURATION = IAccountConfiguration(accountConfiguration);
+    }
+
+    // ══════════════════════════════════════════════
+    //  DEPLOY
+    // ══════════════════════════════════════════════
+
+    /// @notice Deploy a new EIP-8130 account at a deterministic address.
+    /// @param initialActors  Initial actor set. MUST be sorted by `actorId` ascending (matches Create Entry rules).
+    /// @param implementation Wallet code; the SETDELEGATE target. MUST be a bootstrap-aware `IBootstrap`.
+    /// @param userSalt       User-chosen uniqueness factor.
+    /// @return account       The deployed account address.
+    function deploy(
+        IAccountConfiguration.InitialActor[] calldata initialActors,
+        address implementation,
+        bytes32 userSalt
+    ) external returns (address account) {
+        bytes32 ah = _actorsHash(initialActors);
+        bytes32 salt = keccak256(abi.encodePacked(userSalt, ah));
+
+        // (1) Place the delegation indicator at the SETDELEGATE-derived address.
+        account = _setDelegate(salt, implementation);
+
+        // (2) Prime the implementation's bootstrap state. Runs implementation code in `account`'s storage.
+        IBootstrap(account).bootstrap(ah);
+
+        // (3) Register actors. ERC-1271 callback lands at the implementation's bootstrap branch.
+        ACCOUNT_CONFIGURATION.importAccount(account, initialActors, "");
+    }
+
+    // ══════════════════════════════════════════════
+    //  UPGRADE
+    // ══════════════════════════════════════════════
+
+    /// @notice Swap an account's delegate implementation. The account proves authority by being the caller.
+    /// @dev Within an EIP-8130 transaction, the dispatched call's `msg.sender` is the tx `sender`, so any actor
+    ///      authorized on the account (with unrestricted or CONFIG scope) authorizes the upgrade via the
+    ///      natural 8130 path — no factory-held upgrade authority.
+    function upgrade(bytes32 userSalt, bytes32 actorsHash, address newImplementation) external {
+        bytes32 salt = keccak256(abi.encodePacked(userSalt, actorsHash));
+        require(msg.sender == computeAddress(salt), "only account");
+        _setDelegate(salt, newImplementation);
+    }
+
+    // ══════════════════════════════════════════════
+    //  VIEW
+    // ══════════════════════════════════════════════
+
+    /// @notice Compute the deterministic account address for a given initial actor set and user salt.
+    function computeAccount(IAccountConfiguration.InitialActor[] calldata initialActors, bytes32 userSalt)
+        external
+        view
+        returns (address)
+    {
+        bytes32 ah = _actorsHash(initialActors);
+        bytes32 salt = keccak256(abi.encodePacked(userSalt, ah));
+        return computeAddress(salt);
+    }
+
+    /// @notice Compute the SETDELEGATE-derived address for a fully-resolved salt.
+    /// @dev    Mirrors EIP-7819 derivation: `keccak256(0xef0100 || factory || salt)[12:]`.
+    function computeAddress(bytes32 salt) public view returns (address) {
+        return address(uint160(uint256(keccak256(abi.encodePacked(DELEGATION_INDICATOR, address(this), salt)))));
+    }
+
+    /// @notice Compute the actors hash used both as the salt-commitment and as the bootstrap prime.
+    /// @dev    `keccak256(actorHash_0 || ... || actorHash_n)` matching the inner hash of EIP-8130's
+    ///         `ActorInitialization` digest for an unrestricted-actor import.
+    function actorsHash(IAccountConfiguration.InitialActor[] calldata initialActors) external pure returns (bytes32) {
+        return _actorsHash(initialActors);
+    }
+
+    // ══════════════════════════════════════════════
+    //  INTERNALS
+    // ══════════════════════════════════════════════
+
+    function _actorsHash(IAccountConfiguration.InitialActor[] calldata initialActors) internal pure returns (bytes32) {
+        bytes32[] memory perActor = new bytes32[](initialActors.length);
+        for (uint256 i; i < initialActors.length; i++) {
+            // Imported actors are always unrestricted: scope=0, expiry=0, policyType=0, empty policyData.
+            bytes32 configHash = keccak256(
+                abi.encode(_ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint8(0), uint48(0), uint8(0))
+            );
+            perActor[i] = keccak256(abi.encode(_ACTOR_TYPEHASH, initialActors[i].actorId, configHash, _EMPTY_HASH));
+        }
+        return keccak256(abi.encodePacked(perActor));
+    }
+
+    /// @notice Execute EIP-7819 `SETDELEGATE` (opcode 0xf6) and return the resulting account address.
+    /// @dev    Solidity inline assembly cannot emit a raw, currently-unassigned opcode (`verbatim` is Yul-object
+    ///         scope only). When 7819 is adopted, this is expected to be implemented either with the future
+    ///         Yul builtin (`setdelegate(salt, target)`) or with a wrapper contract whose bytecode contains
+    ///         the opcode. Overridable so test environments can simulate the opcode via `vm.etch`; the
+    ///         base implementation reverts so any non-overridden production deployment fails closed.
+    function _setDelegate(
+        bytes32,
+        /* salt */
+        address /* target */
+    )
+        internal
+        virtual
+        returns (
+            address /* account */
+        )
+    {
+        revert("SETDELEGATE: not implemented; override _setDelegate or wait for EIP-7819 deployment");
+    }
+}

--- a/src/examples/factory/SetDelegateFactory.sol
+++ b/src/examples/factory/SetDelegateFactory.sol
@@ -9,12 +9,14 @@ import {IBootstrap} from "./IBootstrap.sol";
 ///         Flow (atomic, one tx frame):
 ///           1. `SETDELEGATE(salt, implementation)` places `0xef0100 || implementation` at a deterministic
 ///              address `keccak256(0xef0100 || factory || salt)[12:]`.
-///           2. `bootstrap(actorsHash)` primes the implementation's bootstrap state in the account's storage.
-///              `actorsHash` is the inner hash of EIP-8130's `ActorInitialization` digest and also feeds the
-///              SETDELEGATE salt, so the address binds to the actor set.
-///           3. `AccountConfiguration.importAccount(account, initialActors, "")` registers the actors.
-///              The ERC-1271 callback lands at the implementation's bootstrap branch, which validates the
-///              presented `ActorInitialization` digest against the primed `actorsHash`.
+///           2. `account.bootstrap(actorsHash, initialActors)` runs the implementation in the account's storage:
+///              it primes a transient latch, calls `AccountConfiguration.importAccount` on itself, and clears the
+///              latch. `actorsHash` is the inner hash of EIP-8130's `ActorInitialization` digest and also feeds
+///              the SETDELEGATE salt, so the address binds to the actor set.
+///
+///         The account drives `importAccount` itself, so AccountConfiguration needs no awareness of this factory
+///         and no changes to support the pattern — the bootstrap window is tracked by the account's own transient
+///         state.
 ///
 ///         Squatting / front-running defenses:
 ///           - `SETDELEGATE` address derivation includes `msg.sender`, so a different factory yields a
@@ -23,20 +25,11 @@ import {IBootstrap} from "./IBootstrap.sol";
 ///             salt and therefore a different address.
 ///           - The full sequence runs in one transaction frame; no intermediate window exists.
 ///
-///         AccountConfiguration is not aware of this factory. No registry, no privileged call path.
-///
 ///         Requires: EIP-7819 (`SETDELEGATE`, opcode 0xf6). Not yet executable on most chains; `_setDelegate`
 ///         is `virtual` so a test subclass can simulate the opcode via `vm.etch`.
 contract SetDelegateFactory {
-    IAccountConfiguration public immutable ACCOUNT_CONFIGURATION;
-
     /// @dev EIP-7702 delegation indicator prefix used in SETDELEGATE address derivation.
     bytes3 internal constant DELEGATION_INDICATOR = 0xef0100;
-
-    /// @dev Mirrors `AccountConfiguration.ACTOR_INITIALIZATION_TYPEHASH`.
-    bytes32 internal constant _ACTOR_INITIALIZATION_TYPEHASH = keccak256(
-        "ActorInitialization(bytes32 salt,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint8 policyType)"
-    );
 
     /// @dev Mirrors `AccountConfiguration.ACTOR_TYPEHASH`.
     bytes32 internal constant _ACTOR_TYPEHASH = keccak256(
@@ -49,10 +42,6 @@ contract SetDelegateFactory {
 
     /// @dev `keccak256("")` — cached because every imported (always-unrestricted) actor has empty `policyData`.
     bytes32 internal constant _EMPTY_HASH = keccak256("");
-
-    constructor(address accountConfiguration) {
-        ACCOUNT_CONFIGURATION = IAccountConfiguration(accountConfiguration);
-    }
 
     // ══════════════════════════════════════════════
     //  DEPLOY
@@ -74,11 +63,9 @@ contract SetDelegateFactory {
         // (1) Place the delegation indicator at the SETDELEGATE-derived address.
         account = _setDelegate(salt, implementation);
 
-        // (2) Prime the implementation's bootstrap state. Runs implementation code in `account`'s storage.
-        IBootstrap(account).bootstrap(ah);
-
-        // (3) Register actors. ERC-1271 callback lands at the implementation's bootstrap branch.
-        ACCOUNT_CONFIGURATION.importAccount(account, initialActors, "");
+        // (2) The account primes its bootstrap latch and atomically imports its actors. The ERC-1271 callback
+        //     AccountConfiguration makes during import lands on the implementation's bootstrap branch.
+        IBootstrap(account).bootstrap(ah, initialActors);
     }
 
     // ══════════════════════════════════════════════

--- a/test/unit/AccountConfiguration/importAccount.t.sol
+++ b/test/unit/AccountConfiguration/importAccount.t.sol
@@ -247,4 +247,20 @@ contract ImportAccountTest is AccountConfigurationTest {
         (uint8 scope,,) = accountConfiguration.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
         assertEq(scope, 0);
     }
+
+    function test_importAccount_revertsOnCodelessAccount() public {
+        // A codeless address (e.g. a fresh EOA or counterfactual address) has no ERC-1271 logic to vouch.
+        // The staticcall returns success with empty data; the magic-value check fails. Squatting prevented —
+        // a SETDELEGATE/CREATE2 counterfactual cannot be imported until its delegate code is actually placed.
+        uint256 ownerPk = 700;
+        address codeless = vm.addr(ownerPk);
+        require(codeless.code.length == 0);
+
+        IAccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(codeless);
+        bytes32 digest = _computeImportDigest(codeless, actors);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPk, digest);
+
+        vm.expectRevert();
+        accountConfiguration.importAccount(codeless, actors, abi.encodePacked(r, s, v));
+    }
 }

--- a/test/unit/examples/factory/SetDelegateFactory.t.sol
+++ b/test/unit/examples/factory/SetDelegateFactory.t.sol
@@ -13,8 +13,6 @@ import {AccountConfigurationTest} from "../../../lib/AccountConfigurationTest.so
 contract TestableSetDelegateFactory is SetDelegateFactory {
     Vm internal constant _vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
-    constructor(address accountConfiguration) SetDelegateFactory(accountConfiguration) {}
-
     function _setDelegate(bytes32 salt, address target) internal override returns (address account) {
         account = computeAddress(salt);
         bytes memory existing = account.code;
@@ -33,7 +31,7 @@ contract SetDelegateFactoryTest is AccountConfigurationTest {
 
     function setUp() public override {
         super.setUp();
-        factory = new TestableSetDelegateFactory(address(accountConfiguration));
+        factory = new TestableSetDelegateFactory();
         implementation = new BootstrapAccount(address(accountConfiguration));
     }
 
@@ -69,8 +67,10 @@ contract SetDelegateFactoryTest is AccountConfigurationTest {
         assertEq(accountConfiguration.getChangeSequences(actual).local, 1);
         assertTrue(accountConfiguration.isActor(actual, bytes32(bytes20(vm.addr(pk)))));
 
-        // Bootstrap branch is permanently closed (sequence > 0).
-        assertTrue(BootstrapAccount(payable(actual)).bootstrapped());
+        // Bootstrap branch is permanently closed: the transient latch was cleared after import, so the import
+        // digest no longer auto-validates — isValidSignature now routes to AccountConfiguration (empty sig fails).
+        bytes32 importDigest = BootstrapAccount(payable(actual)).expectedImportDigest(factory.actorsHash(actors));
+        assertEq(BootstrapAccount(payable(actual)).isValidSignature(importDigest, ""), bytes4(0xffffffff));
     }
 
     function test_deploy_isDeterministic() public {
@@ -90,7 +90,8 @@ contract SetDelegateFactoryTest is AccountConfigurationTest {
 
         factory.deploy(actors, address(implementation), userSalt);
 
-        // Re-deploying the same actors+salt would re-bootstrap a now-initialized account; reverts in bootstrap.
+        // Re-deploying the same actors+salt re-enters bootstrap on a now-initialized account; importAccount's
+        // one-time guard reverts inside the nested call.
         vm.expectRevert();
         factory.deploy(actors, address(implementation), userSalt);
     }
@@ -106,7 +107,7 @@ contract SetDelegateFactoryTest is AccountConfigurationTest {
     }
 
     function test_differentFactory_yieldsDifferentAddress() public {
-        TestableSetDelegateFactory other = new TestableSetDelegateFactory(address(accountConfiguration));
+        TestableSetDelegateFactory other = new TestableSetDelegateFactory();
 
         IAccountConfiguration.InitialActor[] memory actors = _oneActor(700);
         bytes32 userSalt = bytes32(uint256(5));

--- a/test/unit/examples/factory/SetDelegateFactory.t.sol
+++ b/test/unit/examples/factory/SetDelegateFactory.t.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Vm} from "forge-std/Vm.sol";
+
+import {IAccountConfiguration} from "../../../../src/interfaces/IAccountConfiguration.sol";
+import {BootstrapAccount} from "../../../../src/examples/factory/BootstrapAccount.sol";
+import {SetDelegateFactory} from "../../../../src/examples/factory/SetDelegateFactory.sol";
+import {AccountConfigurationTest} from "../../../lib/AccountConfigurationTest.sol";
+
+/// @dev Test-only factory: simulates the EIP-7819 SETDELEGATE opcode via `vm.etch`. Production replaces this
+///      with the real opcode (see `SetDelegateFactory._setDelegate`).
+contract TestableSetDelegateFactory is SetDelegateFactory {
+    Vm internal constant _vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    constructor(address accountConfiguration) SetDelegateFactory(accountConfiguration) {}
+
+    function _setDelegate(bytes32 salt, address target) internal override returns (address account) {
+        account = computeAddress(salt);
+        bytes memory existing = account.code;
+        require(
+            existing.length == 0 || (existing.length >= 3 && bytes3(existing) == bytes3(0xef0100)),
+            "SETDELEGATE: not a delegation"
+        );
+        _vm.etch(account, abi.encodePacked(hex"ef0100", target));
+        // EIP-7819 step 9 also bumps nonce to 1 if zero; the simulation omits this — not needed for the import flow.
+    }
+}
+
+contract SetDelegateFactoryTest is AccountConfigurationTest {
+    TestableSetDelegateFactory internal factory;
+    BootstrapAccount internal implementation;
+
+    function setUp() public override {
+        super.setUp();
+        factory = new TestableSetDelegateFactory(address(accountConfiguration));
+        implementation = new BootstrapAccount(address(accountConfiguration));
+    }
+
+    function _oneActor(uint256 pk) internal view returns (IAccountConfiguration.InitialActor[] memory actors) {
+        actors = new IAccountConfiguration.InitialActor[](1);
+        actors[0] = IAccountConfiguration.InitialActor({
+            actorId: bytes32(bytes20(vm.addr(pk))), authenticator: address(k1Authenticator)
+        });
+    }
+
+    function test_deploy_atomic() public {
+        uint256 pk = 700;
+        IAccountConfiguration.InitialActor[] memory actors = _oneActor(pk);
+        bytes32 userSalt = bytes32(uint256(42));
+
+        address expected = factory.computeAccount(actors, userSalt);
+        address actual = factory.deploy(actors, address(implementation), userSalt);
+
+        assertEq(actual, expected);
+
+        // Delegation indicator placed.
+        bytes memory code = actual.code;
+        assertEq(code.length, 23);
+        assertEq(bytes3(code), bytes3(0xef0100));
+        // Implementation address baked into the indicator.
+        address embedded;
+        assembly {
+            embedded := mload(add(code, 23))
+        }
+        assertEq(embedded, address(implementation));
+
+        // AccountConfiguration registered the actor; account is initialized.
+        assertEq(accountConfiguration.getChangeSequences(actual).local, 1);
+        assertTrue(accountConfiguration.isActor(actual, bytes32(bytes20(vm.addr(pk)))));
+
+        // Bootstrap branch is permanently closed (sequence > 0).
+        assertTrue(BootstrapAccount(payable(actual)).bootstrapped());
+    }
+
+    function test_deploy_isDeterministic() public {
+        uint256 pk = 700;
+        IAccountConfiguration.InitialActor[] memory actors = _oneActor(pk);
+        bytes32 userSalt = bytes32(uint256(7));
+
+        address a = factory.deploy(actors, address(implementation), userSalt);
+        // Same factory + same userSalt + same actors → same address.
+        assertEq(factory.computeAccount(actors, userSalt), a);
+    }
+
+    function test_deploy_revertsOnSecondDeploy() public {
+        uint256 pk = 700;
+        IAccountConfiguration.InitialActor[] memory actors = _oneActor(pk);
+        bytes32 userSalt = bytes32(uint256(1));
+
+        factory.deploy(actors, address(implementation), userSalt);
+
+        // Re-deploying the same actors+salt would re-bootstrap a now-initialized account; reverts in bootstrap.
+        vm.expectRevert();
+        factory.deploy(actors, address(implementation), userSalt);
+    }
+
+    function test_differentActors_yieldsDifferentAddress() public view {
+        IAccountConfiguration.InitialActor[] memory a = _oneActor(700);
+        IAccountConfiguration.InitialActor[] memory b = _oneActor(701);
+        bytes32 userSalt = bytes32(uint256(99));
+
+        address addrA = factory.computeAccount(a, userSalt);
+        address addrB = factory.computeAccount(b, userSalt);
+        assertTrue(addrA != addrB);
+    }
+
+    function test_differentFactory_yieldsDifferentAddress() public {
+        TestableSetDelegateFactory other = new TestableSetDelegateFactory(address(accountConfiguration));
+
+        IAccountConfiguration.InitialActor[] memory actors = _oneActor(700);
+        bytes32 userSalt = bytes32(uint256(5));
+
+        address fromFirst = factory.computeAccount(actors, userSalt);
+        address fromOther = other.computeAccount(actors, userSalt);
+        assertTrue(fromFirst != fromOther);
+    }
+
+    function test_upgrade_onlyAccount() public {
+        uint256 pk = 700;
+        IAccountConfiguration.InitialActor[] memory actors = _oneActor(pk);
+        bytes32 userSalt = bytes32(uint256(2));
+
+        address account = factory.deploy(actors, address(implementation), userSalt);
+        bytes32 ah = factory.actorsHash(actors);
+
+        BootstrapAccount newImpl = new BootstrapAccount(address(accountConfiguration));
+
+        // EOA cannot upgrade.
+        vm.expectRevert();
+        factory.upgrade(userSalt, ah, address(newImpl));
+
+        // Account itself (as caller) can upgrade.
+        vm.prank(account);
+        factory.upgrade(userSalt, ah, address(newImpl));
+
+        bytes memory code = account.code;
+        address embedded;
+        assembly {
+            embedded := mload(add(code, 23))
+        }
+        assertEq(embedded, address(newImpl));
+    }
+
+    function test_postBootstrap_isValidSignature_routesThroughAccountConfig() public {
+        // After bootstrap, ERC-1271 defers to AccountConfiguration. A k1 signature over an arbitrary digest
+        // from the registered actor authenticates via AccountConfiguration.authenticateActor.
+        uint256 pk = 700;
+        IAccountConfiguration.InitialActor[] memory actors = _oneActor(pk);
+        bytes32 userSalt = bytes32(uint256(3));
+
+        address account = factory.deploy(actors, address(implementation), userSalt);
+
+        bytes32 digest = keccak256("hello");
+        bytes memory auth = _buildK1Auth(pk, digest);
+
+        bytes4 magic = BootstrapAccount(payable(account)).isValidSignature(digest, auth);
+        assertEq(magic, bytes4(0x1626ba7e));
+    }
+}


### PR DESCRIPTION
## Summary

Reference, unaudited example of an external account factory that combines **EIP-7819** (`SETDELEGATE`) with **EIP-8130** (`importAccount`) to deploy lightweight, upgradeable delegate accounts at deterministic addresses.

The headline property: **this needs no changes to `AccountConfiguration`.** A keyless factory account has no signature to present at import time, so it must answer "am I in my one-time bootstrap window?" during its own `importAccount` ERC-1271 callback. It answers that from **its own transient (EIP-1153) latch**, not by reading AccountConfiguration's `localSequence`.

`BootstrapAccount.bootstrap` does it all in one frame: set latch → call `importAccount` on itself → clear latch. While the latch is set (only across that nested import), `isValidSignature` validates the import digest against the primed `actorsHash`; otherwise it defers to `authenticateActor`. The latch is transient, so it cannot leak past the tx, and `importAccount`'s one-time guard prevents any second import — the bootstrap branch is reachable exactly once.

### Changes
- `AccountConfiguration.sol`: **no change** vs `main` (an earlier revision of this PR deferred the `localSequence` write; that's now reverted — the pattern no longer needs it).
- `src/examples/factory/BootstrapAccount.sol`: transient bootstrap latch + self-driven import; bootstrap-aware ERC-1271.
- `src/examples/factory/SetDelegateFactory.sol`: `deploy` = `SETDELEGATE` + `account.bootstrap(...)`; drops the now-unused `AccountConfiguration` reference.
- `src/examples/factory/IBootstrap.sol`: `bootstrap(actorsHash, initialActors)`.
- `src/examples/factory/README.md`: rewritten for the self-contained design.
- Tests for the factory flow + a codeless-import revert test.

### Squatting / front-running defenses
- `SETDELEGATE` derivation includes the factory (`msg.sender`) and a salt that commits to the actor set, so address ↔ actor-set binding is collision-hard.
- `SETDELEGATE → bootstrap` is atomic in one tx; no interposition window.
- Codeless counterfactual addresses can't be imported (no-code staticcall → empty → magic check fails).

### Spec prerequisite (already on `main`)
- `importAccount` does not reject `0xef0100…` delegated code. That rule never closed an attack surface (a compromised k1 key already drains a delegated EOA via standard 7702/1559 txs) but did block this pattern. The ERC-1271 callback is the sole account ↔ actor-set binding.

### Caveats
- EIP-7819 is Draft; `SETDELEGATE` isn't executable on most chains. Tests simulate the opcode via `vm.etch` (`TestableSetDelegateFactory`).
- `BootstrapAccount` is intentionally minimal (no execution/auth plumbing beyond Solady `Receiver`).

## Test plan
- [x] `forge build` (evm_version osaka)
- [x] `forge test` — 179 passed, 0 failed
- [x] `forge test --match-path 'test/unit/examples/factory/*'` — 7 passed
- [x] `forge test --match-path '.../importAccount.t.sol'` — 10 passed
- [x] `forge fmt --check` clean