### PR TITLE
chore: add forge fmt pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Pre-commit hook: enforce `forge fmt` so commits don't fail CI's `forge fmt --check`
+# step (see .github/workflows/test.yml). Enable for your clone with:
+#
+#     git config core.hooksPath .githooks
+#
+if ! command -v forge >/dev/null 2>&1; then
+    echo "pre-commit: 'forge' not found on PATH; skipping fmt check." >&2
+    echo "            Install Foundry (https://getfoundry.sh) to enable it." >&2
+    exit 0
+fi
+
+if ! forge fmt --check; then
+    echo >&2
+    echo "pre-commit: Solidity formatting issues detected (see diff above)." >&2
+    echo "            Run 'forge fmt', then re-stage and commit." >&2
+    exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ forge build
 forge test
 ```
 
+### Format
+
+```shell
+forge fmt
+```
+
+CI runs `forge fmt --check`, so commits with unformatted Solidity will fail. A pre-commit hook in `.githooks/` runs the same check locally. Enable it once per clone:
+
+```shell
+git config core.hooksPath .githooks
+```
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Add a tracked `.githooks/pre-commit` that runs `forge fmt --check`, mirroring the CI `Run Forge fmt` step, so unformatted Solidity is caught locally before it fails CI.
- The hook no-ops with a friendly message if `forge` isn't on `PATH`.
- Document enabling it (`git config core.hooksPath .githooks`) and add a `forge fmt` section to the README.

## Context
PR #18's CI failed on `forge fmt --check`. This adds a local guard so that doesn't recur.

## Test plan
- [x] `forge fmt --check` passes on `main`
- [x] Hook passes on a clean tree
- [x] Hook blocks (exit 1) on a deliberately mis-formatted file, printing the diff and fix instructions