### PR TITLE
PolicyManager: external callers, permissionless install, SessionPolicy worked example

### DIFF
--- a/src/examples/policies/PolicyManager.sol
+++ b/src/examples/policies/PolicyManager.sol
@@ -8,6 +8,16 @@ import {IAccountConfiguration} from "../../interfaces/IAccountConfiguration.sol"
 import {ITransactionContext, TX_CONTEXT_ADDRESS} from "../../interfaces/ITransactionContext.sol";
 import {Policy} from "./Policy.sol";
 
+/// @dev Recommended `authenticator` for an actor that represents an *external caller* governed by a policy (e.g. a
+///      subscription provider): an address that may act ONLY through its policy manager's external entrypoints, never
+///      directly. Distinct from `EXTERNAL_CALLER_AUTHENTICATOR` (which grants direct `executeBatch`): this is a
+///      no-code, hash-derived sentinel, so the actor is recognized by AccountConfiguration (non-zero authenticator)
+///      yet cannot drive the account directly and cannot authenticate an 8130 transaction (its `authenticate()` would
+///      call into empty code and fail). Only the account-side authorization (and these examples/tests) ever reference
+///      it; neither the account nor the manager runtime reads it — `executeFor` authorizes purely on
+///      `actorId == bytes20(msg.sender)`, `policy_manager == this`, and a non-zero commitment.
+address constant EXTERNAL_POLICY_AUTHENTICATOR = address(uint160(uint256(keccak256("externalPolicyCaller"))));
+
 /// @title PolicyManager
 ///
 /// @notice Minimal, self-contained reference policy manager for EIP-8130 actor policies.
@@ -21,6 +31,15 @@ import {Policy} from "./Policy.sol";
 ///        here is the account itself. That is the authorization boundary: only a gated session-key transaction
 ///        (routed through the account) can invoke {execute}.
 ///
+///      Two acting models, two entrypoints:
+///      - {execute}: the *account itself* acts (a gated session key, dispatched by the protocol as the account). The
+///        acting identity comes from the transaction-context precompile and `account == msg.sender`.
+///      - {executeFor} / {executeForMany}: an *external caller* acts on behalf of one or more accounts that authorized
+///        it (e.g. a subscription provider pulling from many accounts in one transaction). Identity is the caller
+///        itself (`actorId == bytes20(msg.sender)`) and `account` is an explicit argument. Because there is no
+///        protocol routing on this path, these re-add the `policy_manager == address(this)` check that {execute}
+///        omits.
+///
 ///      Commitment binding: the account authorizes a {PolicyBinding}; its `keccak256` is the `commitment`. When the
 ///      account authorizes the session-key actor it stores a non-zero `policyType`, `policy_manager = address(this)`, and
 ///      `policy_commitment = commitment` in the Account Configuration contract. At {install} the manager reads that
@@ -28,8 +47,8 @@ import {Policy} from "./Policy.sol";
 ///      accessors and requires the target and commitment to match, so an install can only succeed for a policy the
 ///      account actually signed for this manager.
 ///
-///      Scope: install-by-direct-account-call and execute only. Signature-based install, replacement, and
-///      uninstall are intentionally omitted from this reference.
+///      Scope: install-by-direct-account-call, plus account-acting {execute} and external-caller {executeFor} /
+///      {executeForMany}. Signature-based install, replacement, and uninstall are intentionally omitted.
 contract PolicyManager is ReentrancyGuard {
     using Address for address;
 
@@ -69,15 +88,23 @@ contract PolicyManager is ReentrancyGuard {
 
     event PolicyInstalled(address indexed account, address indexed policy, bytes32 indexed commitment);
     event PolicyExecuted(address indexed account, address indexed policy, bytes32 indexed commitment, address caller);
+    /// @dev Emitted by {executeForMany} when one account in a best-effort batch is skipped (its per-account
+    ///      enforcement reverted, e.g. revoked/expired binding, over budget, or a failing account call).
+    event PullSkipped(address indexed account, address indexed policy, bytes32 indexed actorId);
 
     error PolicyNotInstalled(bytes32 commitment);
     error PolicyAlreadyInstalled(bytes32 commitment);
     error UnauthorizedAccount(address caller, address account);
     error OutsideValidityWindow(uint40 validAfter, uint40 validUntil, uint256 timestamp);
     error CommitmentNotAuthorized(bytes32 actorId, address target, bytes32 commitment);
-    /// @dev The acting actor (from the transaction-context precompile) has no live policy commitment for the
-    ///      caller account — i.e. it is not a gated actor of this account, or it has been revoked/expired.
+    /// @dev The acting actor has no live policy commitment for the account — i.e. it is not a gated actor of this
+    ///      account, was revoked/expired, or (on the external path) the account did not gate this manager for it.
     error NoActivePolicy(bytes32 actorId);
+    /// @dev {executeForMany} array length mismatch between `accounts` and `executionData`.
+    error LengthMismatch();
+    /// @dev The per-account self-call boundary used by {executeForMany} was invoked by someone other than this
+    ///      contract.
+    error OnlySelf();
 
     /// @notice Computes the commitment (binding identifier) for a binding.
     ///
@@ -153,6 +180,98 @@ contract PolicyManager is ReentrancyGuard {
         bytes32 commitment = ACCOUNT_CONFIGURATION.getPolicyCommitment(account, actorId);
         if (commitment == bytes32(0)) revert NoActivePolicy(actorId);
 
+        // No manager-match check here: on the protocol-dispatched path the 8130 gate already guarantees this manager
+        // is the acting key's configured target (see the dev note above). The external entrypoints below re-add it.
+        _enforce(account, policy, commitment, executionData, account);
+    }
+
+    /// @notice External-caller variant of {execute}: an external party drives a policy that an `account` authorized
+    ///         for it. Used when the actor is not a key *on* the account but a separate party (e.g. a subscription
+    ///         provider) the account opted into.
+    ///
+    /// @dev The acting identity is the caller itself — `actorId == bytes20(msg.sender)` — and `account` is explicit.
+    ///      There is no protocol routing on this path, so unlike {execute} this re-verifies that the account gated
+    ///      *this* manager for the caller (`policy_manager(account, actorId) == address(this)`); the caller cannot
+    ///      forge the identity because it is derived from `msg.sender`. The account must also have registered this
+    ///      manager as an execution-enabled actor (`EXTERNAL_CALLER_AUTHENTICATOR`) for the forwarded `executeBatch`
+    ///      to be accepted.
+    ///
+    /// @param account       Account the call plan will execute against (it authorized the caller).
+    /// @param policy        Policy contract for the binding.
+    /// @param executionData Per-use action parameters interpreted by the policy.
+    function executeFor(address account, address policy, bytes calldata executionData) external nonReentrant {
+        _enforceExternal(account, bytes32(bytes20(msg.sender)), policy, executionData, msg.sender);
+    }
+
+    /// @notice Best-effort cross-account batch of {executeFor}: one external caller, many accounts, one transaction.
+    ///
+    /// @dev Each account is enforced in its own self-call so a single failure (revoked/expired binding, over budget,
+    ///      a reverting account call) is isolated and skipped — it does not roll back the accounts that succeeded.
+    ///      Failures emit {PullSkipped}; `results[i]` reports per-account success. The acting `actorId` is the caller
+    ///      (`bytes20(msg.sender)`) for every entry.
+    ///
+    /// @param accounts      Accounts to pull from (each must have authorized the caller for `policy`).
+    /// @param policy        Policy contract shared across the batch.
+    /// @param executionData Per-account action parameters, parallel to `accounts`.
+    ///
+    /// @return results Per-account success flags, parallel to `accounts`.
+    function executeForMany(address[] calldata accounts, address policy, bytes[] calldata executionData)
+        external
+        nonReentrant
+        returns (bool[] memory results)
+    {
+        if (accounts.length != executionData.length) revert LengthMismatch();
+        bytes32 actorId = bytes32(bytes20(msg.sender));
+        address caller = msg.sender;
+        results = new bool[](accounts.length);
+        for (uint256 i; i < accounts.length; i++) {
+            // Self-call gives each account its own revert boundary: a failure rolls back only this entry's effects
+            // (its spend accounting + account call) and is caught, so the rest of the batch still settles.
+            try this.enforceExternalSelf(accounts[i], actorId, policy, executionData[i], caller) {
+                results[i] = true;
+            } catch {
+                emit PullSkipped(accounts[i], policy, actorId);
+            }
+        }
+    }
+
+    /// @notice Self-call boundary used by {executeForMany} for per-account revert isolation. Not for external use.
+    ///
+    /// @dev Only callable by this contract (from within {executeForMany}), so the `(account, actorId, caller)` tuple
+    ///      it trusts can only be supplied by the manager itself — never spoofed by an outside caller.
+    function enforceExternalSelf(
+        address account,
+        bytes32 actorId,
+        address policy,
+        bytes calldata executionData,
+        address caller
+    ) external {
+        if (msg.sender != address(this)) revert OnlySelf();
+        _enforceExternal(account, actorId, policy, executionData, caller);
+    }
+
+    /// @dev External-path validation shared by {executeFor} and {enforceExternalSelf}: re-add the manager-match check
+    ///      the protocol path can omit, resolve the live commitment, then run the common enforcement.
+    function _enforceExternal(
+        address account,
+        bytes32 actorId,
+        address policy,
+        bytes calldata executionData,
+        address caller
+    ) internal {
+        if (ACCOUNT_CONFIGURATION.getPolicyManager(account, actorId) != address(this)) {
+            revert NoActivePolicy(actorId);
+        }
+        bytes32 commitment = ACCOUNT_CONFIGURATION.getPolicyCommitment(account, actorId);
+        if (commitment == bytes32(0)) revert NoActivePolicy(actorId);
+        _enforce(account, policy, commitment, executionData, caller);
+    }
+
+    /// @dev Common enforcement for both acting models: validate the installed binding's lifecycle window, run the
+    ///      policy hook, and forward the returned call plan to the account.
+    function _enforce(address account, address policy, bytes32 commitment, bytes calldata executionData, address caller)
+        internal
+    {
         PolicyRecord storage record = _policies[policy][commitment];
         if (!record.installed) revert PolicyNotInstalled(commitment);
 
@@ -163,11 +282,11 @@ contract PolicyManager is ReentrancyGuard {
             revert OutsideValidityWindow(record.validAfter, record.validUntil, block.timestamp);
         }
 
-        bytes memory accountCallData = Policy(policy).onExecute(commitment, account, executionData, account);
+        bytes memory accountCallData = Policy(policy).onExecute(commitment, account, executionData, caller);
         if (accountCallData.length == 0) return;
 
         account.functionCall(accountCallData);
-        emit PolicyExecuted(account, policy, commitment, account);
+        emit PolicyExecuted(account, policy, commitment, caller);
     }
 
     /// @dev Reads the authenticated actor of the in-flight EIP-8130 transaction from the transaction-context

--- a/src/examples/policies/PolicyManager.sol
+++ b/src/examples/policies/PolicyManager.sol
@@ -47,8 +47,9 @@ address constant EXTERNAL_POLICY_AUTHENTICATOR = address(uint160(uint256(keccak2
 ///      accessors and requires the target and commitment to match, so an install can only succeed for a policy the
 ///      account actually signed for this manager.
 ///
-///      Scope: install-by-direct-account-call, plus account-acting {execute} and external-caller {executeFor} /
-///      {executeForMany}. Signature-based install, replacement, and uninstall are intentionally omitted.
+///      Scope: permissionless {install} (gated by the account's signed commitment, not the caller), account-acting
+///      {execute}, and external-caller {executeFor} / {executeForMany}. Signature-based install, replacement, and
+///      uninstall are intentionally omitted.
 contract PolicyManager is ReentrancyGuard {
     using Address for address;
 

--- a/src/examples/policies/PolicyManager.sol
+++ b/src/examples/policies/PolicyManager.sol
@@ -88,14 +88,17 @@ contract PolicyManager is ReentrancyGuard {
 
     event PolicyInstalled(address indexed account, address indexed policy, bytes32 indexed commitment);
     event PolicyExecuted(address indexed account, address indexed policy, bytes32 indexed commitment, address caller);
-    /// @dev Emitted by {executeForMany} when one account in a best-effort batch is skipped (its per-account
-    ///      enforcement reverted, e.g. revoked/expired binding, over budget, or a failing account call).
-    event PullSkipped(address indexed account, address indexed policy, bytes32 indexed actorId);
+    /// @dev Emitted by {executeForMany} when one account in a best-effort batch is skipped because its per-account
+    ///      enforcement reverted (e.g. revoked/expired binding, over budget, or a failing account call).
+    event ExecutionSkipped(address indexed account, address indexed policy, bytes32 indexed actorId);
 
     error PolicyNotInstalled(bytes32 commitment);
     error PolicyAlreadyInstalled(bytes32 commitment);
     error OutsideValidityWindow(uint40 validAfter, uint40 validUntil, uint256 timestamp);
     error CommitmentNotAuthorized(bytes32 actorId, address target, bytes32 commitment);
+    /// @dev The executing account is not the account the commitment was installed for. Commitments are opaque in
+    ///      AccountConfiguration, so this binds execution (and the commitment-keyed policy state) to its owner.
+    error CommitmentAccountMismatch(address expected, address actual);
     /// @dev The acting actor has no live policy commitment for the account — i.e. it is not a gated actor of this
     ///      account, was revoked/expired, or (on the external path) the account did not gate this manager for it.
     error NoActivePolicy(bytes32 actorId);
@@ -137,7 +140,11 @@ contract PolicyManager is ReentrancyGuard {
     /// @param binding The account-authorized binding.
     ///
     /// @return commitment The binding's commitment.
-    function install(bytes32 actorId, PolicyBinding calldata binding) external returns (bytes32 commitment) {
+    function install(bytes32 actorId, PolicyBinding calldata binding)
+        external
+        nonReentrant
+        returns (bytes32 commitment)
+    {
         commitment = _commitment(binding);
 
         // The account must have signed this exact commitment for this manager when authorizing `actorId`. Read the
@@ -212,8 +219,8 @@ contract PolicyManager is ReentrancyGuard {
     ///
     /// @dev Each account is enforced in its own self-call so a single failure (revoked/expired binding, over budget,
     ///      a reverting account call) is isolated and skipped — it does not roll back the accounts that succeeded.
-    ///      Failures emit {PullSkipped}; `results[i]` reports per-account success. The acting `actorId` is the caller
-    ///      (`bytes20(msg.sender)`) for every entry.
+    ///      Failures emit {ExecutionSkipped}; `results[i]` reports per-account success. The acting `actorId` is the
+    ///      caller (`bytes20(msg.sender)`) for every entry.
     ///
     /// @param accounts      Accounts to pull from (each must have authorized the caller for `policy`).
     /// @param policy        Policy contract shared across the batch.
@@ -235,7 +242,7 @@ contract PolicyManager is ReentrancyGuard {
             try this.enforceExternalSelf(accounts[i], actorId, policy, executionData[i], caller) {
                 results[i] = true;
             } catch {
-                emit PullSkipped(accounts[i], policy, actorId);
+                emit ExecutionSkipped(accounts[i], policy, actorId);
             }
         }
     }
@@ -279,6 +286,12 @@ contract PolicyManager is ReentrancyGuard {
     {
         PolicyRecord storage record = _policies[policy][commitment];
         if (!record.installed) revert PolicyNotInstalled(commitment);
+
+        // Bind execution to the commitment's owning account. Commitments are opaque in AccountConfiguration, so a
+        // different account could store a victim's commitment value in its own actor config and otherwise drive — and
+        // exhaust — the victim's commitment-keyed policy state (e.g. a shared spend counter). `record.account` is
+        // fixed at install to the account named in the commitment preimage, so this always holds for legitimate use.
+        if (record.account != account) revert CommitmentAccountMismatch(record.account, account);
 
         if (
             (record.validAfter != 0 && block.timestamp < record.validAfter)

--- a/src/examples/policies/PolicyManager.sol
+++ b/src/examples/policies/PolicyManager.sol
@@ -94,7 +94,6 @@ contract PolicyManager is ReentrancyGuard {
 
     error PolicyNotInstalled(bytes32 commitment);
     error PolicyAlreadyInstalled(bytes32 commitment);
-    error UnauthorizedAccount(address caller, address account);
     error OutsideValidityWindow(uint40 validAfter, uint40 validUntil, uint256 timestamp);
     error CommitmentNotAuthorized(bytes32 actorId, address target, bytes32 commitment);
     /// @dev The acting actor has no live policy commitment for the account — i.e. it is not a gated actor of this
@@ -121,24 +120,30 @@ contract PolicyManager is ReentrancyGuard {
 
     /// @notice Installs a policy binding the account has authorized for a specific actor.
     ///
-    /// @dev MUST be called by `binding.account`. The manager re-derives the binding's `commitment` and confirms the
-    ///      account signed it for this manager by reading the resolved policy manager and commitment for `actorId`
-    ///      (via the granular accessors): the resolved target must be this manager and the resolved commitment must
-    ///      equal the binding's. The committed `policyConfig` is then handed to the policy's install hook, which
-    ///      stores it keyed by commitment.
+    /// @dev Permissionless: callable by anyone, not just `binding.account`. The account's *authorization* is the
+    ///      gate, not the caller — the manager re-derives the binding's `commitment` and requires the account to have
+    ///      signed exactly it for this manager when configuring `actorId` (the resolved policy manager must be this
+    ///      contract and the resolved commitment must equal the binding's). An install can therefore only ever
+    ///      materialize a binding the account already committed to, so anyone may submit it (e.g. a subscription
+    ///      provider self-serving install after the account signs the actor change off-chain). The committed
+    ///      `policyConfig` is then handed to the policy's install hook, which stores it keyed by commitment.
     ///
-    /// @param actorId The session-key actor the account configured with this policy (non-zero policyType).
+    ///      Install is one-shot per commitment: a second install of the same `(policy, commitment)` reverts
+    ///      {PolicyAlreadyInstalled}, so it can never reset an installed binding's accounting (e.g. spend counters).
+    ///      Changing any binding field yields a different commitment — a separate, independently-accounted binding,
+    ///      not a reset of the old one.
+    ///
+    /// @param actorId The actor the account configured with this policy (non-zero policyType).
     /// @param binding The account-authorized binding.
     ///
     /// @return commitment The binding's commitment.
     function install(bytes32 actorId, PolicyBinding calldata binding) external returns (bytes32 commitment) {
-        if (msg.sender != binding.account) revert UnauthorizedAccount(msg.sender, binding.account);
-
         commitment = _commitment(binding);
 
         // The account must have signed this exact commitment for this manager when authorizing `actorId`. Read the
         // gate target and signed commitment via the single-SLOAD granular accessors: the manager never needs the
-        // policyType byte, so this avoids the extra ActorConfig SLOAD that getPolicy performs.
+        // policyType byte, so this avoids the extra ActorConfig SLOAD that getPolicy performs. This (not msg.sender)
+        // is the authorization gate, which is why install is permissionless.
         address target = ACCOUNT_CONFIGURATION.getPolicyManager(binding.account, actorId);
         bytes32 signedCommitment = ACCOUNT_CONFIGURATION.getPolicyCommitment(binding.account, actorId);
         if (target != address(this) || signedCommitment != commitment) {

--- a/src/examples/policies/README.md
+++ b/src/examples/policies/README.md
@@ -62,5 +62,49 @@ selectors whose ABI is known: `SessionPolicy` hardcodes the standard ERC-20 set 
 consumed for those selectors on a limited token, native-ETH limits from each call's `value`, and every other
 selector is governed by target/selector gating alone.
 
+#### Worked example
+
+Configure one session key that (1) has full, uncapped access to one ERC-20 (the "MyApp" token), (2) may spend at
+most **$5 of USDC per month**, and (3) may call the MyApp app contract as much as it wants, but only through two
+chosen selectors. Three call scopes + one spend limit:
+
+```solidity
+address MYAPP_TOKEN; // the "MyApp" ERC-20
+address USDC;        // 6 decimals
+address MYAPP;       // the MyApp app contract
+bytes4  selStake = MyApp.stake.selector;
+bytes4  selClaim = MyApp.claim.selector;
+
+// Spend limits: ONLY USDC ($5/month). MyApp token has no entry, so it is uncapped.
+SessionPolicy.TokenLimit[] memory limits = new SessionPolicy.TokenLimit[](1);
+limits[0] = SessionPolicy.TokenLimit({token: USDC, limit: 5e6, period: 30 days});
+
+SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](3);
+
+// (a) MyApp token: full access — empty rules => any selector; no TokenLimit => no spend cap.
+scopes[0] = SessionPolicy.CallScope({target: MYAPP_TOKEN, selectorRules: new SessionPolicy.SelectorRule[](0)});
+
+// (b) USDC: `transfer` only, so the $5/month cap can't be sidestepped by another selector.
+SessionPolicy.SelectorRule[] memory usdcRules = new SessionPolicy.SelectorRule[](1);
+usdcRules[0] = SessionPolicy.SelectorRule({selector: IERC20.transfer.selector, recipients: new address[](0)});
+scopes[1] = SessionPolicy.CallScope({target: USDC, selectorRules: usdcRules});
+
+// (c) MyApp contract: two chosen selectors, unlimited calls.
+SessionPolicy.SelectorRule[] memory appRules = new SessionPolicy.SelectorRule[](2);
+appRules[0] = SessionPolicy.SelectorRule({selector: selStake, recipients: new address[](0)});
+appRules[1] = SessionPolicy.SelectorRule({selector: selClaim, recipients: new address[](0)});
+scopes[2] = SessionPolicy.CallScope({target: MYAPP, selectorRules: appRules});
+
+bytes memory policyConfig = abi.encode(SessionPolicy.Config({tokenLimits: limits, callScopes: scopes}));
+```
+
+With that installed, the key may transfer any amount of the MyApp token, spend up to $5 of USDC per rolling month
+(refreshing the next month), and call `stake` / `claim` on MyApp without limit — while a USDC transfer over budget
+reverts `ExceededAllowance`, a third MyApp selector reverts `SelectorNotAllowed`, and any other contract reverts
+`TargetNotAllowed`. Two choices to note: modeling "full token access" as *any selector* also permits `approve` /
+`transferFrom` on that token (use a single `transfer` rule to restrict to transfers); and USDC is pinned to
+`transfer` precisely so the cap is airtight. End-to-end test:
+[`test_workedExample_fullTokenAccess_monthlyUsdc_appSelectors`](../../../test/unit/examples/SessionPolicy.t.sol).
+
 > Out of scope for this reference: signature-based install, replacement, and uninstall. See
 > [base/account-policies](https://github.com/base/account-policies) for a fuller policy framework.

--- a/src/examples/policies/README.md
+++ b/src/examples/policies/README.md
@@ -14,10 +14,13 @@ gates identically on any non-zero `policyType` and does not interpret the value;
    `policy_manager = PolicyManager`, and `policy_commitment = keccak256` of an account-authorized
    [`PolicyBinding`](./PolicyManager.sol). The Account Configuration contract exposes this via
    [`getPolicy(account, actorId)`](../../interfaces/IAccountConfiguration.sol).
-2. **Install.** The account calls `PolicyManager.install(actorId, binding)`. The manager re-derives the
-   commitment and confirms `getPolicy` resolves to `(this, commitment)` — so an install can only succeed for a
-   policy the account actually signed for this manager. The committed `policyConfig` is then handed to the
-   policy's install hook, which stores it keyed by commitment.
+2. **Install.** Anyone (the account itself, the session key, or a third party) calls
+   `PolicyManager.install(actorId, binding)`. The manager re-derives the commitment and confirms `getPolicy`
+   resolves to `(this, commitment)` — so an install can only succeed for a policy the account actually signed for
+   this manager, which is what makes the call permissionless. The committed `policyConfig` is then handed to the
+   policy's install hook, which stores it keyed by commitment. Install is one-shot per commitment, so it can never
+   reset an installed binding's accounting (e.g. spend counters); changing any binding field yields a different
+   commitment — a separate, independently-accounted binding.
 3. **Use.** When the session key transacts, the protocol gate resolves the key's allowed target
    (`policy_manager(account, actorId)`) and reverts any call whose `call.to` isn't that address before dispatch, so
    the key's call can only arrive at `PolicyManager.execute(policy, executionData)` with `msg.sender == account`.

--- a/src/examples/policies/README.md
+++ b/src/examples/policies/README.md
@@ -40,7 +40,7 @@ session key ──(8130 gate: only PolicyManager)──▶ PolicyManager.execute
 
 | Contract | Role |
 |----------|------|
-| `PolicyManager` | Minimal manager: install verifies the account's signed commitment; `execute` (account-acting) reads the acting actor from the transaction-context precompile; `executeFor` / `executeForMany` (external-caller) let an authorized outside party drive one or many accounts. All paths run the policy → `account.executeBatch`. |
+| `PolicyManager` | Minimal manager: install (permissionless) verifies the account's signed commitment; `execute` (account-acting) reads the acting actor from the transaction-context precompile; `executeFor` / `executeForMany` (external-caller) let an authorized outside party drive one or many accounts. All paths run the policy → `account.executeBatch`. |
 | `Policy` | Base hook: `onInstall` (store committed config) + `onExecute` (enforce + build call plan). |
 | `SessionPolicy` | Unified "session key" policy: combines a target allowlist, per-target selector rules, per-selector recipient allowlists, and per-token (and native-ETH) recurring/one-time spend limits — all enforced atomically on each call. |
 | `RecurringAllowance` | Periodic-allowance accounting library (ported from base/account-policies); used by `SessionPolicy` for spend accounting. |
@@ -126,8 +126,11 @@ caller, not the protocol.
   and skipped** (emitting `PullSkipped`) rather than reverting the whole batch — one delinquent subscriber doesn't
   block the rest.
 
-**Opt-in (per account, once).** The account authorizes the provider as a *policy-only* actor — it has no authority
-of its own, it only carries a binding the manager enforces:
+**Opt-in (per account, once).** The account's only on-chain obligation is a single **off-chain signature** over an
+actor change. Because `applySignedActorChanges` is signature-gated and `install` is permissionless (gated by the
+signed commitment, not by `msg.sender`), the provider can submit everything itself — apply the signed change,
+`install`, then `executeFor` — so the account never needs to send a transaction. The account authorizes the provider
+as a *policy-only* actor — it has no authority of its own, it only carries a binding the manager enforces:
 
 ```solidity
 // actorId = bytes20(provider). The provider never signs an 8130 tx; it acts by being msg.sender.

--- a/src/examples/policies/README.md
+++ b/src/examples/policies/README.md
@@ -40,7 +40,7 @@ session key ──(8130 gate: only PolicyManager)──▶ PolicyManager.execute
 
 | Contract | Role |
 |----------|------|
-| `PolicyManager` | Minimal manager: install verifies the account's signed commitment; `execute` reads the acting actor from the transaction-context precompile, reads its live commitment, then policy → `account.executeBatch`. |
+| `PolicyManager` | Minimal manager: install verifies the account's signed commitment; `execute` (account-acting) reads the acting actor from the transaction-context precompile; `executeFor` / `executeForMany` (external-caller) let an authorized outside party drive one or many accounts. All paths run the policy → `account.executeBatch`. |
 | `Policy` | Base hook: `onInstall` (store committed config) + `onExecute` (enforce + build call plan). |
 | `SessionPolicy` | Unified "session key" policy: combines a target allowlist, per-target selector rules, per-selector recipient allowlists, and per-token (and native-ETH) recurring/one-time spend limits — all enforced atomically on each call. |
 | `RecurringAllowance` | Periodic-allowance accounting library (ported from base/account-policies); used by `SessionPolicy` for spend accounting. |
@@ -105,6 +105,47 @@ reverts `ExceededAllowance`, a third MyApp selector reverts `SelectorNotAllowed`
 `transferFrom` on that token (use a single `transfer` rule to restrict to transfers); and USDC is pinned to
 `transfer` precisely so the cap is airtight. End-to-end test:
 [`test_workedExample_fullTokenAccess_monthlyUsdc_appSelectors`](../../../test/unit/examples/SessionPolicy.t.sol).
+
+### External callers (subscriptions)
+
+The flows above are *account-acting*: a session key on the account transacts, the protocol dispatches as the
+account, and `execute` learns the acting actor from the transaction-context precompile. But sometimes the actor
+isn't a key on the account at all — e.g. a **subscription provider** that wants to make **one** batch call pulling
+from many accounts, rather than each account running its own session key. For that, identity must come from the
+caller, not the protocol.
+
+`executeFor(account, policy, executionData)` is the external-caller entrypoint:
+
+- **Identity is the caller:** `actorId = bytes20(msg.sender)`, and `account` is an explicit argument. The caller
+  can't forge the identity because it's derived from `msg.sender`.
+- **No protocol routing, so the manager re-checks itself:** it re-adds the `policy_manager(account, actorId) ==
+  address(this)` check that the account-acting `execute` omits (the 8130 gate guarantees routing only on the
+  dispatched path). So a provider can only pull through the exact manager the account authorized.
+- **One identity, many accounts:** `executeForMany(accounts[], policy, executionData[])` runs each account in its
+  own self-call so a single failure (revoked/expired binding, over budget, a reverting account call) is **isolated
+  and skipped** (emitting `PullSkipped`) rather than reverting the whole batch — one delinquent subscriber doesn't
+  block the rest.
+
+**Opt-in (per account, once).** The account authorizes the provider as a *policy-only* actor — it has no authority
+of its own, it only carries a binding the manager enforces:
+
+```solidity
+// actorId = bytes20(provider). The provider never signs an 8130 tx; it acts by being msg.sender.
+IAccountConfiguration.ActorConfig({
+    authenticator: EXTERNAL_POLICY_AUTHENTICATOR, // recognized actor; NO direct executeBatch; not 8130-usable
+    scope:         0x02,                          // SCOPE_SENDER — required non-zero (a policy actor can't be scopeless),
+                                                  //   but inert here since the sentinel can't authenticate a tx
+    expiry:        0,
+    policyType:    0x01                           // gated; policy_manager = manager, policy_commitment = own salt
+});
+```
+
+Critically, the provider must **not** be registered with `EXTERNAL_CALLER_AUTHENTICATOR` — that sentinel grants
+*direct, unrestricted* `executeBatch` and would let the provider bypass the policy entirely. `EXTERNAL_POLICY_AUTHENTICATOR`
+is a no-code sentinel: the actor is recognized (non-zero authenticator) but can neither drive the account directly
+nor authenticate an 8130 transaction. Give the provider its **own salt** so its commitment — and therefore its
+spend budget — is isolated from any session keys on the account. End-to-end tests:
+[`ExternalPolicyCaller.t.sol`](../../../test/unit/examples/ExternalPolicyCaller.t.sol).
 
 > Out of scope for this reference: signature-based install, replacement, and uninstall. See
 > [base/account-policies](https://github.com/base/account-policies) for a fuller policy framework.

--- a/test/unit/examples/ExternalPolicyCaller.t.sol
+++ b/test/unit/examples/ExternalPolicyCaller.t.sol
@@ -146,7 +146,7 @@ contract ExternalPolicyCallerTest is AccountConfigurationTest {
         data[2] = _pull(20e6);
 
         vm.expectEmit(true, true, true, false);
-        emit PolicyManager.PullSkipped(a2, address(policy), bytes32(bytes20(provider)));
+        emit PolicyManager.ExecutionSkipped(a2, address(policy), bytes32(bytes20(provider)));
 
         vm.prank(provider);
         bool[] memory results = manager.executeForMany(accounts, address(policy), data);
@@ -157,6 +157,27 @@ contract ExternalPolicyCallerTest is AccountConfigurationTest {
         // a1 and a3 settled; a2 was skipped entirely.
         assertEq(token.balanceOf(recipient), 30e6);
         assertEq(token.balanceOf(a2), 1_000e6);
+    }
+
+    function test_executeFor_revertsWhenCommitmentBelongsToAnotherAccount() public {
+        // Victim opts the provider in; commitment is installed with record.account == victim.
+        address victim = _optIn(bytes32(uint256(1)), 100e6, MONTH);
+        (, bytes32 victimCommitment) = _binding(victim, 1, 100e6, MONTH);
+
+        // Attacker points its OWN actor (actorId = bytes20(provider)) at the victim's opaque commitment + this
+        // manager. AccountConfiguration stores the commitment verbatim, so nothing stops this registration.
+        address attacker = _createAccount(bytes32(uint256(2)));
+        _authorizeProvider(attacker, address(manager), victimCommitment);
+
+        // Driving the attacker account against the victim's commitment must be rejected — otherwise the attacker
+        // could exhaust the victim's shared, commitment-keyed spend counter.
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.CommitmentAccountMismatch.selector, victim, attacker));
+        vm.prank(provider);
+        manager.executeFor(attacker, address(policy), _pull(10e6));
+
+        // Nothing moved: the attack reverted, so the victim's shared spend counter and balances are untouched.
+        assertEq(token.balanceOf(recipient), 0);
+        assertEq(policy.getCurrentSpend(victimCommitment, address(token)).spend, 0);
     }
 
     function test_executeForMany_revertsOnLengthMismatch() public {

--- a/test/unit/examples/ExternalPolicyCaller.t.sol
+++ b/test/unit/examples/ExternalPolicyCaller.t.sol
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccountConfiguration} from "../../../src/interfaces/IAccountConfiguration.sol";
+import {EXTERNAL_CALLER_AUTHENTICATOR} from "../../../src/accounts/DefaultAccount.sol";
+
+import {PolicyManager, EXTERNAL_POLICY_AUTHENTICATOR} from "../../../src/examples/policies/PolicyManager.sol";
+import {SessionPolicy} from "../../../src/examples/policies/SessionPolicy.sol";
+import {RecurringAllowance} from "../../../src/examples/policies/RecurringAllowance.sol";
+
+import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
+
+contract ExtMockERC20 {
+    mapping(address => uint256) public balanceOf;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+}
+
+/// @notice Exercises the external-caller flow of {PolicyManager}: a party that is *not* a key on the account (e.g. a
+///         subscription provider) is authorized by accounts to pull within a policy, and drives one or many accounts
+///         via {PolicyManager.executeFor} / {executeForMany}. Identity is the caller itself
+///         (`actorId == bytes20(msg.sender)`); the provider actor is registered with `EXTERNAL_POLICY_AUTHENTICATOR`
+///         so it can only act through the manager, never directly.
+contract ExternalPolicyCallerTest is AccountConfigurationTest {
+    PolicyManager internal manager;
+    SessionPolicy internal policy;
+    ExtMockERC20 internal token;
+
+    address internal provider = address(0x9405); // the external caller (subscription provider)
+    address internal recipient = address(0x5EE);
+
+    uint256 internal constant ROOT_PK = 0xA11CE;
+    uint8 internal constant SCOPE_SENDER = 0x02;
+    uint8 internal constant POLICY_GATED = 0x01;
+    uint8 internal constant AUTHORIZE_ACTOR = 0x01;
+    uint8 internal constant REVOKE_ACTOR = 0x02;
+
+    bytes4 internal constant TRANSFER = bytes4(keccak256("transfer(address,uint256)"));
+    uint40 internal constant MONTH = 30 days;
+
+    function setUp() public override {
+        super.setUp();
+        vm.warp(1_700_000_000);
+
+        manager = new PolicyManager(address(accountConfiguration));
+        policy = new SessionPolicy(address(manager));
+        token = new ExtMockERC20();
+    }
+
+    // ── Single-account external pull ──
+
+    function test_executeFor_happyPath() public {
+        address account = _optIn(bytes32(uint256(1)), 100e6, MONTH);
+
+        vm.prank(provider);
+        manager.executeFor(account, address(policy), _pull(30e6));
+
+        assertEq(token.balanceOf(recipient), 30e6);
+        assertEq(token.balanceOf(account), 1_000e6 - 30e6);
+    }
+
+    function test_executeFor_revertsForUnauthorizedCaller() public {
+        address account = _optIn(bytes32(uint256(1)), 100e6, MONTH);
+
+        // A different external address was never authorized by the account → no manager binding for its actorId.
+        address stranger = address(0xBAD);
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.NoActivePolicy.selector, bytes32(bytes20(stranger))));
+        vm.prank(stranger);
+        manager.executeFor(account, address(policy), _pull(1));
+    }
+
+    function test_executeFor_revertsWhenManagerNotGated() public {
+        // The account authorized the provider, but pointed it at a *different* manager. This manager must refuse,
+        // since the external path has no protocol routing to lean on.
+        address account = _createAccount(bytes32(uint256(1)));
+        (PolicyManager.PolicyBinding memory binding, bytes32 commitment) = _binding(account, 7, 100e6, MONTH);
+        _authorizeProvider(account, address(0xDEAD), commitment); // wrong manager
+
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.NoActivePolicy.selector, bytes32(bytes20(provider))));
+        vm.prank(provider);
+        manager.executeFor(account, address(policy), _pull(1));
+        binding; // silence unused
+    }
+
+    function test_executeFor_revertsAfterRevoke() public {
+        address account = _optIn(bytes32(uint256(1)), 100e6, MONTH);
+
+        _revokeProvider(account);
+
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.NoActivePolicy.selector, bytes32(bytes20(provider))));
+        vm.prank(provider);
+        manager.executeFor(account, address(policy), _pull(1));
+    }
+
+    function test_executeFor_revertsOverBudget() public {
+        address account = _optIn(bytes32(uint256(1)), 50e6, MONTH);
+
+        vm.prank(provider);
+        manager.executeFor(account, address(policy), _pull(50e6));
+
+        // A second pull this month would exceed the $50 cap.
+        vm.expectRevert(abi.encodeWithSelector(RecurringAllowance.ExceededAllowance.selector, 51e6, 50e6));
+        vm.prank(provider);
+        manager.executeFor(account, address(policy), _pull(1e6));
+    }
+
+    function test_executeFor_refreshesNextMonth() public {
+        address account = _optIn(bytes32(uint256(1)), 50e6, MONTH);
+
+        vm.prank(provider);
+        manager.executeFor(account, address(policy), _pull(50e6));
+
+        vm.warp(block.timestamp + MONTH);
+        vm.prank(provider);
+        manager.executeFor(account, address(policy), _pull(40e6));
+
+        assertEq(token.balanceOf(recipient), 90e6);
+    }
+
+    // ── Cross-account best-effort batch ──
+
+    function test_executeForMany_bestEffort_isolatesFailures() public {
+        // Three subscribers; the middle one authorized the provider but never installed the binding, so its pull
+        // reverts (PolicyNotInstalled) and must be skipped without blocking the other two.
+        address a1 = _optIn(bytes32(uint256(1)), 100e6, MONTH);
+        address a2 = _createAccount(bytes32(uint256(2)));
+        (, bytes32 c2) = _binding(a2, 2, 100e6, MONTH);
+        _authorizeProvider(a2, address(manager), c2); // authorized but NOT installed
+        address a3 = _optIn(bytes32(uint256(3)), 100e6, MONTH);
+
+        address[] memory accounts = new address[](3);
+        accounts[0] = a1;
+        accounts[1] = a2;
+        accounts[2] = a3;
+        bytes[] memory data = new bytes[](3);
+        data[0] = _pull(10e6);
+        data[1] = _pull(10e6);
+        data[2] = _pull(20e6);
+
+        vm.expectEmit(true, true, true, false);
+        emit PolicyManager.PullSkipped(a2, address(policy), bytes32(bytes20(provider)));
+
+        vm.prank(provider);
+        bool[] memory results = manager.executeForMany(accounts, address(policy), data);
+
+        assertTrue(results[0]);
+        assertFalse(results[1]);
+        assertTrue(results[2]);
+        // a1 and a3 settled; a2 was skipped entirely.
+        assertEq(token.balanceOf(recipient), 30e6);
+        assertEq(token.balanceOf(a2), 1_000e6);
+    }
+
+    function test_executeForMany_revertsOnLengthMismatch() public {
+        address[] memory accounts = new address[](2);
+        bytes[] memory data = new bytes[](1);
+        vm.expectRevert(PolicyManager.LengthMismatch.selector);
+        vm.prank(provider);
+        manager.executeForMany(accounts, address(policy), data);
+    }
+
+    function test_enforceExternalSelf_revertsForExternalCaller() public {
+        // The self-call boundary used by the batch must reject any caller other than the manager itself.
+        vm.expectRevert(PolicyManager.OnlySelf.selector);
+        vm.prank(provider);
+        manager.enforceExternalSelf(address(0x1), bytes32(bytes20(provider)), address(policy), _pull(1), provider);
+    }
+
+    // ── Helpers ──
+
+    function _pull(uint256 amount) internal view returns (bytes memory) {
+        return abi.encode(
+            SessionPolicy.Action({
+                target: address(token), value: 0, data: abi.encodeCall(ExtMockERC20.transfer, (recipient, amount))
+            })
+        );
+    }
+
+    /// @dev SessionPolicy config: allow any selector on `token`, with a USDC-style recurring spend limit.
+    function _config(uint256 limit, uint40 period) internal view returns (bytes memory) {
+        SessionPolicy.TokenLimit[] memory limits = new SessionPolicy.TokenLimit[](1);
+        limits[0] = SessionPolicy.TokenLimit({token: address(token), limit: limit, period: period});
+        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
+        scopes[0] =
+            SessionPolicy.CallScope({target: address(token), selectorRules: new SessionPolicy.SelectorRule[](0)});
+        return abi.encode(SessionPolicy.Config({tokenLimits: limits, callScopes: scopes}));
+    }
+
+    function _binding(address account, uint256 salt, uint256 limit, uint40 period)
+        internal
+        view
+        returns (PolicyManager.PolicyBinding memory binding, bytes32 commitment)
+    {
+        binding = PolicyManager.PolicyBinding({
+            account: account,
+            policy: address(policy),
+            policyConfig: _config(limit, period),
+            validAfter: 0,
+            validUntil: 0,
+            salt: salt
+        });
+        commitment = manager.commitmentOf(binding);
+    }
+
+    /// @dev Full opt-in for one subscriber: create the account, mint it tokens, authorize the provider as an
+    ///      external-policy actor gated to this manager, and install the binding.
+    function _optIn(bytes32 accountSalt, uint256 limit, uint40 period) internal returns (address account) {
+        account = _createAccount(accountSalt);
+        (PolicyManager.PolicyBinding memory binding, bytes32 commitment) =
+            _binding(account, uint256(accountSalt), limit, period);
+        _authorizeProvider(account, address(manager), commitment);
+        vm.prank(account);
+        manager.install(bytes32(bytes20(provider)), binding);
+    }
+
+    function _createAccount(bytes32 salt) internal returns (address account) {
+        IAccountConfiguration.InitialActor memory root = IAccountConfiguration.InitialActor({
+            actorId: bytes32(bytes20(vm.addr(ROOT_PK))), authenticator: address(k1Authenticator)
+        });
+        IAccountConfiguration.InitialActor memory mgr = IAccountConfiguration.InitialActor({
+            actorId: bytes32(bytes20(address(manager))), authenticator: EXTERNAL_CALLER_AUTHENTICATOR
+        });
+        IAccountConfiguration.InitialActor[] memory actors = new IAccountConfiguration.InitialActor[](2);
+        (actors[0], actors[1]) = root.actorId < mgr.actorId ? (root, mgr) : (mgr, root);
+
+        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
+        account = accountConfiguration.createAccount(salt, bytecode, actors);
+        token.mint(account, 1_000e6);
+    }
+
+    /// @dev Authorize the provider as an external-policy actor: no direct authority, gated to `policyManager` with
+    ///      `commitment`. The actorId is the provider's own address.
+    function _authorizeProvider(address account, address policyManager, bytes32 commitment) internal {
+        IAccountConfiguration.ActorConfig memory cfg = IAccountConfiguration.ActorConfig({
+            authenticator: EXTERNAL_POLICY_AUTHENTICATOR, scope: SCOPE_SENDER, expiry: 0, policyType: POLICY_GATED
+        });
+        IAccountConfiguration.ActorChange[] memory changes = new IAccountConfiguration.ActorChange[](1);
+        changes[0] = IAccountConfiguration.ActorChange({
+            actorId: bytes32(bytes20(provider)),
+            changeType: AUTHORIZE_ACTOR,
+            data: abi.encode(cfg, abi.encodePacked(policyManager, commitment))
+        });
+        _applyAsRoot(account, changes);
+    }
+
+    function _revokeProvider(address account) internal {
+        IAccountConfiguration.ActorChange[] memory changes = new IAccountConfiguration.ActorChange[](1);
+        changes[0] = IAccountConfiguration.ActorChange({
+            actorId: bytes32(bytes20(provider)), changeType: REVOKE_ACTOR, data: ""
+        });
+        _applyAsRoot(account, changes);
+    }
+
+    function _applyAsRoot(address account, IAccountConfiguration.ActorChange[] memory changes) internal {
+        uint64 chainId = uint64(block.chainid);
+        uint64 sequence = accountConfiguration.getChangeSequences(account).local;
+        bytes32 digest = _computeActorChangeBatchDigest(account, chainId, sequence, changes);
+        accountConfiguration.applySignedActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
+    }
+}

--- a/test/unit/examples/PolicyManager.t.sol
+++ b/test/unit/examples/PolicyManager.t.sol
@@ -62,11 +62,32 @@ contract PolicyManagerTest is AccountConfigurationTest {
 
     // ── Install authorization ──
 
-    function test_install_revertsForNonAccountCaller() public {
+    function test_install_isPermissionless_anyCallerForAuthorizedBinding() public {
+        // Install is gated by the account's signed commitment, not by msg.sender: once the account has authorized the
+        // actor's commitment, a third party (e.g. a subscription provider) can submit the install itself.
         PolicyManager.PolicyBinding memory binding = _binding(1);
-        vm.expectRevert(abi.encodeWithSelector(PolicyManager.UnauthorizedAccount.selector, stranger, account));
+        bytes32 actorId = _sessionActorId(1);
+        bytes32 commitment = manager.commitmentOf(binding);
+        _authorizePolicyActor(actorId, commitment);
+
         vm.prank(stranger);
-        manager.install(bytes32(0), binding);
+        manager.install(actorId, binding);
+
+        assertTrue(manager.getPolicyRecord(address(policy), commitment).installed);
+    }
+
+    function test_install_revertsWhenAlreadyInstalled() public {
+        // One-shot per commitment: re-installing the same binding cannot reset its accounting.
+        PolicyManager.PolicyBinding memory binding = _binding(1);
+        bytes32 actorId = _sessionActorId(1);
+        bytes32 commitment = manager.commitmentOf(binding);
+        _authorizePolicyActor(actorId, commitment);
+        vm.prank(account);
+        manager.install(actorId, binding);
+
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.PolicyAlreadyInstalled.selector, commitment));
+        vm.prank(account);
+        manager.install(actorId, binding);
     }
 
     function test_install_revertsWhenCommitmentNotAuthorized() public {

--- a/test/unit/examples/PolicyManager.t.sol
+++ b/test/unit/examples/PolicyManager.t.sol
@@ -60,6 +60,26 @@ contract PolicyManagerTest is AccountConfigurationTest {
         manager.execute(address(policy), _action());
     }
 
+    function test_execute_revertsForCrossAccountCommitmentReuse() public {
+        // Victim installs a binding for itself; record.account = victim. Note: AccountConfiguration stores the
+        // commitment as opaque bytes, so an attacker can register an actor on their *own* account that points at the
+        // victim's commitment value + this manager. The manager must reject when the executing account is not the
+        // one the binding was installed for, otherwise the attacker could drive (and exhaust) the victim's
+        // commitment-keyed policy state — e.g. a shared spend counter.
+        bytes32 victimActorId = _installSession(1);
+        bytes32 victimCommitment = ACCOUNT_CONFIGURATION_commitment(victimActorId);
+
+        // Build an attacker account that "authorizes" an actor with the victim's commitment value and this manager.
+        (address attacker, uint256 attackerOwnerPk) = _createAttackerAccount();
+        bytes32 attackerActorId = keccak256(abi.encode("attacker-session", uint256(1)));
+        _authorizePolicyActorOn(attacker, attackerOwnerPk, attackerActorId, victimCommitment);
+
+        _mockActingActor(attackerActorId);
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.CommitmentAccountMismatch.selector, account, attacker));
+        vm.prank(attacker);
+        manager.execute(address(policy), _action());
+    }
+
     // ── Install authorization ──
 
     function test_install_isPermissionless_anyCallerForAuthorizedBinding() public {
@@ -186,6 +206,46 @@ contract PolicyManagerTest is AccountConfigurationTest {
         uint64 sequence = accountConfiguration.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, chainId, sequence, changes);
         accountConfiguration.applySignedActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
+    }
+
+    function ACCOUNT_CONFIGURATION_commitment(bytes32 actorId) internal view returns (bytes32) {
+        return accountConfiguration.getPolicyCommitment(account, actorId);
+    }
+
+    /// @dev Build a second account owned by a distinct root key (the "attacker"), with this manager registered as
+    ///      an execution-enabled actor (`EXTERNAL_CALLER_AUTHENTICATOR`).
+    function _createAttackerAccount() internal returns (address attacker, uint256 attackerOwnerPk) {
+        attackerOwnerPk = 0xB0B;
+        IAccountConfiguration.InitialActor memory root = IAccountConfiguration.InitialActor({
+            actorId: bytes32(bytes20(vm.addr(attackerOwnerPk))), authenticator: address(k1Authenticator)
+        });
+        IAccountConfiguration.InitialActor memory mgr = IAccountConfiguration.InitialActor({
+            actorId: bytes32(bytes20(address(manager))), authenticator: EXTERNAL_CALLER_AUTHENTICATOR
+        });
+        IAccountConfiguration.InitialActor[] memory actors = new IAccountConfiguration.InitialActor[](2);
+        (actors[0], actors[1]) = root.actorId < mgr.actorId ? (root, mgr) : (mgr, root);
+
+        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
+        attacker = accountConfiguration.createAccount(bytes32(uint256(0xA77ACE2)), bytecode, actors);
+    }
+
+    /// @dev Variant of {_authorizePolicyActor} that operates on an arbitrary `target` account signed by its owner.
+    ///      Used to register a victim's commitment value on a different account — the cross-account reuse case.
+    function _authorizePolicyActorOn(address target_, uint256 ownerPk, bytes32 actorId, bytes32 commitment) internal {
+        IAccountConfiguration.ActorConfig memory cfg = IAccountConfiguration.ActorConfig({
+            authenticator: address(k1Authenticator), scope: SCOPE_SENDER, expiry: 0, policyType: POLICY_GATED
+        });
+        bytes memory policyData = abi.encodePacked(address(manager), commitment);
+
+        IAccountConfiguration.ActorChange[] memory changes = new IAccountConfiguration.ActorChange[](1);
+        changes[0] = IAccountConfiguration.ActorChange({
+            actorId: actorId, changeType: AUTHORIZE_ACTOR, data: abi.encode(cfg, policyData)
+        });
+
+        uint64 chainId = uint64(block.chainid);
+        uint64 sequence = accountConfiguration.getChangeSequences(target_).local;
+        bytes32 digest = _computeActorChangeBatchDigest(target_, chainId, sequence, changes);
+        accountConfiguration.applySignedActorChanges(target_, chainId, changes, _buildK1Auth(ownerPk, digest));
     }
 
     function _revokePolicyActor(bytes32 actorId) internal {

--- a/test/unit/examples/SessionPolicy.t.sol
+++ b/test/unit/examples/SessionPolicy.t.sol
@@ -35,6 +35,10 @@ contract SessionMockTarget {
     function other(uint256 v) external {
         value = v;
     }
+
+    function adminOnly(uint256 v) external {
+        value = v;
+    }
 }
 
 /// @notice Exercises the unified {SessionPolicy}: target allowlist, per-target selector rules, recipient
@@ -270,6 +274,78 @@ contract SessionPolicyTest is AccountConfigurationTest {
         manager.execute(
             address(policy), _action(address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (mallory, 1)))
         );
+    }
+
+    // ── Worked example ──
+    //
+    // A single session key that: (1) has full, uncapped access to one ERC-20 (the "MyApp" token); (2) may spend at
+    // most $5 of USDC per month; and (3) may call the MyApp app contract as much as it wants, but only through two
+    // chosen selectors. This is the example documented in the policies README.
+
+    function test_workedExample_fullTokenAccess_monthlyUsdc_appSelectors() public {
+        // A second ERC-20 plays the role of USDC (6 decimals); `token` (minted in setUp) is the MyApp token.
+        SessionMockERC20 usdc = new SessionMockERC20();
+        usdc.mint(account, 1_000e6);
+        uint40 monthPeriod = 30 days;
+        uint256 fiveUsdc = 5e6; // $5 at 6 decimals
+
+        // Spend limits: only USDC ($5/month). The MyApp token has no entry, so its transfers are uncapped.
+        SessionPolicy.TokenLimit[] memory limits = new SessionPolicy.TokenLimit[](1);
+        limits[0] = SessionPolicy.TokenLimit({token: address(usdc), limit: fiveUsdc, period: monthPeriod});
+
+        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](3);
+        // (a) MyApp token: full access — any selector, and no spend cap (no TokenLimit above).
+        scopes[0] = _anySelectorScope(address(token));
+        // (b) USDC: transfer only, so the $5/month cap can't be sidestepped by another selector.
+        SessionPolicy.SelectorRule[] memory usdcRules = new SessionPolicy.SelectorRule[](1);
+        usdcRules[0] = SessionPolicy.SelectorRule({selector: TRANSFER, recipients: _noRecipients()});
+        scopes[1] = SessionPolicy.CallScope({target: address(usdc), selectorRules: usdcRules});
+        // (c) MyApp app contract: two chosen selectors, unlimited calls.
+        SessionPolicy.SelectorRule[] memory appRules = new SessionPolicy.SelectorRule[](2);
+        appRules[0] =
+            SessionPolicy.SelectorRule({selector: SessionMockTarget.setValue.selector, recipients: _noRecipients()});
+        appRules[1] =
+            SessionPolicy.SelectorRule({selector: SessionMockTarget.other.selector, recipients: _noRecipients()});
+        scopes[2] = SessionPolicy.CallScope({target: address(target), selectorRules: appRules});
+
+        bytes32 actorId = _install(_config(limits, scopes));
+
+        // Uncapped MyApp token transfer.
+        _execute(actorId, address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 750_000e18)));
+        assertEq(token.balanceOf(bob), 750_000e18);
+
+        // USDC within the monthly cap.
+        _execute(actorId, address(usdc), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 3e6)));
+        assertEq(usdc.balanceOf(bob), 3e6);
+
+        // MyApp app calls, both selectors, repeatedly.
+        _execute(actorId, address(target), 0, abi.encodeCall(SessionMockTarget.setValue, (1)));
+        _execute(actorId, address(target), 0, abi.encodeCall(SessionMockTarget.other, (2)));
+        _execute(actorId, address(target), 0, abi.encodeCall(SessionMockTarget.setValue, (3)));
+        assertEq(target.value(), 3);
+
+        // A further $3 USDC this month would total $6 > $5 → rejected.
+        _mockActingActor(actorId);
+        vm.expectRevert(abi.encodeWithSelector(RecurringAllowance.ExceededAllowance.selector, 6e6, fiveUsdc));
+        vm.prank(account);
+        manager.execute(
+            address(policy), _action(address(usdc), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 3e6)))
+        );
+
+        // A selector outside the two chosen ones on MyApp → rejected.
+        _mockActingActor(actorId);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SessionPolicy.SelectorNotAllowed.selector, address(target), SessionMockTarget.adminOnly.selector
+            )
+        );
+        vm.prank(account);
+        manager.execute(address(policy), _action(address(target), 0, abi.encodeCall(SessionMockTarget.adminOnly, (9))));
+
+        // Next month: the USDC budget refreshes back to $5.
+        vm.warp(block.timestamp + monthPeriod);
+        _execute(actorId, address(usdc), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 4e6)));
+        assertEq(usdc.balanceOf(bob), 3e6 + 4e6);
     }
 
     // ── Install guards ──


### PR DESCRIPTION
## Summary
- **SessionPolicy worked example** — end-to-end test + README walkthrough of one key combining all gating dimensions (full ERC-20 access, $5/month USDC, two-selector app access).
- **External callers** — new `executeFor` / `executeForMany` so a party that is not a key on the account (e.g. a subscription provider) can drive one or many accounts through a policy in a single transaction. Identity is `bytes20(msg.sender)`; the external path re-adds the `policy_manager == this` check that the protocol-routed `execute` can omit; `executeForMany` isolates each account in its own self-call so a single failure (revoked / over-budget / reverting account call) is skipped, not fatal. Introduces `EXTERNAL_POLICY_AUTHENTICATOR` — a no-code sentinel marking a policy-only actor that can act *only* through the manager.
- **Permissionless install** — drop the `msg.sender == binding.account` check on `install`. The account's signed commitment is the real gate, so a provider can self-serve the entire setup after a single off-chain signature; install is `nonReentrant` and one-shot per commitment (cannot reset accounting).
- **Security fix** — bind execution to `record.account == account` in `_enforce`. Without it, a malicious account could register a victim's opaque commitment value in its own actor config and drive (and exhaust) the victim's commitment-keyed policy state, e.g. a shared spend counter. Regression tests on both `execute` and `executeFor` paths.

## Test plan
- [x] 207 forge tests passing (15 manager + 9 external-caller + 17 SessionPolicy + ...)
- [x] `forge fmt` / lint clean
- [ ] CI green