### PR TITLE
AccountConfiguration: make authorizeActor an upsert

### DIFF
--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -171,6 +171,13 @@ contract AccountConfiguration is IAccountConfiguration {
     {
         account = computeAddress(userSalt, bytecode, initialActors);
 
+        // Block re-initialization of an already-bootstrapped account. localSequence doubles as the initialized flag,
+        // so a prior createAccount/import set it to 1; multichainSequence guards an account that established 8130
+        // state via a global (chainId 0) change. This must be explicit: now that authorizeActor is an upsert it no
+        // longer reverts on a duplicate initial actor, and the create2 below is intentionally swallowed (pop), so a
+        // duplicate createAccount would otherwise silently re-initialize.
+        require(_accountState[account].localSequence == 0 && _accountState[account].multichainSequence == 0);
+
         // Mark the account initialized: localSequence doubles as the initialized flag, so setting it to 1 blocks
         // importAccount (which requires localSequence == 0) from running against an already-created account.
         // Created accounts have contract code at a CREATE2 address, so the default EOA path (recovered == account)
@@ -180,7 +187,6 @@ contract AccountConfiguration is IAccountConfiguration {
         _accountState[account].localSequence = 1;
         _accountState[account].flags = FLAG_REVOKE_DEFAULT_EOA;
 
-        // Initialize account actors (reverts naturally on duplicate via _authorizeActor)
         _initializeAccount(account, initialActors);
 
         // Create account code at the CREATE2 address derived from the packed actors commitment.
@@ -500,19 +506,15 @@ contract AccountConfiguration is IAccountConfiguration {
             // other so a k1 and a non-k1 self are never simultaneously live.
             AccountState storage st = _accountState[account];
             if (config.authenticator == K1_AUTHENTICATOR) {
-                // Re-authorize guard: only from a disabled self (flag set) or the unconfigured implicit owner
-                // (all-zero inline). Reconfiguring a live, non-trivially-scoped self requires revoking it first.
-                require(
-                    _isDefaultEoaRevoked(account)
-                        || (st.defaultEOAScope == 0 && st.defaultEOAPolicyType == 0 && st.defaultEOAExpiry == 0)
-                );
+                // Upsert: overwrite a live self in place (no re-auth guard); the end state equals revoke-then-
+                // authorize. Re-enabling a previously revoked self is just the flag clear below.
                 delete _actorConfig[actorId][account]; // mutual exclusion: drop any non-k1 self
                 st.defaultEOAScope = config.scope;
                 st.defaultEOAPolicyType = config.policyType;
                 st.defaultEOAExpiry = config.expiry;
                 st.flags &= ~FLAG_REVOKE_DEFAULT_EOA; // enable the inline self
             } else {
-                require(_actorConfig[actorId][account].authenticator == address(0));
+                // Upsert: overwrite any existing non-k1 self in place.
                 _actorConfig[actorId][account] = config;
                 // Mutual exclusion: disable and clear the inline k1 self.
                 st.flags |= FLAG_REVOKE_DEFAULT_EOA;
@@ -531,9 +533,12 @@ contract AccountConfiguration is IAccountConfiguration {
             return;
         }
 
-        // Non-self actor: single _actorConfig home.
-        require(_actorConfig[actorId][account].authenticator == address(0));
+        // Non-self actor: single _actorConfig home. Upsert: overwrite in place. Reset the policy slots first so an
+        // actor moving policy-bearing -> none (or to a different manager) can't leak stale policy state, preserving
+        // the "policy_commitment non-zero iff policyType non-zero" invariant.
         _actorConfig[actorId][account] = config;
+        delete _policyCommitment[actorId][account];
+        delete _policyManager[actorId][account];
         if (commitment != bytes32(0)) _policyCommitment[actorId][account] = commitment;
         if (manager != address(0)) _policyManager[actorId][account] = manager;
 

--- a/test/unit/AccountConfiguration/applyKeyChange.t.sol
+++ b/test/unit/AccountConfiguration/applyKeyChange.t.sol
@@ -250,16 +250,19 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         assertTrue(accountConfiguration.isActor(account, thirdActorId));
     }
 
-    function test_revertsOnDuplicateActorAuthorization() public {
+    function test_reauthorizeNonSelfActor_upsertsInPlace() public {
+        // authorizeActor is an upsert: re-authorizing an already-configured (non-self) actor overwrites its config
+        // in place rather than reverting. Here the owner actor is re-scoped from unrestricted (0x00) to CHANGE_ACTORS.
         (address account, bytes32 actorActorId) = _createK1Account(ACTOR_PK);
 
+        uint8 newScope = accountConfiguration.SCOPE_CHANGE_ACTORS();
         IAccountConfiguration.ActorChange[] memory changes = new IAccountConfiguration.ActorChange[](1);
         changes[0] = IAccountConfiguration.ActorChange({
             actorId: actorActorId,
             changeType: 0x01,
             data: abi.encode(
                 IAccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: newScope, expiry: 0, policyType: 0x00
                 }),
                 bytes("")
             )
@@ -269,8 +272,33 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
         bytes memory auth = _buildK1Auth(ACTOR_PK, digest);
 
-        vm.expectRevert();
         accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+
+        IAccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, actorActorId);
+        assertEq(cfg.scope, newScope);
+        assertEq(cfg.authenticator, address(k1Authenticator));
+    }
+
+    function test_reauthorizeLiveK1Self_rescopesWithoutPriorRevoke() public {
+        // Re-authorizing the inline k1 self is now an in-place upsert — no prior revoke required, even when the self
+        // is live with a non-trivial scope. (Previously this reverted unless the self was revoked or all-zero.)
+        uint256 eoaPk = 500;
+        address eoa = vm.addr(eoaPk);
+        bytes32 selfActorId = bytes32(bytes20(eoa));
+
+        // First: the implicit owner (all-zero inline, live) scopes the self to CHANGE_ACTORS so it can keep signing.
+        uint8 changeActors = accountConfiguration.SCOPE_CHANGE_ACTORS();
+        _rescopeSelf(eoa, eoaPk, changeActors);
+        assertEq(accountConfiguration.getActorConfig(eoa, selfActorId).scope, changeActors);
+
+        // Second: re-scope the now-live, non-trivially-scoped self again (no revoke in between).
+        uint8 newScope = changeActors | 0x02; // CHANGE_ACTORS | SENDER
+        _rescopeSelf(eoa, eoaPk, newScope);
+
+        IAccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(eoa, selfActorId);
+        assertEq(cfg.scope, newScope);
+        assertEq(cfg.authenticator, accountConfiguration.K1_AUTHENTICATOR());
+        assertTrue(accountConfiguration.isActor(eoa, selfActorId));
     }
 
     function test_revertsOnRevokingNonExistentActor() public {
@@ -707,6 +735,24 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
     }
 
     // ── Helpers ──
+
+    /// @dev Authorize/overwrite the EOA's own inline k1 self-actorId with the given scope, signed by the EOA key.
+    function _rescopeSelf(address eoa, uint256 eoaPk, uint8 scope) internal {
+        IAccountConfiguration.ActorChange[] memory changes = new IAccountConfiguration.ActorChange[](1);
+        changes[0] = IAccountConfiguration.ActorChange({
+            actorId: bytes32(bytes20(eoa)),
+            changeType: 0x01,
+            data: abi.encode(
+                IAccountConfiguration.ActorConfig({
+                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: scope, expiry: 0, policyType: 0x00
+                }),
+                bytes("")
+            )
+        });
+        uint64 seq = accountConfiguration.getChangeSequences(eoa).local;
+        bytes32 digest = _computeActorChangeBatchDigest(eoa, uint64(block.chainid), seq, changes);
+        accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), changes, _buildK1Auth(eoaPk, digest));
+    }
 
     function _authorizeActor(address account, uint256 pk, bytes32 newActorId, address authenticator) internal {
         _authorizeActorWithScope(account, pk, newActorId, authenticator, 0x00);

--- a/test/unit/AccountConfiguration/policyAccessors.t.sol
+++ b/test/unit/AccountConfiguration/policyAccessors.t.sol
@@ -145,6 +145,41 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         assertEq(accountConfiguration.getPolicyManager(eoa, selfActorId), address(0));
     }
 
+    function test_getPolicyAccessors_clearedOnReauthorizeToNone() public {
+        // Upsert path: re-authorizing a policy-bearing actor down to POLICY_NONE must clear both policy slots, so no
+        // stale (manager, commitment) leaks and the "commitment non-zero iff policyType non-zero" invariant holds.
+        (address account,) = _createK1Account(ROOT_PK);
+        bytes32 sessionActorId = bytes32(bytes20(vm.addr(SESSION_PK)));
+
+        _authorizePolicyActor(account, ROOT_PK, sessionActorId, DUMMY_MANAGER, DUMMY_COMMITMENT);
+        assertEq(accountConfiguration.getPolicyCommitment(account, sessionActorId), DUMMY_COMMITMENT);
+        assertEq(accountConfiguration.getPolicyManager(account, sessionActorId), DUMMY_MANAGER);
+
+        // Overwrite the same actor as ungated (policyType == POLICY_NONE).
+        _authorizeUngatedActor(account, ROOT_PK, sessionActorId, address(k1Authenticator));
+
+        assertEq(accountConfiguration.getPolicyCommitment(account, sessionActorId), bytes32(0));
+        assertEq(accountConfiguration.getPolicyManager(account, sessionActorId), address(0));
+        IAccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, sessionActorId);
+        assertEq(cfg.policyType, 0x00);
+        assertEq(cfg.scope, 0x00);
+    }
+
+    function test_getPolicyAccessors_updatedOnReauthorizeToNewManager() public {
+        // Upsert to a *different* (manager, commitment) must replace, not merge.
+        (address account,) = _createK1Account(ROOT_PK);
+        bytes32 sessionActorId = bytes32(bytes20(vm.addr(SESSION_PK)));
+
+        _authorizePolicyActor(account, ROOT_PK, sessionActorId, DUMMY_MANAGER, DUMMY_COMMITMENT);
+
+        address newManager = address(0xBEEF);
+        bytes32 newCommitment = bytes32(uint256(0xD00D));
+        _authorizePolicyActor(account, ROOT_PK, sessionActorId, newManager, newCommitment);
+
+        assertEq(accountConfiguration.getPolicyManager(account, sessionActorId), newManager);
+        assertEq(accountConfiguration.getPolicyCommitment(account, sessionActorId), newCommitment);
+    }
+
     // ── Isolation (correct mapping key derivation) ──
 
     function test_getPolicyAccessors_isolatedAcrossActors() public {


### PR DESCRIPTION
## Summary
- **`authorizeActor` is now an upsert.** Authorizing an already-configured `actorId` overwrites its config in place instead of reverting; the end state equals revoke-then-authorize (event stays `ActorAuthorized`, last-event-wins). Removes the self-k1 re-authorization guard and the two require-empty checks.
- **Policy-slot reset on the non-self path (correctness).** An actor moving policy-bearing → none (or to a different manager) now clears both `_policyManager` / `_policyCommitment` slots first, so stale `(manager, commitment)` can't leak — preserving the "commitment non-zero iff policyType non-zero" invariant. The self path already did this.
- **Explicit re-init guard on `createAccount`.** Its duplicate-account protection previously relied on the now-removed `authorizeActor` require-empty (the `create2` redeploy is intentionally swallowed via `pop`). Without an explicit guard, a duplicate `createAccount` would silently re-initialize an existing account, so this adds `require(localSequence == 0 && multichainSequence == 0)`, mirroring `importAccount`.

Preserved: authenticator floor, policy-scope guard, `_slicePolicy`, the self dual-home mutual exclusion, `_revokeActor`, and lock gating.

## Test plan
- [x] Flipped `test_revertsOnDuplicateActorAuthorization` → `test_reauthorizeNonSelfActor_upsertsInPlace` (success + updated scope)
- [x] Added `test_reauthorizeLiveK1Self_rescopesWithoutPriorRevoke` (re-scope a live k1 self, no prior revoke)
- [x] Added `test_getPolicyAccessors_clearedOnReauthorizeToNone` and `…updatedOnReauthorizeToNewManager`
- [x] `test_createAccount_revertsOnDuplicate` still passes (now via the explicit guard)
- [x] 210 forge tests passing; `forge fmt` / lint clean
- [x] CI green