### PR TITLE
feat: SCOPE_POLICY, SCOPE_NONCE, admin=scope-0 (match EIP #9)

### DIFF
--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -21,10 +21,9 @@ contract AccountConfiguration {
         address authenticator;
         uint8 scope;
         uint48 expiry; // Unix seconds; 0 = no expiry. Actor invalid once block.timestamp > expiry
-        uint16 nonceLane; // Protocol-side nonce lane; this contract stores it verbatim and does not interpret it
     }
 
-    // Minimal actor used for account creation and import (always unrestricted: scope=0x00, nonceLane=0, no expiry).
+    // Minimal actor used for account creation and import (always unrestricted: scope=0x00, no expiry).
     struct InitialActor {
         bytes32 actorId;
         address authenticator;
@@ -48,9 +47,7 @@ contract AccountConfiguration {
     ///      The defaultEOA* fields are the inline home for the account's own secp256k1 ("self") key — the actor whose
     ///      actorId is bytes32(bytes20(account)). When FLAG_REVOKE_DEFAULT_EOA is unset, a k1 signature recovering to
     ///      the account authenticates with this inline config (all-zero = full owner; non-zero scope/expiry = a
-    ///      scoped self key), resolved in a single SLOAD. There is no inline nonceLane: the inline self always
-    ///      reports nonceLane 0; a self key needing a non-zero lane must be configured as a non-k1 self (or use the
-    ///      full ActorConfig via an explicit k1 actor). Policy gating (when scope & SCOPE_POLICY != 0) is still keyed
+    ///      scoped self key), resolved in a single SLOAD. Policy gating (when scope & SCOPE_POLICY != 0) is still keyed
     ///      by actorId in the shared _policyManager/_policyCommitment keyspace. The separate _actorConfig[self][account]
     ///      slot is reserved for a *non-k1* self authenticator (e.g. a post-quantum verifier returning the
     ///      self-actorId); the two homes are mutually exclusive (see _authorizeActor).
@@ -74,17 +71,17 @@ contract AccountConfiguration {
     ///      attacks. Bound to the current chainId so an import signature cannot be replayed on another chain.
     ///      Initial actors are hashed structurally via ACTOR_TYPEHASH / ACTORCONFIG_TYPEHASH below.
     bytes32 public constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
-        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint16 nonceLane)"
+        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry)"
     );
 
     /// @dev Per-actor typehash used to structurally hash each Actor within an ActorInitialization import digest.
     bytes32 public constant ACTOR_TYPEHASH = keccak256(
-        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint16 nonceLane)"
+        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry)"
     );
 
     /// @dev Per-config typehash used to structurally hash an Actor's ActorConfig within an import digest.
     bytes32 public constant ACTORCONFIG_TYPEHASH =
-        keccak256("ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint16 nonceLane)");
+        keccak256("ActorConfig(address authenticator,uint8 scope,uint48 expiry)");
 
     /// @dev Typehash for signed actor changes, NOT compliant with EIP-712 to mitigate phishing attacks.
     bytes32 public constant SIGNED_ACTOR_CHANGES_TYPEHASH = keccak256(
@@ -119,10 +116,7 @@ contract AccountConfiguration {
     /// @notice Actor can pay for transactions with account as payer
     uint8 public constant SCOPE_PAYER = 0x04;
 
-    /// @notice Actor can change account configuration (authorize/revoke actors). This is an administrative,
-    ///         root-equivalent capability: a config key can authorize brand-new unrestricted owners, so it must be
-    ///         treated as being as powerful as full ownership.
-    uint8 public constant SCOPE_CONFIG = 0x08;
+    // 0x08 is spare (unused).
 
     /// @notice Actor is gated to a policy: every call it makes must land on the resolved manager (this contract
     ///         stores manager + commitment; the protocol enforces that the actor's calls only ever reach that
@@ -131,18 +125,10 @@ contract AccountConfiguration {
     ///         enforced here.
     uint8 public constant SCOPE_POLICY = 0x10;
 
-    // ----------------------------------------------------------------------------------------------------------------
-    // NONCE LANES
-    // ----------------------------------------------------------------------------------------------------------------
-
-    /// @notice Sentinel `nonceLane` value: the actor is not bound to a specific lane. This contract stores
-    ///         `nonceLane` verbatim and never interprets it; lane semantics (including this sentinel) are
-    ///         protocol-side.
-    uint16 public constant NONCE_LANE_UNBOUND = 0;
-
-    /// @notice Sentinel `nonceLane` value: the actor may only transact nonce-lessly (protocol-side semantics; this
-    ///         contract does not interpret it).
-    uint16 public constant NONCE_LANE_NONCELESS_ONLY = type(uint16).max;
+    /// @notice Actor is bound to a protocol-side nonce lane. This contract stores the scope bit verbatim and does
+    ///         not interpret it — nonce lane semantics (including which lane, and how lanes are allocated) are
+    ///         entirely protocol-side, analogous to the old nonceLane field this bit replaces.
+    uint8 public constant SCOPE_NONCE = 0x20;
 
     /// @dev Authenticator namespace: 1 = the canonical secp256k1 ("K1") verifier (native ecrecover); 2..max = custom
     ///      IAuthenticator contracts. address(0) is reserved as the "no actor configured" storage sentinel and is
@@ -176,9 +162,9 @@ contract AccountConfiguration {
 
     /// @notice Emitted when an actor is authorized (created or updated).
     /// @param actorData Tightly packed authorization surface, mirroring the storage/wire packing:
-    ///        authenticator(20) || scope(1) || expiry(6) || nonceLane(2) — 29 bytes — and, only when
+    ///        authenticator(20) || scope(1) || expiry(6) — 27 bytes — and, only when
     ///        scope & SCOPE_POLICY != 0, followed by the resolved policy gate: manager(20) || commitment(32).
-    ///        So the payload is 29 bytes for an ungated actor and 81 bytes for a policy-gated one; no zero policy
+    ///        So the payload is 27 bytes for an ungated actor and 79 bytes for a policy-gated one; no zero policy
     ///        words are emitted when there is no policy.
     event ActorAuthorized(address indexed account, bytes32 indexed actorId, bytes actorData);
 
@@ -365,8 +351,9 @@ contract AccountConfiguration {
 
     /// @notice Apply a batch of signed actor changes (authorize/revoke) to an account's configuration.
     /// @dev Authenticates `auth` against the account's actors and requires the resolved actor to be unrestricted
-    ///      (scope 0) or to hold SCOPE_CONFIG. Replay is bound by chainId (0 = multichain, else the current
-    ///      chain) and a monotonic per-account sequence consumed on each call.
+    ///      (scope 0) — there is no elevated scope for changing actors; admin is exactly scope == 0. Replay is
+    ///      bound by chainId (0 = multichain, else the current chain) and a monotonic per-account sequence
+    ///      consumed on each call.
     function applySignedActorChanges(
         address account,
         uint256 chainId,
@@ -381,10 +368,10 @@ contract AccountConfiguration {
 
         // Compute digest and authenticate
         bytes32 digest = _computeSignedActorChangesDigest(account, chainId, sequence, actorChanges);
-        (uint8 scope,,) = authenticateActor(account, digest, auth);
+        (uint8 scope,) = authenticateActor(account, digest, auth);
 
-        // Require actor has scope to change actors (scope == 0 means unrestricted)
-        if (scope != 0 && scope & SCOPE_CONFIG == 0) revert UnauthorizedActorChange();
+        // Only an unrestricted actor (scope 0) may change actors; there is no elevated "admin" scope bit.
+        if (scope != 0) revert UnauthorizedActorChange();
 
         // Apply actorChanges
         for (uint256 i; i < actorChanges.length; i++) {
@@ -443,7 +430,7 @@ contract AccountConfiguration {
         view
         returns (bool verified)
     {
-        try this.authenticateActor(account, hash, signature) returns (uint8 scope, uint16, address) {
+        try this.authenticateActor(account, hash, signature) returns (uint8 scope, address) {
             return scope == 0 || scope & SCOPE_SIGNER != 0;
         } catch {
             return false;
@@ -454,18 +441,17 @@ contract AccountConfiguration {
     ///         the verified actor's authorization surface so a consumer (e.g. an ERC-4337 account) can make a
     ///         full authorization decision from a single call without re-deriving the actorId.
     /// @dev Authorization is scope + policy, not scope alone. `scope` is the actor's capability set (including
-    ///      whether SCOPE_POLICY is set); `nonceLane` and `policyTarget` are the actor's other authorization
-    ///      surface. `nonceLane` is stored verbatim and never interpreted by this contract — its semantics
-    ///      (including the NONCE_LANE_* sentinels) are protocol-side. `policyTarget` is the resolved policy
-    ///      *manager* (never the signed commitment, which stays an execution-time read via getPolicy), or
-    ///      address(0) when ungated.
+    ///      whether SCOPE_POLICY or SCOPE_NONCE is set); `policyTarget` is the actor's other authorization surface.
+    ///      `scope` (including bits like SCOPE_NONCE) is stored verbatim and never interpreted by this contract —
+    ///      protocol-side semantics for those bits (e.g. nonce lane allocation) live outside this contract.
+    ///      `policyTarget` is the resolved policy *manager* (never the signed commitment, which stays an
+    ///      execution-time read via getPolicy), or address(0) when ungated.
     /// @return scope The scope of the verified actor (0x00 = unrestricted).
-    /// @return nonceLane The actor's nonce lane, stored verbatim (0 for the inline self — see AccountState).
     /// @return policyTarget The actor's policy gate target, or address(0) if ungated.
     function authenticateActor(address account, bytes32 hash, bytes calldata auth)
         public
         view
-        returns (uint8 scope, uint16 nonceLane, address policyTarget)
+        returns (uint8 scope, address policyTarget)
     {
         if (auth.length < 20) revert InvalidAuthLength();
         return _authenticate(account, hash, address(bytes20(auth[:20])), auth[20:]);
@@ -497,17 +483,16 @@ contract AccountConfiguration {
 
     /// @dev With a populated _actorConfig entry, returns it verbatim (any non-self actor, or a non-k1 self). For the
     ///      self-actorId without such an entry, the k1 self lives inline in AccountState: a live one (flag unset)
-    ///      reports as a native ecrecover owner carrying its inline scope/expiry (all-zero = full owner) and
-    ///      nonceLane 0 (never stored inline); a disabled one — or any unknown actor — reports as the all-zero
-    ///      (empty) config. This keeps live-vs-disabled unambiguous without a sentinel.
+    ///      reports as a native ecrecover owner carrying its inline scope/expiry (all-zero = full owner); a
+    ///      disabled one — or any unknown actor — reports as the all-zero (empty) config. This keeps
+    ///      live-vs-disabled unambiguous without a sentinel.
     function getActorConfig(address account, bytes32 actorId) external view returns (ActorConfig memory) {
         ActorConfig memory config = _actorConfig[actorId][account];
         if (config.authenticator != address(0)) return config;
         if (actorId == bytes32(bytes20(account)) && !_isDefaultEoaRevoked(account)) {
             AccountState storage st = _accountState[account];
-            return ActorConfig({
-                authenticator: K1_AUTHENTICATOR, scope: st.defaultEOAScope, expiry: st.defaultEOAExpiry, nonceLane: 0
-            });
+            return
+                ActorConfig({authenticator: K1_AUTHENTICATOR, scope: st.defaultEOAScope, expiry: st.defaultEOAExpiry});
         }
         return config;
     }
@@ -599,11 +584,11 @@ contract AccountConfiguration {
             if (initialActors[i].actorId <= previousActorId) revert ActorsNotSortedOrDuplicate();
             previousActorId = initialActors[i].actorId;
 
-            // Initial actors are always unrestricted owners: scope 0x00, no expiry, no policy, no nonce lane. The
-            // InitialActor type cannot express scope/expiry/nonceLane/policy, so these defaults are structural.
-            // Scoped keys and session-key policies are added later via applySignedActorChanges.
+            // Initial actors are always unrestricted owners: scope 0x00, no expiry, no policy. The InitialActor
+            // type cannot express scope/expiry/policy, so these defaults are structural. Scoped keys and
+            // session-key policies are added later via applySignedActorChanges.
             ActorConfig memory config =
-                ActorConfig({authenticator: initialActors[i].authenticator, scope: 0, expiry: 0, nonceLane: 0});
+                ActorConfig({authenticator: initialActors[i].authenticator, scope: 0, expiry: 0});
             _authorizeActor(account, initialActors[i].actorId, config, "");
         }
     }
@@ -626,8 +611,7 @@ contract AccountConfiguration {
             AccountState storage st = _accountState[account];
             if (config.authenticator == K1_AUTHENTICATOR) {
                 // Upsert: overwrite a live self in place (no re-auth guard); the end state equals revoke-then-
-                // authorize. Re-enabling a previously revoked self is just the flag clear below. nonceLane is not
-                // stored inline: the inline self always reports nonceLane 0 (see AccountState).
+                // authorize. Re-enabling a previously revoked self is just the flag clear below.
                 delete _actorConfig[actorId][account]; // mutual exclusion: drop any non-k1 self
                 st.defaultEOAScope = config.scope;
                 st.defaultEOAExpiry = config.expiry;
@@ -663,8 +647,8 @@ contract AccountConfiguration {
         _emitActorAuthorized(account, actorId, config, manager, commitment);
     }
 
-    /// @dev Emit ActorAuthorized with a tightly packed payload. The config packs to 29 bytes
-    ///      (authenticator || scope || expiry || nonceLane); the policy gate (manager || commitment, 52 bytes)
+    /// @dev Emit ActorAuthorized with a tightly packed payload. The config packs to 27 bytes
+    ///      (authenticator || scope || expiry); the policy gate (manager || commitment, 52 bytes)
     ///      is appended only for a policy-gated actor, so no zero policy words are emitted otherwise.
     function _emitActorAuthorized(
         address account,
@@ -674,8 +658,8 @@ contract AccountConfiguration {
         bytes32 commitment
     ) private {
         bytes memory actorData = manager == address(0)
-            ? abi.encodePacked(config.authenticator, config.scope, config.expiry, config.nonceLane)
-            : abi.encodePacked(config.authenticator, config.scope, config.expiry, config.nonceLane, manager, commitment);
+            ? abi.encodePacked(config.authenticator, config.scope, config.expiry)
+            : abi.encodePacked(config.authenticator, config.scope, config.expiry, manager, commitment);
         emit ActorAuthorized(account, actorId, actorData);
     }
 
@@ -748,12 +732,11 @@ contract AccountConfiguration {
     {
         bytes32[] memory actorHashes = new bytes32[](initialActors.length);
         for (uint256 i; i < initialActors.length; i++) {
-            // Imported actors are unrestricted owners: scope, expiry, and nonceLane are 0 and policyData is empty.
-            // The digest retains the full Actor/ActorConfig typehash structure (zero-filled) for a single canonical
-            // type, matching the importAccount signature payload in EIP-8130.
-            bytes32 configHash = keccak256(
-                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint8(0), uint48(0), uint16(0))
-            );
+            // Imported actors are unrestricted owners: scope and expiry are 0 and policyData is empty. The digest
+            // retains the full Actor/ActorConfig typehash structure (zero-filled) for a single canonical type,
+            // matching the importAccount signature payload in EIP-8130.
+            bytes32 configHash =
+                keccak256(abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint8(0), uint48(0)));
             actorHashes[i] = keccak256(abi.encode(ACTOR_TYPEHASH, initialActors[i].actorId, configHash, keccak256("")));
         }
 
@@ -806,7 +789,7 @@ contract AccountConfiguration {
     function _authenticate(address account, bytes32 hash, address authenticator, bytes calldata data)
         internal
         view
-        returns (uint8 scope, uint16 nonceLane, address policyTarget)
+        returns (uint8 scope, address policyTarget)
     {
         if (authenticator == K1_AUTHENTICATOR) return _authenticateK1(account, hash, data);
 
@@ -817,33 +800,32 @@ contract AccountConfiguration {
         if (config.authenticator != authenticator) revert AuthenticatorMismatch();
         // Expiry is read from the same slot; an expired actor fails authentication. 0 = no expiry.
         if (config.expiry != 0 && block.timestamp > config.expiry) revert ActorExpired();
-        return (config.scope, config.nonceLane, _policyManager[actorId][account]);
+        return (config.scope, _policyManager[actorId][account]);
     }
 
     /// @dev The single secp256k1 ("K1") path. Recovers the signer (EIP-2 enforced), then resolves the actor:
     ///        - signer == account -> the inline self config in AccountState (one SLOAD): the flag gates the whole
     ///          key (set => revert), and when live the scope/expiry come from the inline fields (all-zero = full
-    ///          owner; non-zero = a scoped self); nonceLane is always 0 (not stored inline — see AccountState). A
-    ///          non-k1 self is unreachable here by construction (it requires its own authenticator), and mutual
-    ///          exclusion keeps the flag set whenever one is live.
+    ///          owner; non-zero = a scoped self). A non-k1 self is unreachable here by construction (it requires
+    ///          its own authenticator), and mutual exclusion keeps the flag set whenever one is live.
     ///        - otherwise the signer's actorId must carry an explicit K1 config in _actorConfig (any other k1 actor).
     ///      Both the common self and other-actor paths cost a single SLOAD plus the policy-manager read.
     function _authenticateK1(address account, bytes32 hash, bytes calldata data)
         internal
         view
-        returns (uint8, uint16, address)
+        returns (uint8, address)
     {
         address recovered = _recoverSigner(hash, data);
         if (recovered == address(0)) revert InvalidSignature();
 
         if (recovered == account) {
             // Inline self: a single SLOAD resolves the whole key. The flag disables it entirely; otherwise the
-            // inline scope/expiry govern (all-zero = full owner). nonceLane is always 0 for the inline self.
+            // inline scope/expiry govern (all-zero = full owner).
             AccountState storage st = _accountState[account];
             if (st.flags & FLAG_REVOKE_DEFAULT_EOA != 0) revert DefaultEoaRevoked();
             if (st.defaultEOAExpiry != 0 && block.timestamp > st.defaultEOAExpiry) revert ActorExpired();
             bytes32 selfActorId = bytes32(bytes20(account));
-            return (st.defaultEOAScope, 0, _policyManager[selfActorId][account]);
+            return (st.defaultEOAScope, _policyManager[selfActorId][account]);
         }
 
         bytes32 actorId = bytes32(bytes20(recovered));
@@ -851,7 +833,7 @@ contract AccountConfiguration {
         if (config.authenticator != K1_AUTHENTICATOR) revert AuthenticatorMismatch();
         // Expiry is read from the same slot; an expired actor fails authentication. 0 = no expiry.
         if (config.expiry != 0 && block.timestamp > config.expiry) revert ActorExpired();
-        return (config.scope, config.nonceLane, _policyManager[actorId][account]);
+        return (config.scope, _policyManager[actorId][account]);
     }
 
     /// @dev True if the account's default (implicit) EOA has been revoked via the AccountState flag.

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -163,7 +163,8 @@ contract AccountConfiguration {
     /// @notice Actor can sponsor gas on behalf of a different sender (payer != sender).
     uint8 public constant SCOPE_SPONSOR_PAYER = 0x10;
 
-    // Note: ERC-1271 signing is admin-only (scope == 0x00), not a grant — there is no SIGNER scope bit.
+    // Note: ERC-1271 signing is authorized for any operational actor (admin scope == 0x00, or a SENDER actor
+    // without POLICY), not a separate grant — there is no SIGNER scope bit. See verifySignature.
 
     // 0x20, 0x40, 0x80 are spare (unused).
 
@@ -597,23 +598,27 @@ contract AccountConfiguration {
     /// @notice Validates an account signature in `authenticator(20) || data` format; never reverts.
     ///
     /// @dev ERC-1271-style boolean check: returns false on any failure (invalid signature, unknown/revoked actor,
-    ///      actorId not bound to the presented authenticator, or a non-admin scoped actor). authenticateActor
+    ///      actorId not bound to the presented authenticator, or a non-operational actor). authenticateActor
     ///      reverts on failure, so it is called externally and the revert is caught.
     ///
     /// @param account The account the signature is validated against.
     /// @param hash The digest that was signed.
     /// @param signature Authenticator(20) || authenticator-specific data.
     ///
-    /// @return verified True if the signature is valid and the resolved actor is the admin.
+    /// @return verified True if the signature is valid and the resolved actor is operational (admin, or a SENDER
+    ///         actor that does not carry POLICY).
     function verifySignature(address account, bytes32 hash, bytes calldata signature)
         external
         view
         returns (bool verified)
     {
         try this.authenticateActor(account, hash, signature) returns (uint8 scope, address) {
-            // ERC-1271 signing is authorized only for the admin actor (scope == 0x00); there is no SIGNER grant.
-            // Scoped signing is expressed at the account layer via a POLICY key's approved-hash pattern, not here.
-            return scope == 0;
+            // ERC-1271 signing is authorized for any operational actor: the admin (scope == 0x00), or a SENDER actor
+            // that is not gated by a policy (SCOPE_SENDER set AND SCOPE_POLICY unset). Signing is an encoding of
+            // authority a SENDER actor already holds via calls, not a separate grant, so it needs no dedicated scope
+            // bit. A POLICY-bearing actor is not operational and cannot sign: a signature acts outside its policy
+            // gate, so honoring one would let it act off its gate.
+            return scope == 0 || ((scope & SCOPE_SENDER != 0) && (scope & SCOPE_POLICY == 0));
         } catch {
             return false;
         }

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -21,10 +21,10 @@ contract AccountConfiguration {
         address authenticator;
         uint8 scope;
         uint48 expiry; // Unix seconds; 0 = no expiry. Actor invalid once block.timestamp > expiry
-        uint8 policyType; // 0x00 = none; any non-zero = gated to stored manager (value interpreted by the manager)
+        uint16 nonceLane; // Protocol-side nonce lane; this contract stores it verbatim and does not interpret it
     }
 
-    // Minimal actor used for account creation and import (always unrestricted: scope=0x00, policyType=0x00, no expiry).
+    // Minimal actor used for account creation and import (always unrestricted: scope=0x00, nonceLane=0, no expiry).
     struct InitialActor {
         bytes32 actorId;
         address authenticator;
@@ -33,7 +33,7 @@ contract AccountConfiguration {
     struct Actor {
         bytes32 actorId;
         ActorConfig config;
-        // Sliced by policyType: empty (0x00); manager[20] || commitment[32] (non-zero).
+        // Sliced by scope: empty when scope & SCOPE_POLICY == 0; manager[20] || commitment[32] when set.
         bytes policyData;
     }
 
@@ -47,10 +47,13 @@ contract AccountConfiguration {
     ///      localSequence > 0 doubles as the account initialized flag.
     ///      The defaultEOA* fields are the inline home for the account's own secp256k1 ("self") key — the actor whose
     ///      actorId is bytes32(bytes20(account)). When FLAG_REVOKE_DEFAULT_EOA is unset, a k1 signature recovering to
-    ///      the account authenticates with this inline config (all-zero = full owner; non-zero scope/expiry/policy =
-    ///      a scoped self key), resolved in a single SLOAD. The separate _actorConfig[self][account] slot is reserved
-    ///      for a *non-k1* self authenticator (e.g. a post-quantum verifier returning the self-actorId); the two
-    ///      homes are mutually exclusive (see _authorizeActor).
+    ///      the account authenticates with this inline config (all-zero = full owner; non-zero scope/expiry = a
+    ///      scoped self key), resolved in a single SLOAD. There is no inline nonceLane: the inline self always
+    ///      reports nonceLane 0; a self key needing a non-zero lane must be configured as a non-k1 self (or use the
+    ///      full ActorConfig via an explicit k1 actor). Policy gating (when scope & SCOPE_POLICY != 0) is still keyed
+    ///      by actorId in the shared _policyManager/_policyCommitment keyspace. The separate _actorConfig[self][account]
+    ///      slot is reserved for a *non-k1* self authenticator (e.g. a post-quantum verifier returning the
+    ///      self-actorId); the two homes are mutually exclusive (see _authorizeActor).
     struct AccountState {
         uint64 multichainSequence; // 8 bytes
         uint64 localSequence; // 8 bytes – also serves as initialized flag
@@ -58,7 +61,6 @@ contract AccountConfiguration {
         uint16 unlockDelay; // 2 bytes
         uint8 flags; // 1 byte – bitfield; bit 0 = default EOA revoked (see FLAG_REVOKE_DEFAULT_EOA)
         uint8 defaultEOAScope; // 1 byte – inline self k1 scope (0 = full owner)
-        uint8 defaultEOAPolicyType; // 1 byte – inline self k1 policy sub-type (0 = none)
         uint48 defaultEOAExpiry; // 6 bytes – inline self k1 expiry (Unix seconds; 0 = no expiry)
     }
 
@@ -72,17 +74,17 @@ contract AccountConfiguration {
     ///      attacks. Bound to the current chainId so an import signature cannot be replayed on another chain.
     ///      Initial actors are hashed structurally via ACTOR_TYPEHASH / ACTORCONFIG_TYPEHASH below.
     bytes32 public constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
-        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint8 policyType)"
+        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint16 nonceLane)"
     );
 
     /// @dev Per-actor typehash used to structurally hash each Actor within an ActorInitialization import digest.
     bytes32 public constant ACTOR_TYPEHASH = keccak256(
-        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint8 policyType)"
+        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint16 nonceLane)"
     );
 
     /// @dev Per-config typehash used to structurally hash an Actor's ActorConfig within an import digest.
     bytes32 public constant ACTORCONFIG_TYPEHASH =
-        keccak256("ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint8 policyType)");
+        keccak256("ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint16 nonceLane)");
 
     /// @dev Typehash for signed actor changes, NOT compliant with EIP-712 to mitigate phishing attacks.
     bytes32 public constant SIGNED_ACTOR_CHANGES_TYPEHASH = keccak256(
@@ -105,19 +107,6 @@ contract AccountConfiguration {
     uint8 public constant REVOKE_ACTOR = 0x02;
 
     // ----------------------------------------------------------------------------------------------------------------
-    // ACTOR POLICY TYPES
-    // ----------------------------------------------------------------------------------------------------------------
-
-    /// @notice No execution policy; actor is ungated.
-    uint8 public constant POLICY_NONE = 0x00;
-
-    /// @notice Canonical non-zero policy type. Any non-zero `policyType` gates the actor to its stored
-    ///         manager + commitment (self-enforcement is manager == account); the contract does not interpret
-    ///         the specific value, leaving it for the manager to read as a sub-type. `0x01` is the value used
-    ///         when no sub-type is needed.
-    uint8 public constant POLICY_GATED = 0x01;
-
-    // ----------------------------------------------------------------------------------------------------------------
     // ACTOR ELEVATED SCOPES
     // ----------------------------------------------------------------------------------------------------------------
 
@@ -132,9 +121,28 @@ contract AccountConfiguration {
 
     /// @notice Actor can change account configuration (authorize/revoke actors). This is an administrative,
     ///         root-equivalent capability: a config key can authorize brand-new unrestricted owners, so it must be
-    ///         treated as being as powerful as full ownership. Policy-bearing actors are barred from holding it
-    ///         (see _authorizeActor), since a policy could otherwise be escaped by minting a fresh unrestricted actor.
+    ///         treated as being as powerful as full ownership.
     uint8 public constant SCOPE_CONFIG = 0x08;
+
+    /// @notice Actor is gated to a policy: every call it makes must land on the resolved manager (this contract
+    ///         stores manager + commitment; the protocol enforces that the actor's calls only ever reach that
+    ///         target). This contract does not reject scope combinations (e.g. SCOPE_POLICY | SCOPE_PAYER) — any
+    ///         use-time exclusivity between SCOPE_POLICY and the account's other capabilities is protocol-side, not
+    ///         enforced here.
+    uint8 public constant SCOPE_POLICY = 0x10;
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // NONCE LANES
+    // ----------------------------------------------------------------------------------------------------------------
+
+    /// @notice Sentinel `nonceLane` value: the actor is not bound to a specific lane. This contract stores
+    ///         `nonceLane` verbatim and never interprets it; lane semantics (including this sentinel) are
+    ///         protocol-side.
+    uint16 public constant NONCE_LANE_UNBOUND = 0;
+
+    /// @notice Sentinel `nonceLane` value: the actor may only transact nonce-lessly (protocol-side semantics; this
+    ///         contract does not interpret it).
+    uint16 public constant NONCE_LANE_NONCELESS_ONLY = type(uint16).max;
 
     /// @dev Authenticator namespace: 1 = the canonical secp256k1 ("K1") verifier (native ecrecover); 2..max = custom
     ///      IAuthenticator contracts. address(0) is reserved as the "no actor configured" storage sentinel and is
@@ -168,10 +176,10 @@ contract AccountConfiguration {
 
     /// @notice Emitted when an actor is authorized (created or updated).
     /// @param actorData Tightly packed authorization surface, mirroring the storage/wire packing:
-    ///        authenticator(20) || scope(1) || expiry(6) || policyType(1) — 28 bytes — and, only when
-    ///        policyType != 0x00, followed by the resolved policy gate: manager(20) || commitment(32).
-    ///        So the payload is 28 bytes for an unrestricted/ungated actor and 80 bytes for a policy-gated one;
-    ///        no zero policy words are emitted when there is no policy.
+    ///        authenticator(20) || scope(1) || expiry(6) || nonceLane(2) — 29 bytes — and, only when
+    ///        scope & SCOPE_POLICY != 0, followed by the resolved policy gate: manager(20) || commitment(32).
+    ///        So the payload is 29 bytes for an ungated actor and 81 bytes for a policy-gated one; no zero policy
+    ///        words are emitted when there is no policy.
     event ActorAuthorized(address indexed account, bytes32 indexed actorId, bytes actorData);
 
     event ActorRevoked(address indexed account, bytes32 indexed actorId);
@@ -217,9 +225,7 @@ contract AccountConfiguration {
     error ActorsNotSortedOrDuplicate();
     /// @dev An actor config named an authenticator below the K1 sentinel (i.e. address(0)).
     error InvalidAuthenticator();
-    /// @dev A policy-bearing actor must be scope-restricted and must not hold change-actors scope.
-    error InvalidPolicyScope();
-    /// @dev The policyData length or embedded manager/commitment did not match the policyType.
+    /// @dev The policyData length or embedded manager/commitment did not match `scope & SCOPE_POLICY`.
     error InvalidPolicyData();
     /// @dev The referenced actor is not currently authorized on the account.
     error UnknownActor();
@@ -248,11 +254,11 @@ contract AccountConfiguration {
     /// @dev Account must be inner-most mapping key to pass ERC-7562 storage access rules for ERC-4337 compatibility.
     mapping(bytes32 actorId => mapping(address account => ActorConfig)) internal _actorConfig;
 
-    /// @notice Per-actor signed policy commitment. Set when policyType != 0x00.
+    /// @notice Per-actor signed policy commitment. Set when the actor's scope carries SCOPE_POLICY.
     /// @dev Read only during execution (via getPolicy), never during signature validity checks.
     mapping(bytes32 actorId => mapping(address account => bytes32)) internal _policyCommitment;
 
-    /// @notice Per-actor policy manager address. Set when policyType != 0x00.
+    /// @notice Per-actor policy manager address. Set when the actor's scope carries SCOPE_POLICY.
     mapping(bytes32 actorId => mapping(address account => address)) internal _policyManager;
 
     /// @notice Per-account state: sequences, lock status (single slot per account)
@@ -437,7 +443,7 @@ contract AccountConfiguration {
         view
         returns (bool verified)
     {
-        try this.authenticateActor(account, hash, signature) returns (uint8 scope, uint8, address) {
+        try this.authenticateActor(account, hash, signature) returns (uint8 scope, uint16, address) {
             return scope == 0 || scope & SCOPE_SIGNER != 0;
         } catch {
             return false;
@@ -447,19 +453,19 @@ contract AccountConfiguration {
     /// @notice Authenticate an account approved a hash using auth in authenticator(20) || data format, returning
     ///         the verified actor's authorization surface so a consumer (e.g. an ERC-4337 account) can make a
     ///         full authorization decision from a single call without re-deriving the actorId.
-    /// @dev Authorization is scope + policy, not scope alone. `scope` is the actor's capability set; `policyType`
-    ///      and `policyTarget` describe its policy gate. `policyType` is the per-actor policy sub-type byte —
-    ///      currently `0x00` (none) or non-zero (gated); its specific non-zero value is reserved for future,
-    ///      manager-defined semantics and is returned here so the return shape need not change when that lands.
-    ///      `policyTarget` is the resolved policy *manager* (never the signed commitment, which stays an
-    ///      execution-time read via getPolicy), or address(0) when ungated.
+    /// @dev Authorization is scope + policy, not scope alone. `scope` is the actor's capability set (including
+    ///      whether SCOPE_POLICY is set); `nonceLane` and `policyTarget` are the actor's other authorization
+    ///      surface. `nonceLane` is stored verbatim and never interpreted by this contract — its semantics
+    ///      (including the NONCE_LANE_* sentinels) are protocol-side. `policyTarget` is the resolved policy
+    ///      *manager* (never the signed commitment, which stays an execution-time read via getPolicy), or
+    ///      address(0) when ungated.
     /// @return scope The scope of the verified actor (0x00 = unrestricted).
-    /// @return policyType The actor's policy sub-type byte (0x00 = none).
+    /// @return nonceLane The actor's nonce lane, stored verbatim (0 for the inline self — see AccountState).
     /// @return policyTarget The actor's policy gate target, or address(0) if ungated.
     function authenticateActor(address account, bytes32 hash, bytes calldata auth)
         public
         view
-        returns (uint8 scope, uint8 policyType, address policyTarget)
+        returns (uint8 scope, uint16 nonceLane, address policyTarget)
     {
         if (auth.length < 20) revert InvalidAuthLength();
         return _authenticate(account, hash, address(bytes20(auth[:20])), auth[20:]);
@@ -491,60 +497,43 @@ contract AccountConfiguration {
 
     /// @dev With a populated _actorConfig entry, returns it verbatim (any non-self actor, or a non-k1 self). For the
     ///      self-actorId without such an entry, the k1 self lives inline in AccountState: a live one (flag unset)
-    ///      reports as a native ecrecover owner carrying its inline scope/expiry/policy (all-zero = full owner); a
-    ///      disabled one — or any unknown actor — reports as the all-zero (empty) config. This keeps live-vs-disabled
-    ///      unambiguous without a sentinel.
+    ///      reports as a native ecrecover owner carrying its inline scope/expiry (all-zero = full owner) and
+    ///      nonceLane 0 (never stored inline); a disabled one — or any unknown actor — reports as the all-zero
+    ///      (empty) config. This keeps live-vs-disabled unambiguous without a sentinel.
     function getActorConfig(address account, bytes32 actorId) external view returns (ActorConfig memory) {
         ActorConfig memory config = _actorConfig[actorId][account];
         if (config.authenticator != address(0)) return config;
         if (actorId == bytes32(bytes20(account)) && !_isDefaultEoaRevoked(account)) {
             AccountState storage st = _accountState[account];
             return ActorConfig({
-                authenticator: K1_AUTHENTICATOR,
-                scope: st.defaultEOAScope,
-                expiry: st.defaultEOAExpiry,
-                policyType: st.defaultEOAPolicyType
+                authenticator: K1_AUTHENTICATOR, scope: st.defaultEOAScope, expiry: st.defaultEOAExpiry, nonceLane: 0
             });
         }
         return config;
     }
 
-    /// @notice Resolves an actor's policy sub-type, gate target, and signed commitment.
-    /// @dev Convenience aggregator for off-chain consumers. Enforcement is at execution: this resolves the actor's
-    ///      policy sub-type, where a policy-bearing actor may call, and the commitment a target validates presented
-    ///      parameters against. 0x00 -> (0, 0, 0); non-zero -> (policyType, manager, commitment). The policy
-    ///      manager/commitment are keyed by actorId, so the inline k1 self and a non-k1 self share that keyspace;
-    ///      mutual exclusion guarantees at most one is live, so the active gate is read by actorId.
-    ///      On-chain consumers (notably the policy manager validating a dispatched 8130 tx) should prefer the
-    ///      single-SLOAD `getPolicyCommitment` / `getPolicyManager` accessors.
-    /// @return policyType The actor's policy sub-type byte (0x00 = none).
+    /// @notice Resolves an actor's policy gate target and signed commitment.
+    /// @dev Convenience aggregator for off-chain consumers, equivalent to `(getPolicyManager, getPolicyCommitment)`.
+    ///      Enforcement is at execution: this resolves where a policy-gated actor may call and the commitment a
+    ///      target validates presented parameters against. The policy manager/commitment are keyed by actorId, so
+    ///      the inline k1 self and a non-k1 self share that keyspace; mutual exclusion guarantees at most one is
+    ///      live, so the active gate is read by actorId. Both slots are non-zero iff the actor is currently
+    ///      policy-gated (see _authorizeActor / _revokeActor), so a zero return unambiguously means "no policy / no
+    ///      actor". On-chain consumers (notably the policy manager validating a dispatched 8130 tx) should prefer
+    ///      the single-SLOAD `getPolicyCommitment` / `getPolicyManager` accessors directly.
     /// @return target The actor's policy gate target (manager), or address(0) if ungated.
     /// @return commitment The actor's signed policy commitment, or bytes32(0) if ungated.
-    function getPolicy(address account, bytes32 actorId)
-        external
-        view
-        returns (uint8 policyType, address target, bytes32 commitment)
-    {
-        ActorConfig storage stored = _actorConfig[actorId][account];
-        if (stored.authenticator != address(0)) {
-            policyType = stored.policyType;
-        } else if (actorId == bytes32(bytes20(account)) && !_isDefaultEoaRevoked(account)) {
-            // Inline k1 self: policy lives in AccountState's policyType byte, manager/commitment keyed by actorId.
-            policyType = _accountState[account].defaultEOAPolicyType;
-        } else {
-            return (POLICY_NONE, address(0), bytes32(0));
-        }
-        if (policyType == POLICY_NONE) return (POLICY_NONE, address(0), bytes32(0));
-        return (policyType, _policyManager[actorId][account], _policyCommitment[actorId][account]);
+    function getPolicy(address account, bytes32 actorId) external view returns (address target, bytes32 commitment) {
+        return (_policyManager[actorId][account], _policyCommitment[actorId][account]);
     }
 
     /// @notice Resolves an actor's signed policy commitment, or bytes32(0) if ungated / no actor.
     /// @dev Single SLOAD. Intended for a policy manager's per-tx validation read on the protocol-dispatched
-    ///      8130 tx path: the manager already knows its own address and policy sub-type, so the commitment is
-    ///      the only state it needs from this contract to validate. The invariant maintained by
-    ///      _authorizeActor / _revokeActor is that this slot is non-zero iff the actor has a non-zero
-    ///      policyType, across both the inline-k1 self and the _actorConfig homes (manager/commitment share a
-    ///      single keyspace keyed by actorId), so a zero return unambiguously means "no policy / no actor".
+    ///      8130 tx path: the manager already knows its own address, so the commitment is the only state it needs
+    ///      from this contract to validate. The invariant maintained by _authorizeActor / _revokeActor is that this
+    ///      slot is non-zero iff the actor is currently policy-gated (scope & SCOPE_POLICY != 0), across both the
+    ///      inline-k1 self and the _actorConfig homes (manager/commitment share a single keyspace keyed by actorId),
+    ///      so a zero return unambiguously means "no policy / no actor".
     function getPolicyCommitment(address account, bytes32 actorId) external view returns (bytes32) {
         return _policyCommitment[actorId][account];
     }
@@ -610,12 +599,11 @@ contract AccountConfiguration {
             if (initialActors[i].actorId <= previousActorId) revert ActorsNotSortedOrDuplicate();
             previousActorId = initialActors[i].actorId;
 
-            // Initial actors are always unrestricted owners: scope 0x00, no expiry, no policy. The InitialActor type
-            // cannot express scope/expiry/policy, so these defaults are structural. Scoped keys and session-key
-            // policies are added later via applySignedActorChanges.
-            ActorConfig memory config = ActorConfig({
-                authenticator: initialActors[i].authenticator, scope: 0, expiry: 0, policyType: POLICY_NONE
-            });
+            // Initial actors are always unrestricted owners: scope 0x00, no expiry, no policy, no nonce lane. The
+            // InitialActor type cannot express scope/expiry/nonceLane/policy, so these defaults are structural.
+            // Scoped keys and session-key policies are added later via applySignedActorChanges.
+            ActorConfig memory config =
+                ActorConfig({authenticator: initialActors[i].authenticator, scope: 0, expiry: 0, nonceLane: 0});
             _authorizeActor(account, initialActors[i].actorId, config, "");
         }
     }
@@ -626,15 +614,10 @@ contract AccountConfiguration {
     {
         if (config.authenticator < K1_AUTHENTICATOR) revert InvalidAuthenticator();
 
-        // A policy-bearing actor must be scope-restricted and may not hold CONFIG scope: the policy gate only
-        // covers SENDER-context calls, so a CONFIG-scoped (or unrestricted) key could authorize new, unrestricted
-        // actors and escape its policy entirely. Applies to every home (inline self, non-k1 self, any other actor).
-        if (config.policyType != POLICY_NONE) {
-            if (config.scope == 0 || config.scope & SCOPE_CONFIG != 0) revert InvalidPolicyScope();
-        }
-
-        // Slice the signed policy by policyType. The commitment is opaque to the protocol.
-        (address manager, bytes32 commitment) = _slicePolicy(config.policyType, policyData);
+        // Slice the signed policy by scope & SCOPE_POLICY. The commitment is opaque to the protocol. This contract
+        // does not reject scope combinations (e.g. SCOPE_POLICY | SCOPE_PAYER) — any use-time exclusivity between
+        // SCOPE_POLICY and the account's other capabilities is protocol-side, not enforced here.
+        (address manager, bytes32 commitment) = _slicePolicy(config.scope, policyData);
 
         if (actorId == bytes32(bytes20(account))) {
             // Self-actorId is routed by authenticator type and the two homes are mutually exclusive: the k1 self
@@ -643,10 +626,10 @@ contract AccountConfiguration {
             AccountState storage st = _accountState[account];
             if (config.authenticator == K1_AUTHENTICATOR) {
                 // Upsert: overwrite a live self in place (no re-auth guard); the end state equals revoke-then-
-                // authorize. Re-enabling a previously revoked self is just the flag clear below.
+                // authorize. Re-enabling a previously revoked self is just the flag clear below. nonceLane is not
+                // stored inline: the inline self always reports nonceLane 0 (see AccountState).
                 delete _actorConfig[actorId][account]; // mutual exclusion: drop any non-k1 self
                 st.defaultEOAScope = config.scope;
-                st.defaultEOAPolicyType = config.policyType;
                 st.defaultEOAExpiry = config.expiry;
                 st.flags &= ~FLAG_REVOKE_DEFAULT_EOA; // enable the inline self
             } else {
@@ -655,7 +638,6 @@ contract AccountConfiguration {
                 // Mutual exclusion: disable and clear the inline k1 self.
                 st.flags |= FLAG_REVOKE_DEFAULT_EOA;
                 st.defaultEOAScope = 0;
-                st.defaultEOAPolicyType = 0;
                 st.defaultEOAExpiry = 0;
             }
             // Policy manager/commitment are keyed by actorId (shared keyspace across both self homes): reset, then
@@ -670,8 +652,8 @@ contract AccountConfiguration {
         }
 
         // Non-self actor: single _actorConfig home. Upsert: overwrite in place. Reset the policy slots first so an
-        // actor moving policy-bearing -> none (or to a different manager) can't leak stale policy state, preserving
-        // the "policy_commitment non-zero iff policyType non-zero" invariant.
+        // actor moving policy-gated -> ungated (or to a different manager) can't leak stale policy state, preserving
+        // the "policy_commitment non-zero iff scope & SCOPE_POLICY != 0" invariant.
         _actorConfig[actorId][account] = config;
         delete _policyCommitment[actorId][account];
         delete _policyManager[actorId][account];
@@ -681,9 +663,9 @@ contract AccountConfiguration {
         _emitActorAuthorized(account, actorId, config, manager, commitment);
     }
 
-    /// @dev Emit ActorAuthorized with a tightly packed payload. The config packs to 28 bytes
-    ///      (authenticator || scope || expiry || policyType); the policy gate (manager || commitment, 52 bytes)
-    ///      is appended only for a policy-bearing actor, so no zero policy words are emitted otherwise.
+    /// @dev Emit ActorAuthorized with a tightly packed payload. The config packs to 29 bytes
+    ///      (authenticator || scope || expiry || nonceLane); the policy gate (manager || commitment, 52 bytes)
+    ///      is appended only for a policy-gated actor, so no zero policy words are emitted otherwise.
     function _emitActorAuthorized(
         address account,
         bytes32 actorId,
@@ -691,24 +673,22 @@ contract AccountConfiguration {
         address manager,
         bytes32 commitment
     ) private {
-        bytes memory actorData = config.policyType == POLICY_NONE
-            ? abi.encodePacked(config.authenticator, config.scope, config.expiry, config.policyType)
-            : abi.encodePacked(
-                config.authenticator, config.scope, config.expiry, config.policyType, manager, commitment
-            );
+        bytes memory actorData = manager == address(0)
+            ? abi.encodePacked(config.authenticator, config.scope, config.expiry, config.nonceLane)
+            : abi.encodePacked(config.authenticator, config.scope, config.expiry, config.nonceLane, manager, commitment);
         emit ActorAuthorized(account, actorId, actorData);
     }
 
-    /// @dev Validates `policyData` against `policyType` and returns (manager, commitment).
-    ///      0x00: empty data -> (0, 0). Any non-zero value: manager[20] || commitment[32] -> (manager, commitment).
-    ///      Length mismatches revert. The protocol does not interpret the specific non-zero value; self-enforcement
-    ///      is expressed as manager == account.
-    function _slicePolicy(uint8 policyType, bytes memory policyData)
+    /// @dev Validates `policyData` against `scope & SCOPE_POLICY` and returns (manager, commitment).
+    ///      Unset: empty data -> (0, 0). Set: manager[20] || commitment[32] -> (manager, commitment).
+    ///      Length mismatches revert. The protocol does not interpret the commitment value; self-enforcement is
+    ///      expressed as manager == account.
+    function _slicePolicy(uint8 scope, bytes memory policyData)
         internal
         pure
         returns (address manager, bytes32 commitment)
     {
-        if (policyType == POLICY_NONE) {
+        if (scope & SCOPE_POLICY == 0) {
             if (policyData.length != 0) revert InvalidPolicyData();
         } else {
             if (policyData.length != 52) revert InvalidPolicyData();
@@ -732,7 +712,6 @@ contract AccountConfiguration {
             AccountState storage st = _accountState[account];
             st.flags |= FLAG_REVOKE_DEFAULT_EOA;
             st.defaultEOAScope = 0;
-            st.defaultEOAPolicyType = 0;
             st.defaultEOAExpiry = 0;
         }
         emit ActorRevoked(account, actorId);
@@ -769,11 +748,11 @@ contract AccountConfiguration {
     {
         bytes32[] memory actorHashes = new bytes32[](initialActors.length);
         for (uint256 i; i < initialActors.length; i++) {
-            // Imported actors are unrestricted owners: scope, expiry, and policyType are 0 and policyData is empty.
+            // Imported actors are unrestricted owners: scope, expiry, and nonceLane are 0 and policyData is empty.
             // The digest retains the full Actor/ActorConfig typehash structure (zero-filled) for a single canonical
             // type, matching the importAccount signature payload in EIP-8130.
             bytes32 configHash = keccak256(
-                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint8(0), uint48(0), uint8(0))
+                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint8(0), uint48(0), uint16(0))
             );
             actorHashes[i] = keccak256(abi.encode(ACTOR_TYPEHASH, initialActors[i].actorId, configHash, keccak256("")));
         }
@@ -827,7 +806,7 @@ contract AccountConfiguration {
     function _authenticate(address account, bytes32 hash, address authenticator, bytes calldata data)
         internal
         view
-        returns (uint8 scope, uint8 policyType, address policyTarget)
+        returns (uint8 scope, uint16 nonceLane, address policyTarget)
     {
         if (authenticator == K1_AUTHENTICATOR) return _authenticateK1(account, hash, data);
 
@@ -838,33 +817,33 @@ contract AccountConfiguration {
         if (config.authenticator != authenticator) revert AuthenticatorMismatch();
         // Expiry is read from the same slot; an expired actor fails authentication. 0 = no expiry.
         if (config.expiry != 0 && block.timestamp > config.expiry) revert ActorExpired();
-        return (config.scope, config.policyType, _resolvePolicyTarget(account, actorId, config.policyType));
+        return (config.scope, config.nonceLane, _policyManager[actorId][account]);
     }
 
     /// @dev The single secp256k1 ("K1") path. Recovers the signer (EIP-2 enforced), then resolves the actor:
     ///        - signer == account -> the inline self config in AccountState (one SLOAD): the flag gates the whole
-    ///          key (set => revert), and when live the scope/policy/expiry come from the inline fields (all-zero =
-    ///          full owner; non-zero = a scoped self). A non-k1 self is unreachable here by construction (it
-    ///          requires its own authenticator), and mutual exclusion keeps the flag set whenever one is live.
+    ///          key (set => revert), and when live the scope/expiry come from the inline fields (all-zero = full
+    ///          owner; non-zero = a scoped self); nonceLane is always 0 (not stored inline — see AccountState). A
+    ///          non-k1 self is unreachable here by construction (it requires its own authenticator), and mutual
+    ///          exclusion keeps the flag set whenever one is live.
     ///        - otherwise the signer's actorId must carry an explicit K1 config in _actorConfig (any other k1 actor).
-    ///      Both the common self and other-actor paths cost a single SLOAD.
+    ///      Both the common self and other-actor paths cost a single SLOAD plus the policy-manager read.
     function _authenticateK1(address account, bytes32 hash, bytes calldata data)
         internal
         view
-        returns (uint8, uint8, address)
+        returns (uint8, uint16, address)
     {
         address recovered = _recoverSigner(hash, data);
         if (recovered == address(0)) revert InvalidSignature();
 
         if (recovered == account) {
             // Inline self: a single SLOAD resolves the whole key. The flag disables it entirely; otherwise the
-            // inline scope/policy/expiry govern (all-zero = full owner).
+            // inline scope/expiry govern (all-zero = full owner). nonceLane is always 0 for the inline self.
             AccountState storage st = _accountState[account];
             if (st.flags & FLAG_REVOKE_DEFAULT_EOA != 0) revert DefaultEoaRevoked();
             if (st.defaultEOAExpiry != 0 && block.timestamp > st.defaultEOAExpiry) revert ActorExpired();
-            uint8 policyType = st.defaultEOAPolicyType;
-            return
-                (st.defaultEOAScope, policyType, _resolvePolicyTarget(account, bytes32(bytes20(account)), policyType));
+            bytes32 selfActorId = bytes32(bytes20(account));
+            return (st.defaultEOAScope, 0, _policyManager[selfActorId][account]);
         }
 
         bytes32 actorId = bytes32(bytes20(recovered));
@@ -872,20 +851,12 @@ contract AccountConfiguration {
         if (config.authenticator != K1_AUTHENTICATOR) revert AuthenticatorMismatch();
         // Expiry is read from the same slot; an expired actor fails authentication. 0 = no expiry.
         if (config.expiry != 0 && block.timestamp > config.expiry) revert ActorExpired();
-        return (config.scope, config.policyType, _resolvePolicyTarget(account, actorId, config.policyType));
+        return (config.scope, config.nonceLane, _policyManager[actorId][account]);
     }
 
     /// @dev True if the account's default (implicit) EOA has been revoked via the AccountState flag.
     function _isDefaultEoaRevoked(address account) internal view returns (bool) {
         return _accountState[account].flags & FLAG_REVOKE_DEFAULT_EOA != 0;
-    }
-
-    /// @dev Resolves an actor's policy gate target: address(0) when ungated (policyType == 0x00), otherwise the
-    ///      stored policy manager. Reads only the manager address, never the signed commitment, so it is safe to
-    ///      call during signature validation (e.g. ERC-4337 validateUserOp).
-    function _resolvePolicyTarget(address account, bytes32 actorId, uint8 policyType) internal view returns (address) {
-        if (policyType == POLICY_NONE) return address(0);
-        return _policyManager[actorId][account];
     }
 
     function _recoverSigner(bytes32 hash, bytes calldata data) internal pure returns (address recovered) {

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -366,9 +366,11 @@ contract AccountConfiguration {
     // FUNCTIONS
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice Deploys a new account with its initial actors, which are always registered as unrestricted owners
-    ///         (scope 0x00, no expiry, no policy); scoped keys and session-key policies are added afterwards via
-    ///         applySignedActorChanges. The implicit default-EOA key is disabled on creation.
+    /// @notice Deploys a new account with its initial actors. Each initial actor is registered with its declared
+    ///         `scope` and, when `scope & SCOPE_POLICY` is set, its `policyData` (an external `manager` is expressible
+    ///         at create; `manager = account` is not, as the address is unknown at commitment time). `expiry` is
+    ///         always 0 at create — scoped-with-expiry keys are added afterwards via applySignedActorChanges. The
+    ///         implicit default-EOA key is disabled on creation.
     ///
     /// @dev Reverts with BytecodeTooLarge when `bytecode` exceeds the maximum encodable length.
     /// @dev Reverts with AlreadyInitialized when the account already has EIP-8130 state.
@@ -379,7 +381,7 @@ contract AccountConfiguration {
     ///
     /// @param userSalt Caller-chosen salt mixed into the CREATE2 address derivation.
     /// @param bytecode Account deployment bytecode to CREATE2 at the derived address.
-    /// @param initialActors Bootstrap owners, strictly ascending by actorId; each becomes an unrestricted owner.
+    /// @param initialActors Bootstrap actors, strictly ascending by actorId; each carries its declared scope/policyData.
     ///
     /// @return account The deployed account address.
     function createAccount(bytes32 userSalt, bytes calldata bytecode, InitialActor[] calldata initialActors)
@@ -438,7 +440,7 @@ contract AccountConfiguration {
     /// @param account The account being imported.
     /// @param chainId Replay domain of the import signature: 0 = multichain (valid on every chain), otherwise it
     ///        must equal the current chain.
-    /// @param initialActors Bootstrap owners, strictly ascending by actorId; each becomes an unrestricted owner.
+    /// @param initialActors Bootstrap actors, strictly ascending by actorId; each carries its declared scope/policyData.
     /// @param signature ERC-1271 signature the account validates over the import digest.
     function importAccount(
         address account,

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -111,6 +111,13 @@ contract AccountConfiguration {
     bytes32 public constant ACTORCHANGE_TYPEHASH =
         keccak256("ActorChange(uint8 changeType,bytes32 actorId,bytes data)");
 
+    /// @notice Typehash binding a signed lock-state change to its account, chainId, op, unlock delay, and sequence.
+    ///
+    /// @dev NOT compliant with EIP-712, to mitigate phishing attacks. Lock changes are local-channel only, so the
+    ///      digest always binds the current chainId (there is no multichain lock).
+    bytes32 public constant LOCK_CHANGE_TYPEHASH =
+        keccak256("SignedLockChange(address account,uint256 chainId,uint8 op,uint16 unlockDelay,uint64 sequence)");
+
     // ----------------------------------------------------------------------------------------------------------------
     // ACTOR CHANGE TYPES
     // ----------------------------------------------------------------------------------------------------------------
@@ -120,6 +127,16 @@ contract AccountConfiguration {
 
     /// @notice Revoke an actor from the account
     uint8 public constant REVOKE_ACTOR = 0x02;
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // LOCK CHANGE OPS
+    // ----------------------------------------------------------------------------------------------------------------
+
+    /// @notice applySignedLockChanges op that hard-locks the account.
+    uint8 public constant LOCK_OP = 0x01;
+
+    /// @notice applySignedLockChanges op that initiates the unlock of a hard-locked account.
+    uint8 public constant UNLOCK_OP = 0x02;
 
     // ----------------------------------------------------------------------------------------------------------------
     // ACTOR ELEVATED SCOPES
@@ -252,11 +269,21 @@ contract AccountConfiguration {
     /// @notice The importAccount ERC-1271 signature check did not return the magic value.
     error InvalidImportSignature();
 
-    /// @notice lock() was called with a zero unlock delay.
+    /// @notice A lock op (op = 1) carried a zero unlock delay.
     error ZeroUnlockDelay();
 
-    /// @notice initiateUnlock() was called when the account was not in the locked (unlocksAt == max) state.
+    /// @notice An unlock op (op = 2) was requested when the account was not in the hard-locked (unlocksAt == max)
+    ///         state (never locked, or an unlock was already initiated).
     error NotLocked();
+
+    /// @notice applySignedLockChanges carried an unrecognized op (neither LOCK_OP nor UNLOCK_OP).
+    error UnknownLockOp();
+
+    /// @notice An unlock op (op = 2) carried a non-zero unlock delay (unlock delay is set only by the lock op).
+    error InvalidUnlockDelay();
+
+    /// @notice The authenticated actor lacks the scope required to change the lock state (admin, scope 0, only).
+    error UnauthorizedLockChange();
 
     /// @notice The auth blob is shorter than the 20-byte authenticator selector prefix.
     error InvalidAuthLength();
@@ -500,35 +527,67 @@ contract AccountConfiguration {
     // ACCOUNT LOCKS
     // ----------------------------------------------------------------------------------------------------------------
 
-    /// @notice Locks the caller's account to freeze actor configuration until an unlock is initiated and elapses.
+    /// @notice Applies a signed lock-state change (hard-lock or initiate-unlock) to an account.
     ///
-    /// @dev Reverts with AccountIsLocked when the account is already locked.
-    /// @dev Reverts with ZeroUnlockDelay when `unlockDelay` is zero.
+    /// @dev Lock state changes ONLY through this signed EVM entry point. Authorization comes entirely from the
+    ///      signature, so anyone may relay the call; the digest is authenticated against the account's actors and
+    ///      the resolved actor must be unrestricted (scope 0, admin) — there is no elevated scope for changing the
+    ///      lock. Lock changes are local-channel only: the digest binds `block.chainid` and a monotonic per-account
+    ///      `localSequence` consumed on each call (mirroring applySignedActorChanges so both signed entry points
+    ///      stay coherent on the same counter).
+    /// @dev op = LOCK_OP (1): only from the unlocked state (reverts AccountIsLocked if currently locked). Stores
+    ///      `unlockDelay` and sets the hard-locked state (unlocksAt == type(uint40).max). Emits AccountLocked.
+    /// @dev op = UNLOCK_OP (2): only from the hard-locked state with no pending unlock (reverts NotLocked
+    ///      otherwise); `unlockDelay` MUST be 0. Sets unlocksAt = block.timestamp + storedDelay, zeroes the stored
+    ///      delay. Emits AccountUnlockInitiated.
+    /// @dev Reverts with InvalidAuthLength, InvalidSignature, AuthenticationFailed, AuthenticatorMismatch,
+    ///      ActorExpired, or DefaultEoaRevoked when `auth` fails to authenticate a live actor.
+    /// @dev Reverts with UnauthorizedLockChange when the authenticated actor is not unrestricted (scope != 0).
+    /// @dev Reverts with ZeroUnlockDelay when a lock op carries a zero unlock delay.
+    /// @dev Reverts with AccountIsLocked when a lock op targets an already-locked account.
+    /// @dev Reverts with InvalidUnlockDelay when an unlock op carries a non-zero unlock delay.
+    /// @dev Reverts with NotLocked when an unlock op targets an account that is not hard-locked.
+    /// @dev Reverts with UnknownLockOp when `op` is neither LOCK_OP nor UNLOCK_OP.
     ///
-    /// @param unlockDelay Delay in seconds, after initiateUnlock, before the account unlocks (max uint16, ~18 hours).
-    function lock(uint16 unlockDelay) external onlyUnlocked(msg.sender) {
-        // Require non-zero unlock delay
-        if (unlockDelay == 0) revert ZeroUnlockDelay();
+    /// @param account The account whose lock state is changed.
+    /// @param op The lock operation: LOCK_OP (1) to hard-lock, UNLOCK_OP (2) to initiate an unlock.
+    /// @param unlockDelay Delay in seconds before the account unlocks after an unlock is initiated (lock op only,
+    ///        max uint16, ~18 hours); MUST be 0 for the unlock op.
+    /// @param auth Authenticator(20) || authenticator-specific data authenticating an unrestricted actor.
+    function applySignedLockChanges(address account, uint8 op, uint16 unlockDelay, bytes calldata auth) external {
+        // Local channel only: bind the digest to the current chain and consume the local sequence (post-increment,
+        // hashing the pre-increment value — identical to applySignedActorChanges so both paths share one counter).
+        uint64 sequence = _accountState[account].localSequence++;
 
-        AccountState storage config = _accountState[msg.sender];
+        bytes32 digest = _computeSignedLockChangesDigest(account, block.chainid, op, unlockDelay, sequence);
+        (uint8 scope,) = authenticateActor(account, digest, auth);
 
-        config.unlocksAt = type(uint40).max;
-        config.unlockDelay = unlockDelay;
-        emit AccountLocked(msg.sender, unlockDelay);
-    }
+        // Only an unrestricted actor (scope 0) may change the lock; there is no elevated "admin" scope bit.
+        if (scope != 0) revert UnauthorizedLockChange();
 
-    /// @notice Initiates unlocking the caller's account; it becomes unlocked once the configured delay elapses.
-    ///
-    /// @dev Reverts with NotLocked when the account is not in the locked state.
-    function initiateUnlock() external {
-        AccountState storage config = _accountState[msg.sender];
+        AccountState storage config = _accountState[account];
 
-        // Require account is locked and unlock has not been initiated
-        if (config.unlocksAt != type(uint40).max) revert NotLocked();
+        if (op == LOCK_OP) {
+            // Lock only from the unlocked state; clear any stale (expired) unlock timestamp first.
+            if (_checkAndClearLock(account)) revert AccountIsLocked();
+            // Require non-zero unlock delay.
+            if (unlockDelay == 0) revert ZeroUnlockDelay();
 
-        config.unlocksAt = uint40(block.timestamp + config.unlockDelay);
-        config.unlockDelay = 0;
-        emit AccountUnlockInitiated(msg.sender, config.unlocksAt);
+            config.unlocksAt = type(uint40).max;
+            config.unlockDelay = unlockDelay;
+            emit AccountLocked(account, unlockDelay);
+        } else if (op == UNLOCK_OP) {
+            // The unlock op never sets the delay; it consumes the delay stored by the lock op.
+            if (unlockDelay != 0) revert InvalidUnlockDelay();
+            // Require the account is hard-locked and an unlock has not already been initiated.
+            if (config.unlocksAt != type(uint40).max) revert NotLocked();
+
+            config.unlocksAt = uint40(block.timestamp + config.unlockDelay);
+            config.unlockDelay = 0;
+            emit AccountUnlockInitiated(account, config.unlocksAt);
+        } else {
+            revert UnknownLockOp();
+        }
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -996,6 +1055,19 @@ contract AccountConfiguration {
                 keccak256(abi.encodePacked(actorChangeHashes))
             )
         );
+    }
+
+    /// @dev Computes the digest signed over an applySignedLockChanges call, binding the lock op and its unlock delay
+    ///      to `account`, `chainId`, and `sequence` via LOCK_CHANGE_TYPEHASH. Lock changes are local-channel only,
+    ///      so callers always pass the current chainId.
+    function _computeSignedLockChangesDigest(
+        address account,
+        uint256 chainId,
+        uint8 op,
+        uint16 unlockDelay,
+        uint64 sequence
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encode(LOCK_CHANGE_TYPEHASH, account, chainId, op, unlockDelay, sequence));
     }
 
     // ----------------------------------------------------------------------------------------------------------------

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -54,8 +54,15 @@ contract AccountConfiguration {
 
     /// @notice Per-account packed state: sequences, lock status, and the inline home for the account's k1 self key.
     ///
-    /// @dev Packed into a single storage slot (exactly 32 bytes).
+    /// @dev Packed into a single storage slot; the field layout is normative (nodes read the raw slot for mempool
+    ///      rate-limit tiering, see the EIP's Account Lock section). Field order and widths match the spec's
+    ///      account-state table: multichainSequence, localSequence, flags, lockUnion, defaultEOAScope,
+    ///      defaultEOAExpiry, then 3 reserved bytes that MUST stay zero.
     ///      localSequence > 0 doubles as the account initialized flag.
+    ///      `flags` is a bitfield: bit 0 (FLAG_REVOKE_DEFAULT_EOA) disables the k1 self key; bit 1 (FLAG_LOCKED)
+    ///      freezes actor configuration; bit 2 (FLAG_UNLOCK_INITIATED) selects how `lockUnion` is interpreted.
+    ///      `lockUnion` is a union field: while FLAG_UNLOCK_INITIATED is clear it holds the configured unlock delay
+    ///      (seconds, uint16 range); while set it holds unlocksAt (the timestamp at which the unlock takes effect).
     ///      The defaultEOA* fields are the inline home for the account's own secp256k1 ("self") key — the actor whose
     ///      actorId is bytes32(bytes20(account)). When FLAG_REVOKE_DEFAULT_EOA is unset, a k1 signature recovering to
     ///      the account authenticates with this inline config (all-zero = full owner; non-zero scope/expiry = a
@@ -66,11 +73,11 @@ contract AccountConfiguration {
     struct AccountState {
         uint64 multichainSequence; // 8 bytes
         uint64 localSequence; // 8 bytes – also serves as initialized flag
-        uint40 unlocksAt; // 5 bytes
-        uint16 unlockDelay; // 2 bytes
-        uint8 flags; // 1 byte – bitfield; bit 0 = default EOA revoked (see FLAG_REVOKE_DEFAULT_EOA)
+        uint8 flags; // 1 byte – bitfield: bit 0 REVOKE_DEFAULT_EOA, bit 1 LOCKED, bit 2 UNLOCK_INITIATED
+        uint40 lockUnion; // 5 bytes – union: unlockDelay while UNLOCK_INITIATED clear, else unlocksAt (timestamp)
         uint8 defaultEOAScope; // 1 byte – inline self k1 scope (0 = full owner)
         uint48 defaultEOAExpiry; // 6 bytes – inline self k1 expiry (Unix seconds; 0 = no expiry)
+        // 3 bytes reserved (remaining slot bytes); MUST stay zero.
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -191,6 +198,17 @@ contract AccountConfiguration {
     ///         clears it (re-enabling the inline self, possibly scoped).
     uint8 public constant FLAG_REVOKE_DEFAULT_EOA = 0x01;
 
+    /// @notice AccountState.flags bit (spec `LOCKED`): when set, actor configuration is frozen — all config changes
+    ///         and delegation are rejected on both the account-changes and applySignedActorChanges paths. The only
+    ///         permitted operation while locked is initiating an unlock. Cleared lazily once an initiated unlock
+    ///         elapses (see applySignedLockChanges).
+    uint8 public constant FLAG_LOCKED = 0x02;
+
+    /// @notice AccountState.flags bit (spec `UNLOCK_INITIATED`): selects how the packed `lockUnion` field is read.
+    ///         While clear, `lockUnion` holds the configured unlock delay (seconds); while set, it holds unlocksAt
+    ///         (the timestamp at which the pending unlock takes effect). Only meaningful when FLAG_LOCKED is set.
+    uint8 public constant FLAG_UNLOCK_INITIATED = 0x04;
+
     /// @dev secp256k1 half-order (n/2). Per EIP-2, only the lower-half `s` value is accepted to reject signature
     ///      malleability. Equal to (secp256k1n - 1) / 2.
     uint256 internal constant SECP256K1_HALF_ORDER = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0;
@@ -273,8 +291,8 @@ contract AccountConfiguration {
     /// @notice A lock op (op = 1) carried a zero unlock delay.
     error ZeroUnlockDelay();
 
-    /// @notice An unlock op (op = 2) was requested when the account was not in the hard-locked (unlocksAt == max)
-    ///         state (never locked, or an unlock was already initiated).
+    /// @notice An unlock op (op = 2) was requested when the account was not in the hard-locked state (FLAG_LOCKED set,
+    ///         FLAG_UNLOCK_INITIATED clear) — i.e. never locked, or an unlock was already initiated.
     error NotLocked();
 
     /// @notice applySignedLockChanges carried an unrecognized op (neither LOCK_OP nor UNLOCK_OP).
@@ -540,11 +558,11 @@ contract AccountConfiguration {
     ///      stay coherent on the same counter). Because both entry points share this counter, a pre-signed local
     ///      actor change and a lock op contend for the same sequence: whichever is relayed first consumes it and
     ///      invalidates the other until it is re-signed at the next sequence.
-    /// @dev op = LOCK_OP (1): only from the unlocked state (reverts AccountIsLocked if currently locked). Stores
-    ///      `unlockDelay` and sets the hard-locked state (unlocksAt == type(uint40).max). Emits AccountLocked.
+    /// @dev op = LOCK_OP (1): only from the unlocked state (reverts AccountIsLocked if currently locked). Sets
+    ///      FLAG_LOCKED and stores `unlockDelay` in `lockUnion`. Emits AccountLocked.
     /// @dev op = UNLOCK_OP (2): only from the hard-locked state with no pending unlock (reverts NotLocked
-    ///      otherwise); `unlockDelay` MUST be 0. Sets unlocksAt = block.timestamp + storedDelay, zeroes the stored
-    ///      delay. Emits AccountUnlockInitiated.
+    ///      otherwise); `unlockDelay` MUST be 0. Sets FLAG_UNLOCK_INITIATED and overwrites `lockUnion` with
+    ///      unlocksAt = block.timestamp + storedDelay. Emits AccountUnlockInitiated.
     /// @dev Reverts with InvalidAuthLength, InvalidSignature, AuthenticationFailed, AuthenticatorMismatch,
     ///      ActorExpired, or DefaultEoaRevoked when `auth` fails to authenticate a live actor.
     /// @dev Reverts with UnauthorizedLockChange when the authenticated actor is not unrestricted (scope != 0).
@@ -573,23 +591,27 @@ contract AccountConfiguration {
         AccountState storage config = _accountState[account];
 
         if (op == LOCK_OP) {
-            // Lock only from the unlocked state; clear any stale (expired) unlock timestamp first.
+            // Lock only from the unlocked state; lazily clear any elapsed unlock (also clears LOCKED) first.
             if (_checkAndClearLock(account)) revert AccountIsLocked();
             // Require non-zero unlock delay.
             if (unlockDelay == 0) revert ZeroUnlockDelay();
 
-            config.unlocksAt = type(uint40).max;
-            config.unlockDelay = unlockDelay;
+            // Post-clear the lock bits are clear, so set FLAG_LOCKED and stash the delay in the union.
+            config.flags |= FLAG_LOCKED;
+            config.lockUnion = unlockDelay;
             emit AccountLocked(account, unlockDelay);
         } else if (op == UNLOCK_OP) {
             // The unlock op never sets the delay; it consumes the delay stored by the lock op.
             if (unlockDelay != 0) revert InvalidUnlockDelay();
-            // Require the account is hard-locked and an unlock has not already been initiated.
-            if (config.unlocksAt != type(uint40).max) revert NotLocked();
+            // Require the account is hard-locked (LOCKED set) with no unlock already initiated (UNLOCK_INITIATED clear).
+            uint8 flags = config.flags;
+            if (flags & FLAG_LOCKED == 0 || flags & FLAG_UNLOCK_INITIATED != 0) revert NotLocked();
 
-            config.unlocksAt = uint40(block.timestamp + config.unlockDelay);
-            config.unlockDelay = 0;
-            emit AccountUnlockInitiated(account, config.unlocksAt);
+            // Reinterpret the union: it held the stored delay, now it holds the effective unlock timestamp.
+            uint40 unlocksAt = uint40(block.timestamp + uint16(config.lockUnion));
+            config.flags = flags | FLAG_UNLOCK_INITIATED;
+            config.lockUnion = unlocksAt;
+            emit AccountUnlockInitiated(account, unlocksAt);
         } else {
             revert UnknownLockOp();
         }
@@ -780,7 +802,7 @@ contract AccountConfiguration {
     ///
     /// @return True if the account is locked at the current block timestamp.
     function isLocked(address account) external view returns (bool) {
-        return block.timestamp < _accountState[account].unlocksAt;
+        return _isLocked(_accountState[account]);
     }
 
     /// @notice Returns the account's full lock status.
@@ -797,26 +819,46 @@ contract AccountConfiguration {
         returns (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 unlockDelay)
     {
         AccountState storage config = _accountState[account];
-        return (
-            block.timestamp < config.unlocksAt, // locked if current time is before unlocksAt
-            config.unlocksAt != 0 && config.unlocksAt != type(uint40).max, // hasInitiatedUnlock if unlocksAt non-zero and not max
-            config.unlocksAt,
-            config.unlockDelay
-        );
+        uint8 flags = config.flags;
+        if (flags & FLAG_LOCKED == 0) {
+            // Unlocked: no lock bits set.
+            return (false, false, 0, 0);
+        }
+        if (flags & FLAG_UNLOCK_INITIATED == 0) {
+            // Hard-locked: lockUnion holds the configured delay; synthesize the max sentinel for unlocksAt.
+            return (true, false, type(uint40).max, uint16(config.lockUnion));
+        }
+        // Unlock initiated: lockUnion holds the effective unlock timestamp; the delay has been consumed.
+        uint40 unlocksAt = config.lockUnion;
+        return (block.timestamp < unlocksAt, true, unlocksAt, 0);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // INTERNAL FUNCTIONS
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice Returns true if the account is locked; clears the stored unlock timestamp once it has expired.
-    function _checkAndClearLock(address account) internal returns (bool locked) {
-        // Early return if account is locked
-        uint40 unlocksAt = _accountState[account].unlocksAt;
-        if (block.timestamp < unlocksAt) return true;
+    /// @notice Returns whether the account's configuration is currently frozen, WITHOUT mutating storage.
+    function _isLocked(AccountState storage st) private view returns (bool) {
+        uint8 flags = st.flags;
+        if (flags & FLAG_LOCKED == 0) return false; // not locked
+        if (flags & FLAG_UNLOCK_INITIATED == 0) return true; // hard-locked
+        return block.timestamp < st.lockUnion; // pending unlock: frozen until the timestamp elapses
+    }
 
-        // Account is unlocked, clear storage if non-zero
-        if (unlocksAt != 0) _accountState[account].unlocksAt = 0;
+    /// @notice Returns true if the account is locked; lazily clears the lock flags/union once an initiated unlock has
+    ///         elapsed (the "cleared by the next op" rule).
+    function _checkAndClearLock(address account) internal returns (bool locked) {
+        AccountState storage st = _accountState[account];
+        uint8 flags = st.flags;
+        if (flags & FLAG_LOCKED == 0) return false; // already unlocked
+        if (flags & FLAG_UNLOCK_INITIATED == 0) return true; // hard-locked, no pending unlock
+
+        // An unlock has been initiated: still frozen until the stored timestamp elapses.
+        if (block.timestamp < st.lockUnion) return true;
+
+        // Elapsed: clear the lock bits and the union so the account returns to the unlocked state.
+        st.flags = flags & ~(FLAG_LOCKED | FLAG_UNLOCK_INITIATED);
+        st.lockUnion = 0;
         return false;
     }
 

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -535,7 +535,9 @@ contract AccountConfiguration {
     ///      the resolved actor must be unrestricted (scope 0, admin) — there is no elevated scope for changing the
     ///      lock. Lock changes are local-channel only: the digest binds `block.chainid` and a monotonic per-account
     ///      `localSequence` consumed on each call (mirroring applySignedActorChanges so both signed entry points
-    ///      stay coherent on the same counter).
+    ///      stay coherent on the same counter). Because both entry points share this counter, a pre-signed local
+    ///      actor change and a lock op contend for the same sequence: whichever is relayed first consumes it and
+    ///      invalidates the other until it is re-signed at the next sequence.
     /// @dev op = LOCK_OP (1): only from the unlocked state (reverts AccountIsLocked if currently locked). Stores
     ///      `unlockDelay` and sets the hard-locked state (unlocksAt == type(uint40).max). Emits AccountLocked.
     /// @dev op = UNLOCK_OP (2): only from the hard-locked state with no pending unlock (reverts NotLocked
@@ -1097,7 +1099,9 @@ contract AccountConfiguration {
         if (config.authenticator != authenticator) revert AuthenticatorMismatch();
         // Expiry is read from the same slot; an expired actor fails authentication. 0 = no expiry.
         if (config.expiry != 0 && block.timestamp > config.expiry) revert ActorExpired();
-        return (config.scope, _policyManager[actorId][account]);
+        // Read the policy-manager slot only for a policy-gated actor; non-policy actors (incl. admin) skip the SLOAD.
+        address policyTarget = (config.scope & SCOPE_POLICY != 0) ? _policyManager[actorId][account] : address(0);
+        return (config.scope, policyTarget);
     }
 
     /// @dev The single secp256k1 ("K1") path. Recovers the signer (EIP-2 enforced), then resolves the actor:
@@ -1106,7 +1110,8 @@ contract AccountConfiguration {
     ///          owner; non-zero = a scoped self). A non-k1 self is unreachable here by construction (it requires
     ///          its own authenticator), and mutual exclusion keeps the flag set whenever one is live.
     ///        - otherwise the signer's actorId must carry an explicit K1 config in _actorConfig (any other k1 actor).
-    ///      Both the common self and other-actor paths cost a single SLOAD plus the policy-manager read.
+    ///      Both the common self and other-actor paths cost a single SLOAD; the policy-manager slot is read only for a
+    ///      policy-gated actor (`scope & SCOPE_POLICY != 0`), so non-policy authentications avoid the extra SLOAD.
     function _authenticateK1(address account, bytes32 hash, bytes calldata data)
         internal
         view
@@ -1122,7 +1127,10 @@ contract AccountConfiguration {
             if (st.flags & FLAG_REVOKE_DEFAULT_EOA != 0) revert DefaultEoaRevoked();
             if (st.defaultEOAExpiry != 0 && block.timestamp > st.defaultEOAExpiry) revert ActorExpired();
             bytes32 selfActorId = bytes32(bytes20(account));
-            return (st.defaultEOAScope, _policyManager[selfActorId][account]);
+            uint8 selfScope = st.defaultEOAScope;
+            // Skip the policy-manager SLOAD unless this self key is policy-gated (the common admin self never is).
+            address policyTarget = (selfScope & SCOPE_POLICY != 0) ? _policyManager[selfActorId][account] : address(0);
+            return (selfScope, policyTarget);
         }
 
         bytes32 actorId = bytes32(bytes20(recovered));
@@ -1130,7 +1138,9 @@ contract AccountConfiguration {
         if (config.authenticator != K1_AUTHENTICATOR) revert AuthenticatorMismatch();
         // Expiry is read from the same slot; an expired actor fails authentication. 0 = no expiry.
         if (config.expiry != 0 && block.timestamp > config.expiry) revert ActorExpired();
-        return (config.scope, _policyManager[actorId][account]);
+        // Read the policy-manager slot only for a policy-gated actor; non-policy actors skip the SLOAD.
+        address policyTarget = (config.scope & SCOPE_POLICY != 0) ? _policyManager[actorId][account] : address(0);
+        return (config.scope, policyTarget);
     }
 
     /// @dev True if the account's default (implicit) EOA has been revoked via the AccountState flag.

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -130,7 +130,7 @@ contract AccountConfiguration {
 
     /// @notice Actor is gated to a policy: every call it makes must land on the resolved manager (this contract
     ///         stores manager + commitment; the protocol enforces that the actor's calls only ever reach that
-    ///         target). This contract does not reject scope combinations (e.g. SCOPE_POLICY | SCOPE_PAYER) — any
+    ///         target). This contract does not reject scope combinations (e.g. SCOPE_POLICY | SCOPE_SELF_PAYER) — any
     ///         use-time exclusivity between SCOPE_POLICY and the account's other capabilities is protocol-side, not
     ///         enforced here.
     uint8 public constant SCOPE_POLICY = 0x02;
@@ -140,11 +140,13 @@ contract AccountConfiguration {
     ///         entirely protocol-side.
     uint8 public constant SCOPE_NONCE = 0x04;
 
-    /// @notice Actor can pay for transactions with account as payer
-    uint8 public constant SCOPE_PAYER = 0x08;
+    /// @notice Actor can self-pay gas for the account's own operations (payer == sender).
+    uint8 public constant SCOPE_SELF_PAYER = 0x08;
 
-    /// @notice Actor can sign arbitrary messages with account
-    uint8 public constant SCOPE_SIGNER = 0x10;
+    /// @notice Actor can sponsor gas on behalf of a different sender (payer != sender).
+    uint8 public constant SCOPE_SPONSOR_PAYER = 0x10;
+
+    // Note: ERC-1271 signing is admin-only (scope == 0x00), not a grant — there is no SIGNER scope bit.
 
     // 0x20, 0x40, 0x80 are spare (unused).
 
@@ -536,23 +538,23 @@ contract AccountConfiguration {
     /// @notice Validates an account signature in `authenticator(20) || data` format; never reverts.
     ///
     /// @dev ERC-1271-style boolean check: returns false on any failure (invalid signature, unknown/revoked actor,
-    ///      actorId not bound to the presented authenticator, or an actor lacking SIGNER scope). authenticateActor
+    ///      actorId not bound to the presented authenticator, or a non-admin scoped actor). authenticateActor
     ///      reverts on failure, so it is called externally and the revert is caught.
     ///
     /// @param account The account the signature is validated against.
     /// @param hash The digest that was signed.
     /// @param signature Authenticator(20) || authenticator-specific data.
     ///
-    /// @return verified True if the signature is valid and the resolved actor may sign messages.
+    /// @return verified True if the signature is valid and the resolved actor is the admin.
     function verifySignature(address account, bytes32 hash, bytes calldata signature)
         external
         view
         returns (bool verified)
     {
         try this.authenticateActor(account, hash, signature) returns (uint8 scope, address) {
-            // Unrestricted (scope 0) always verifies. Otherwise the actor must hold SCOPE_SIGNER and must NOT be
-            // policy-bearing: a policy-gated actor is never a valid ERC-1271 signer, even if SIGNER is also set.
-            return scope == 0 || ((scope & SCOPE_SIGNER != 0) && (scope & SCOPE_POLICY == 0));
+            // ERC-1271 signing is authorized only for the admin actor (scope == 0x00); there is no SIGNER grant.
+            // Scoped signing is expressed at the account layer via a POLICY key's approved-hash pattern, not here.
+            return scope == 0;
         } catch {
             return false;
         }
@@ -792,7 +794,7 @@ contract AccountConfiguration {
         if (config.authenticator < K1_AUTHENTICATOR) revert InvalidAuthenticator();
 
         // Slice the signed policy by scope & SCOPE_POLICY. The commitment is opaque to the protocol. This contract
-        // does not reject scope combinations (e.g. SCOPE_POLICY | SCOPE_PAYER) — any use-time exclusivity between
+        // does not reject scope combinations (e.g. SCOPE_POLICY | SCOPE_SELF_PAYER) — any use-time exclusivity between
         // SCOPE_POLICY and the account's other capabilities is protocol-side, not enforced here.
         (address manager, bytes32 commitment) = _slicePolicy(config.scope, policyData);
 

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -76,8 +76,8 @@ contract DefaultAccount is Receiver {
     //  ERC-1271
     // ══════════════════════════════════════════════
 
-    /// @notice Validates an ERC-1271 signature via AccountConfiguration; requires the verified actor to be the
-    ///         unrestricted admin (scope == 0x00) — ERC-1271 signing is admin-only. Never reverts.
+    /// @notice Validates an ERC-1271 signature via AccountConfiguration; requires the verified actor to be
+    ///         operational (the unrestricted admin, scope == 0x00, or a SENDER actor without POLICY). Never reverts.
     ///
     /// @param hash The digest to authenticate.
     /// @param signature Auth data in `authenticator || data` format.

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -76,8 +76,8 @@ contract DefaultAccount is Receiver {
     //  ERC-1271
     // ══════════════════════════════════════════════
 
-    /// @notice Validates an ERC-1271 signature via AccountConfiguration; requires the verified actor to hold
-    ///         SIGNER scope or be an unrestricted owner. Never reverts.
+    /// @notice Validates an ERC-1271 signature via AccountConfiguration; requires the verified actor to be the
+    ///         unrestricted admin (scope == 0x00) — ERC-1271 signing is admin-only. Never reverts.
     ///
     /// @param hash The digest to authenticate.
     /// @param signature Auth data in `authenticator || data` format.

--- a/src/accounts/UpgradeableAccount.sol
+++ b/src/accounts/UpgradeableAccount.sol
@@ -13,19 +13,14 @@ import {DefaultAccount} from "./DefaultAccount.sol";
 ///         Deploy behind an UpgradeableProxy instead of ERC-1167.
 ///         7702 accounts don't need this — they can re-delegate anytime.
 ///
-///         Upgrades are authorized via upgradeBySignature — a CONFIG-key-signed, relayable upgrade with
+///         Upgrades are authorized via upgradeBySignature — an unrestricted-owner-signed, relayable upgrade with
 ///         compare-and-swap replay protection that is safe to broadcast across every chain the account lives on.
 ///         See {_authorizeUpgrade} for how the signature requirement is enforced on the actual implementation
 ///         change.
 contract UpgradeableAccount is DefaultAccount, UUPSUpgradeable {
-    /// @dev AccountConfiguration scope granting authority to change account configuration ("CONFIG"). An account
-    ///      gates upgrades on this scope so the same key that manages the account's actors can also manage its
-    ///      implementation.
-    uint8 internal constant SCOPE_CONFIG = 0x08;
-
     /// @dev One-shot flag set by {upgradeBySignature} immediately before its internal self-call to
-    ///      `upgradeToAndCall`, and consumed by {_authorizeUpgrade} to confirm a CONFIG-scoped signature has
-    ///      already authorized this specific upgrade.
+    ///      `upgradeToAndCall`, and consumed by {_authorizeUpgrade} to confirm an unrestricted-owner (scope 0)
+    ///      signature has already authorized this specific upgrade.
     bool private _upgradeAuthorized;
 
     /// @dev Typehash binding a signed upgrade to (account, from, to, dataHash). chainId is intentionally omitted:
@@ -37,13 +32,13 @@ contract UpgradeableAccount is DefaultAccount, UUPSUpgradeable {
 
     /// @dev The current implementation does not match the signed `fromImplementation` (compare-and-swap failed).
     error UpgradeFromMismatch();
-    /// @dev The authenticated actor may not authorize upgrades (not an unrestricted owner and lacks CONFIG scope).
+    /// @dev The authenticated actor may not authorize upgrades (not an unrestricted owner).
     error UpgradeUnauthorized();
 
     constructor(address accountConfiguration) DefaultAccount(accountConfiguration) {}
 
-    /// @dev {upgradeBySignature} is the only place that sets {_upgradeAuthorized}, so satisfying this confirms a
-    ///      CONFIG-scoped signature has already authorized the implementation change being applied.
+    /// @dev {upgradeBySignature} is the only place that sets {_upgradeAuthorized}, so satisfying this confirms an
+    ///      unrestricted-owner signature has already authorized the implementation change being applied.
     function _authorizeUpgrade(address) internal override {
         require(_upgradeAuthorized);
         _upgradeAuthorized = false;
@@ -80,9 +75,9 @@ contract UpgradeableAccount is DefaultAccount, UUPSUpgradeable {
             abi.encode(SIGNED_UPGRADE_TYPEHASH, address(this), fromImplementation, toImplementation, keccak256(data))
         );
 
-        // A CONFIG key authorizes the upgrade: an unrestricted owner (scope 0) or an actor with SCOPE_CONFIG.
-        (uint8 scope,,) = ACCOUNT_CONFIGURATION.authenticateActor(address(this), digest, auth);
-        if (scope != 0 && scope & SCOPE_CONFIG == 0) revert UpgradeUnauthorized();
+        // Only an unrestricted owner (scope 0) may authorize an upgrade; there is no elevated "admin" scope bit.
+        (uint8 scope,) = ACCOUNT_CONFIGURATION.authenticateActor(address(this), digest, auth);
+        if (scope != 0) revert UpgradeUnauthorized();
 
         // Reuse Solady's tested upgrade path (proxiableUUID check, Upgraded event, optional init delegatecall).
         // The flag set above is what satisfies _authorizeUpgrade for this call.

--- a/src/accounts/example/BackwardsCompatible4337Account.sol
+++ b/src/accounts/example/BackwardsCompatible4337Account.sol
@@ -133,10 +133,10 @@ contract BackwardsCompatible4337Account is DefaultAccount {
     /// @return valid True if `auth` is a valid signature from a live actor of this account.
     /// @return scope The verified actor's scope (0x00 = unrestricted owner).
     function _authenticate(bytes32 hash, bytes memory auth) internal view returns (bool valid, uint8 scope) {
-        // nonceLane and policyTarget are protocol-side / policy-manager concerns this reduced 4337 bridge does not
-        // replicate: a SCOPE_POLICY actor is rejected below by the SCOPE_SENDER check (see {_authorize}), since this
-        // repo does not implement protocol-side lane/exclusivity checks.
-        try ACCOUNT_CONFIGURATION.authenticateActor(address(this), hash, auth) returns (uint8 s, uint16, address) {
+        // policyTarget is a protocol-side / policy-manager concern this reduced 4337 bridge does not replicate:
+        // a SCOPE_POLICY actor is rejected below by the SCOPE_SENDER check (see {_authorize}), since this repo
+        // does not implement protocol-side lane/exclusivity checks.
+        try ACCOUNT_CONFIGURATION.authenticateActor(address(this), hash, auth) returns (uint8 s, address) {
             return (true, s);
         } catch {
             return (false, 0);

--- a/src/accounts/example/BackwardsCompatible4337Account.sol
+++ b/src/accounts/example/BackwardsCompatible4337Account.sol
@@ -54,7 +54,7 @@ contract BackwardsCompatible4337Account is DefaultAccount {
 
     /// @dev Elevated-scope bitflags, mirroring AccountConfiguration. A scope of 0x00 is an unrestricted owner.
     uint8 internal constant SCOPE_SENDER = 0x01; // may initiate transactions (authorize the op's calls)
-    uint8 internal constant SCOPE_PAYER = 0x08; // may spend account funds paying for the op
+    uint8 internal constant SCOPE_SELF_PAYER = 0x08; // may self-pay gas for the account's own op (payer == sender)
 
     constructor(address accountConfiguration) DefaultAccount(accountConfiguration) {}
 
@@ -94,7 +94,7 @@ contract BackwardsCompatible4337Account is DefaultAccount {
     ///
     ///      Op authentication (both paths) enforces the verified actor's elevated scope:
     ///        - the actor must be unrestricted (scope 0x00) or hold {SCOPE_SENDER} to authorize the calls;
-    ///        - a self-funded op (`missingAccountFunds != 0`) additionally requires {SCOPE_PAYER}.
+    ///        - a self-funded op (`missingAccountFunds != 0`) additionally requires {SCOPE_SELF_PAYER}.
     ///      This reduced 4337 bridge does not replicate the native-dispatch policy-target gate: a SCOPE_POLICY
     ///      actor without SCOPE_SENDER is rejected here by construction (see {_authorize}), and this repo does not
     ///      implement protocol-side lane/exclusivity checks for actors that combine SCOPE_POLICY with SCOPE_SENDER.
@@ -151,7 +151,7 @@ contract BackwardsCompatible4337Account is DefaultAccount {
     ///         independently reviewable and overridable.
     /// @dev Enforces:
     ///        - scope 0x00 is an unrestricted owner; any other actor must hold {SCOPE_SENDER} to authorize the calls;
-    ///        - a self-funded op (`missingAccountFunds != 0`) additionally requires {SCOPE_PAYER}.
+    ///        - a self-funded op (`missingAccountFunds != 0`) additionally requires {SCOPE_SELF_PAYER}.
     ///      A SCOPE_POLICY actor without SCOPE_SENDER fails the check below by construction — this reduced 4337
     ///      bridge does not give policy-gated actors special call-target enforcement (that is native-dispatch,
     ///      protocol-side behavior out of scope for this repo). An actor combining SCOPE_POLICY | SCOPE_SENDER is
@@ -162,7 +162,7 @@ contract BackwardsCompatible4337Account is DefaultAccount {
         // scope 0x00 = unrestricted owner; otherwise the actor must explicitly hold the required scopes.
         if (scope != 0) {
             if (scope & SCOPE_SENDER == 0) return false;
-            if (missingAccountFunds != 0 && scope & SCOPE_PAYER == 0) return false;
+            if (missingAccountFunds != 0 && scope & SCOPE_SELF_PAYER == 0) return false;
         }
         return true;
     }

--- a/src/accounts/example/BackwardsCompatible4337Account.sol
+++ b/src/accounts/example/BackwardsCompatible4337Account.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {AccountConfiguration} from "../../AccountConfiguration.sol";
-import {Call, DefaultAccount} from "../DefaultAccount.sol";
+import {DefaultAccount} from "../DefaultAccount.sol";
 
 struct PackedUserOperation {
     address sender;
@@ -82,18 +82,19 @@ contract BackwardsCompatible4337Account is DefaultAccount {
     }
 
     /// @notice Validates `userOp` by authenticating it as a plain authenticator blob over `userOpHash` and
-    ///         enforcing the verified actor's elevated scope and policy. A signature carrying signed actor/owner
-    ///         changes additionally applies them during validation before the op itself is authenticated.
+    ///         enforcing the verified actor's elevated scope. A signature carrying signed actor/owner changes
+    ///         additionally applies them during validation before the op itself is authenticated.
     /// @dev Signed-actor-changes path: each set is applied via `applySignedActorChanges` (empty batch rejected).
     ///      Every slot it writes is keyed by `account`, so under ERC-7562 it's the account's own associated
     ///      storage — allowed by STO-021 for an existing account; only a combined create+change op falls under
     ///      STO-022, requiring the AccountConfiguration factory to be staked.
     ///
-    ///      Op authentication (both paths) enforces the verified actor's elevated scope and policy:
+    ///      Op authentication (both paths) enforces the verified actor's elevated scope:
     ///        - the actor must be unrestricted (scope 0x00) or hold {SCOPE_SENDER} to authorize the calls;
-    ///        - a self-funded op (`missingAccountFunds != 0`) additionally requires {SCOPE_PAYER};
-    ///        - a policy-gated actor (non-zero `policyType`) may only drive calls to its policy target, so
-    ///          `userOp.callData` must be an `executeBatch` whose every call targets that address.
+    ///        - a self-funded op (`missingAccountFunds != 0`) additionally requires {SCOPE_PAYER}.
+    ///      This reduced 4337 bridge does not replicate the native-dispatch policy-target gate: a SCOPE_POLICY
+    ///      actor without SCOPE_SENDER is rejected here by construction (see {_authorize}), and this repo does not
+    ///      implement protocol-side lane/exclusivity checks for actors that combine SCOPE_POLICY with SCOPE_SENDER.
     function _validateSignature(PackedUserOperation calldata userOp, bytes32 userOpHash, uint256 missingAccountFunds)
         internal
         returns (bool)
@@ -120,70 +121,45 @@ contract BackwardsCompatible4337Account is DefaultAccount {
         }
 
         // Applying changes never authorizes the op; `opAuth` must still sign for this `userOpHash`.
-        (bool valid, uint8 scope, address policyTarget) = _authenticate(userOpHash, opAuth);
+        (bool valid, uint8 scope) = _authenticate(userOpHash, opAuth);
         if (!valid) return false;
 
         // Authentication only proves WHO signed; authorization decides whether that actor may drive THIS op.
-        return _authorize(scope, policyTarget, userOp.callData, missingAccountFunds);
+        return _authorize(scope, missingAccountFunds);
     }
 
-    /// @notice Authenticates `auth` over `hash` via AccountConfiguration, resolving the signing actor's authorization
-    ///         surface. This answers only "who signed", never "may they do this" — see {_authorize}.
+    /// @notice Authenticates `auth` over `hash` via AccountConfiguration, resolving the signing actor's scope.
+    ///         This answers only "who signed", never "may they do this" — see {_authorize}.
     /// @return valid True if `auth` is a valid signature from a live actor of this account.
     /// @return scope The verified actor's scope (0x00 = unrestricted owner).
-    /// @return policyTarget The verified actor's policy gate target, or address(0) if ungated.
-    function _authenticate(bytes32 hash, bytes memory auth)
-        internal
-        view
-        returns (bool valid, uint8 scope, address policyTarget)
-    {
-        // policyType is reserved for future manager-defined semantics; the account gates on scope + target today.
-        try ACCOUNT_CONFIGURATION.authenticateActor(address(this), hash, auth) returns (uint8 s, uint8, address p) {
-            return (true, s, p);
+    function _authenticate(bytes32 hash, bytes memory auth) internal view returns (bool valid, uint8 scope) {
+        // nonceLane and policyTarget are protocol-side / policy-manager concerns this reduced 4337 bridge does not
+        // replicate: a SCOPE_POLICY actor is rejected below by the SCOPE_SENDER check (see {_authorize}), since this
+        // repo does not implement protocol-side lane/exclusivity checks.
+        try ACCOUNT_CONFIGURATION.authenticateActor(address(this), hash, auth) returns (uint8 s, uint16, address) {
+            return (true, s);
         } catch {
-            return (false, 0, address(0));
+            return (false, 0);
         }
     }
 
-    /// @notice Decides whether an already-authenticated actor may drive this UserOperation, from its scope and
-    ///         policy gate. Split out from {_authenticate} so the two concerns — who signed vs. what they may do —
-    ///         are independently reviewable and overridable.
+    /// @notice Decides whether an already-authenticated actor may drive this UserOperation, from its scope.
+    ///         Split out from {_authenticate} so the two concerns — who signed vs. what they may do — are
+    ///         independently reviewable and overridable.
     /// @dev Enforces:
     ///        - scope 0x00 is an unrestricted owner; any other actor must hold {SCOPE_SENDER} to authorize the calls;
-    ///        - a self-funded op (`missingAccountFunds != 0`) additionally requires {SCOPE_PAYER};
-    ///        - a policy-gated actor (`policyTarget != address(0)`) may only drive calls to its policy target, so
-    ///          `callData` must be a non-empty `executeBatch` whose every call targets that address.
+    ///        - a self-funded op (`missingAccountFunds != 0`) additionally requires {SCOPE_PAYER}.
+    ///      A SCOPE_POLICY actor without SCOPE_SENDER fails the check below by construction — this reduced 4337
+    ///      bridge does not give policy-gated actors special call-target enforcement (that is native-dispatch,
+    ///      protocol-side behavior out of scope for this repo). An actor combining SCOPE_POLICY | SCOPE_SENDER is
+    ///      authorized here exactly like any other SENDER-scoped actor.
     /// @param scope The verified actor's scope (0x00 = unrestricted owner).
-    /// @param policyTarget The verified actor's policy gate target, or address(0) if ungated.
-    /// @param callData The op's callData (committed to by `userOpHash`), gated against `policyTarget`.
     /// @param missingAccountFunds The prefund the account owes the EntryPoint; non-zero means a self-funded op.
-    function _authorize(uint8 scope, address policyTarget, bytes calldata callData, uint256 missingAccountFunds)
-        internal
-        view
-        virtual
-        returns (bool)
-    {
+    function _authorize(uint8 scope, uint256 missingAccountFunds) internal view virtual returns (bool) {
         // scope 0x00 = unrestricted owner; otherwise the actor must explicitly hold the required scopes.
         if (scope != 0) {
             if (scope & SCOPE_SENDER == 0) return false;
             if (missingAccountFunds != 0 && scope & SCOPE_PAYER == 0) return false;
-        }
-
-        // A policy-gated actor may only direct the account's calls to its policy target.
-        if (policyTarget != address(0) && !_callsTargetOnly(callData, policyTarget)) return false;
-
-        return true;
-    }
-
-    /// @dev True iff `callData` is a non-empty `executeBatch` whose every call targets `policyTarget`.
-    ///      Because `userOpHash` commits to `callData`, enforcing this during validation binds the gated
-    ///      actor's authorization to calls that stay within its policy target.
-    function _callsTargetOnly(bytes calldata callData, address policyTarget) internal pure returns (bool) {
-        if (callData.length < 4 || bytes4(callData[:4]) != DefaultAccount.executeBatch.selector) return false;
-        Call[] memory calls = abi.decode(callData[4:], (Call[]));
-        if (calls.length == 0) return false;
-        for (uint256 i; i < calls.length; i++) {
-            if (calls[i].target != policyTarget) return false;
         }
         return true;
     }

--- a/src/authenticators/DelegateAuthenticator.sol
+++ b/src/authenticators/DelegateAuthenticator.sol
@@ -54,7 +54,7 @@ contract DelegateAuthenticator is IAuthenticator {
         address nestedAuthenticator = address(bytes20(nestedAuth[:20]));
         if (nestedAuthenticator == address(this)) revert RecursiveDelegation();
 
-        // Nested signer must have SIGNATURE scope on the delegate account.
+        // Nested actor must be the admin (scope == 0x00) of the delegate account — ERC-1271 signing is admin-only.
         if (!ACCOUNT_CONFIGURATION.verifySignature(delegate, hash, nestedAuth)) revert InvalidNestedSignature();
     }
 }

--- a/src/authenticators/DelegateAuthenticator.sol
+++ b/src/authenticators/DelegateAuthenticator.sol
@@ -54,7 +54,15 @@ contract DelegateAuthenticator is IAuthenticator {
         address nestedAuthenticator = address(bytes20(nestedAuth[:20]));
         if (nestedAuthenticator == address(this)) revert RecursiveDelegation();
 
-        // Nested actor must be the admin (scope == 0x00) of the delegate account — ERC-1271 signing is admin-only.
-        if (!ACCOUNT_CONFIGURATION.verifySignature(delegate, hash, nestedAuth)) revert InvalidNestedSignature();
+        // The nested actor MUST be the admin (scope == 0x00) of the delegate account. This is enforced
+        // independently of verifySignature, which is now operational (signing is not admin-only, but a delegate
+        // vouch requires admin to preserve non-escalation): an operational SENDER key can sign for its own account,
+        // yet it must NOT be able to vouch as a delegate here. authenticateActor reverts on any auth failure and
+        // otherwise returns the resolved scope, so we require scope == 0x00 explicitly.
+        try ACCOUNT_CONFIGURATION.authenticateActor(delegate, hash, nestedAuth) returns (uint8 nestedScope, address) {
+            if (nestedScope != 0) revert InvalidNestedSignature();
+        } catch {
+            revert InvalidNestedSignature();
+        }
     }
 }

--- a/src/examples/policies/Policy.sol
+++ b/src/examples/policies/Policy.sol
@@ -11,7 +11,7 @@ import {PolicyManager} from "./PolicyManager.sol";
 ///      per-use *action* (`executionData`, supplied when the session key transacts) into an account call plan.
 ///      The plan is ABI-encoded calldata that the manager forwards to the account (e.g. `executeBatch`).
 ///
-///      This is the example/reference shape for an EIP-8130 actor policy (non-zero `policyType`): the
+///      This is the example/reference shape for an EIP-8130 actor policy (`scope & SCOPE_POLICY != 0`): the
 ///      manager is the single call target a restricted actor may reach, and policies express *what* that actor
 ///      may do. All hooks are callable only by the configured {PolicyManager}.
 abstract contract Policy {

--- a/src/examples/policies/PolicyManager.sol
+++ b/src/examples/policies/PolicyManager.sol
@@ -25,7 +25,7 @@ address constant EXTERNAL_POLICY_AUTHENTICATOR = address(uint160(uint256(keccak2
 /// @dev Role in the EIP-8130 flow:
 ///      - The manager is registered as an execution-enabled actor on the account (an actor whose authenticator is
 ///        `TRUSTED_EXECUTOR`), so it may drive the account via `executeBatch`.
-///      - A restricted session-key actor is configured with a non-zero `policyType` and `policy_manager =
+///      - A restricted session-key actor is configured with `scope & SCOPE_POLICY != 0` and `policy_manager =
 ///        address(this)`, so the protocol gate forces every call that actor makes to land on this manager.
 ///      - When the session key transacts, the protocol dispatches its call *as the account*, so `msg.sender`
 ///        here is the account itself. That is the authorization boundary: only a gated session-key transaction
@@ -41,8 +41,8 @@ address constant EXTERNAL_POLICY_AUTHENTICATOR = address(uint160(uint256(keccak2
 ///        omits.
 ///
 ///      Commitment binding: the account authorizes a {PolicyBinding}; its `keccak256` is the `commitment`. When the
-///      account authorizes the session-key actor it stores a non-zero `policyType`, `policy_manager = address(this)`, and
-///      `policy_commitment = commitment` in the Account Configuration contract. At {install} the manager reads that
+///      account authorizes the session-key actor it stores `scope & SCOPE_POLICY != 0`, `policy_manager =
+///      address(this)`, and `policy_commitment = commitment` in the Account Configuration contract. At {install} the manager reads that
 ///      binding back via the single-SLOAD {AccountConfiguration.getPolicyManager} / {AccountConfiguration.getPolicyCommitment}
 ///      accessors and requires the target and commitment to match, so an install can only succeed for a policy the
 ///      account actually signed for this manager.
@@ -100,8 +100,11 @@ contract PolicyManager is ReentrancyGuard {
     ///      AccountConfiguration, so this binds execution (and the commitment-keyed policy state) to its owner.
     error CommitmentAccountMismatch(address expected, address actual);
     /// @dev The acting actor has no live policy commitment for the account — i.e. it is not a gated actor of this
-    ///      account, was revoked/expired, or (on the external path) the account did not gate this manager for it.
+    ///      account, was revoked, or (on the external path) the account did not gate this manager for it.
     error NoActivePolicy(bytes32 actorId);
+    /// @dev The acting actor's `ActorConfig.expiry` has passed. Commitment is not cleared on expiry (only on revoke),
+    ///      so the manager must enforce this itself — especially on {executeFor}, which has no protocol auth path.
+    error ActorExpired(bytes32 actorId);
     /// @dev {executeForMany} array length mismatch between `accounts` and `executionData`.
     error LengthMismatch();
     /// @dev The per-account self-call boundary used by {executeForMany} was invoked by someone other than this
@@ -136,7 +139,7 @@ contract PolicyManager is ReentrancyGuard {
     ///      Changing any binding field yields a different commitment — a separate, independently-accounted binding,
     ///      not a reset of the old one.
     ///
-    /// @param actorId The actor the account configured with this policy (non-zero policyType).
+    /// @param actorId The actor the account configured with this policy (scope & SCOPE_POLICY != 0).
     /// @param binding The account-authorized binding.
     ///
     /// @return commitment The binding's commitment.
@@ -149,7 +152,7 @@ contract PolicyManager is ReentrancyGuard {
 
         // The account must have signed this exact commitment for this manager when authorizing `actorId`. Read the
         // gate target and signed commitment via the single-SLOAD granular accessors: the manager never needs the
-        // policyType byte, so this avoids the extra ActorConfig SLOAD that getPolicy performs. This (not msg.sender)
+        // actor's scope, so this avoids the extra ActorConfig SLOAD that getPolicy performs. This (not msg.sender)
         // is the authorization gate, which is why install is permissionless.
         address target = ACCOUNT_CONFIGURATION.getPolicyManager(binding.account, actorId);
         bytes32 signedCommitment = ACCOUNT_CONFIGURATION.getPolicyCommitment(binding.account, actorId);
@@ -179,7 +182,8 @@ contract PolicyManager is ReentrancyGuard {
     ///      transaction-context precompile and takes the account from `msg.sender` (the protocol sets
     ///      `msg.sender == sender == account` at a dispatched `call.to`, and using `msg.sender` confines execution
     ///      to that direct dispatch path). It then needs only the live signed `commitment` (a single SLOAD) to
-    ///      locate the installed binding — a revoked or expired actor has a zero commitment and is rejected.
+    ///      locate the installed binding — a revoked actor has a zero commitment and is rejected. Actor expiry is
+    ///      checked separately: expiry does not clear the commitment slot, so a stale key would otherwise still drive.
     ///
     /// @param policy        Policy contract for the binding.
     /// @param executionData Per-use action parameters interpreted by the policy.
@@ -188,9 +192,10 @@ contract PolicyManager is ReentrancyGuard {
         bytes32 actorId = _actingActorId();
 
         // Single-SLOAD read of the live signed commitment for the acting actor. Zero means the actor is not a gated
-        // key of this account (or was revoked/expired): there is no binding to enforce, so reject.
+        // key of this account (or was revoked): there is no binding to enforce, so reject.
         bytes32 commitment = ACCOUNT_CONFIGURATION.getPolicyCommitment(account, actorId);
         if (commitment == bytes32(0)) revert NoActivePolicy(actorId);
+        _requireNotExpired(account, actorId);
 
         // No manager-match check here: on the protocol-dispatched path the 8130 gate already guarantees this manager
         // is the acting key's configured target (see the dev note above). The external entrypoints below re-add it.
@@ -263,7 +268,8 @@ contract PolicyManager is ReentrancyGuard {
     }
 
     /// @dev External-path validation shared by {executeFor} and {enforceExternalSelf}: re-add the manager-match check
-    ///      the protocol path can omit, resolve the live commitment, then run the common enforcement.
+    ///      the protocol path can omit, resolve the live commitment, enforce actor expiry (no protocol auth on this
+    ///      path), then run the common enforcement.
     function _enforceExternal(
         address account,
         bytes32 actorId,
@@ -276,7 +282,15 @@ contract PolicyManager is ReentrancyGuard {
         }
         bytes32 commitment = ACCOUNT_CONFIGURATION.getPolicyCommitment(account, actorId);
         if (commitment == bytes32(0)) revert NoActivePolicy(actorId);
+        _requireNotExpired(account, actorId);
         _enforce(account, policy, commitment, executionData, caller);
+    }
+
+    /// @dev Reject when the acting actor's stored expiry has passed. Commitment is only cleared on revoke, not on
+    ///      expiry, so this check is required on every execution path (protocol-dispatched and external).
+    function _requireNotExpired(address account, bytes32 actorId) internal view {
+        AccountConfiguration.ActorConfig memory config = ACCOUNT_CONFIGURATION.getActorConfig(account, actorId);
+        if (config.expiry != 0 && block.timestamp > config.expiry) revert ActorExpired(actorId);
     }
 
     /// @dev Common enforcement for both acting models: validate the installed binding's lifecycle window, run the

--- a/src/examples/policies/README.md
+++ b/src/examples/policies/README.md
@@ -143,11 +143,14 @@ as a *policy-only* actor — it has no authority of its own, it only carries a b
 AccountConfiguration.ActorConfig({
     authenticator: EXTERNAL_POLICY_AUTHENTICATOR, // recognized actor; NO direct executeBatch; not 8130-usable
     scope:         0x10,                          // SCOPE_POLICY — gated initiation only (MAY also OR SCOPE_PAYER
-                                                  //   for self-pay; MUST NOT combine with SENDER/SIGNER/CONFIG)
-    expiry:        0,
-    nonceLane:     0
+                                                  //   for self-pay; MUST NOT combine with SENDER/SIGNER)
+    expiry:        0
 });
 ```
+
+`SCOPE_NONCE` (`0x20`) is a separate, orthogonal scope bit: it marks an actor as bound to a protocol-side nonce
+lane. This contract stores the bit verbatim and never interprets it — lane allocation/semantics are entirely
+protocol-side — so it isn't part of the policy flow above and is only mentioned here for completeness.
 
 Critically, the provider must **not** be registered with `TRUSTED_EXECUTOR` — that sentinel grants
 *direct, unrestricted* `executeBatch` and would let the provider bypass the policy entirely. `EXTERNAL_POLICY_AUTHENTICATOR`

--- a/src/examples/policies/README.md
+++ b/src/examples/policies/README.md
@@ -29,7 +29,9 @@ protocol-side, not enforced by this contract.
    Because reaching this manager already proves it is the key's gate, `execute` does not re-check the target: it
    reads the acting `actorId` from the [transaction-context precompile](../../interfaces/ITransactionContext.sol)
    (`getTransactionSenderActorId()`) and needs the live `getPolicyCommitment(account, actorId)` (a single SLOAD)
-   to locate the installed binding — a revoked key has a zero commitment and stops immediately. Actor expiry is
+   to locate the installed binding — a revoked key has a zero commitment and stops immediately. (A real binding's
+   commitment is a `keccak256` hash, never zero, so this manager treats a `SCOPE_POLICY` actor configured with a
+   zero `commitment` as having no active policy — there is nothing installable to enforce.) Actor expiry is
    checked separately via `getActorConfig` (expiry does not clear the commitment slot). It then invokes the policy,
    which enforces the committed policy against the per-use action and returns an `executeBatch` call plan that the
    manager — an execution-enabled actor (`TRUSTED_EXECUTOR`) — forwards to the account.
@@ -143,7 +145,7 @@ as a *policy-only* actor — it has no authority of its own, it only carries a b
 AccountConfiguration.ActorConfig({
     authenticator: EXTERNAL_POLICY_AUTHENTICATOR, // recognized actor; NO direct executeBatch; not 8130-usable
     scope:         0x02,                          // SCOPE_POLICY — gated initiation only (MAY also OR SCOPE_SELF_PAYER
-                                                  //   for self-pay; MUST NOT combine with SENDER)
+                                                  //   for self-pay; SHOULD NOT combine with SENDER — POLICY gates regardless)
     expiry:        0
 });
 ```

--- a/src/examples/policies/README.md
+++ b/src/examples/policies/README.md
@@ -2,15 +2,17 @@
 
 Reference, **unaudited** example of a policy manager for EIP-8130 restricted actors.
 
-In EIP-8130, a restricted actor (e.g. a session key) is configured with a non-zero `policyType`, which stores a
+In EIP-8130, a restricted actor (e.g. a session key) is configured with `scope & SCOPE_POLICY != 0`, which stores a
 `policy_manager` address and an opaque `policy_commitment` in the Account Configuration contract. The protocol
 gate forces every call that actor makes to land on that single manager. These contracts are an example of what
-that manager can be: one that enforces application-specific limits and then drives the account. (The protocol
-gates identically on any non-zero `policyType` and does not interpret the value; this example uses `0x01`.)
+that manager can be: one that enforces application-specific limits and then drives the account. `SCOPE_POLICY`
+(`0x10`) may be combined with other scope bits (e.g. `SCOPE_POLICY | SCOPE_PAYER`) — `AccountConfiguration` does
+not reject scope combinations; use-time exclusivity between policy gating and an actor's other capabilities is
+protocol-side, not enforced by this contract.
 
 ## Flow
 
-1. **Authorize + commit.** The account authorizes the session key with `policyType = 0x01`,
+1. **Authorize + commit.** The account authorizes the session key with `scope = SCOPE_POLICY`,
    `policy_manager = PolicyManager`, and `policy_commitment = keccak256` of an account-authorized
    [`PolicyBinding`](./PolicyManager.sol). The Account Configuration contract exposes this via
    [`getPolicy(account, actorId)`](../../AccountConfiguration.sol).
@@ -26,11 +28,11 @@ gates identically on any non-zero `policyType` and does not interpret the value;
    the key's call can only arrive at `PolicyManager.execute(policy, executionData)` with `msg.sender == account`.
    Because reaching this manager already proves it is the key's gate, `execute` does not re-check the target: it
    reads the acting `actorId` from the [transaction-context precompile](../../interfaces/ITransactionContext.sol)
-   (`getTransactionSenderActorId()`) and needs only the live `getPolicyCommitment(account, actorId)` (a single
-   SLOAD) to locate the installed binding — a revoked or expired key has a zero commitment and stops immediately.
-   It then invokes the policy, which enforces the committed policy against the per-use action and returns an
-   `executeBatch` call plan that the manager — an execution-enabled actor (`TRUSTED_EXECUTOR`) —
-   forwards to the account.
+   (`getTransactionSenderActorId()`) and needs the live `getPolicyCommitment(account, actorId)` (a single SLOAD)
+   to locate the installed binding — a revoked key has a zero commitment and stops immediately. Actor expiry is
+   checked separately via `getActorConfig` (expiry does not clear the commitment slot). It then invokes the policy,
+   which enforces the committed policy against the per-use action and returns an `executeBatch` call plan that the
+   manager — an execution-enabled actor (`TRUSTED_EXECUTOR`) — forwards to the account.
 
 ```
 session key ──(8130 gate: only PolicyManager)──▶ PolicyManager.execute
@@ -62,8 +64,9 @@ given key needs.
 Recipient allowlists and spend-limit accounting require decoding a call's arguments, which is only possible for
 selectors whose ABI is known: `SessionPolicy` hardcodes the standard ERC-20 set (`transfer`, `transferFrom`,
 `approve`). A recipient allowlist may only be attached to one of those (enforced at install); spend limits are
-consumed for those selectors on a limited token, native-ETH limits from each call's `value`, and every other
-selector is governed by target/selector gating alone.
+consumed for those selectors on a limited token (`approve` included, so an allowance cannot exceed the remaining
+budget), native-ETH limits from each call's `value`, and every other selector is governed by target/selector gating
+alone. `anySelector` on a limited token is rejected at install — pin an explicit selector allowlist instead.
 
 #### Worked example
 
@@ -126,8 +129,8 @@ caller, not the protocol.
   dispatched path). So a provider can only pull through the exact manager the account authorized.
 - **One identity, many accounts:** `executeForMany(accounts[], policy, executionData[])` runs each account in its
   own self-call so a single failure (revoked/expired binding, over budget, a reverting account call) is **isolated
-  and skipped** (emitting `PullSkipped`) rather than reverting the whole batch — one delinquent subscriber doesn't
-  block the rest.
+  and skipped** (emitting `ExecutionSkipped`) rather than reverting the whole batch — one delinquent subscriber
+  doesn't block the rest.
 
 **Opt-in (per account, once).** The account's only on-chain obligation is a single **off-chain signature** over an
 actor change. Because `applySignedActorChanges` is signature-gated and `install` is permissionless (gated by the
@@ -139,10 +142,10 @@ as a *policy-only* actor — it has no authority of its own, it only carries a b
 // actorId = bytes20(provider). The provider never signs an 8130 tx; it acts by being msg.sender.
 AccountConfiguration.ActorConfig({
     authenticator: EXTERNAL_POLICY_AUTHENTICATOR, // recognized actor; NO direct executeBatch; not 8130-usable
-    scope:         0x02,                          // SCOPE_SENDER — required non-zero (a policy actor can't be scopeless),
-                                                  //   but inert here since the sentinel can't authenticate a tx
+    scope:         0x10,                          // SCOPE_POLICY — gated initiation only (MAY also OR SCOPE_PAYER
+                                                  //   for self-pay; MUST NOT combine with SENDER/SIGNER/CONFIG)
     expiry:        0,
-    policyType:    0x01                           // gated; policy_manager = manager, policy_commitment = own salt
+    nonceLane:     0
 });
 ```
 

--- a/src/examples/policies/README.md
+++ b/src/examples/policies/README.md
@@ -6,7 +6,7 @@ In EIP-8130, a restricted actor (e.g. a session key) is configured with `scope &
 `policy_manager` address and an opaque `policy_commitment` in the Account Configuration contract. The protocol
 gate forces every call that actor makes to land on that single manager. These contracts are an example of what
 that manager can be: one that enforces application-specific limits and then drives the account. `SCOPE_POLICY`
-(`0x10`) may be combined with other scope bits (e.g. `SCOPE_POLICY | SCOPE_PAYER`) — `AccountConfiguration` does
+(`0x10`) may be combined with other scope bits (e.g. `SCOPE_POLICY | SCOPE_SELF_PAYER`) — `AccountConfiguration` does
 not reject scope combinations; use-time exclusivity between policy gating and an actor's other capabilities is
 protocol-side, not enforced by this contract.
 
@@ -142,8 +142,8 @@ as a *policy-only* actor — it has no authority of its own, it only carries a b
 // actorId = bytes20(provider). The provider never signs an 8130 tx; it acts by being msg.sender.
 AccountConfiguration.ActorConfig({
     authenticator: EXTERNAL_POLICY_AUTHENTICATOR, // recognized actor; NO direct executeBatch; not 8130-usable
-    scope:         0x10,                          // SCOPE_POLICY — gated initiation only (MAY also OR SCOPE_PAYER
-                                                  //   for self-pay; MUST NOT combine with SENDER/SIGNER)
+    scope:         0x10,                          // SCOPE_POLICY — gated initiation only (MAY also OR SCOPE_SELF_PAYER
+                                                  //   for self-pay; MUST NOT combine with SENDER)
     expiry:        0
 });
 ```

--- a/src/examples/policies/README.md
+++ b/src/examples/policies/README.md
@@ -6,7 +6,7 @@ In EIP-8130, a restricted actor (e.g. a session key) is configured with `scope &
 `policy_manager` address and an opaque `policy_commitment` in the Account Configuration contract. The protocol
 gate forces every call that actor makes to land on that single manager. These contracts are an example of what
 that manager can be: one that enforces application-specific limits and then drives the account. `SCOPE_POLICY`
-(`0x10`) may be combined with other scope bits (e.g. `SCOPE_POLICY | SCOPE_SELF_PAYER`) — `AccountConfiguration` does
+(`0x02`) may be combined with other scope bits (e.g. `SCOPE_POLICY | SCOPE_SELF_PAYER`) — `AccountConfiguration` does
 not reject scope combinations; use-time exclusivity between policy gating and an actor's other capabilities is
 protocol-side, not enforced by this contract.
 
@@ -142,14 +142,14 @@ as a *policy-only* actor — it has no authority of its own, it only carries a b
 // actorId = bytes20(provider). The provider never signs an 8130 tx; it acts by being msg.sender.
 AccountConfiguration.ActorConfig({
     authenticator: EXTERNAL_POLICY_AUTHENTICATOR, // recognized actor; NO direct executeBatch; not 8130-usable
-    scope:         0x10,                          // SCOPE_POLICY — gated initiation only (MAY also OR SCOPE_SELF_PAYER
+    scope:         0x02,                          // SCOPE_POLICY — gated initiation only (MAY also OR SCOPE_SELF_PAYER
                                                   //   for self-pay; MUST NOT combine with SENDER)
     expiry:        0
 });
 ```
 
-`SCOPE_NONCE` (`0x20`) is a separate, orthogonal scope bit: it marks an actor as bound to a protocol-side nonce
-lane. This contract stores the bit verbatim and never interprets it — lane allocation/semantics are entirely
+`SCOPE_NONCE` (`0x04`) is a separate, orthogonal scope bit: it permits a restricted actor to use sequenced
+`nonce_key`s. This contract stores the bit verbatim and never interprets it — nonce semantics are entirely
 protocol-side — so it isn't part of the policy flow above and is only mentioned here for completeness.
 
 Critically, the provider must **not** be registered with `TRUSTED_EXECUTOR` — that sentinel grants

--- a/src/examples/policies/SessionPolicy.sol
+++ b/src/examples/policies/SessionPolicy.sol
@@ -119,13 +119,23 @@ contract SessionPolicy is Policy {
     ///      window spans [0, max], so the cumulative spend simply never refreshes within representable time.
     uint40 internal constant ONE_TIME_PERIOD = type(uint40).max;
 
+    /// @dev The action's `target` is not in the committed call-target allowlist.
     error TargetNotAllowed(address target);
+    /// @dev `selector` is not permitted on `target` (the target pins an explicit selector allowlist that omits it).
     error SelectorNotAllowed(address target, bytes4 selector);
+    /// @dev `recipient` (decoded from the ERC-20 call) is not in the selector's committed recipient allowlist.
     error RecipientNotAllowed(address target, bytes4 selector, address recipient);
+    /// @dev The action carried 1–3 bytes of calldata: too short to hold a 4-byte selector, so it is rejected rather
+    ///      than guessed.
     error MissingSelector();
+    /// @dev A configured spend `limit` exceeds uint160 and cannot be stored in the normalized allowance field.
     error LimitTooLarge(address token, uint256 limit);
+    /// @dev A configured spend limit was zero, which would be a no-op cap; reject at install to fail closed.
     error ZeroLimit(address token);
+    /// @dev A recipient allowlist was attached to a selector whose recipient argument this policy cannot decode
+    ///      (only the standard ERC-20 selectors are supported).
     error RecipientRuleUnsupportedSelector(bytes4 selector);
+    /// @dev A supported ERC-20 call's calldata was too short to decode its (recipient, amount) arguments.
     error MalformedTokenCall(bytes4 selector);
     /// @dev A limited token must pin its allowed selectors: `anySelector` would let non-ERC20 methods move value
     ///      without debiting the spend cap. Native-ETH limits (`token == address(0)`) are unaffected — they gate
@@ -136,6 +146,14 @@ contract SessionPolicy is Policy {
 
     // ── Views ──
 
+    /// @notice Returns the committed target scope for a binding: whether the target is allowed at all, and whether
+    ///         any selector is permitted on it (i.e. no explicit selector allowlist was configured).
+    ///
+    /// @param commitment The installed binding's commitment.
+    /// @param target     The call target to resolve.
+    ///
+    /// @return allowed     True if `target` is in the binding's call-target allowlist.
+    /// @return anySelector True if any selector is permitted on `target` (no per-selector gating).
     function isTargetAllowed(bytes32 commitment, address target)
         external
         view
@@ -145,6 +163,15 @@ contract SessionPolicy is Policy {
         return (s.allowed, s.anySelector);
     }
 
+    /// @notice Returns the committed selector rule for a `(target, selector)` pair: whether the selector is allowed
+    ///         and whether a recipient allowlist applies to it.
+    ///
+    /// @param commitment The installed binding's commitment.
+    /// @param target     The call target the selector rule belongs to.
+    /// @param selector   The 4-byte function selector to resolve.
+    ///
+    /// @return allowed        True if `selector` is permitted on `target`.
+    /// @return recipientBound True if a recipient allowlist is enforced for this selector.
     function getSelectorRule(bytes32 commitment, address target, bytes4 selector)
         external
         view
@@ -154,6 +181,14 @@ contract SessionPolicy is Policy {
         return (r.allowed, r.recipientBound);
     }
 
+    /// @notice Returns whether `recipient` is in the committed recipient allowlist for a `(target, selector)` pair.
+    ///
+    /// @param commitment The installed binding's commitment.
+    /// @param target     The call target the selector rule belongs to.
+    /// @param selector   The 4-byte function selector the allowlist is attached to.
+    /// @param recipient  The recipient address to check.
+    ///
+    /// @return True if `recipient` is allowed for `selector` on `target`.
     function isRecipientAllowed(bytes32 commitment, address target, bytes4 selector, address recipient)
         external
         view
@@ -162,6 +197,14 @@ contract SessionPolicy is Policy {
         return _recipientAllowed[commitment][target][selector][recipient];
     }
 
+    /// @notice Returns the committed spend cap for a token (or native ETH via `token == address(0)`).
+    ///
+    /// @param commitment The installed binding's commitment.
+    /// @param token      ERC-20 token address, or address(0) for the native-ETH cap.
+    ///
+    /// @return set       True if a spend cap is configured for `token`.
+    /// @return allowance The per-period spend cap (normalized to uint160).
+    /// @return period    The recurring period in seconds, or {ONE_TIME_PERIOD} for a one-time (never-resetting) cap.
     function getTokenLimit(bytes32 commitment, address token)
         external
         view
@@ -171,6 +214,15 @@ contract SessionPolicy is Policy {
         return (t.set, t.allowance, t.period);
     }
 
+    /// @notice Returns the current-period spend usage for a token's cap under a binding.
+    ///
+    /// @dev Reflects the remaining budget for the active window: the returned {RecurringAllowance.PeriodUsage} carries
+    ///      the period bounds and the amount already spent within them.
+    ///
+    /// @param commitment The installed binding's commitment.
+    /// @param token      ERC-20 token address, or address(0) for the native-ETH cap.
+    ///
+    /// @return The current period's usage snapshot (window bounds and spend so far).
     function getCurrentSpend(bytes32 commitment, address token)
         external
         view
@@ -182,6 +234,12 @@ contract SessionPolicy is Policy {
 
     // ── Hooks ──
 
+    /// @dev Decodes the committed {Config} once and flattens it into the commitment-keyed lookup mappings that
+    ///      {_onExecute} reads. Validates and normalizes every spend cap (rejects {ZeroLimit} and {LimitTooLarge},
+    ///      folds a zero period into {ONE_TIME_PERIOD}); for each call scope records the target (rejecting
+    ///      {AnySelectorOnLimitedToken} when a limited token would be left with untracked selectors) and, per
+    ///      selector rule, whether a recipient allowlist applies (rejecting {RecipientRuleUnsupportedSelector} for a
+    ///      selector whose recipient cannot be decoded) plus the recipient set itself.
     function _onInstall(bytes32 commitment, address, bytes calldata policyConfig) internal override {
         Config memory config = abi.decode(policyConfig, (Config));
 
@@ -220,6 +278,12 @@ contract SessionPolicy is Policy {
         }
     }
 
+    /// @dev Enforces every configured dimension against a single decoded {Action} atomically, then returns the
+    ///      account call plan. In order: the target allowlist ({TargetNotAllowed}); for calls carrying a selector,
+    ///      the per-target selector allowlist ({SelectorNotAllowed}) and, when bound, the recipient allowlist
+    ///      ({RecipientNotAllowed}); the ERC-20 spend cap for decodable spend selectors on a limited token; and the
+    ///      native-ETH spend cap consumed from the call `value`. Calldata of 1–3 bytes is rejected ({MissingSelector}).
+    ///      On success returns the `executeBatch` calldata for a single {Call} mirroring the action.
     function _onExecute(bytes32 commitment, address, bytes calldata executionData, address)
         internal
         override
@@ -284,14 +348,17 @@ contract SessionPolicy is Policy {
         return RecurringAllowance.Limit({allowance: cap.allowance, period: cap.period, start: 0, end: type(uint40).max});
     }
 
+    /// @dev Derives the per-(binding, token) usage key so each token's spend accounting is isolated per commitment.
     function _spendKey(bytes32 commitment, address token) internal pure returns (bytes32) {
         return keccak256(abi.encode(commitment, token));
     }
 
+    /// @dev True for the standard ERC-20 selectors this policy can decode for recipient + amount semantics.
     function _isErc20Selector(bytes4 selector) internal pure returns (bool) {
         return selector == TRANSFER || selector == TRANSFER_FROM || selector == APPROVE;
     }
 
+    /// @dev Reads the leading 4-byte selector from `data` (caller guarantees `data.length >= 4`).
     function _selectorOf(bytes memory data) internal pure returns (bytes4 selector) {
         assembly ("memory-safe") {
             selector := mload(add(data, 0x20))

--- a/src/examples/policies/SessionPolicy.sol
+++ b/src/examples/policies/SessionPolicy.sol
@@ -24,9 +24,10 @@ import {RecurringAllowance} from "./RecurringAllowance.sol";
 ///      decoding the call's arguments, which is only possible for selectors whose ABI layout is known. This policy
 ///      hardcodes the standard ERC-20 set — `transfer`, `transferFrom`, `approve`. Consequences:
 ///        - A recipient allowlist may only be attached to one of those selectors (enforced at install).
-///        - Spend limits are consumed only for those selectors when called on a limited token; other selectors on
-///          a token are governed solely by target/selector gating. To prevent untracked token movement, simply do
-///          not allow non-spend selectors on a limited token via the selector rules.
+///        - Spend limits are consumed only for those selectors when called on a limited token (`approve` included,
+///          so an allowance grant cannot exceed the remaining budget). `anySelector` on a limited token is rejected
+///          at install; pin an explicit selector allowlist instead. Non-spend selectors on a limited token are still
+///          governed only by that allowlist — do not list methods that move value outside the tracked set.
 ///        - Native-ETH limits are consumed from each call's `value`, independent of calldata.
 contract SessionPolicy is Policy {
     using RecurringAllowance for RecurringAllowance.State;
@@ -126,6 +127,10 @@ contract SessionPolicy is Policy {
     error ZeroLimit(address token);
     error RecipientRuleUnsupportedSelector(bytes4 selector);
     error MalformedTokenCall(bytes4 selector);
+    /// @dev A limited token must pin its allowed selectors: `anySelector` would let non-ERC20 methods move value
+    ///      without debiting the spend cap. Native-ETH limits (`token == address(0)`) are unaffected — they gate
+    ///      call `value`, not a call target.
+    error AnySelectorOnLimitedToken(address token);
 
     constructor(address policyManager) Policy(policyManager) {}
 
@@ -192,6 +197,11 @@ contract SessionPolicy is Policy {
         for (uint256 i; i < config.callScopes.length; i++) {
             CallScope memory scope = config.callScopes[i];
             bool anySelector = scope.selectorRules.length == 0;
+            // Fail closed: a TokenLimit on this target only tracks transfer/transferFrom/approve, so anySelector
+            // would let other methods move value untracked. Require an explicit selector allowlist instead.
+            if (anySelector && _tokenSpend[commitment][scope.target].set) {
+                revert AnySelectorOnLimitedToken(scope.target);
+            }
             _targetScope[commitment][scope.target] = TargetScope({allowed: true, anySelector: anySelector});
 
             for (uint256 j; j < scope.selectorRules.length; j++) {

--- a/test/lib/AccountConfigurationTest.sol
+++ b/test/lib/AccountConfigurationTest.sol
@@ -37,6 +37,12 @@ contract AccountConfigurationTest is Test {
 
     bytes32 constant ACTORCHANGE_TYPEHASH = keccak256("ActorChange(uint8 changeType,bytes32 actorId,bytes data)");
 
+    bytes32 constant LOCK_CHANGE_TYPEHASH =
+        keccak256("SignedLockChange(address account,uint256 chainId,uint8 op,uint16 unlockDelay,uint64 sequence)");
+
+    uint8 constant LOCK_OP = 0x01;
+    uint8 constant UNLOCK_OP = 0x02;
+
     function setUp() public virtual {
         accountConfiguration = new AccountConfiguration();
         k1Authenticator = accountConfiguration.K1_AUTHENTICATOR();
@@ -117,6 +123,44 @@ contract AccountConfigurationTest is Test {
                 SIGNED_ACTOR_CHANGES_TYPEHASH, account, chainId, sequence, keccak256(abi.encodePacked(actorChangeHash))
             )
         );
+    }
+
+    // ── Signed lock-change helpers ──
+    //
+    // Lock state changes go through applySignedLockChanges: a relayable, admin-authorized (scope 0) signed call.
+    // These helpers drive it for an account controlled by `pk` — either the account's inline default-EOA self (an
+    // uninitialized EOA at vm.addr(pk)) or a k1 admin actor whose actorId is bytes32(bytes20(vm.addr(pk))).
+
+    function _computeLockChangeDigest(address account, uint256 chainId, uint8 op, uint16 unlockDelay, uint64 sequence)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(LOCK_CHANGE_TYPEHASH, account, chainId, op, unlockDelay, sequence));
+    }
+
+    /// @dev Admin auth blob for a lock op (op = 1) at the account's current local sequence.
+    function _lockAuth(uint256 pk, address account, uint16 unlockDelay) internal view returns (bytes memory) {
+        uint64 seq = accountConfiguration.getChangeSequences(account).local;
+        bytes32 digest = _computeLockChangeDigest(account, block.chainid, LOCK_OP, unlockDelay, seq);
+        return _buildK1Auth(pk, digest);
+    }
+
+    /// @dev Admin auth blob for an unlock op (op = 2) at the account's current local sequence.
+    function _unlockAuth(uint256 pk, address account) internal view returns (bytes memory) {
+        uint64 seq = accountConfiguration.getChangeSequences(account).local;
+        bytes32 digest = _computeLockChangeDigest(account, block.chainid, UNLOCK_OP, 0, seq);
+        return _buildK1Auth(pk, digest);
+    }
+
+    /// @dev Relay a signed lock op (op = 1) authorized by `pk`.
+    function _signedLock(uint256 pk, address account, uint16 unlockDelay) internal {
+        accountConfiguration.applySignedLockChanges(account, LOCK_OP, unlockDelay, _lockAuth(pk, account, unlockDelay));
+    }
+
+    /// @dev Relay a signed unlock op (op = 2) authorized by `pk`.
+    function _signedUnlock(uint256 pk, address account) internal {
+        accountConfiguration.applySignedLockChanges(account, UNLOCK_OP, 0, _unlockAuth(pk, account));
     }
 
     // ── Fuzzed key bounding ──

--- a/test/unit/AccountConfiguration/applyAccountChange.t.sol
+++ b/test/unit/AccountConfiguration/applyAccountChange.t.sol
@@ -107,9 +107,7 @@ contract AccountLockTest is AccountConfigurationTest {
             actorId: bytes32(bytes20(vm.addr(400))),
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });
@@ -142,9 +140,7 @@ contract AccountLockTest is AccountConfigurationTest {
             actorId: bytes32(bytes20(vm.addr(500))),
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });

--- a/test/unit/AccountConfiguration/applyAccountChange.t.sol
+++ b/test/unit/AccountConfiguration/applyAccountChange.t.sol
@@ -4,31 +4,22 @@ pragma solidity ^0.8.30;
 import {AccountConfiguration} from "../../../src/AccountConfiguration.sol";
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 
-/// @notice Branch-complete, fuzz-by-default suite for the account lock surface: lock(uint16), initiateUnlock(),
-///         isLocked, getLockStatus, the onlyUnlocked modifier and _checkAndClearLock. lock/initiateUnlock act on
-///         msg.sender, so the account is pranked as itself; lock() is callable by any address as itself, so most
-///         lock-side tests prank an arbitrary fuzzed address. Tests that must drive an onlyUnlocked-guarded config
+/// @notice Branch-complete, fuzz-by-default suite for the account lock surface: applySignedLockChanges (op = lock /
+///         unlock), isLocked, getLockStatus, the onlyUnlocked modifier and _checkAndClearLock. Lock state changes
+///         ONLY through applySignedLockChanges — a relayable, admin-authorized (scope 0) signed call — so lock-side
+///         tests use a controllable key: an uninitialized EOA at vm.addr(pk) signs with its inline default-EOA self
+///         (scope 0 admin), and anyone (here the test) relays. Tests that must drive an onlyUnlocked-guarded config
 ///         path (applySignedActorChanges) create a real k1 account so the authenticated actor can change actors.
 contract AccountLockTest is AccountConfigurationTest {
     // ── Local fuzz-bound helpers ──
 
-    /// @dev Keep a fuzzed msg.sender out of the zero address, the system contract, and the forge-std cheatcode /
-    ///      console addresses so vm.prank drives a clean, code-free account acting as itself.
+    /// @dev Keep a fuzzed account out of the zero address, the system contract, and the forge-std cheatcode /
+    ///      console addresses so it acts as a clean, code-free account.
     function _assumeSafeAccount(address account) internal view {
         vm.assume(account != address(0));
         vm.assume(account != address(accountConfiguration));
         vm.assume(account != VM_ADDRESS);
         vm.assume(account != CONSOLE);
-    }
-
-    function _lockAccount(address account, uint16 unlockDelay) internal {
-        vm.prank(account);
-        accountConfiguration.lock(unlockDelay);
-    }
-
-    function _initiateUnlock(address account) internal {
-        vm.prank(account);
-        accountConfiguration.initiateUnlock();
     }
 
     /// @dev A single authorize-actor change granting an unrestricted k1 owner (scope 0, no expiry, no policy).
@@ -48,58 +39,169 @@ contract AccountLockTest is AccountConfigurationTest {
         });
     }
 
-    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // REVERTS (source order: lock -> initiateUnlock -> onlyUnlocked on other functions)
-    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-
-    /// @notice lock(0) reverts ZeroUnlockDelay for any account acting as itself.
-    /// @dev Exercises the `unlockDelay == 0` guard in lock(); the onlyUnlocked prelude passes (fresh, unlocksAt == 0).
-    function test_lock_revert_zeroUnlockDelay(address account) public {
-        _assumeSafeAccount(account);
-
-        vm.prank(account);
-        vm.expectRevert(AccountConfiguration.ZeroUnlockDelay.selector);
-        accountConfiguration.lock(0);
+    /// @dev Authorize a k1 actor (actorId = bytes32(bytes20(newSigner))) with `scope` on `account`, signed by the
+    ///      account's admin owner `ownerPk`.
+    function _authorizeK1ActorWithScope(address account, uint256 ownerPk, address newSigner, uint8 scope) internal {
+        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
+        changes[0] = AccountConfiguration.ActorChange({
+            changeType: 0x01,
+            actorId: bytes32(bytes20(newSigner)),
+            data: abi.encode(
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0}),
+                bytes("")
+            )
+        });
+        uint64 chainId = uint64(block.chainid);
+        uint64 seq = accountConfiguration.getChangeSequences(account).local;
+        bytes32 digest = _computeActorChangeBatchDigest(account, chainId, seq, changes);
+        bytes memory auth = _buildK1Auth(ownerPk, digest);
+        accountConfiguration.applySignedActorChanges(account, chainId, changes, auth);
     }
 
-    /// @notice lock() reverts AccountIsLocked when the account is already hard-locked.
-    /// @dev Second lock hits onlyUnlocked -> _checkAndClearLock with unlocksAt == type(uint40).max (locked branch).
-    function test_lock_revert_whenAlreadyHardLocked(address account, uint16 firstDelay, uint16 secondDelay) public {
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // REVERTS (source order: authorization -> lock op -> unlock op -> onlyUnlocked on other functions)
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice applySignedLockChanges reverts UnauthorizedLockChange when the signer is a scoped (non-admin) actor.
+    /// @dev The owner authorizes a SCOPE_SENDER k1 actor, which then signs a lock op; scope != 0 is rejected after
+    ///      authentication, before any lock-state work.
+    function test_applySignedLockChanges_revert_whenSignerNotAdmin(uint256 ownerSeed, uint256 scopedSeed, uint16 delay)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 scopedPk = _boundK1Pk(scopedSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(scopedPk));
+        delay = uint16(bound(delay, 1, type(uint16).max));
+        (address account,) = _createK1Account(ownerPk);
+        address scopedSigner = vm.addr(scopedPk);
+        vm.assume(scopedSigner != account);
+
+        _authorizeK1ActorWithScope(account, ownerPk, scopedSigner, accountConfiguration.SCOPE_SENDER());
+
+        bytes memory auth = _lockAuth(scopedPk, account, delay);
+        vm.expectRevert(AccountConfiguration.UnauthorizedLockChange.selector);
+        accountConfiguration.applySignedLockChanges(account, LOCK_OP, delay, auth);
+    }
+
+    /// @notice applySignedLockChanges reverts UnknownLockOp for any op other than LOCK_OP / UNLOCK_OP.
+    function test_applySignedLockChanges_revert_unknownOp(uint256 pkSeed, uint8 op, uint16 delay) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+        vm.assume(op != LOCK_OP && op != UNLOCK_OP);
+
+        uint64 seq = accountConfiguration.getChangeSequences(account).local;
+        bytes32 digest = _computeLockChangeDigest(account, block.chainid, op, delay, seq);
+        bytes memory auth = _buildK1Auth(pk, digest);
+
+        vm.expectRevert(AccountConfiguration.UnknownLockOp.selector);
+        accountConfiguration.applySignedLockChanges(account, op, delay, auth);
+    }
+
+    /// @notice A lock op (op = 1) with a zero unlock delay reverts ZeroUnlockDelay.
+    /// @dev Exercises the `unlockDelay == 0` guard on the lock branch; the unlocked-state check passes (fresh account).
+    function test_lock_revert_zeroUnlockDelay(uint256 pkSeed) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+
+        bytes memory auth = _lockAuth(pk, account, 0);
+        vm.expectRevert(AccountConfiguration.ZeroUnlockDelay.selector);
+        accountConfiguration.applySignedLockChanges(account, LOCK_OP, 0, auth);
+    }
+
+    /// @notice A lock op reverts AccountIsLocked when the account is already hard-locked.
+    /// @dev Second lock hits _checkAndClearLock with unlocksAt == type(uint40).max (locked branch).
+    function test_lock_revert_whenAlreadyHardLocked(uint256 pkSeed, uint16 firstDelay, uint16 secondDelay) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
         _assumeSafeAccount(account);
         firstDelay = uint16(bound(firstDelay, 1, type(uint16).max));
         secondDelay = uint16(bound(secondDelay, 1, type(uint16).max));
 
-        _lockAccount(account, firstDelay);
+        _signedLock(pk, account, firstDelay);
 
-        vm.prank(account);
+        bytes memory auth = _lockAuth(pk, account, secondDelay);
         vm.expectRevert(AccountConfiguration.AccountIsLocked.selector);
-        accountConfiguration.lock(secondDelay);
+        accountConfiguration.applySignedLockChanges(account, LOCK_OP, secondDelay, auth);
     }
 
-    /// @notice initiateUnlock() reverts NotLocked when the account has never been locked (unlocksAt == 0).
-    /// @dev The `unlocksAt != type(uint40).max` guard fires on a fresh account whose unlocksAt is 0.
-    function test_initiateUnlock_revert_whenNeverLocked(address account) public {
+    /// @notice An unlock op (op = 2) with a non-zero unlock delay reverts InvalidUnlockDelay.
+    /// @dev The delay guard fires before the hard-locked-state check, so it trips even on a fresh account.
+    function test_unlock_revert_nonZeroUnlockDelay(uint256 pkSeed, uint16 delay) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+
+        uint64 seq = accountConfiguration.getChangeSequences(account).local;
+        bytes32 digest = _computeLockChangeDigest(account, block.chainid, UNLOCK_OP, delay, seq);
+        bytes memory auth = _buildK1Auth(pk, digest);
+
+        vm.expectRevert(AccountConfiguration.InvalidUnlockDelay.selector);
+        accountConfiguration.applySignedLockChanges(account, UNLOCK_OP, delay, auth);
+    }
+
+    /// @notice An unlock op reverts NotLocked when the account has never been locked (unlocksAt == 0).
+    function test_initiateUnlock_revert_whenNeverLocked(uint256 pkSeed) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
         _assumeSafeAccount(account);
 
-        vm.prank(account);
+        bytes memory auth = _unlockAuth(pk, account);
         vm.expectRevert(AccountConfiguration.NotLocked.selector);
-        accountConfiguration.initiateUnlock();
+        accountConfiguration.applySignedLockChanges(account, UNLOCK_OP, 0, auth);
     }
 
-    /// @notice initiateUnlock() reverts NotLocked once an unlock has already been initiated.
-    /// @dev After initiateUnlock, unlocksAt is a finite timestamp (!= max), so a second initiateUnlock reverts.
-    function test_initiateUnlock_revert_whenUnlockAlreadyInitiated(address account, uint16 delay, uint256 t0) public {
+    /// @notice An unlock op reverts NotLocked once an unlock has already been initiated.
+    /// @dev After the first unlock, unlocksAt is a finite timestamp (!= max), so a second unlock reverts.
+    function test_initiateUnlock_revert_whenUnlockAlreadyInitiated(uint256 pkSeed, uint16 delay, uint256 t0) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
         _assumeSafeAccount(account);
         delay = uint16(bound(delay, 1, type(uint16).max));
         t0 = bound(t0, 1, 1e9);
 
-        _lockAccount(account, delay);
+        _signedLock(pk, account, delay);
         vm.warp(t0);
-        _initiateUnlock(account);
+        _signedUnlock(pk, account);
 
-        vm.prank(account);
+        bytes memory auth = _unlockAuth(pk, account);
         vm.expectRevert(AccountConfiguration.NotLocked.selector);
-        accountConfiguration.initiateUnlock();
+        accountConfiguration.applySignedLockChanges(account, UNLOCK_OP, 0, auth);
+    }
+
+    /// @notice A replayed lock auth fails: the local sequence advanced on the first success, so the signed digest no
+    ///         longer matches and authentication fails.
+    function test_applySignedLockChanges_revert_whenAuthReplayed(uint256 pkSeed, uint16 delay) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+
+        bytes memory auth = _lockAuth(pk, account, delay); // signed over sequence 0
+        accountConfiguration.applySignedLockChanges(account, LOCK_OP, delay, auth); // sequence 0 -> 1
+
+        vm.expectRevert();
+        accountConfiguration.applySignedLockChanges(account, LOCK_OP, delay, auth);
+    }
+
+    /// @notice A lock auth signed over a sequence other than the account's current one fails to authenticate.
+    function test_applySignedLockChanges_revert_whenSequenceWrong(uint256 pkSeed, uint16 delay, uint64 seqOffset)
+        public
+    {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+        seqOffset = uint64(bound(seqOffset, 1, type(uint64).max - 1));
+
+        uint64 wrongSeq = accountConfiguration.getChangeSequences(account).local + seqOffset;
+        bytes32 digest = _computeLockChangeDigest(account, block.chainid, LOCK_OP, delay, wrongSeq);
+        bytes memory auth = _buildK1Auth(pk, digest);
+
+        vm.expectRevert();
+        accountConfiguration.applySignedLockChanges(account, LOCK_OP, delay, auth);
     }
 
     /// @notice applySignedActorChanges reverts AccountIsLocked while the target account is hard-locked.
@@ -109,7 +211,7 @@ contract AccountLockTest is AccountConfigurationTest {
         delay = uint16(bound(delay, 1, type(uint16).max));
         (address account,) = _createK1Account(pk);
 
-        _lockAccount(account, delay);
+        _signedLock(pk, account, delay);
 
         AccountConfiguration.ActorChange[] memory changes = _oneAuthorizeChange(bytes32(bytes20(vm.addr(pk))));
         uint64 chainId = uint64(block.chainid);
@@ -124,11 +226,13 @@ contract AccountLockTest is AccountConfigurationTest {
     /// @notice importAccount reverts AccountIsLocked while the target account is hard-locked.
     /// @dev The onlyUnlocked(account) modifier runs before the import body, so the lock guard is asserted in
     ///      isolation on a second, distinct function (empty initialActors never reached).
-    function test_importAccount_revert_whenLocked(address account, uint16 delay) public {
+    function test_importAccount_revert_whenLocked(uint256 pkSeed, uint16 delay) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
         _assumeSafeAccount(account);
         delay = uint16(bound(delay, 1, type(uint16).max));
 
-        _lockAccount(account, delay);
+        _signedLock(pk, account, delay);
 
         AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](0);
         vm.expectRevert(AccountConfiguration.AccountIsLocked.selector);
@@ -139,13 +243,15 @@ contract AccountLockTest is AccountConfigurationTest {
     // HAPPY PATHS / BRANCH COVERAGE
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice lock() hard-locks the account: unlocksAt == type(uint40).max and the delay is stored.
+    /// @notice A lock op hard-locks the account: unlocksAt == type(uint40).max and the delay is stored.
     /// @dev getLockStatus reports locked, not-yet-initiated, sentinel unlocksAt and the stored delay; isLocked true.
-    function test_lock_success_setsHardLockStatus(address account, uint16 delay) public {
+    function test_lock_success_setsHardLockStatus(uint256 pkSeed, uint16 delay) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
         _assumeSafeAccount(account);
         delay = uint16(bound(delay, 1, type(uint16).max));
 
-        _lockAccount(account, delay);
+        _signedLock(pk, account, delay);
 
         (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 storedDelay) =
             accountConfiguration.getLockStatus(account);
@@ -156,41 +262,45 @@ contract AccountLockTest is AccountConfigurationTest {
         assertTrue(accountConfiguration.isLocked(account));
     }
 
-    /// @notice lock() emits AccountLocked(account, unlockDelay) exactly once. Sole assertion of this event.
-    function test_lock_success_emitsAccountLocked(address account, uint16 delay) public {
+    /// @notice A lock op emits AccountLocked(account, unlockDelay) exactly once. Sole assertion of this event.
+    function test_lock_success_emitsAccountLocked(uint256 pkSeed, uint16 delay) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
         _assumeSafeAccount(account);
         delay = uint16(bound(delay, 1, type(uint16).max));
 
+        bytes memory auth = _lockAuth(pk, account, delay);
         vm.expectEmit(true, false, false, true, address(accountConfiguration));
         emit AccountConfiguration.AccountLocked(account, delay);
-        vm.prank(account);
-        accountConfiguration.lock(delay);
+        accountConfiguration.applySignedLockChanges(account, LOCK_OP, delay, auth);
     }
 
     /// @notice An account can be re-locked after a prior unlock delay has fully elapsed.
     /// @dev Drives _checkAndClearLock through its expiry-clear branch (block.timestamp >= unlocksAt, unlocksAt != 0):
     ///      the stale timestamp is cleared to 0 and the fresh lock succeeds, hard-locking again with the new delay.
     function test_lock_success_relockAfterUnlockExpired(
-        address account,
+        uint256 pkSeed,
         uint16 firstDelay,
         uint16 secondDelay,
         uint256 t0,
         uint256 extra
     ) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
         _assumeSafeAccount(account);
         firstDelay = uint16(bound(firstDelay, 1, type(uint16).max));
         secondDelay = uint16(bound(secondDelay, 1, type(uint16).max));
         t0 = bound(t0, 1, 1e9);
         extra = bound(extra, 0, 1e9);
 
-        _lockAccount(account, firstDelay);
+        _signedLock(pk, account, firstDelay);
         vm.warp(t0);
-        _initiateUnlock(account);
+        _signedUnlock(pk, account);
 
         vm.warp(t0 + firstDelay + extra); // at or past unlocksAt: account is unlocked
         assertFalse(accountConfiguration.isLocked(account));
 
-        _lockAccount(account, secondDelay);
+        _signedLock(pk, account, secondDelay);
 
         (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 storedDelay) =
             accountConfiguration.getLockStatus(account);
@@ -200,16 +310,18 @@ contract AccountLockTest is AccountConfigurationTest {
         assertEq(storedDelay, secondDelay);
     }
 
-    /// @notice initiateUnlock() sets unlocksAt = block.timestamp + delay and zeroes the stored delay.
+    /// @notice An unlock op sets unlocksAt = block.timestamp + delay and zeroes the stored delay.
     /// @dev Before the delay elapses the account is still locked but now reports hasInitiatedUnlock; unlockDelay is 0.
-    function test_initiateUnlock_success_setsUnlocksAtAndClearsDelay(address account, uint16 delay, uint256 t0) public {
+    function test_initiateUnlock_success_setsUnlocksAtAndClearsDelay(uint256 pkSeed, uint16 delay, uint256 t0) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
         _assumeSafeAccount(account);
         delay = uint16(bound(delay, 1, type(uint16).max));
         t0 = bound(t0, 1, 1e9);
 
-        _lockAccount(account, delay);
+        _signedLock(pk, account, delay);
         vm.warp(t0);
-        _initiateUnlock(account);
+        _signedUnlock(pk, account);
 
         (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 storedDelay) =
             accountConfiguration.getLockStatus(account);
@@ -220,19 +332,21 @@ contract AccountLockTest is AccountConfigurationTest {
         assertTrue(accountConfiguration.isLocked(account));
     }
 
-    /// @notice initiateUnlock() emits AccountUnlockInitiated(account, unlocksAt) exactly once. Sole assertion.
-    function test_initiateUnlock_success_emitsAccountUnlockInitiated(address account, uint16 delay, uint256 t0) public {
+    /// @notice An unlock op emits AccountUnlockInitiated(account, unlocksAt) exactly once. Sole assertion.
+    function test_initiateUnlock_success_emitsAccountUnlockInitiated(uint256 pkSeed, uint16 delay, uint256 t0) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
         _assumeSafeAccount(account);
         delay = uint16(bound(delay, 1, type(uint16).max));
         t0 = bound(t0, 1, 1e9);
 
-        _lockAccount(account, delay);
+        _signedLock(pk, account, delay);
         vm.warp(t0);
 
+        bytes memory auth = _unlockAuth(pk, account);
         vm.expectEmit(true, false, false, true, address(accountConfiguration));
         emit AccountConfiguration.AccountUnlockInitiated(account, uint40(t0 + delay));
-        vm.prank(account);
-        accountConfiguration.initiateUnlock();
+        accountConfiguration.applySignedLockChanges(account, UNLOCK_OP, 0, auth);
     }
 
     /// @notice isLocked is false for an account that has never been locked (unlocksAt == 0).
@@ -243,30 +357,34 @@ contract AccountLockTest is AccountConfigurationTest {
     }
 
     /// @notice isLocked stays true for a hard-locked account at any reachable timestamp (unlocksAt == max sentinel).
-    function test_isLocked_success_trueWhileHardLocked(address account, uint16 delay, uint256 ts) public {
+    function test_isLocked_success_trueWhileHardLocked(uint256 pkSeed, uint16 delay, uint256 ts) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
         _assumeSafeAccount(account);
         delay = uint16(bound(delay, 1, type(uint16).max));
 
-        _lockAccount(account, delay);
+        _signedLock(pk, account, delay);
 
         vm.warp(bound(ts, 1, 1e12)); // any timestamp below the uint40 sentinel keeps block.timestamp < unlocksAt
         assertTrue(accountConfiguration.isLocked(account));
     }
 
-    /// @notice isLocked remains true after initiateUnlock while block.timestamp is strictly before unlocksAt.
+    /// @notice isLocked remains true after an unlock is initiated while block.timestamp is strictly before unlocksAt.
     function test_isLocked_success_trueBeforeUnlockDelayElapses(
-        address account,
+        uint256 pkSeed,
         uint16 delay,
         uint256 t0,
         uint256 within
     ) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
         _assumeSafeAccount(account);
         delay = uint16(bound(delay, 1, type(uint16).max));
         t0 = bound(t0, 1, 1e9);
 
-        _lockAccount(account, delay);
+        _signedLock(pk, account, delay);
         vm.warp(t0);
-        _initiateUnlock(account);
+        _signedUnlock(pk, account);
 
         vm.warp(bound(within, t0, t0 + delay - 1)); // strictly before unlocksAt == t0 + delay
         assertTrue(accountConfiguration.isLocked(account));
@@ -274,20 +392,19 @@ contract AccountLockTest is AccountConfigurationTest {
 
     /// @notice isLocked flips to false once block.timestamp reaches or passes unlocksAt after an initiated unlock.
     /// @dev Includes the exact boundary (extra == 0): isLocked is `block.timestamp < unlocksAt`, so == is unlocked.
-    function test_isLocked_success_falseAfterUnlockDelayElapses(
-        address account,
-        uint16 delay,
-        uint256 t0,
-        uint256 extra
-    ) public {
+    function test_isLocked_success_falseAfterUnlockDelayElapses(uint256 pkSeed, uint16 delay, uint256 t0, uint256 extra)
+        public
+    {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
         _assumeSafeAccount(account);
         delay = uint16(bound(delay, 1, type(uint16).max));
         t0 = bound(t0, 1, 1e9);
         extra = bound(extra, 0, 1e9);
 
-        _lockAccount(account, delay);
+        _signedLock(pk, account, delay);
         vm.warp(t0);
-        _initiateUnlock(account);
+        _signedUnlock(pk, account);
 
         vm.warp(t0 + delay + extra); // at or past unlocksAt
         assertFalse(accountConfiguration.isLocked(account));
@@ -308,19 +425,21 @@ contract AccountLockTest is AccountConfigurationTest {
     /// @dev getLockStatus is a pure view: it never runs _checkAndClearLock, so the finite unlocksAt is not zeroed and
     ///      the hasInitiatedUnlock branch (unlocksAt != 0 && != max) reports true even though the account is unlocked.
     function test_getLockStatus_success_afterUnlockElapsedNotCleared(
-        address account,
+        uint256 pkSeed,
         uint16 delay,
         uint256 t0,
         uint256 extra
     ) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
         _assumeSafeAccount(account);
         delay = uint16(bound(delay, 1, type(uint16).max));
         t0 = bound(t0, 1, 1e9);
         extra = bound(extra, 0, 1e9);
 
-        _lockAccount(account, delay);
+        _signedLock(pk, account, delay);
         vm.warp(t0);
-        _initiateUnlock(account);
+        _signedUnlock(pk, account);
 
         vm.warp(t0 + delay + extra); // past unlocksAt, but no onlyUnlocked call to clear it
 
@@ -332,7 +451,7 @@ contract AccountLockTest is AccountConfigurationTest {
         assertEq(storedDelay, 0);
     }
 
-    /// @notice Full lock -> initiateUnlock -> warp-past -> config change cycle: once the delay elapses,
+    /// @notice Full lock -> initiate-unlock -> warp-past -> config change cycle: once the delay elapses,
     ///         _checkAndClearLock lets an onlyUnlocked config change through and the new actor is authorized.
     /// @dev Drives the expiry-clear branch of _checkAndClearLock on the real applySignedActorChanges path.
     function test_applySignedActorChanges_success_afterFullUnlockCycle(
@@ -353,9 +472,9 @@ contract AccountLockTest is AccountConfigurationTest {
         vm.assume(newActor != vm.addr(pk));
         bytes32 newActorId = bytes32(bytes20(newActor));
 
-        _lockAccount(account, delay);
+        _signedLock(pk, account, delay);
         vm.warp(t0);
-        _initiateUnlock(account);
+        _signedUnlock(pk, account);
         vm.warp(t0 + delay + extra); // at or past unlocksAt: unlocked
         assertFalse(accountConfiguration.isLocked(account));
 

--- a/test/unit/AccountConfiguration/applyAccountChange.t.sol
+++ b/test/unit/AccountConfiguration/applyAccountChange.t.sol
@@ -108,7 +108,7 @@ contract AccountLockTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -143,7 +143,7 @@ contract AccountLockTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )

--- a/test/unit/AccountConfiguration/applyAccountChange.t.sol
+++ b/test/unit/AccountConfiguration/applyAccountChange.t.sol
@@ -111,7 +111,7 @@ contract AccountLockTest is AccountConfigurationTest {
     }
 
     /// @notice A lock op reverts AccountIsLocked when the account is already hard-locked.
-    /// @dev Second lock hits _checkAndClearLock with unlocksAt == type(uint40).max (locked branch).
+    /// @dev Second lock hits _checkAndClearLock with FLAG_LOCKED set and FLAG_UNLOCK_INITIATED clear (hard-locked branch).
     function test_lock_revert_whenAlreadyHardLocked(uint256 pkSeed, uint16 firstDelay, uint16 secondDelay) public {
         uint256 pk = _boundK1Pk(pkSeed);
         address account = vm.addr(pk);
@@ -142,7 +142,7 @@ contract AccountLockTest is AccountConfigurationTest {
         accountConfiguration.applySignedLockChanges(account, UNLOCK_OP, delay, auth);
     }
 
-    /// @notice An unlock op reverts NotLocked when the account has never been locked (unlocksAt == 0).
+    /// @notice An unlock op reverts NotLocked when the account has never been locked (FLAG_LOCKED clear).
     function test_initiateUnlock_revert_whenNeverLocked(uint256 pkSeed) public {
         uint256 pk = _boundK1Pk(pkSeed);
         address account = vm.addr(pk);
@@ -154,7 +154,7 @@ contract AccountLockTest is AccountConfigurationTest {
     }
 
     /// @notice An unlock op reverts NotLocked once an unlock has already been initiated.
-    /// @dev After the first unlock, unlocksAt is a finite timestamp (!= max), so a second unlock reverts.
+    /// @dev After the first unlock, FLAG_UNLOCK_INITIATED is set, so a second unlock reverts.
     function test_initiateUnlock_revert_whenUnlockAlreadyInitiated(uint256 pkSeed, uint16 delay, uint256 t0) public {
         uint256 pk = _boundK1Pk(pkSeed);
         address account = vm.addr(pk);
@@ -243,8 +243,9 @@ contract AccountLockTest is AccountConfigurationTest {
     // HAPPY PATHS / BRANCH COVERAGE
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice A lock op hard-locks the account: unlocksAt == type(uint40).max and the delay is stored.
-    /// @dev getLockStatus reports locked, not-yet-initiated, sentinel unlocksAt and the stored delay; isLocked true.
+    /// @notice A lock op hard-locks the account: FLAG_LOCKED set, delay stored in lockUnion.
+    /// @dev getLockStatus reports locked, not-yet-initiated, the synthesized max sentinel for unlocksAt and the stored
+    ///      delay; isLocked true.
     function test_lock_success_setsHardLockStatus(uint256 pkSeed, uint16 delay) public {
         uint256 pk = _boundK1Pk(pkSeed);
         address account = vm.addr(pk);
@@ -276,7 +277,7 @@ contract AccountLockTest is AccountConfigurationTest {
     }
 
     /// @notice An account can be re-locked after a prior unlock delay has fully elapsed.
-    /// @dev Drives _checkAndClearLock through its expiry-clear branch (block.timestamp >= unlocksAt, unlocksAt != 0):
+    /// @dev Drives _checkAndClearLock through its lazy-clear branch (UNLOCK_INITIATED set, block.timestamp >= stored unlocksAt):
     ///      the stale timestamp is cleared to 0 and the fresh lock succeeds, hard-locking again with the new delay.
     function test_lock_success_relockAfterUnlockExpired(
         uint256 pkSeed,
@@ -349,14 +350,15 @@ contract AccountLockTest is AccountConfigurationTest {
         accountConfiguration.applySignedLockChanges(account, UNLOCK_OP, 0, auth);
     }
 
-    /// @notice isLocked is false for an account that has never been locked (unlocksAt == 0).
+    /// @notice isLocked is false for an account that has never been locked (FLAG_LOCKED clear).
     function test_isLocked_success_falseWhenNeverLocked(address account, uint256 ts) public {
         _assumeSafeAccount(account);
         vm.warp(bound(ts, 1, 1e12));
         assertFalse(accountConfiguration.isLocked(account));
     }
 
-    /// @notice isLocked stays true for a hard-locked account at any reachable timestamp (unlocksAt == max sentinel).
+    /// @notice isLocked stays true for a hard-locked account at any timestamp (FLAG_LOCKED set, no pending unlock —
+    ///         hard-lock is timestamp-independent).
     function test_isLocked_success_trueWhileHardLocked(uint256 pkSeed, uint16 delay, uint256 ts) public {
         uint256 pk = _boundK1Pk(pkSeed);
         address account = vm.addr(pk);
@@ -365,7 +367,7 @@ contract AccountLockTest is AccountConfigurationTest {
 
         _signedLock(pk, account, delay);
 
-        vm.warp(bound(ts, 1, 1e12)); // any timestamp below the uint40 sentinel keeps block.timestamp < unlocksAt
+        vm.warp(bound(ts, 1, 1e12)); // hard-lock ignores the clock: FLAG_LOCKED set with no pending unlock
         assertTrue(accountConfiguration.isLocked(account));
     }
 
@@ -422,8 +424,8 @@ contract AccountLockTest is AccountConfigurationTest {
 
     /// @notice getLockStatus after the delay elapses (with no intervening onlyUnlocked call) still surfaces the
     ///         initiated-unlock state: unlocked, but hasInitiatedUnlock true and unlocksAt unchanged.
-    /// @dev getLockStatus is a pure view: it never runs _checkAndClearLock, so the finite unlocksAt is not zeroed and
-    ///      the hasInitiatedUnlock branch (unlocksAt != 0 && != max) reports true even though the account is unlocked.
+    /// @dev getLockStatus is a pure view: it never runs _checkAndClearLock, so the lock flags/union are not cleared and
+    ///      the FLAG_UNLOCK_INITIATED branch reports hasInitiatedUnlock true even though the account is now unlocked.
     function test_getLockStatus_success_afterUnlockElapsedNotCleared(
         uint256 pkSeed,
         uint16 delay,
@@ -490,5 +492,35 @@ contract AccountLockTest is AccountConfigurationTest {
         // The onlyUnlocked prelude cleared the stale unlock timestamp back to 0.
         (,, uint40 unlocksAt,) = accountConfiguration.getLockStatus(account);
         assertEq(unlocksAt, 0);
+    }
+
+    /// @notice applySignedActorChanges still reverts AccountIsLocked after an unlock is initiated but before its delay
+    ///         elapses: config stays frozen for the whole notice window, not just while hard-locked.
+    /// @dev Drives the pending-unlock branch of _checkAndClearLock (FLAG_UNLOCK_INITIATED set, block.timestamp <
+    ///      stored unlocksAt) on the real onlyUnlocked-guarded config path — distinct from the hard-locked branch.
+    function test_applySignedActorChanges_revert_whileUnlockPending(
+        uint256 pkSeed,
+        uint16 delay,
+        uint256 t0,
+        uint256 within
+    ) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+        t0 = bound(t0, 1, 1e9);
+        (address account,) = _createK1Account(pk);
+
+        _signedLock(pk, account, delay);
+        vm.warp(t0);
+        _signedUnlock(pk, account);
+        vm.warp(bound(within, t0, t0 + delay - 1)); // strictly before unlocksAt == t0 + delay: still frozen
+
+        AccountConfiguration.ActorChange[] memory changes = _oneAuthorizeChange(bytes32(bytes20(vm.addr(pk))));
+        uint64 chainId = uint64(block.chainid);
+        uint64 seq = accountConfiguration.getChangeSequences(account).local;
+        bytes32 digest = _computeActorChangeBatchDigest(account, chainId, seq, changes);
+        bytes memory auth = _buildK1Auth(pk, digest);
+
+        vm.expectRevert(AccountConfiguration.AccountIsLocked.selector);
+        accountConfiguration.applySignedActorChanges(account, chainId, changes, auth);
     }
 }

--- a/test/unit/AccountConfiguration/applyKeyChange.t.sol
+++ b/test/unit/AccountConfiguration/applyKeyChange.t.sol
@@ -20,7 +20,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -50,7 +50,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x04, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: 0x04, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -100,7 +100,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -110,7 +110,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -150,7 +150,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -177,7 +177,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -205,7 +205,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -235,7 +235,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -261,7 +261,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: newScope, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: newScope, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -325,7 +325,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -357,7 +357,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -441,7 +441,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -465,7 +465,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -569,7 +569,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -597,7 +597,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -629,7 +629,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -668,7 +668,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -705,7 +705,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -743,7 +743,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: scope, expiry: 0, policyType: 0x00
+                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: scope, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -769,9 +769,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: authenticator, scope: scope, expiry: 0, policyType: 0x00
-                }),
+                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0, nonceLane: 0}),
                 bytes("")
             )
         });
@@ -810,9 +808,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: authenticator, scope: scope, expiry: 0, policyType: 0x00
-                }),
+                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0, nonceLane: 0}),
                 bytes("")
             )
         });

--- a/test/unit/AccountConfiguration/applyKeyChange.t.sol
+++ b/test/unit/AccountConfiguration/applyKeyChange.t.sol
@@ -19,9 +19,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });
@@ -49,9 +47,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x04, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x04, expiry: 0}),
                 bytes("")
             )
         });
@@ -99,9 +95,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: actor1,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });
@@ -109,9 +103,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: actor2,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });
@@ -149,9 +141,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: bytes32(bytes20(vm.addr(300))),
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });
@@ -176,9 +166,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: thirdActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });
@@ -191,7 +179,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         assertTrue(accountConfiguration.isActor(account, thirdActorId));
     }
 
-    function test_scopedActor_cannotAuthorizeWithoutConfigScope() public {
+    function test_scopedActor_cannotAuthorizeWithoutAdmin_senderScope() public {
         (address account,) = _createK1Account(ACTOR_PK);
 
         address newSigner = vm.addr(NEW_ACTOR_PK);
@@ -204,9 +192,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: thirdActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });
@@ -219,13 +205,15 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
     }
 
-    function test_scopedActor_canAuthorizeWithConfigScope() public {
+    function test_scopedActor_cannotAuthorizeWithoutAdmin_nonceScope() public {
+        // There is no elevated "admin" scope bit: admin is exactly scope == 0. An actor scoped with SCOPE_NONCE
+        // (a protocol-side, uninterpreted bit) is just as unable to change actors as any other non-zero scope.
         (address account,) = _createK1Account(ACTOR_PK);
 
         address newSigner = vm.addr(NEW_ACTOR_PK);
         bytes32 secondActorId = bytes32(bytes20(newSigner));
         _authorizeActorWithScope(
-            account, ACTOR_PK, secondActorId, address(k1Authenticator), accountConfiguration.SCOPE_CONFIG()
+            account, ACTOR_PK, secondActorId, address(k1Authenticator), accountConfiguration.SCOPE_NONCE()
         );
 
         bytes32 thirdActorId = bytes32(bytes20(vm.addr(302)));
@@ -234,9 +222,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: thirdActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });
@@ -245,24 +231,22 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
         bytes memory auth = _buildK1Auth(NEW_ACTOR_PK, digest);
 
+        vm.expectRevert(AccountConfiguration.UnauthorizedActorChange.selector);
         accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
-        assertTrue(accountConfiguration.isActor(account, thirdActorId));
     }
 
     function test_reauthorizeNonSelfActor_upsertsInPlace() public {
         // authorizeActor is an upsert: re-authorizing an already-configured (non-self) actor overwrites its config
-        // in place rather than reverting. Here the owner actor is re-scoped from unrestricted (0x00) to CONFIG.
+        // in place rather than reverting. Here the owner actor is re-scoped from unrestricted (0x00) to SENDER.
         (address account, bytes32 actorActorId) = _createK1Account(ACTOR_PK);
 
-        uint8 newScope = accountConfiguration.SCOPE_CONFIG();
+        uint8 newScope = accountConfiguration.SCOPE_SENDER();
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({
             actorId: actorActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: newScope, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: newScope, expiry: 0}),
                 bytes("")
             )
         });
@@ -279,25 +263,54 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
     }
 
     function test_reauthorizeLiveK1Self_rescopesWithoutPriorRevoke() public {
-        // Re-authorizing the inline k1 self is now an in-place upsert — no prior revoke required, even when the self
-        // is live with a non-trivial scope. (Previously this reverted unless the self was revoked or all-zero.)
+        // Re-authorizing the inline k1 self is an in-place upsert — no prior revoke required — but this exercises
+        // it via a *different*, still-admin (scope 0) signer: the account's implicit owner rescopes the live self
+        // to a non-trivial scope in one step, no revoke in between.
         uint256 eoaPk = 500;
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
 
-        // First: the implicit owner (all-zero inline, live) scopes the self to CONFIG so it can keep signing.
-        uint8 configScope = accountConfiguration.SCOPE_CONFIG();
-        _rescopeSelf(eoa, eoaPk, configScope);
-        assertEq(accountConfiguration.getActorConfig(eoa, selfActorId).scope, configScope);
-
-        // Second: re-scope the now-live, non-trivially-scoped self again (no revoke in between).
-        uint8 newScope = configScope | 0x02; // CONFIG | SENDER
+        uint8 newScope = accountConfiguration.SCOPE_SENDER() | accountConfiguration.SCOPE_PAYER();
         _rescopeSelf(eoa, eoaPk, newScope);
 
         AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(eoa, selfActorId);
         assertEq(cfg.scope, newScope);
         assertEq(cfg.authenticator, accountConfiguration.K1_AUTHENTICATOR());
         assertTrue(accountConfiguration.isActor(eoa, selfActorId));
+    }
+
+    function test_selfActor_downgradedScope_cannotApplyFurtherActorChanges() public {
+        // Admin is exactly scope == 0: once the self-actorId is downgraded to any non-zero scope, that same key
+        // can no longer sign applySignedActorChanges — even though authorizeActor is an in-place upsert that
+        // would otherwise let it keep re-scoping itself without a prior revoke.
+        uint256 eoaPk = 500;
+        address eoa = vm.addr(eoaPk);
+        bytes32 selfActorId = bytes32(bytes20(eoa));
+
+        uint8 senderScope = accountConfiguration.SCOPE_SENDER();
+        uint8 senderPayerScope = senderScope | accountConfiguration.SCOPE_PAYER();
+        _rescopeSelf(eoa, eoaPk, senderScope);
+        assertEq(accountConfiguration.getActorConfig(eoa, selfActorId).scope, senderScope);
+
+        // Build the second (now-unauthorized) change fully before expectRevert, so no intervening (successful)
+        // view calls land between it and the reverting applySignedActorChanges call.
+        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
+        changes[0] = AccountConfiguration.ActorChange({
+            actorId: selfActorId,
+            changeType: 0x01,
+            data: abi.encode(
+                AccountConfiguration.ActorConfig({
+                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: senderPayerScope, expiry: 0
+                }),
+                bytes("")
+            )
+        });
+        uint64 seq = accountConfiguration.getChangeSequences(eoa).local;
+        bytes32 digest = _computeActorChangeBatchDigest(eoa, uint64(block.chainid), seq, changes);
+        bytes memory auth = _buildK1Auth(eoaPk, digest);
+
+        vm.expectRevert(AccountConfiguration.UnauthorizedActorChange.selector);
+        accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), changes, auth);
     }
 
     function test_revertsOnRevokingNonExistentActor() public {
@@ -324,9 +337,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: bytes32(bytes20(vm.addr(300))),
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });
@@ -356,9 +367,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });
@@ -422,7 +431,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
 
         // The same key now authenticates with its downgraded scope (0x02), never full owner (0x00).
         bytes32 hash = keccak256("scoped self");
-        (uint8 scope,,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (uint8 scope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(scope, 0x02);
     }
 
@@ -441,7 +450,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: 0x00, expiry: 0, nonceLane: 0
+                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: 0x00, expiry: 0
                 }),
                 bytes("")
             )
@@ -464,9 +473,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });
@@ -539,7 +546,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
 
         // The own key is a full owner again — now resolved through its explicit self config (the flag stays set, so
         // it is the config, not the implicit fallback, that authorizes it).
-        (uint8 scope,,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (uint8 scope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(scope, 0);
     }
 
@@ -559,7 +566,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         // ── Phase 0: the default EOA is live and authenticates with its own k1 signature (implicit full owner). ──
         assertTrue(accountConfiguration.isActor(eoa, selfActorId));
         bytes32 h0 = keccak256("phase 0");
-        (uint8 scope0,,) = accountConfiguration.authenticateActor(eoa, h0, _buildK1Auth(eoaPk, h0));
+        (uint8 scope0,) = accountConfiguration.authenticateActor(eoa, h0, _buildK1Auth(eoaPk, h0));
         assertEq(scope0, 0);
 
         // ── Phase 1: in one batch signed by the EOA, add the passkey as a full owner and revoke the default EOA. ──
@@ -568,9 +575,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: deviceActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });
@@ -587,7 +592,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         bytes32 h1 = keccak256("phase 1");
         vm.expectRevert();
         accountConfiguration.authenticateActor(eoa, h1, _buildK1Auth(eoaPk, h1));
-        (uint8 scope1,,) = accountConfiguration.authenticateActor(eoa, h1, _buildK1Auth(devicePk, h1));
+        (uint8 scope1,) = accountConfiguration.authenticateActor(eoa, h1, _buildK1Auth(devicePk, h1));
         assertEq(scope1, 0);
 
         // ── Phase 2: the passkey re-enables the K1 key by authorizing the self-actorId as a native k1 owner. ──
@@ -597,7 +602,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: 0x00, expiry: 0, nonceLane: 0
+                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: 0x00, expiry: 0
                 }),
                 bytes("")
             )
@@ -611,7 +616,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         // implicit fallback (the flag is never cleared), so the same k1 signature authenticates.
         assertTrue(accountConfiguration.isActor(eoa, selfActorId));
         bytes32 h2 = keccak256("phase 2");
-        (uint8 scope2,,) = accountConfiguration.authenticateActor(eoa, h2, _buildK1Auth(eoaPk, h2));
+        (uint8 scope2,) = accountConfiguration.authenticateActor(eoa, h2, _buildK1Auth(eoaPk, h2));
         assertEq(scope2, 0);
     }
 
@@ -628,9 +633,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });
@@ -667,9 +670,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: thirdActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });
@@ -704,9 +705,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: thirdActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });
@@ -743,7 +742,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: scope, expiry: 0, nonceLane: 0
+                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: scope, expiry: 0
                 }),
                 bytes("")
             )
@@ -769,8 +768,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0, nonceLane: 0}),
-                bytes("")
+                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes("")
             )
         });
 
@@ -808,8 +806,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0, nonceLane: 0}),
-                bytes("")
+                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes("")
             )
         });
 

--- a/test/unit/AccountConfiguration/applyKeyChange.t.sol
+++ b/test/unit/AccountConfiguration/applyKeyChange.t.sol
@@ -98,7 +98,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         pk = _boundK1Pk(pk);
         (address account, bytes32 ownerId) = _createK1Account(pk);
         vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
-        _lockAccount(account);
+        _lockAccount(pk, account);
 
         AccountConfiguration.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), 0, "");
         bytes memory auth = _authOver(account, pk, ch);
@@ -871,8 +871,8 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
     }
 
-    function _lockAccount(address account) internal {
-        vm.prank(account);
-        accountConfiguration.lock(1 hours);
+    /// @dev Hard-lock `account` via the signed lock path, authorized by its admin owner key `pk`.
+    function _lockAccount(uint256 pk, address account) internal {
+        _signedLock(pk, account, 1 hours);
     }
 }

--- a/test/unit/AccountConfiguration/applyKeyChange.t.sol
+++ b/test/unit/AccountConfiguration/applyKeyChange.t.sol
@@ -8,8 +8,8 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
     uint8 constant SCOPE_SENDER = 0x01;
     uint8 constant SCOPE_POLICY = 0x02;
     uint8 constant SCOPE_NONCE = 0x04;
-    uint8 constant SCOPE_PAYER = 0x08;
-    uint8 constant SCOPE_SIGNER = 0x10;
+    uint8 constant SCOPE_SELF_PAYER = 0x08;
+    uint8 constant SCOPE_SPONSOR_PAYER = 0x10;
 
     /// @notice Authorizing a non-self actor registers it with the given authenticator and unrestricted scope.
     function test_authorizeActor_success_unrestricted(uint256 pk, bytes32 actorId) public {
@@ -182,7 +182,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         assertEq(accountConfiguration.getActorConfig(eoa, selfActorId).scope, firstScope);
 
         // Second admin-signed change rescopes the live self actor in place to a non-admin scope.
-        uint8 newScope = SCOPE_SENDER | SCOPE_PAYER;
+        uint8 newScope = SCOPE_SENDER | SCOPE_SELF_PAYER;
         _rescopeSelf(eoa, eoaPk, newScope);
 
         AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(eoa, selfActorId);

--- a/test/unit/AccountConfiguration/authenticate.t.sol
+++ b/test/unit/AccountConfiguration/authenticate.t.sol
@@ -13,7 +13,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         bytes32 hash = keccak256("authenticate me");
         bytes memory auth = _buildK1Auth(ACTOR_PK, hash);
 
-        (uint8 scope,,) = accountConfiguration.authenticateActor(account, hash, auth);
+        (uint8 scope,) = accountConfiguration.authenticateActor(account, hash, auth);
         assertEq(scope, uint8(0x00));
     }
 
@@ -131,7 +131,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         bytes32 hash = keccak256("scoped authenticate");
         bytes memory auth = _buildK1Auth(401, hash);
 
-        (uint8 scope,,) = accountConfiguration.authenticateActor(account, hash, auth);
+        (uint8 scope,) = accountConfiguration.authenticateActor(account, hash, auth);
         assertEq(scope, uint8(0x01));
     }
 
@@ -145,7 +145,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         bytes32 hash = keccak256("unrestricted");
         bytes memory auth = _buildK1Auth(401, hash);
 
-        (uint8 scope,,) = accountConfiguration.authenticateActor(account, hash, auth);
+        (uint8 scope,) = accountConfiguration.authenticateActor(account, hash, auth);
         assertEq(scope, uint8(0x00));
     }
 
@@ -159,7 +159,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         bytes memory auth = _buildK1Auth(eoaPk, hash);
 
         // No createAccount or importAccount — the EOA is implicitly authorized
-        (uint8 scope,,) = accountConfiguration.authenticateActor(eoa, hash, auth);
+        (uint8 scope,) = accountConfiguration.authenticateActor(eoa, hash, auth);
         assertEq(scope, 0);
     }
 
@@ -213,7 +213,7 @@ contract AuthenticateTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: 0x02, expiry: 0, nonceLane: 0
+                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: 0x02, expiry: 0
                 }),
                 bytes("")
             )
@@ -224,7 +224,7 @@ contract AuthenticateTest is AccountConfigurationTest {
 
         // The own key now returns the downgraded scope (0x02), never full owner (0x00).
         bytes32 hash = keccak256("scoped self auth");
-        (uint8 scope,,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (uint8 scope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(scope, 0x02);
     }
 
@@ -237,7 +237,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         _implicitAuthorizeActor(eoa, eoaPk, bobActorId, accountConfiguration.K1_AUTHENTICATOR());
 
         bytes32 hash = keccak256("explicit non-self actor");
-        (uint8 scope,,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(bobPk, hash));
+        (uint8 scope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(bobPk, hash));
         assertEq(scope, 0);
     }
 
@@ -315,8 +315,7 @@ contract AuthenticateTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0, nonceLane: 0}),
-                bytes("")
+                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes("")
             )
         });
 
@@ -339,10 +338,7 @@ contract AuthenticateTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: authenticator, scope: 0x00, expiry: expiry, nonceLane: 0
-                }),
-                bytes("")
+                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: 0x00, expiry: expiry}), bytes("")
             )
         });
 
@@ -370,8 +366,7 @@ contract AuthenticateTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: 0x00, expiry: 0, nonceLane: 0}),
-                bytes("")
+                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: 0x00, expiry: 0}), bytes("")
             )
         });
 
@@ -395,9 +390,7 @@ contract AuthenticateTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: scope, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0}),
                 abi.encodePacked(policyManager, commitment)
             )
         });
@@ -421,7 +414,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         _authorizeGatedActor(account, ACTOR_PK, sessionActorId, gatedScope, policyManager, keccak256("commit"));
 
         bytes32 hash = keccak256("gated authenticate");
-        (uint8 scope,, address policyTarget) =
+        (uint8 scope, address policyTarget) =
             accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
 
         assertEq(scope, gatedScope);
@@ -432,7 +425,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         (address account,) = _createK1Account(ACTOR_PK);
 
         bytes32 hash = keccak256("ungated authenticate");
-        (uint8 scope,, address policyTarget) =
+        (uint8 scope, address policyTarget) =
             accountConfiguration.authenticateActor(account, hash, _buildK1Auth(ACTOR_PK, hash));
 
         assertEq(scope, uint8(0x00));

--- a/test/unit/AccountConfiguration/authenticate.t.sol
+++ b/test/unit/AccountConfiguration/authenticate.t.sol
@@ -594,13 +594,15 @@ contract AuthenticateTest is AccountConfigurationTest {
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // verifySignature (admin-only)
+    // verifySignature (operational authority)
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice verifySignature returns true only for the admin actor (scope == 0x00); any scoped actor is false.
-    /// @dev Fuzzes the scope space and asserts the boolean equals `scope == 0`, proving ERC-1271 signing is
-    ///      admin-only — there is no SIGNER grant.
-    function test_verifySignature_success_adminOnlyAcrossScopes(
+    /// @notice verifySignature returns true for any operational actor: the admin (scope == 0x00) or a SENDER actor
+    ///         without POLICY. Payer-only / nonce-only (non-SENDER) scopes are not operational and verify false.
+    /// @dev Fuzzes the (POLICY-cleared) scope space and asserts the boolean equals the operational predicate
+    ///      `scope == 0 || (scope & SCOPE_SENDER != 0)`, proving ERC-1271 signing is operational — not admin-only,
+    ///      and with no dedicated SIGNER grant.
+    function test_verifySignature_success_operationalAcrossScopes(
         uint256 ownerSeed,
         uint256 actorSeed,
         uint8 scopeSeed,
@@ -615,11 +617,60 @@ contract AuthenticateTest is AccountConfigurationTest {
         vm.assume(vm.addr(actorPk) != account);
         _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), scope);
 
-        bool expected = scope == 0;
+        bool expected = scope == 0 || (scope & SCOPE_SENDER != 0);
         assertEq(accountConfiguration.verifySignature(account, hash, _buildK1Auth(actorPk, hash)), expected);
     }
 
-    /// @notice A policy-bearing actor is NEVER a valid ERC-1271 signer (signing is admin-only).
+    /// @notice A SENDER actor without POLICY is operational and verifies true via verifySignature.
+    /// @dev Positive guard for the operational-authority path: signing is authority a SENDER key already holds via
+    ///      calls, so it does not require the admin scope. Covers SENDER alone and SENDER combined with the
+    ///      SELF_PAYER / NONCE capability bits (still no POLICY).
+    function test_verifySignature_success_trueForSenderWithoutPolicy(uint256 ownerSeed, uint256 actorSeed, bytes32 hash)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 actorPk = _boundK1Pk(actorSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(actorPk));
+
+        (address account,) = _createK1Account(ownerPk);
+        vm.assume(vm.addr(actorPk) != account);
+        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+
+        _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_SENDER);
+        assertTrue(accountConfiguration.verifySignature(account, hash, _buildK1Auth(actorPk, hash)));
+
+        _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_SENDER | SCOPE_SELF_PAYER);
+        assertTrue(accountConfiguration.verifySignature(account, hash, _buildK1Auth(actorPk, hash)));
+
+        _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_SENDER | SCOPE_NONCE);
+        assertTrue(accountConfiguration.verifySignature(account, hash, _buildK1Auth(actorPk, hash)));
+    }
+
+    /// @notice A non-SENDER capability-only actor (SELF_PAYER-only, SPONSOR_PAYER-only, NONCE-only) is NOT
+    ///         operational and verifies false.
+    /// @dev Negative guard: only admin or SENDER-without-POLICY are operational.
+    function test_verifySignature_success_falseForNonSenderScopes(uint256 ownerSeed, uint256 actorSeed, bytes32 hash)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 actorPk = _boundK1Pk(actorSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(actorPk));
+
+        (address account,) = _createK1Account(ownerPk);
+        vm.assume(vm.addr(actorPk) != account);
+        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+
+        _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_SELF_PAYER);
+        assertFalse(accountConfiguration.verifySignature(account, hash, _buildK1Auth(actorPk, hash)));
+
+        _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_SPONSOR_PAYER);
+        assertFalse(accountConfiguration.verifySignature(account, hash, _buildK1Auth(actorPk, hash)));
+
+        _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_NONCE);
+        assertFalse(accountConfiguration.verifySignature(account, hash, _buildK1Auth(actorPk, hash)));
+    }
+
+    /// @notice A policy-bearing actor is NEVER a valid ERC-1271 signer (a POLICY actor is not operational).
     /// @dev verifySignature must return false for a scoped SCOPE_POLICY actor.
     function test_verifySignature_success_falseForPolicyActor(
         uint256 ownerSeed,
@@ -638,7 +689,10 @@ contract AuthenticateTest is AccountConfigurationTest {
         vm.assume(vm.addr(sessionPk) != account);
         bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
         _authorizeGatedActor(account, ownerPk, sessionActorId, SCOPE_POLICY, manager, commitment);
+        assertFalse(accountConfiguration.verifySignature(account, hash, _buildK1Auth(sessionPk, hash)));
 
+        // SENDER | POLICY is still not operational: the POLICY bit disqualifies it even though SENDER is set.
+        _authorizeGatedActor(account, ownerPk, sessionActorId, SCOPE_SENDER | SCOPE_POLICY, manager, commitment);
         assertFalse(accountConfiguration.verifySignature(account, hash, _buildK1Auth(sessionPk, hash)));
     }
 

--- a/test/unit/AccountConfiguration/authenticate.t.sol
+++ b/test/unit/AccountConfiguration/authenticate.t.sol
@@ -22,8 +22,8 @@ contract AuthenticateTest is AccountConfigurationTest {
     uint8 constant SCOPE_SENDER = 0x01;
     uint8 constant SCOPE_POLICY = 0x02;
     uint8 constant SCOPE_NONCE = 0x04;
-    uint8 constant SCOPE_PAYER = 0x08;
-    uint8 constant SCOPE_SIGNER = 0x10;
+    uint8 constant SCOPE_SELF_PAYER = 0x08;
+    uint8 constant SCOPE_SPONSOR_PAYER = 0x10;
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // REVERTS (source order)
@@ -594,13 +594,13 @@ contract AuthenticateTest is AccountConfigurationTest {
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // verifySignature (SIGNER gate + POLICY exclusion)
+    // verifySignature (admin-only)
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice verifySignature returns true iff scope is unrestricted or carries SCOPE_SIGNER (POLICY bit cleared).
-    /// @dev Fuzzes the scope space with SCOPE_POLICY masked out (no policyData) and asserts the boolean equals
-    ///      `scope == 0 || scope & SIGNER != 0`, proving the SIGNER gate across scope combinations.
-    function test_verifySignature_success_signerGateAcrossScopes(
+    /// @notice verifySignature returns true only for the admin actor (scope == 0x00); any scoped actor is false.
+    /// @dev Fuzzes the scope space and asserts the boolean equals `scope == 0`, proving ERC-1271 signing is
+    ///      admin-only — there is no SIGNER grant.
+    function test_verifySignature_success_adminOnlyAcrossScopes(
         uint256 ownerSeed,
         uint256 actorSeed,
         uint8 scopeSeed,
@@ -615,13 +615,13 @@ contract AuthenticateTest is AccountConfigurationTest {
         vm.assume(vm.addr(actorPk) != account);
         _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), scope);
 
-        bool expected = scope == 0 || scope & SCOPE_SIGNER != 0;
+        bool expected = scope == 0;
         assertEq(accountConfiguration.verifySignature(account, hash, _buildK1Auth(actorPk, hash)), expected);
     }
 
-    /// @notice A policy-bearing actor is NEVER a valid ERC-1271 signer, even when SIGNER is also set.
-    /// @dev verifySignature must return false for a SCOPE_POLICY | SCOPE_SIGNER actor (POLICY excludes signing).
-    function test_verifySignature_success_falseForPolicySignerActor(
+    /// @notice A policy-bearing actor is NEVER a valid ERC-1271 signer (signing is admin-only).
+    /// @dev verifySignature must return false for a scoped SCOPE_POLICY actor.
+    function test_verifySignature_success_falseForPolicyActor(
         uint256 ownerSeed,
         uint256 sessionSeed,
         address manager,
@@ -637,7 +637,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(sessionPk) != account);
         bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
-        _authorizeGatedActor(account, ownerPk, sessionActorId, SCOPE_POLICY | SCOPE_SIGNER, manager, commitment);
+        _authorizeGatedActor(account, ownerPk, sessionActorId, SCOPE_POLICY, manager, commitment);
 
         assertFalse(accountConfiguration.verifySignature(account, hash, _buildK1Auth(sessionPk, hash)));
     }

--- a/test/unit/AccountConfiguration/authenticate.t.sol
+++ b/test/unit/AccountConfiguration/authenticate.t.sol
@@ -213,7 +213,7 @@ contract AuthenticateTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: 0x02, expiry: 0, policyType: 0x00
+                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: 0x02, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -315,9 +315,7 @@ contract AuthenticateTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: authenticator, scope: scope, expiry: 0, policyType: 0x00
-                }),
+                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0, nonceLane: 0}),
                 bytes("")
             )
         });
@@ -342,7 +340,7 @@ contract AuthenticateTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: authenticator, scope: 0x00, expiry: expiry, policyType: 0x00
+                    authenticator: authenticator, scope: 0x00, expiry: expiry, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -372,9 +370,7 @@ contract AuthenticateTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: authenticator, scope: 0x00, expiry: 0, policyType: 0x00
-                }),
+                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: 0x00, expiry: 0, nonceLane: 0}),
                 bytes("")
             )
         });
@@ -391,7 +387,6 @@ contract AuthenticateTest is AccountConfigurationTest {
         uint256 ownerPk,
         bytes32 newActorId,
         uint8 scope,
-        uint8 policyType,
         address policyManager,
         bytes32 commitment
     ) internal {
@@ -401,7 +396,7 @@ contract AuthenticateTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: scope, expiry: 0, policyType: policyType
+                    authenticator: address(k1Authenticator), scope: scope, expiry: 0, nonceLane: 0
                 }),
                 abi.encodePacked(policyManager, commitment)
             )
@@ -414,22 +409,22 @@ contract AuthenticateTest is AccountConfigurationTest {
         );
     }
 
-    /// @notice authenticate surfaces the actor's full authorization: scope, the reserved policyType byte, and the
+    /// @notice authenticate surfaces the actor's full authorization: scope (including SCOPE_POLICY) and the
     ///         resolved policy target (the manager); the commitment stays an execution-time read.
-    function test_authenticate_returnsScopePolicyTypeAndTarget() public {
+    function test_authenticate_returnsScopeAndPolicyTarget() public {
         (address account,) = _createK1Account(ACTOR_PK);
 
         uint256 sessionPk = 410;
         bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
         address policyManager = address(0xB0B);
-        _authorizeGatedActor(account, ACTOR_PK, sessionActorId, 0x02, 0x01, policyManager, keccak256("commit"));
+        uint8 gatedScope = 0x02 | accountConfiguration.SCOPE_POLICY();
+        _authorizeGatedActor(account, ACTOR_PK, sessionActorId, gatedScope, policyManager, keccak256("commit"));
 
         bytes32 hash = keccak256("gated authenticate");
-        (uint8 scope, uint8 policyType, address policyTarget) =
+        (uint8 scope,, address policyTarget) =
             accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
 
-        assertEq(scope, uint8(0x02));
-        assertEq(policyType, uint8(0x01));
+        assertEq(scope, gatedScope);
         assertEq(policyTarget, policyManager);
     }
 
@@ -437,11 +432,10 @@ contract AuthenticateTest is AccountConfigurationTest {
         (address account,) = _createK1Account(ACTOR_PK);
 
         bytes32 hash = keccak256("ungated authenticate");
-        (uint8 scope, uint8 policyType, address policyTarget) =
+        (uint8 scope,, address policyTarget) =
             accountConfiguration.authenticateActor(account, hash, _buildK1Auth(ACTOR_PK, hash));
 
         assertEq(scope, uint8(0x00));
-        assertEq(policyType, uint8(0x00));
         assertEq(policyTarget, address(0));
     }
 }

--- a/test/unit/AccountConfiguration/createAccount.t.sol
+++ b/test/unit/AccountConfiguration/createAccount.t.sol
@@ -163,7 +163,7 @@ contract CreateAccountTest is AccountConfigurationTest {
         assertEq(cfg.authenticator, address(k1Authenticator));
         assertEq(cfg.scope, 0x00);
         assertEq(cfg.expiry, 0);
-        assertEq(cfg.policyType, 0x00);
+        assertEq(cfg.nonceLane, 0);
 
         // Created accounts are marked initialized (localSequence == 1).
         assertEq(accountConfiguration.getChangeSequences(account).local, 1);

--- a/test/unit/AccountConfiguration/createAccount.t.sol
+++ b/test/unit/AccountConfiguration/createAccount.t.sol
@@ -163,7 +163,6 @@ contract CreateAccountTest is AccountConfigurationTest {
         assertEq(cfg.authenticator, address(k1Authenticator));
         assertEq(cfg.scope, 0x00);
         assertEq(cfg.expiry, 0);
-        assertEq(cfg.nonceLane, 0);
 
         // Created accounts are marked initialized (localSequence == 1).
         assertEq(accountConfiguration.getChangeSequences(account).local, 1);

--- a/test/unit/AccountConfiguration/importAccount.t.sol
+++ b/test/unit/AccountConfiguration/importAccount.t.sol
@@ -25,13 +25,12 @@ contract ImportAccountTest is AccountConfigurationTest {
     // the full Actor/ActorConfig typehash structure; for imported (always unrestricted) actors the config fields are
     // zero and policyData is empty.
     bytes32 constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
-        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint16 nonceLane)"
+        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry)"
     );
     bytes32 constant ACTOR_TYPEHASH = keccak256(
-        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint16 nonceLane)"
+        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry)"
     );
-    bytes32 constant ACTORCONFIG_TYPEHASH =
-        keccak256("ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint16 nonceLane)");
+    bytes32 constant ACTORCONFIG_TYPEHASH = keccak256("ActorConfig(address authenticator,uint8 scope,uint48 expiry)");
 
     /// @dev Convenience: bind the digest to the current chain (the common per-chain import).
     function _computeImportDigest(address account, AccountConfiguration.InitialActor[] memory initialActors)
@@ -49,9 +48,8 @@ contract ImportAccountTest is AccountConfigurationTest {
     ) internal pure returns (bytes32) {
         bytes32[] memory actorHashes = new bytes32[](initialActors.length);
         for (uint256 i; i < initialActors.length; i++) {
-            bytes32 configHash = keccak256(
-                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint8(0), uint48(0), uint16(0))
-            );
+            bytes32 configHash =
+                keccak256(abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint8(0), uint48(0)));
             actorHashes[i] = keccak256(abi.encode(ACTOR_TYPEHASH, initialActors[i].actorId, configHash, keccak256("")));
         }
         return keccak256(
@@ -140,9 +138,7 @@ contract ImportAccountTest is AccountConfigurationTest {
             actorId: bytes32(bytes20(device)),
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });
@@ -255,7 +251,7 @@ contract ImportAccountTest is AccountConfigurationTest {
         // The same key still authenticates as a full owner — now resolved through its explicit self config rather
         // than the (disabled) implicit fallback.
         bytes32 h = keccak256("post import");
-        (uint8 scope,,) = accountConfiguration.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
+        (uint8 scope,) = accountConfiguration.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
         assertEq(scope, 0);
     }
 

--- a/test/unit/AccountConfiguration/importAccount.t.sol
+++ b/test/unit/AccountConfiguration/importAccount.t.sol
@@ -147,21 +147,22 @@ contract ImportAccountTest is AccountConfigurationTest {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     /// @notice Verifies importAccount reverts when the account is hard-locked (onlyUnlocked runs before all else).
-    /// @dev lock() sets unlocksAt = type(uint40).max, so the account stays locked regardless of warp; any non-zero
-    ///      unlock delay locks it. The onlyUnlocked modifier trips before the chainId/sequence/signature checks.
+    /// @dev A lock op sets unlocksAt = type(uint40).max, so the account stays locked regardless of warp; any non-zero
+    ///      unlock delay locks it. The onlyUnlocked modifier trips before the chainId/sequence/signature checks, so
+    ///      the account is a controllable EOA (its inline default-EOA self signs the lock) and the actors/sig are
+    ///      never reached.
     function test_importAccount_revert_accountIsLocked(uint256 ownerSeed, uint16 delay, bool multichain) public {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
         vm.assume(delay != 0);
+        address account = vm.addr(ownerPk);
 
-        AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(vm.addr(ownerPk));
+        AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(account);
         uint256 chainId = _acceptedChainId(multichain);
-        (MockERC1271Wallet wallet, bytes memory sig) = _walletAndSig(ownerPk, chainId, actors);
 
-        vm.prank(address(wallet));
-        accountConfiguration.lock(delay);
+        _signedLock(ownerPk, account, delay);
 
         vm.expectRevert(AccountConfiguration.AccountIsLocked.selector);
-        accountConfiguration.importAccount(address(wallet), chainId, actors, sig);
+        accountConfiguration.importAccount(account, chainId, actors, "");
     }
 
     /// @notice Verifies importAccount reverts for a chainId that is neither 0 (multichain) nor the current chain.

--- a/test/unit/AccountConfiguration/importAccount.t.sol
+++ b/test/unit/AccountConfiguration/importAccount.t.sol
@@ -25,13 +25,13 @@ contract ImportAccountTest is AccountConfigurationTest {
     // the full Actor/ActorConfig typehash structure; for imported (always unrestricted) actors the config fields are
     // zero and policyData is empty.
     bytes32 constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
-        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint8 policyType)"
+        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint16 nonceLane)"
     );
     bytes32 constant ACTOR_TYPEHASH = keccak256(
-        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint8 policyType)"
+        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint16 nonceLane)"
     );
     bytes32 constant ACTORCONFIG_TYPEHASH =
-        keccak256("ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint8 policyType)");
+        keccak256("ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint16 nonceLane)");
 
     /// @dev Convenience: bind the digest to the current chain (the common per-chain import).
     function _computeImportDigest(address account, AccountConfiguration.InitialActor[] memory initialActors)
@@ -50,7 +50,7 @@ contract ImportAccountTest is AccountConfigurationTest {
         bytes32[] memory actorHashes = new bytes32[](initialActors.length);
         for (uint256 i; i < initialActors.length; i++) {
             bytes32 configHash = keccak256(
-                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint8(0), uint48(0), uint8(0))
+                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint8(0), uint48(0), uint16(0))
             );
             actorHashes[i] = keccak256(abi.encode(ACTOR_TYPEHASH, initialActors[i].actorId, configHash, keccak256("")));
         }
@@ -141,7 +141,7 @@ contract ImportAccountTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )

--- a/test/unit/AccountConfiguration/policyAccessors.t.sol
+++ b/test/unit/AccountConfiguration/policyAccessors.t.sol
@@ -14,7 +14,6 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
     uint256 internal constant EOA_PK = 500;
 
     uint8 internal constant SCOPE_SENDER = 0x02;
-    uint8 internal constant POLICY_GATED = 0x01;
     uint8 internal constant AUTHORIZE_ACTOR = 0x01;
     uint8 internal constant REVOKE_ACTOR = 0x02;
 
@@ -44,15 +43,14 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         bytes32 sessionActorId = bytes32(bytes20(vm.addr(SESSION_PK)));
         _authorizePolicyActor(account, ROOT_PK, sessionActorId, DUMMY_MANAGER, DUMMY_COMMITMENT);
 
-        (uint8 policyType, address target, bytes32 commitment) = accountConfiguration.getPolicy(account, sessionActorId);
-        assertEq(policyType, POLICY_GATED);
+        (address target, bytes32 commitment) = accountConfiguration.getPolicy(account, sessionActorId);
         assertEq(target, accountConfiguration.getPolicyManager(account, sessionActorId));
         assertEq(commitment, accountConfiguration.getPolicyCommitment(account, sessionActorId));
     }
 
     // ── Inline-k1 self home (self-actorId K1 with policy) ──
     //
-    // The inline-k1 self lives in AccountState (scope/policyType/expiry), but the policy *manager* and
+    // The inline-k1 self lives in AccountState (scope/expiry), but the policy *manager* and
     // *commitment* are keyed by actorId in the shared keyspace — so the granular accessors must work
     // identically to the explicit-actor home. This branch is the one `getPolicy` reaches via its `else if`.
 
@@ -80,8 +78,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
 
         _authorizeInlineSelfWithPolicy(eoa, EOA_PK, DUMMY_MANAGER, DUMMY_COMMITMENT);
 
-        (uint8 policyType, address target, bytes32 commitment) = accountConfiguration.getPolicy(eoa, selfActorId);
-        assertEq(policyType, POLICY_GATED);
+        (address target, bytes32 commitment) = accountConfiguration.getPolicy(eoa, selfActorId);
         assertEq(target, accountConfiguration.getPolicyManager(eoa, selfActorId));
         assertEq(commitment, accountConfiguration.getPolicyCommitment(eoa, selfActorId));
     }
@@ -89,7 +86,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
     // ── Zero cases (invariant: zero accessor return iff no policy) ──
 
     function test_getPolicyAccessors_ungatedActor_returnsZero() public {
-        // An actor with policyType == POLICY_NONE never has manager/commitment set (per _authorizeActor's
+        // An actor whose scope lacks SCOPE_POLICY never has manager/commitment set (per _authorizeActor's
         // conditional writes), so the accessors must return zero for it.
         (address account,) = _createK1Account(ROOT_PK);
         bytes32 newActorId = bytes32(bytes20(vm.addr(SESSION_PK)));
@@ -145,8 +142,9 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
     }
 
     function test_getPolicyAccessors_clearedOnReauthorizeToNone() public {
-        // Upsert path: re-authorizing a policy-bearing actor down to POLICY_NONE must clear both policy slots, so no
-        // stale (manager, commitment) leaks and the "commitment non-zero iff policyType non-zero" invariant holds.
+        // Upsert path: re-authorizing a policy-bearing actor down to a scope without SCOPE_POLICY must clear both
+        // policy slots, so no stale (manager, commitment) leaks and the "commitment non-zero iff SCOPE_POLICY set"
+        // invariant holds.
         (address account,) = _createK1Account(ROOT_PK);
         bytes32 sessionActorId = bytes32(bytes20(vm.addr(SESSION_PK)));
 
@@ -154,13 +152,12 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         assertEq(accountConfiguration.getPolicyCommitment(account, sessionActorId), DUMMY_COMMITMENT);
         assertEq(accountConfiguration.getPolicyManager(account, sessionActorId), DUMMY_MANAGER);
 
-        // Overwrite the same actor as ungated (policyType == POLICY_NONE).
+        // Overwrite the same actor as ungated (scope without SCOPE_POLICY).
         _authorizeUngatedActor(account, ROOT_PK, sessionActorId, address(k1Authenticator));
 
         assertEq(accountConfiguration.getPolicyCommitment(account, sessionActorId), bytes32(0));
         assertEq(accountConfiguration.getPolicyManager(account, sessionActorId), address(0));
         AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, sessionActorId);
-        assertEq(cfg.policyType, 0x00);
         assertEq(cfg.scope, 0x00);
     }
 
@@ -177,6 +174,41 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
 
         assertEq(accountConfiguration.getPolicyManager(account, sessionActorId), newManager);
         assertEq(accountConfiguration.getPolicyCommitment(account, sessionActorId), newCommitment);
+    }
+
+    function test_authorizePolicyActor_allowsAnyScopeCombination() public {
+        // This contract does not reject scope combinations: an actor may carry SCOPE_POLICY alongside any other
+        // scope bits (or none) — use-time exclusivity between SCOPE_POLICY and other capabilities is protocol-side,
+        // not enforced here.
+        (address account,) = _createK1Account(ROOT_PK);
+
+        uint8[4] memory otherScopes = [
+            uint8(0),
+            accountConfiguration.SCOPE_SIGNER(),
+            accountConfiguration.SCOPE_PAYER(),
+            accountConfiguration.SCOPE_CONFIG()
+        ];
+        for (uint256 i; i < otherScopes.length; i++) {
+            bytes32 actorId = bytes32(bytes20(vm.addr(SESSION_PK + i + 1)));
+            uint8 scope = otherScopes[i] | accountConfiguration.SCOPE_POLICY();
+            AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
+                authenticator: address(k1Authenticator), scope: scope, expiry: 0, nonceLane: 0
+            });
+            AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
+            changes[0] = AccountConfiguration.ActorChange({
+                actorId: actorId,
+                changeType: AUTHORIZE_ACTOR,
+                data: abi.encode(cfg, abi.encodePacked(DUMMY_MANAGER, DUMMY_COMMITMENT))
+            });
+            uint64 seq = accountConfiguration.getChangeSequences(account).local;
+            bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
+            accountConfiguration.applySignedActorChanges(
+                account, uint64(block.chainid), changes, _buildK1Auth(ROOT_PK, digest)
+            );
+
+            assertEq(accountConfiguration.getPolicyManager(account, actorId), DUMMY_MANAGER);
+            assertEq(accountConfiguration.getPolicyCommitment(account, actorId), DUMMY_COMMITMENT);
+        }
     }
 
     // ── Isolation (correct mapping key derivation) ──
@@ -225,7 +257,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
 
     // ── Helpers ──
 
-    /// @dev Authorize a non-self actor with a gated (policyType=POLICY_GATED) policy bound to (manager, commitment).
+    /// @dev Authorize a non-self actor with a SCOPE_POLICY-gated policy bound to (manager, commitment).
     ///      Signed by the root key, which is the unrestricted-owner k1 actor installed by `_createK1Account`.
     function _authorizePolicyActor(
         address account,
@@ -235,7 +267,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         bytes32 commitment
     ) internal {
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: SCOPE_SENDER, expiry: 0, policyType: POLICY_GATED
+            authenticator: address(k1Authenticator), scope: accountConfiguration.SCOPE_POLICY(), expiry: 0, nonceLane: 0
         });
         bytes memory policyData = abi.encodePacked(policyManager, commitment);
 
@@ -261,9 +293,9 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         bytes32 selfActorId = bytes32(bytes20(eoa));
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
             authenticator: accountConfiguration.K1_AUTHENTICATOR(),
-            scope: SCOPE_SENDER,
+            scope: accountConfiguration.SCOPE_POLICY(),
             expiry: 0,
-            policyType: POLICY_GATED
+            nonceLane: 0
         });
         bytes memory policyData = abi.encodePacked(policyManager, commitment);
 
@@ -283,9 +315,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: AUTHORIZE_ACTOR,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: authenticator, scope: 0x00, expiry: 0, policyType: 0x00
-                }),
+                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: 0x00, expiry: 0, nonceLane: 0}),
                 bytes("")
             )
         });

--- a/test/unit/AccountConfiguration/policyAccessors.t.sol
+++ b/test/unit/AccountConfiguration/policyAccessors.t.sol
@@ -396,8 +396,8 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
 
         uint8[4] memory otherScopes = [
             uint8(0),
-            accountConfiguration.SCOPE_SIGNER(),
-            accountConfiguration.SCOPE_PAYER(),
+            accountConfiguration.SCOPE_SELF_PAYER(),
+            accountConfiguration.SCOPE_SPONSOR_PAYER(),
             accountConfiguration.SCOPE_NONCE()
         ];
         for (uint256 i; i < otherScopes.length; i++) {

--- a/test/unit/AccountConfiguration/policyAccessors.t.sol
+++ b/test/unit/AccountConfiguration/policyAccessors.t.sol
@@ -127,7 +127,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         bytes32 selfActorId = bytes32(bytes20(eoa));
 
         // Pre-authorize a separate unrestricted-owner key. Once we downgrade the self-actorId to
-        // SCOPE_SENDER + policy below, it no longer carries SCOPE_CONFIG and can't sign the revoke.
+        // SCOPE_SENDER + policy below, admin is exactly scope == 0, so it can't sign the revoke.
         bytes32 ownerActorId = bytes32(bytes20(vm.addr(SESSION_PK)));
         _authorizeUngatedActor(eoa, EOA_PK, ownerActorId, address(k1Authenticator));
 
@@ -186,14 +186,13 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
             uint8(0),
             accountConfiguration.SCOPE_SIGNER(),
             accountConfiguration.SCOPE_PAYER(),
-            accountConfiguration.SCOPE_CONFIG()
+            accountConfiguration.SCOPE_NONCE()
         ];
         for (uint256 i; i < otherScopes.length; i++) {
             bytes32 actorId = bytes32(bytes20(vm.addr(SESSION_PK + i + 1)));
             uint8 scope = otherScopes[i] | accountConfiguration.SCOPE_POLICY();
-            AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-                authenticator: address(k1Authenticator), scope: scope, expiry: 0, nonceLane: 0
-            });
+            AccountConfiguration.ActorConfig memory cfg =
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0});
             AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
             changes[0] = AccountConfiguration.ActorChange({
                 actorId: actorId,
@@ -267,7 +266,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         bytes32 commitment
     ) internal {
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: accountConfiguration.SCOPE_POLICY(), expiry: 0, nonceLane: 0
+            authenticator: address(k1Authenticator), scope: accountConfiguration.SCOPE_POLICY(), expiry: 0
         });
         bytes memory policyData = abi.encodePacked(policyManager, commitment);
 
@@ -294,8 +293,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
             authenticator: accountConfiguration.K1_AUTHENTICATOR(),
             scope: accountConfiguration.SCOPE_POLICY(),
-            expiry: 0,
-            nonceLane: 0
+            expiry: 0
         });
         bytes memory policyData = abi.encodePacked(policyManager, commitment);
 
@@ -315,8 +313,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: AUTHORIZE_ACTOR,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: 0x00, expiry: 0, nonceLane: 0}),
-                bytes("")
+                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: 0x00, expiry: 0}), bytes("")
             )
         });
         uint64 seq = accountConfiguration.getChangeSequences(account).local;

--- a/test/unit/accounts/BackwardsCompatible4337Account.t.sol
+++ b/test/unit/accounts/BackwardsCompatible4337Account.t.sol
@@ -93,18 +93,19 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
     }
 
     /// @dev Authorizes a new K1 actor on `account` with the given scope/policy, signed by the unrestricted owner
-    ///      (`ownerPk`) via `applySignedActorChanges`. Returns the new actor's id.
+    ///      (`ownerPk`) via `applySignedActorChanges`. Returns the new actor's id. Policy data is attached whenever
+    ///      `scope` carries SCOPE_POLICY.
     function _authorizeScopedActor(
         address account,
         uint256 ownerPk,
         uint256 newPk,
         uint8 scope,
-        uint8 policyType,
         address policyManager,
         bytes32 commitment
     ) internal returns (bytes32 newActorId) {
         newActorId = bytes32(bytes20(vm.addr(newPk)));
-        bytes memory policyData = policyType == 0 ? bytes("") : abi.encodePacked(policyManager, commitment);
+        bytes memory policyData =
+            scope & accountConfiguration.SCOPE_POLICY() == 0 ? bytes("") : abi.encodePacked(policyManager, commitment);
 
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({
@@ -112,7 +113,7 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: scope, expiry: 0, policyType: policyType
+                    authenticator: address(k1Authenticator), scope: scope, expiry: 0, nonceLane: 0
                 }),
                 policyData
             )
@@ -137,7 +138,7 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -183,7 +184,7 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: TRUSTED_EXECUTOR, scope: SCOPE_SENDER, expiry: 0, policyType: 0
+                    authenticator: TRUSTED_EXECUTOR, scope: SCOPE_SENDER, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )
@@ -374,7 +375,7 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
     function test_isValidSignature_requiresSignerScope() public {
         (address account,) = _create4337Account(ACTOR_PK);
         uint256 senderOnlyPk = 201;
-        _authorizeScopedActor(account, ACTOR_PK, senderOnlyPk, SCOPE_SENDER, 0, address(0), bytes32(0));
+        _authorizeScopedActor(account, ACTOR_PK, senderOnlyPk, SCOPE_SENDER, address(0), bytes32(0));
 
         bytes32 hash = keccak256("sign me");
         bytes memory authData = _buildK1Auth(senderOnlyPk, hash);
@@ -386,7 +387,7 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
     function test_isValidSignature_signerScopeSucceeds() public {
         (address account,) = _create4337Account(ACTOR_PK);
         uint256 signerPk = 202;
-        _authorizeScopedActor(account, ACTOR_PK, signerPk, SCOPE_SIGNER, 0, address(0), bytes32(0));
+        _authorizeScopedActor(account, ACTOR_PK, signerPk, SCOPE_SIGNER, address(0), bytes32(0));
 
         bytes32 hash = keccak256("sign me");
         bytes memory authData = _buildK1Auth(signerPk, hash);
@@ -399,7 +400,7 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
     function test_validateUserOp_senderScopeAuthorizes() public {
         (address account,) = _create4337Account(ACTOR_PK);
         uint256 senderPk = 203;
-        _authorizeScopedActor(account, ACTOR_PK, senderPk, SCOPE_SENDER, 0, address(0), bytes32(0));
+        _authorizeScopedActor(account, ACTOR_PK, senderPk, SCOPE_SENDER, address(0), bytes32(0));
 
         bytes32 userOpHash = keccak256("op");
         PackedUserOperation memory userOp = _buildUserOp(account, _buildK1Auth(senderPk, userOpHash));
@@ -411,7 +412,7 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
     function test_validateUserOp_requiresSenderScope() public {
         (address account,) = _create4337Account(ACTOR_PK);
         uint256 signerOnlyPk = 204;
-        _authorizeScopedActor(account, ACTOR_PK, signerOnlyPk, SCOPE_SIGNER, 0, address(0), bytes32(0));
+        _authorizeScopedActor(account, ACTOR_PK, signerOnlyPk, SCOPE_SIGNER, address(0), bytes32(0));
 
         bytes32 userOpHash = keccak256("op");
         PackedUserOperation memory userOp = _buildUserOp(account, _buildK1Auth(signerOnlyPk, userOpHash));
@@ -427,7 +428,7 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
         (address account,) = _create4337Account(ACTOR_PK);
         vm.deal(account, 1 ether);
         uint256 senderOnlyPk = 205;
-        _authorizeScopedActor(account, ACTOR_PK, senderOnlyPk, SCOPE_SENDER, 0, address(0), bytes32(0));
+        _authorizeScopedActor(account, ACTOR_PK, senderOnlyPk, SCOPE_SENDER, address(0), bytes32(0));
 
         bytes32 userOpHash = keccak256("op");
         PackedUserOperation memory userOp = _buildUserOp(account, _buildK1Auth(senderOnlyPk, userOpHash));
@@ -441,7 +442,7 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
         (address account,) = _create4337Account(ACTOR_PK);
         vm.deal(account, 1 ether);
         uint256 pk = 206;
-        _authorizeScopedActor(account, ACTOR_PK, pk, SCOPE_SENDER | SCOPE_PAYER, 0, address(0), bytes32(0));
+        _authorizeScopedActor(account, ACTOR_PK, pk, SCOPE_SENDER | SCOPE_PAYER, address(0), bytes32(0));
 
         bytes32 userOpHash = keccak256("op");
         PackedUserOperation memory userOp = _buildUserOp(account, _buildK1Auth(pk, userOpHash));
@@ -450,35 +451,42 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
         assertEq(BackwardsCompatible4337Account(payable(account)).validateUserOp(userOp, userOpHash, 0.1 ether), 0);
     }
 
-    // ── Policy gating (calls confined to policy target) ──
+    // ── SCOPE_POLICY (no native-dispatch call-target gating in this reduced 4337 bridge) ──
 
-    function test_validateUserOp_policyGated_allowsCallsToPolicyTarget() public {
+    function test_validateUserOp_policyScopeOnly_rejectedForLackingSenderScope() public {
         (address account,) = _create4337Account(ACTOR_PK);
         address policyManager = address(0xB0B);
         uint256 pk = 207;
-        _authorizeScopedActor(account, ACTOR_PK, pk, SCOPE_SENDER, 0x01, policyManager, keccak256("commit"));
+        _authorizeScopedActor(
+            account, ACTOR_PK, pk, accountConfiguration.SCOPE_POLICY(), policyManager, keccak256("commit")
+        );
 
+        // A pure-SCOPE_POLICY actor lacks SCOPE_SENDER, so this reduced 4337 bridge rejects it outright — it does
+        // not replicate native-dispatch's policy-target call gating.
         bytes memory callData = _executeBatchCallData(policyManager, 0, abi.encodeCall(UserOpMockTarget.setValue, (1)));
         bytes32 userOpHash = keccak256(abi.encode("op", callData));
         PackedUserOperation memory userOp = _buildUserOp(account, callData, _buildK1Auth(pk, userOpHash));
 
         vm.prank(ENTRY_POINT);
-        assertEq(BackwardsCompatible4337Account(payable(account)).validateUserOp(userOp, userOpHash, 0), 0);
+        assertEq(BackwardsCompatible4337Account(payable(account)).validateUserOp(userOp, userOpHash, 0), 1);
     }
 
-    function test_validateUserOp_policyGated_rejectsCallsToOtherTarget() public {
+    function test_validateUserOp_policyAndSenderScope_authorizedWithoutTargetGating() public {
         (address account,) = _create4337Account(ACTOR_PK);
         address policyManager = address(0xB0B);
         uint256 pk = 208;
-        _authorizeScopedActor(account, ACTOR_PK, pk, SCOPE_SENDER, 0x01, policyManager, keccak256("commit"));
+        uint8 scope = SCOPE_SENDER | accountConfiguration.SCOPE_POLICY();
+        _authorizeScopedActor(account, ACTOR_PK, pk, scope, policyManager, keccak256("commit"));
 
-        // Call targets the MockTarget directly, escaping the actor's policy gate.
+        // An actor combining SCOPE_POLICY | SCOPE_SENDER is authorized here exactly like any other SENDER-scoped
+        // actor: this reduced 4337 bridge does not confine its calls to the policy target (that enforcement is
+        // native-dispatch, protocol-side behavior out of scope for this repo).
         bytes memory callData =
             _executeBatchCallData(address(target), 0, abi.encodeCall(UserOpMockTarget.setValue, (1)));
         bytes32 userOpHash = keccak256(abi.encode("op", callData));
         PackedUserOperation memory userOp = _buildUserOp(account, callData, _buildK1Auth(pk, userOpHash));
 
         vm.prank(ENTRY_POINT);
-        assertEq(BackwardsCompatible4337Account(payable(account)).validateUserOp(userOp, userOpHash, 0), 1);
+        assertEq(BackwardsCompatible4337Account(payable(account)).validateUserOp(userOp, userOpHash, 0), 0);
     }
 }

--- a/test/unit/accounts/BackwardsCompatible4337Account.t.sol
+++ b/test/unit/accounts/BackwardsCompatible4337Account.t.sol
@@ -29,8 +29,8 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
     uint256 constant ACTOR_PK = 100;
 
     uint8 constant SCOPE_SENDER = 0x01;
-    uint8 constant SCOPE_PAYER = 0x08;
-    uint8 constant SCOPE_SIGNER = 0x10;
+    uint8 constant SCOPE_SELF_PAYER = 0x08;
+    uint8 constant SCOPE_SPONSOR_PAYER = 0x10;
 
     bytes32 constant SIGNED_ACTOR_CHANGES_MAGIC = keccak256("ERC4337Account.signedActorChanges.v1");
 
@@ -365,27 +365,26 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
         assertEq(BackwardsCompatible4337Account(payable(account)).validateUserOp(userOp, userOpHash, 0), 1);
     }
 
-    // ── SIGNER scope (ERC-1271) ──
+    // ── ERC-1271 signing (admin-only) ──
 
-    function test_isValidSignature_requiresSignerScope() public {
+    function test_isValidSignature_scopedActorCannotSign() public {
         (address account,) = _create4337Account(ACTOR_PK);
-        uint256 senderOnlyPk = 201;
-        _authorizeScopedActor(account, ACTOR_PK, senderOnlyPk, SCOPE_SENDER, address(0), bytes32(0));
+        uint256 scopedPk = 201;
+        _authorizeScopedActor(account, ACTOR_PK, scopedPk, SCOPE_SENDER, address(0), bytes32(0));
 
         bytes32 hash = keccak256("sign me");
-        bytes memory authData = _buildK1Auth(senderOnlyPk, hash);
+        bytes memory authData = _buildK1Auth(scopedPk, hash);
 
-        // A SENDER-only actor lacks SIGNER scope, so ERC-1271 validation must fail.
+        // A scoped (non-admin) actor cannot ERC-1271 sign — signing is admin-only, so validation must fail.
         assertEq(DefaultAccount(payable(account)).isValidSignature(hash, authData), bytes4(0xFFFFFFFF));
     }
 
-    function test_isValidSignature_signerScopeSucceeds() public {
+    function test_isValidSignature_adminSucceeds() public {
         (address account,) = _create4337Account(ACTOR_PK);
-        uint256 signerPk = 202;
-        _authorizeScopedActor(account, ACTOR_PK, signerPk, SCOPE_SIGNER, address(0), bytes32(0));
 
+        // The unrestricted admin actor (scope == 0x00) is the only actor that can ERC-1271 sign.
         bytes32 hash = keccak256("sign me");
-        bytes memory authData = _buildK1Auth(signerPk, hash);
+        bytes memory authData = _buildK1Auth(ACTOR_PK, hash);
 
         assertEq(DefaultAccount(payable(account)).isValidSignature(hash, authData), bytes4(0x1626ba7e));
     }
@@ -406,20 +405,20 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
 
     function test_validateUserOp_requiresSenderScope() public {
         (address account,) = _create4337Account(ACTOR_PK);
-        uint256 signerOnlyPk = 204;
-        _authorizeScopedActor(account, ACTOR_PK, signerOnlyPk, SCOPE_SIGNER, address(0), bytes32(0));
+        uint256 nonSenderPk = 204;
+        _authorizeScopedActor(account, ACTOR_PK, nonSenderPk, SCOPE_SPONSOR_PAYER, address(0), bytes32(0));
 
         bytes32 userOpHash = keccak256("op");
-        PackedUserOperation memory userOp = _buildUserOp(account, _buildK1Auth(signerOnlyPk, userOpHash));
+        PackedUserOperation memory userOp = _buildUserOp(account, _buildK1Auth(nonSenderPk, userOpHash));
 
-        // A SIGNER-only actor cannot initiate transactions: no SENDER scope.
+        // An actor without SENDER scope cannot initiate transactions.
         vm.prank(ENTRY_POINT);
         assertEq(BackwardsCompatible4337Account(payable(account)).validateUserOp(userOp, userOpHash, 0), 1);
     }
 
-    // ── PAYER scope (self-funded ops) ──
+    // ── SELF_PAYER scope (self-funded ops) ──
 
-    function test_validateUserOp_selfFundedRequiresPayerScope() public {
+    function test_validateUserOp_selfFundedRequiresSelfPayerScope() public {
         (address account,) = _create4337Account(ACTOR_PK);
         vm.deal(account, 1 ether);
         uint256 senderOnlyPk = 205;
@@ -428,16 +427,16 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
         bytes32 userOpHash = keccak256("op");
         PackedUserOperation memory userOp = _buildUserOp(account, _buildK1Auth(senderOnlyPk, userOpHash));
 
-        // SENDER but not PAYER: cannot authorize spending the account's funds on gas.
+        // SENDER but not SELF_PAYER: cannot authorize spending the account's funds on gas.
         vm.prank(ENTRY_POINT);
         assertEq(BackwardsCompatible4337Account(payable(account)).validateUserOp(userOp, userOpHash, 0.1 ether), 1);
     }
 
-    function test_validateUserOp_senderPayerScope_selfFundedSucceeds() public {
+    function test_validateUserOp_senderSelfPayerScope_selfFundedSucceeds() public {
         (address account,) = _create4337Account(ACTOR_PK);
         vm.deal(account, 1 ether);
         uint256 pk = 206;
-        _authorizeScopedActor(account, ACTOR_PK, pk, SCOPE_SENDER | SCOPE_PAYER, address(0), bytes32(0));
+        _authorizeScopedActor(account, ACTOR_PK, pk, SCOPE_SENDER | SCOPE_SELF_PAYER, address(0), bytes32(0));
 
         bytes32 userOpHash = keccak256("op");
         PackedUserOperation memory userOp = _buildUserOp(account, _buildK1Auth(pk, userOpHash));

--- a/test/unit/accounts/BackwardsCompatible4337Account.t.sol
+++ b/test/unit/accounts/BackwardsCompatible4337Account.t.sol
@@ -112,9 +112,7 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: scope, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0}),
                 policyData
             )
         });
@@ -137,9 +135,7 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });
@@ -183,9 +179,7 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
             actorId: bytes32(bytes20(relayer)),
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: TRUSTED_EXECUTOR, scope: SCOPE_SENDER, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: TRUSTED_EXECUTOR, scope: SCOPE_SENDER, expiry: 0}),
                 bytes("")
             )
         });

--- a/test/unit/accounts/BackwardsCompatible4337Account.t.sol
+++ b/test/unit/accounts/BackwardsCompatible4337Account.t.sol
@@ -365,24 +365,37 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
         assertEq(BackwardsCompatible4337Account(payable(account)).validateUserOp(userOp, userOpHash, 0), 1);
     }
 
-    // ── ERC-1271 signing (admin-only) ──
+    // ── ERC-1271 signing (operational authority) ──
 
-    function test_isValidSignature_scopedActorCannotSign() public {
+    function test_isValidSignature_nonOperationalActorCannotSign() public {
         (address account,) = _create4337Account(ACTOR_PK);
         uint256 scopedPk = 201;
-        _authorizeScopedActor(account, ACTOR_PK, scopedPk, SCOPE_SENDER, address(0), bytes32(0));
+        // A payer-only (non-SENDER) actor is not operational.
+        _authorizeScopedActor(account, ACTOR_PK, scopedPk, SCOPE_SPONSOR_PAYER, address(0), bytes32(0));
 
         bytes32 hash = keccak256("sign me");
         bytes memory authData = _buildK1Auth(scopedPk, hash);
 
-        // A scoped (non-admin) actor cannot ERC-1271 sign — signing is admin-only, so validation must fail.
+        // A non-operational scoped actor cannot ERC-1271 sign, so validation must fail.
         assertEq(DefaultAccount(payable(account)).isValidSignature(hash, authData), bytes4(0xFFFFFFFF));
+    }
+
+    function test_isValidSignature_operationalSenderSigns() public {
+        (address account,) = _create4337Account(ACTOR_PK);
+        uint256 senderPk = 202;
+        // A SENDER-without-POLICY actor is operational and can ERC-1271 sign.
+        _authorizeScopedActor(account, ACTOR_PK, senderPk, SCOPE_SENDER, address(0), bytes32(0));
+
+        bytes32 hash = keccak256("sign me");
+        bytes memory authData = _buildK1Auth(senderPk, hash);
+
+        assertEq(DefaultAccount(payable(account)).isValidSignature(hash, authData), bytes4(0x1626ba7e));
     }
 
     function test_isValidSignature_adminSucceeds() public {
         (address account,) = _create4337Account(ACTOR_PK);
 
-        // The unrestricted admin actor (scope == 0x00) is the only actor that can ERC-1271 sign.
+        // The unrestricted admin actor (scope == 0x00) is operational and can ERC-1271 sign.
         bytes32 hash = keccak256("sign me");
         bytes memory authData = _buildK1Auth(ACTOR_PK, hash);
 

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -26,9 +26,9 @@ contract DefaultAccountTest is AccountConfigurationTest {
     bytes4 constant ERC1271_MAGIC = 0x1626ba7e;
     bytes4 constant ERC1271_FAIL = 0xFFFFFFFF;
 
-    // Scope bits: SIGNER gates isValidSignature; SENDER is a non-signing scope.
+    // Scope bits: ERC-1271 signing is admin-only (scope == 0x00); SENDER and SPONSOR_PAYER are non-admin scopes.
     uint8 constant SCOPE_SENDER = 0x01;
-    uint8 constant SCOPE_SIGNER = 0x10;
+    uint8 constant SCOPE_SPONSOR_PAYER = 0x10;
 
     // TRUSTED_EXECUTOR sentinel: the authenticator value that marks an actor as a direct-execution caller.
     address constant TRUSTED_EXECUTOR = address(uint160(uint256(keccak256("trustedExecutor"))));
@@ -271,9 +271,9 @@ contract DefaultAccountTest is AccountConfigurationTest {
         assertEq(result, ERC1271_FAIL);
     }
 
-    /// @notice A valid signature from an actor holding a non-signing scope returns the failure magic value.
-    /// @dev verifySignature is false when scope != 0 and SCOPE_SIGNER is unset (here SCOPE_SENDER only).
-    function test_isValidSignature_success_returnsFailureForNonSignerScope(
+    /// @notice A valid signature from an actor holding a non-admin scope returns the failure magic value.
+    /// @dev verifySignature is false when scope != 0 (ERC-1271 signing is admin-only); here SCOPE_SENDER.
+    function test_isValidSignature_success_returnsFailureForNonAdminScope(
         uint256 ownerSeed,
         uint256 actorSeed,
         bytes32 hash
@@ -327,9 +327,10 @@ contract DefaultAccountTest is AccountConfigurationTest {
         assertEq(result, ERC1271_MAGIC);
     }
 
-    /// @notice A valid signature from an actor explicitly scoped SCOPE_SIGNER returns the magic value.
-    /// @dev Covers the `scope & SCOPE_SIGNER != 0` leg of verifySignature (as opposed to the scope == 0 leg).
-    function test_isValidSignature_success_scopedSignerActor(uint256 ownerSeed, uint256 actorSeed, bytes32 hash)
+    /// @notice ERC-1271 signing is admin-only: a scoped (non-admin) actor never validates, even for the former
+    ///         SIGNER bit (0x10, now SCOPE_SPONSOR_PAYER). Only the scope-0 admin returns the magic value.
+    /// @dev There is no SIGNER grant anymore; a scoped actor's valid signature returns the failure magic value.
+    function test_isValidSignature_success_scopedActorCannotSign(uint256 ownerSeed, uint256 actorSeed, bytes32 hash)
         public
     {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
@@ -339,12 +340,12 @@ contract DefaultAccountTest is AccountConfigurationTest {
         address actor = vm.addr(actorPk);
         vm.assume(actor != vm.addr(ownerPk) && actor != account);
 
-        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(actor)), k1Authenticator, SCOPE_SIGNER);
+        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(actor)), k1Authenticator, SCOPE_SPONSOR_PAYER);
 
         bytes memory authData = _buildK1Auth(actorPk, hash);
 
         bytes4 result = DefaultAccount(payable(account)).isValidSignature(hash, authData);
-        assertEq(result, ERC1271_MAGIC);
+        assertEq(result, ERC1271_FAIL);
     }
 
     // ══════════════════════════════════════════════

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -26,8 +26,10 @@ contract DefaultAccountTest is AccountConfigurationTest {
     bytes4 constant ERC1271_MAGIC = 0x1626ba7e;
     bytes4 constant ERC1271_FAIL = 0xFFFFFFFF;
 
-    // Scope bits: ERC-1271 signing is admin-only (scope == 0x00); SENDER and SPONSOR_PAYER are non-admin scopes.
+    // Scope bits: ERC-1271 signing is operational (admin scope == 0x00, or SENDER without POLICY). SELF_PAYER and
+    // SPONSOR_PAYER are non-SENDER capability scopes that are not operational on their own.
     uint8 constant SCOPE_SENDER = 0x01;
+    uint8 constant SCOPE_SELF_PAYER = 0x08;
     uint8 constant SCOPE_SPONSOR_PAYER = 0x10;
 
     // TRUSTED_EXECUTOR sentinel: the authenticator value that marks an actor as a direct-execution caller.
@@ -271,9 +273,9 @@ contract DefaultAccountTest is AccountConfigurationTest {
         assertEq(result, ERC1271_FAIL);
     }
 
-    /// @notice A valid signature from an actor holding a non-admin scope returns the failure magic value.
-    /// @dev verifySignature is false when scope != 0 (ERC-1271 signing is admin-only); here SCOPE_SENDER.
-    function test_isValidSignature_success_returnsFailureForNonAdminScope(
+    /// @notice A valid signature from a payer-only (non-SENDER, non-admin) actor returns the failure magic value.
+    /// @dev verifySignature is false for a non-operational actor; here SCOPE_SELF_PAYER (no SENDER, no admin).
+    function test_isValidSignature_success_returnsFailureForNonOperationalScope(
         uint256 ownerSeed,
         uint256 actorSeed,
         bytes32 hash
@@ -285,13 +287,35 @@ contract DefaultAccountTest is AccountConfigurationTest {
         address actor = vm.addr(actorPk);
         vm.assume(actor != vm.addr(ownerPk) && actor != account);
 
-        // Authorize the actor with SENDER scope only — it can act but cannot validate signatures.
-        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(actor)), k1Authenticator, SCOPE_SENDER);
+        // Authorize the actor with SELF_PAYER scope only — it is not operational and cannot validate signatures.
+        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(actor)), k1Authenticator, SCOPE_SELF_PAYER);
 
         bytes memory authData = _buildK1Auth(actorPk, hash);
 
         bytes4 result = DefaultAccount(payable(account)).isValidSignature(hash, authData);
         assertEq(result, ERC1271_FAIL);
+    }
+
+    /// @notice A valid signature from an operational SENDER-without-POLICY actor returns the ERC-1271 magic value.
+    /// @dev verifySignature is true for an operational actor: signing encodes authority a SENDER key already holds
+    ///      via calls, so it does not require the admin scope.
+    function test_isValidSignature_success_operationalSenderSigns(uint256 ownerSeed, uint256 actorSeed, bytes32 hash)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        (address account,) = _createK1Account(ownerPk);
+
+        uint256 actorPk = _boundK1Pk(actorSeed);
+        address actor = vm.addr(actorPk);
+        vm.assume(actor != vm.addr(ownerPk) && actor != account);
+
+        // Authorize the actor with SENDER scope only (no POLICY) — it is operational and can validate signatures.
+        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(actor)), k1Authenticator, SCOPE_SENDER);
+
+        bytes memory authData = _buildK1Auth(actorPk, hash);
+
+        bytes4 result = DefaultAccount(payable(account)).isValidSignature(hash, authData);
+        assertEq(result, ERC1271_MAGIC);
     }
 
     /// @notice A signature blob shorter than the 20-byte authenticator prefix returns the failure magic value.
@@ -327,9 +351,9 @@ contract DefaultAccountTest is AccountConfigurationTest {
         assertEq(result, ERC1271_MAGIC);
     }
 
-    /// @notice ERC-1271 signing is admin-only: a scoped (non-admin) actor never validates, even for the former
-    ///         SIGNER bit (0x10, now SCOPE_SPONSOR_PAYER). Only the scope-0 admin returns the magic value.
-    /// @dev There is no SIGNER grant anymore; a scoped actor's valid signature returns the failure magic value.
+    /// @notice A non-operational scoped actor never validates, even for the former SIGNER bit (0x10, now
+    ///         SCOPE_SPONSOR_PAYER). Only an operational actor (admin, or SENDER-without-POLICY) returns the magic.
+    /// @dev There is no SIGNER grant anymore; a sponsor-payer actor's valid signature returns the failure magic value.
     function test_isValidSignature_success_scopedActorCannotSign(uint256 ownerSeed, uint256 actorSeed, bytes32 hash)
         public
     {

--- a/test/unit/accounts/DefaultHighRateAccount.t.sol
+++ b/test/unit/accounts/DefaultHighRateAccount.t.sol
@@ -42,9 +42,9 @@ contract DefaultHighRateAccountTest is AccountConfigurationTest {
         account = accountConfiguration.createAccount(bytes32(uint256(0xbeef)), bytecode, actors);
     }
 
-    function _lockAccount(address account, uint16 unlockDelay) internal {
-        vm.prank(account);
-        accountConfiguration.lock(unlockDelay);
+    /// @dev Hard-lock `account` via the signed lock path, authorized by its admin owner key `pk`.
+    function _lockAccount(uint256 pk, address account, uint16 unlockDelay) internal {
+        _signedLock(pk, account, unlockDelay);
     }
 
     function _singleCall(address t, uint256 v, bytes memory d) internal pure returns (Call[] memory calls) {
@@ -112,7 +112,7 @@ contract DefaultHighRateAccountTest is AccountConfigurationTest {
         (address account,) = _createHighRateK1Account(ACTOR_PK);
         vm.deal(account, 1 ether);
 
-        _lockAccount(account, 1 hours);
+        _lockAccount(ACTOR_PK, account, 1 hours);
 
         vm.prank(account);
         vm.expectRevert(DefaultHighRateAccount.AccountLocked.selector);
@@ -123,7 +123,7 @@ contract DefaultHighRateAccountTest is AccountConfigurationTest {
     function test_executeBatch_allowsZeroValueCallsWhenLocked() public {
         (address account,) = _createHighRateK1Account(ACTOR_PK);
 
-        _lockAccount(account, 1 hours);
+        _lockAccount(ACTOR_PK, account, 1 hours);
 
         vm.prank(account);
         DefaultHighRateAccount(payable(account))

--- a/test/unit/accounts/UpgradeableAccount.t.sol
+++ b/test/unit/accounts/UpgradeableAccount.t.sol
@@ -148,7 +148,7 @@ contract UpgradeableAccountTest is AccountConfigurationTest {
 
     /// @dev A plain self-call to upgradeToAndCall must revert: {_authorizeUpgrade} is gated on the one-shot
     ///      `_upgradeAuthorized` flag, not on `msg.sender == address(this)`, so upgrading always requires going
-    ///      through {upgradeBySignature}'s CONFIG-scoped signature check.
+    ///      through {upgradeBySignature}'s unrestricted-owner-scoped signature check.
     function test_upgrade_revertsFromDirectSelfCall() public {
         (address account,) = _createUpgradeableAccount(ACTOR_PK);
         UpgradeableAccountV2 v2Impl = new UpgradeableAccountV2(address(accountConfiguration));
@@ -182,9 +182,9 @@ contract UpgradeableAccountTest is AccountConfigurationTest {
 
     /// @dev Closes the gap the plain self-call check would otherwise leave open: batching a call to
     ///      `upgradeToAndCall` targeting `address(this)` makes that inner call's `msg.sender == address(this)`
-    ///      too, but `executeBatch` never checks CONFIG scope specifically (only that the caller is authorized to
-    ///      drive calls at all, e.g. any SENDER-scoped actor) — so this must revert regardless of who can call
-    ///      `executeBatch`.
+    ///      too, but `executeBatch` never checks for an unrestricted-owner scope specifically (only that the
+    ///      caller is authorized to drive calls at all, e.g. any SENDER-scoped actor) — so this must revert
+    ///      regardless of who can call `executeBatch`.
     function test_upgrade_viaExecuteBatch_reverts() public {
         (address account,) = _createUpgradeableAccount(ACTOR_PK);
         UpgradeableAccountV2 v2Impl = new UpgradeableAccountV2(address(accountConfiguration));
@@ -243,9 +243,7 @@ contract UpgradeableAccountTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: scope, expiry: 0, nonceLane: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0}),
                 bytes("")
             )
         });
@@ -329,11 +327,11 @@ contract UpgradeableAccountTest is AccountConfigurationTest {
         UpgradeableAccount(payable(account)).upgradeBySignature(address(0), address(v2Impl), "", auth);
     }
 
-    function test_upgradeBySignature_revertsNonConfigScope() public {
+    function test_upgradeBySignature_revertsNonAdminScope() public {
         (address account,) = _createUpgradeableAccount(ACTOR_PK);
         UpgradeableAccountV2 v2Impl = new UpgradeableAccountV2(address(accountConfiguration));
 
-        // Authorize a SIGNER-scoped key (lacks CONFIG), then have it sign an upgrade.
+        // Admin is exactly scope == 0: a SIGNER-scoped key (any non-zero scope) cannot authorize an upgrade.
         _addScopedActor(account, ACTOR_PK, SCOPED_PK, accountConfiguration.SCOPE_SIGNER());
 
         bytes32 digest = _upgradeDigest(account, address(0), address(v2Impl), "");
@@ -341,18 +339,6 @@ contract UpgradeableAccountTest is AccountConfigurationTest {
 
         vm.expectRevert(UpgradeableAccount.UpgradeUnauthorized.selector);
         UpgradeableAccount(payable(account)).upgradeBySignature(address(0), address(v2Impl), "", auth);
-    }
-
-    function test_upgradeBySignature_configKeySucceeds() public {
-        (address account,) = _createUpgradeableAccount(ACTOR_PK);
-        UpgradeableAccountV2 v2Impl = new UpgradeableAccountV2(address(accountConfiguration));
-
-        // A CONFIG key (SCOPE_CONFIG) is authorized to upgrade, even though it is not an unrestricted owner.
-        _addScopedActor(account, ACTOR_PK, SCOPED_PK, accountConfiguration.SCOPE_CONFIG());
-
-        _signedUpgrade(account, SCOPED_PK, address(0), address(v2Impl), "");
-
-        assertEq(UpgradeableAccountV2(payable(account)).version(), 2);
     }
 
     function test_upgradeBySignature_revertsInvalidSignature() public {

--- a/test/unit/accounts/UpgradeableAccount.t.sol
+++ b/test/unit/accounts/UpgradeableAccount.t.sol
@@ -335,8 +335,8 @@ contract UpgradeableAccountTest is AccountConfigurationTest {
         (address account,) = _createUpgradeableAccount(ACTOR_PK);
         UpgradeableAccountV2 v2Impl = new UpgradeableAccountV2(address(accountConfiguration));
 
-        // Admin is exactly scope == 0: a SIGNER-scoped key (any non-zero scope) cannot authorize an upgrade.
-        _addScopedActor(account, ACTOR_PK, SCOPED_PK, accountConfiguration.SCOPE_SIGNER());
+        // Admin is exactly scope == 0: a scoped key (any non-zero scope) cannot authorize an upgrade.
+        _addScopedActor(account, ACTOR_PK, SCOPED_PK, accountConfiguration.SCOPE_SPONSOR_PAYER());
 
         bytes32 digest = _upgradeDigest(account, address(0), address(v2Impl), "");
         bytes memory auth = _buildK1Auth(SCOPED_PK, digest);

--- a/test/unit/accounts/UpgradeableAccount.t.sol
+++ b/test/unit/accounts/UpgradeableAccount.t.sol
@@ -244,7 +244,7 @@ contract UpgradeableAccountTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: scope, expiry: 0, policyType: 0x00
+                    authenticator: address(k1Authenticator), scope: scope, expiry: 0, nonceLane: 0
                 }),
                 bytes("")
             )

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -11,11 +11,13 @@ import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 ///         Guards, in source-execution order, each reverting with a custom error:
 ///           1. InvalidDataLength       — data.length < 40
 ///           2. RecursiveDelegation     — nestedAuthenticator == address(this) (blocks 1-hop recursion)
-///           3. InvalidNestedSignature  — verifySignature(delegate, hash, nestedAuth) is false
+///           3. InvalidNestedSignature  — the nested auth does not resolve to the admin actor on `delegate`
 ///         On success returns actorId = bytes32(bytes20(delegate)).
 ///
-///         verifySignature(delegate, hash, nestedAuth) is true iff the nested auth resolves to the admin
-///         actor on `delegate` (scope == 0x00) — ERC-1271 signing is admin-only, there is no SIGNER grant.
+///         The delegate vouch requires the nested auth to resolve to the ADMIN actor on `delegate` (scope ==
+///         0x00). This admin-only requirement is enforced independently of verifySignature (via authenticateActor
+///         + an explicit scope == 0 check): verifySignature is now operational (a SENDER-without-POLICY key can
+///         sign), but such a key must NOT be able to vouch as a delegate, so a non-admin nested actor reverts.
 contract DelegateAuthenticatorTest is AccountConfigurationTest {
     uint8 constant SCOPE_SENDER = 0x01;
     uint8 constant SCOPE_POLICY = 0x02;
@@ -54,10 +56,10 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
         delegateAuthenticator.authenticate(hash, data);
     }
 
-    // ── Guard 3: require(verifySignature(...)) ──
+    // ── Guard 3: nested actor must be admin (authenticateActor + scope == 0, decoupled from verifySignature) ──
 
     /// @dev A well-formed k1 nested auth whose recovered signer is not an actor on the delegate account
-    ///      makes verifySignature return false (authenticateActor reverts, caught as false).
+    ///      makes authenticateActor revert (caught) so the delegate vouch reverts InvalidNestedSignature.
     function test_authenticate_revert_invalidNestedSignature(uint256 ownerSeed, uint256 wrongSeed, bytes32 hash)
         public
     {
@@ -76,8 +78,8 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
     }
 
     /// @dev The nested signature is valid for account A's owner, but the delegate passed is account B, where
-    ///      that signer is not an actor. Confirms the delegate address scopes verification: verifySignature
-    ///      returns false and guard 3 reverts.
+    ///      that signer is not an actor. Confirms the delegate address scopes verification: authenticateActor
+    ///      reverts (caught) and guard 3 reverts InvalidNestedSignature.
     function test_authenticate_revert_delegateMismatch(uint256 ownerASeed, uint256 ownerBSeed, bytes32 hash) public {
         uint256 ownerAPk = _boundK1Pk(ownerASeed);
         uint256 ownerBPk = _boundK1Pk(ownerBSeed);
@@ -96,7 +98,7 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
     }
 
     /// @dev A nested signer that is a live actor on the delegate account but holds any non-zero (non-admin) scope
-    ///      fails verifySignature (signing is admin-only) and guard 3 reverts.
+    ///      is rejected: the delegate vouch requires admin (scope == 0x00) and guard 3 reverts.
     function test_authenticate_revert_nestedSignerIsScoped(
         uint256 ownerSeed,
         uint256 signerSeed,
@@ -107,7 +109,7 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
         uint256 signerPk = _boundK1Pk(signerSeed);
         vm.assume(vm.addr(ownerPk) != vm.addr(signerPk));
 
-        // Any non-zero scope → non-admin → verifySignature must return false. Clear POLICY so the scoped actor
+        // Any non-zero scope → non-admin → the delegate vouch must revert. Clear POLICY so the scoped actor
         // needs no policyData at authorization time.
         uint8 scope = uint8(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_POLICY;
         vm.assume(scope != 0);
@@ -122,9 +124,34 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
         delegateAuthenticator.authenticate(hash, data);
     }
 
+    /// @dev Regression guard for the operational/admin decoupling: a SENDER-without-POLICY nested actor on the
+    ///      delegate account CAN verifySignature (it is operational), yet it MUST NOT satisfy the delegate vouch,
+    ///      which stays admin-only. Asserts verifySignature is true for the same actor, then that the vouch reverts.
+    function test_authenticate_revert_operationalSenderCannotVouch(uint256 ownerSeed, uint256 signerSeed, bytes32 hash)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 signerPk = _boundK1Pk(signerSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(signerPk));
+
+        (address delegateAccount,) = _createK1Account(ownerPk);
+        vm.assume(vm.addr(signerPk) != delegateAccount);
+        _authorizeScopedK1Actor(delegateAccount, ownerPk, signerPk, SCOPE_SENDER);
+
+        bytes memory nestedAuth = abi.encodePacked(k1Authenticator, _signDigest(signerPk, hash));
+
+        // The SENDER-without-POLICY actor is operational: verifySignature returns true.
+        assertTrue(accountConfiguration.verifySignature(delegateAccount, hash, nestedAuth));
+
+        // But it cannot vouch as a delegate — the nested check stays admin-only.
+        bytes memory data = abi.encodePacked(delegateAccount, nestedAuth);
+        vm.expectRevert(DelegateAuthenticator.InvalidNestedSignature.selector);
+        delegateAuthenticator.authenticate(hash, data);
+    }
+
     // ── Happy paths ──
 
-    /// @dev An unrestricted (scope 0x00) initial owner passes verifySignature via the `scope == 0` branch;
+    /// @dev An unrestricted (scope 0x00) initial owner is admin, so the delegate vouch succeeds;
     ///      authenticate returns actorId = bytes32(bytes20(delegate)).
     function test_authenticate_success_unrestrictedNestedSigner(uint256 ownerSeed, bytes32 hash) public {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
@@ -138,7 +165,7 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
     }
 
     /// @dev The former SIGNER bit (0x10, now SCOPE_SPONSOR_PAYER) no longer grants signing: a nested actor holding
-    ///      it is non-admin, so verifySignature returns false and guard 3 reverts.
+    ///      it is non-admin (and non-operational), so the delegate vouch reverts.
     function test_authenticate_revert_formerSignerBitCannotSign(uint256 ownerSeed, uint256 signerSeed, bytes32 hash)
         public
     {

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -125,9 +125,8 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
     /// @dev Authorizes a new K1 actor (`newPk`) with `scope` on `account`, signed by the
     ///      unrestricted owner (`ownerPk`) via applySignedActorChanges on the local chain.
     function _authorizeScopedK1Actor(address account, uint256 ownerPk, uint256 newPk, uint8 scope) internal {
-        AccountConfiguration.ActorConfig memory config = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: scope, expiry: 0, nonceLane: 0
-        });
+        AccountConfiguration.ActorConfig memory config =
+            AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0});
 
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -14,14 +14,14 @@ import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 ///           3. InvalidNestedSignature  — verifySignature(delegate, hash, nestedAuth) is false
 ///         On success returns actorId = bytes32(bytes20(delegate)).
 ///
-///         verifySignature(delegate, hash, nestedAuth) is true iff the nested auth resolves to a live
-///         actor on `delegate` whose scope is unrestricted (0x00) or carries SCOPE_SIGNER.
+///         verifySignature(delegate, hash, nestedAuth) is true iff the nested auth resolves to the admin
+///         actor on `delegate` (scope == 0x00) — ERC-1271 signing is admin-only, there is no SIGNER grant.
 contract DelegateAuthenticatorTest is AccountConfigurationTest {
     uint8 constant SCOPE_SENDER = 0x01;
     uint8 constant SCOPE_POLICY = 0x02;
     uint8 constant SCOPE_NONCE = 0x04;
-    uint8 constant SCOPE_PAYER = 0x08;
-    uint8 constant SCOPE_SIGNER = 0x10;
+    uint8 constant SCOPE_SELF_PAYER = 0x08;
+    uint8 constant SCOPE_SPONSOR_PAYER = 0x10;
     uint8 constant AUTHORIZE_ACTOR = 0x01;
 
     // ── Guard 1: require(data.length >= 40) ──
@@ -95,9 +95,9 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
         delegateAuthenticator.authenticate(hash, data);
     }
 
-    /// @dev A nested signer that is a live actor on the delegate account but holds a non-zero scope lacking
-    ///      SCOPE_SIGNER (e.g. PAYER/SENDER/NONCE combinations) fails verifySignature and guard 3 reverts.
-    function test_authenticate_revert_nestedSignerLacksSignerScope(
+    /// @dev A nested signer that is a live actor on the delegate account but holds any non-zero (non-admin) scope
+    ///      fails verifySignature (signing is admin-only) and guard 3 reverts.
+    function test_authenticate_revert_nestedSignerIsScoped(
         uint256 ownerSeed,
         uint256 signerSeed,
         uint8 scopeSeed,
@@ -107,9 +107,9 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
         uint256 signerPk = _boundK1Pk(signerSeed);
         vm.assume(vm.addr(ownerPk) != vm.addr(signerPk));
 
-        // Non-zero scope with the SIGNER bit cleared → verifySignature must return false. Clear POLICY too so the
-        // scoped actor needs no policyData at authorization time.
-        uint8 scope = uint8(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_SIGNER & ~SCOPE_POLICY;
+        // Any non-zero scope → non-admin → verifySignature must return false. Clear POLICY so the scoped actor
+        // needs no policyData at authorization time.
+        uint8 scope = uint8(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_POLICY;
         vm.assume(scope != 0);
 
         (address delegateAccount,) = _createK1Account(ownerPk);
@@ -137,30 +137,23 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
         assertEq(actorId, bytes32(bytes20(delegateAccount)));
     }
 
-    /// @dev A scoped actor whose scope carries the SCOPE_SIGNER bit passes verifySignature via the
-    ///      `scope & SCOPE_SIGNER != 0` branch; authenticate returns actorId = bytes32(bytes20(delegate)).
-    function test_authenticate_success_signerScopedNestedSigner(
-        uint256 ownerSeed,
-        uint256 signerSeed,
-        uint8 scopeSeed,
-        bytes32 hash
-    ) public {
+    /// @dev The former SIGNER bit (0x10, now SCOPE_SPONSOR_PAYER) no longer grants signing: a nested actor holding
+    ///      it is non-admin, so verifySignature returns false and guard 3 reverts.
+    function test_authenticate_revert_formerSignerBitCannotSign(uint256 ownerSeed, uint256 signerSeed, bytes32 hash)
+        public
+    {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
         uint256 signerPk = _boundK1Pk(signerSeed);
         vm.assume(vm.addr(ownerPk) != vm.addr(signerPk));
 
-        // Any scope with the SIGNER bit set (always non-zero) → verifySignature true via the SIGNER branch. Clear
-        // POLICY: a policy-bearing actor is never a valid signer (and would need policyData to authorize).
-        uint8 scope = (uint8(bound(uint256(scopeSeed), 0, 255)) | SCOPE_SIGNER) & ~SCOPE_POLICY;
-
         (address delegateAccount,) = _createK1Account(ownerPk);
-        _authorizeScopedK1Actor(delegateAccount, ownerPk, signerPk, scope);
+        _authorizeScopedK1Actor(delegateAccount, ownerPk, signerPk, SCOPE_SPONSOR_PAYER);
 
         bytes memory nestedAuth = abi.encodePacked(k1Authenticator, _signDigest(signerPk, hash));
         bytes memory data = abi.encodePacked(delegateAccount, nestedAuth);
 
-        bytes32 actorId = delegateAuthenticator.authenticate(hash, data);
-        assertEq(actorId, bytes32(bytes20(delegateAccount)));
+        vm.expectRevert(DelegateAuthenticator.InvalidNestedSignature.selector);
+        delegateAuthenticator.authenticate(hash, data);
     }
 
     // ── Helpers ──

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -126,7 +126,7 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
     ///      unrestricted owner (`ownerPk`) via applySignedActorChanges on the local chain.
     function _authorizeScopedK1Actor(address account, uint256 ownerPk, uint256 newPk, uint8 scope) internal {
         AccountConfiguration.ActorConfig memory config = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: scope, expiry: 0, policyType: 0
+            authenticator: address(k1Authenticator), scope: scope, expiry: 0, nonceLane: 0
         });
 
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);

--- a/test/unit/examples/ExternalPolicyCaller.t.sol
+++ b/test/unit/examples/ExternalPolicyCaller.t.sol
@@ -90,6 +90,17 @@ contract ExternalPolicyCallerTest is AccountConfigurationTest {
         binding; // silence unused
     }
 
+    function test_executeFor_revertsWhenCommitmentZero() public {
+        // The account gated the provider to *this* manager but with a zero (empty) commitment. The manager-match
+        // passes, but the live commitment read resolves to zero, so there is no binding to enforce.
+        address account = _createAccount(bytes32(uint256(1)));
+        _authorizeProvider(account, address(manager), bytes32(0));
+
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.NoActivePolicy.selector, bytes32(bytes20(provider))));
+        vm.prank(provider);
+        manager.executeFor(account, address(policy), _pull(1));
+    }
+
     function test_executeFor_revertsAfterRevoke() public {
         address account = _optIn(bytes32(uint256(1)), 100e6, MONTH);
 

--- a/test/unit/examples/ExternalPolicyCaller.t.sol
+++ b/test/unit/examples/ExternalPolicyCaller.t.sol
@@ -284,7 +284,7 @@ contract ExternalPolicyCallerTest is AccountConfigurationTest {
 
     function _authorizeProvider(address account, address policyManager, bytes32 commitment, uint48 expiry) internal {
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: EXTERNAL_POLICY_AUTHENTICATOR, scope: SCOPE_POLICY, expiry: expiry, nonceLane: 0
+            authenticator: EXTERNAL_POLICY_AUTHENTICATOR, scope: SCOPE_POLICY, expiry: expiry
         });
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({

--- a/test/unit/examples/ExternalPolicyCaller.t.sol
+++ b/test/unit/examples/ExternalPolicyCaller.t.sol
@@ -39,7 +39,7 @@ contract ExternalPolicyCallerTest is AccountConfigurationTest {
 
     uint256 internal constant ROOT_PK = 0xA11CE;
     uint8 internal constant SCOPE_SENDER = 0x02;
-    uint8 internal constant POLICY_GATED = 0x01;
+    uint8 internal constant SCOPE_POLICY = 0x10;
     uint8 internal constant AUTHORIZE_ACTOR = 0x01;
     uint8 internal constant REVOKE_ACTOR = 0x02;
 
@@ -96,6 +96,17 @@ contract ExternalPolicyCallerTest is AccountConfigurationTest {
         _revokeProvider(account);
 
         vm.expectRevert(abi.encodeWithSelector(PolicyManager.NoActivePolicy.selector, bytes32(bytes20(provider))));
+        vm.prank(provider);
+        manager.executeFor(account, address(policy), _pull(1));
+    }
+
+    function test_executeFor_revertsWhenActorExpired() public {
+        // External path has no protocol auth, so expiry must be enforced in the manager.
+        uint48 expiry = uint48(block.timestamp + 1 days);
+        address account = _optInWithExpiry(bytes32(uint256(1)), 100e6, MONTH, expiry);
+
+        vm.warp(uint256(expiry) + 1);
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.ActorExpired.selector, bytes32(bytes20(provider))));
         vm.prank(provider);
         manager.executeFor(account, address(policy), _pull(1));
     }
@@ -205,13 +216,14 @@ contract ExternalPolicyCallerTest is AccountConfigurationTest {
         );
     }
 
-    /// @dev SessionPolicy config: allow any selector on `token`, with a USDC-style recurring spend limit.
+    /// @dev SessionPolicy config: `transfer` only on `token`, with a USDC-style recurring spend limit.
     function _config(uint256 limit, uint40 period) internal view returns (bytes memory) {
         SessionPolicy.TokenLimit[] memory limits = new SessionPolicy.TokenLimit[](1);
         limits[0] = SessionPolicy.TokenLimit({token: address(token), limit: limit, period: period});
+        SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
+        rules[0] = SessionPolicy.SelectorRule({selector: ExtMockERC20.transfer.selector, recipients: new address[](0)});
         SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] =
-            SessionPolicy.CallScope({target: address(token), selectorRules: new SessionPolicy.SelectorRule[](0)});
+        scopes[0] = SessionPolicy.CallScope({target: address(token), selectorRules: rules});
         return abi.encode(SessionPolicy.Config({tokenLimits: limits, callScopes: scopes}));
     }
 
@@ -234,10 +246,17 @@ contract ExternalPolicyCallerTest is AccountConfigurationTest {
     /// @dev Full opt-in for one subscriber: create the account, mint it tokens, authorize the provider as an
     ///      external-policy actor gated to this manager, and install the binding.
     function _optIn(bytes32 accountSalt, uint256 limit, uint40 period) internal returns (address account) {
+        return _optInWithExpiry(accountSalt, limit, period, 0);
+    }
+
+    function _optInWithExpiry(bytes32 accountSalt, uint256 limit, uint40 period, uint48 expiry)
+        internal
+        returns (address account)
+    {
         account = _createAccount(accountSalt);
         (PolicyManager.PolicyBinding memory binding, bytes32 commitment) =
             _binding(account, uint256(accountSalt), limit, period);
-        _authorizeProvider(account, address(manager), commitment);
+        _authorizeProvider(account, address(manager), commitment, expiry);
         vm.prank(account);
         manager.install(bytes32(bytes20(provider)), binding);
     }
@@ -260,8 +279,12 @@ contract ExternalPolicyCallerTest is AccountConfigurationTest {
     /// @dev Authorize the provider as an external-policy actor: no direct authority, gated to `policyManager` with
     ///      `commitment`. The actorId is the provider's own address.
     function _authorizeProvider(address account, address policyManager, bytes32 commitment) internal {
+        _authorizeProvider(account, policyManager, commitment, 0);
+    }
+
+    function _authorizeProvider(address account, address policyManager, bytes32 commitment, uint48 expiry) internal {
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: EXTERNAL_POLICY_AUTHENTICATOR, scope: SCOPE_SENDER, expiry: 0, policyType: POLICY_GATED
+            authenticator: EXTERNAL_POLICY_AUTHENTICATOR, scope: SCOPE_POLICY, expiry: expiry, nonceLane: 0
         });
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({

--- a/test/unit/examples/PolicyManager.t.sol
+++ b/test/unit/examples/PolicyManager.t.sol
@@ -24,7 +24,7 @@ contract PolicyManagerTest is AccountConfigurationTest {
     uint256 internal constant ROOT_PK = 0xA11CE;
 
     uint8 internal constant SCOPE_SENDER = 0x02;
-    uint8 internal constant POLICY_GATED = 0x01;
+    uint8 internal constant SCOPE_POLICY = 0x10;
     uint8 internal constant AUTHORIZE_ACTOR = 0x01;
     uint8 internal constant REVOKE_ACTOR = 0x02;
 
@@ -56,6 +56,18 @@ contract PolicyManagerTest is AccountConfigurationTest {
 
         // Revoke cleared the policy slots; the per-call commitment read now resolves to zero.
         vm.expectRevert(abi.encodeWithSelector(PolicyManager.NoActivePolicy.selector, actorId));
+        vm.prank(account);
+        manager.execute(address(policy), _action());
+    }
+
+    function test_execute_revertsWhenActorExpired() public {
+        // Expiry does not clear the commitment slot — only revoke does — so the manager must enforce it itself.
+        uint48 expiry = uint48(block.timestamp + 1 days);
+        bytes32 actorId = _installSessionWithExpiry(1, expiry);
+
+        vm.warp(uint256(expiry) + 1);
+        _mockActingActor(actorId);
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.ActorExpired.selector, actorId));
         vm.prank(account);
         manager.execute(address(policy), _action());
     }
@@ -130,8 +142,7 @@ contract PolicyManagerTest is AccountConfigurationTest {
         bytes32 actorId = _sessionActorId(9);
         _authorizePolicyActor(actorId, commitment);
 
-        (uint8 policyType, address resolvedTarget, bytes32 signed) = accountConfiguration.getPolicy(account, actorId);
-        assertEq(policyType, accountConfiguration.POLICY_GATED());
+        (address resolvedTarget, bytes32 signed) = accountConfiguration.getPolicy(account, actorId);
         assertEq(resolvedTarget, address(manager));
         assertEq(signed, commitment);
     }
@@ -169,9 +180,13 @@ contract PolicyManagerTest is AccountConfigurationTest {
     }
 
     function _installSession(uint256 salt) internal returns (bytes32 actorId) {
+        return _installSessionWithExpiry(salt, 0);
+    }
+
+    function _installSessionWithExpiry(uint256 salt, uint48 expiry) internal returns (bytes32 actorId) {
         PolicyManager.PolicyBinding memory binding = _binding(salt);
         actorId = _sessionActorId(salt);
-        _authorizePolicyActor(actorId, manager.commitmentOf(binding));
+        _authorizePolicyActor(actorId, manager.commitmentOf(binding), expiry);
         vm.prank(account);
         manager.install(actorId, binding);
     }
@@ -192,8 +207,12 @@ contract PolicyManagerTest is AccountConfigurationTest {
     }
 
     function _authorizePolicyActor(bytes32 actorId, bytes32 commitment) internal {
+        _authorizePolicyActor(actorId, commitment, 0);
+    }
+
+    function _authorizePolicyActor(bytes32 actorId, bytes32 commitment, uint48 expiry) internal {
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: SCOPE_SENDER, expiry: 0, policyType: POLICY_GATED
+            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: expiry, nonceLane: 0
         });
         bytes memory policyData = abi.encodePacked(address(manager), commitment);
 
@@ -233,7 +252,7 @@ contract PolicyManagerTest is AccountConfigurationTest {
     ///      Used to register a victim's commitment value on a different account — the cross-account reuse case.
     function _authorizePolicyActorOn(address target_, uint256 ownerPk, bytes32 actorId, bytes32 commitment) internal {
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: SCOPE_SENDER, expiry: 0, policyType: POLICY_GATED
+            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0, nonceLane: 0
         });
         bytes memory policyData = abi.encodePacked(address(manager), commitment);
 

--- a/test/unit/examples/PolicyManager.t.sol
+++ b/test/unit/examples/PolicyManager.t.sol
@@ -212,7 +212,7 @@ contract PolicyManagerTest is AccountConfigurationTest {
 
     function _authorizePolicyActor(bytes32 actorId, bytes32 commitment, uint48 expiry) internal {
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: expiry, nonceLane: 0
+            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: expiry
         });
         bytes memory policyData = abi.encodePacked(address(manager), commitment);
 
@@ -251,9 +251,8 @@ contract PolicyManagerTest is AccountConfigurationTest {
     /// @dev Variant of {_authorizePolicyActor} that operates on an arbitrary `target` account signed by its owner.
     ///      Used to register a victim's commitment value on a different account — the cross-account reuse case.
     function _authorizePolicyActorOn(address target_, uint256 ownerPk, bytes32 actorId, bytes32 commitment) internal {
-        AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0, nonceLane: 0
-        });
+        AccountConfiguration.ActorConfig memory cfg =
+            AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0});
         bytes memory policyData = abi.encodePacked(address(manager), commitment);
 
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);

--- a/test/unit/examples/PolicyManager.t.sol
+++ b/test/unit/examples/PolicyManager.t.sol
@@ -6,9 +6,22 @@ import {ITransactionContext, TX_CONTEXT_ADDRESS} from "../../../src/interfaces/I
 import {TRUSTED_EXECUTOR} from "../../../src/accounts/DefaultAccount.sol";
 
 import {PolicyManager} from "../../../src/examples/policies/PolicyManager.sol";
+import {Policy} from "../../../src/examples/policies/Policy.sol";
 import {SessionPolicy} from "../../../src/examples/policies/SessionPolicy.sol";
 
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
+
+/// @notice A policy whose execute hook returns an empty call plan, exercising {PolicyManager._enforce}'s no-op
+///         early return (no forwarded account call, no {PolicyExecuted} event).
+contract EmptyPlanPolicy is Policy {
+    constructor(address policyManager) Policy(policyManager) {}
+
+    function _onInstall(bytes32, address, bytes calldata) internal override {}
+
+    function _onExecute(bytes32, address, bytes calldata, address) internal pure override returns (bytes memory) {
+        return "";
+    }
+}
 
 /// @notice Manager-level coverage for {PolicyManager}: the install authorization checks and the per-call execute
 ///         authorization boundary, independent of any specific policy's enforcement logic. {SessionPolicy} is used as
@@ -134,6 +147,75 @@ contract PolicyManagerTest is AccountConfigurationTest {
         manager.install(actorId, binding);
     }
 
+    function test_execute_revertsBeforeValidAfter() public {
+        // Binding is not yet active: block.timestamp < validAfter.
+        uint40 validAfter = uint40(block.timestamp + 1 days);
+        (bytes32 actorId,) = _installSessionWithWindow(1, validAfter, 0);
+        _mockActingActor(actorId);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(PolicyManager.OutsideValidityWindow.selector, validAfter, uint40(0), block.timestamp)
+        );
+        vm.prank(account);
+        manager.execute(address(policy), _action());
+    }
+
+    function test_execute_revertsAfterValidUntil() public {
+        // Binding has expired: block.timestamp >= validUntil.
+        uint40 validUntil = uint40(block.timestamp + 1 days);
+        (bytes32 actorId,) = _installSessionWithWindow(2, 0, validUntil);
+        _mockActingActor(actorId);
+
+        vm.warp(uint256(validUntil));
+        vm.expectRevert(
+            abi.encodeWithSelector(PolicyManager.OutsideValidityWindow.selector, uint40(0), validUntil, block.timestamp)
+        );
+        vm.prank(account);
+        manager.execute(address(policy), _action());
+    }
+
+    function test_execute_revertsWhenPolicyNotInstalled() public {
+        // Actor is authorized (commitment resolves) but the binding was never installed at the manager.
+        PolicyManager.PolicyBinding memory binding = _binding(11);
+        bytes32 actorId = _sessionActorId(11);
+        bytes32 commitment = manager.commitmentOf(binding);
+        _authorizePolicyActor(actorId, commitment);
+
+        _mockActingActor(actorId);
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.PolicyNotInstalled.selector, commitment));
+        vm.prank(account);
+        manager.execute(address(policy), _action());
+    }
+
+    function test_execute_emptyCallPlanIsNoOp() public {
+        // A policy that returns an empty call plan hits the manager's no-op early return: no account call, no event.
+        EmptyPlanPolicy emptyPolicy = new EmptyPlanPolicy(address(manager));
+        PolicyManager.PolicyBinding memory binding = PolicyManager.PolicyBinding({
+            account: account, policy: address(emptyPolicy), policyConfig: "", validAfter: 0, validUntil: 0, salt: 42
+        });
+        bytes32 actorId = _sessionActorId(42);
+        bytes32 commitment = manager.commitmentOf(binding);
+        _authorizePolicyActor(actorId, commitment);
+        vm.prank(account);
+        manager.install(actorId, binding);
+
+        _mockActingActor(actorId);
+        vm.recordLogs();
+        vm.prank(account);
+        manager.execute(address(emptyPolicy), _action());
+        // No PolicyExecuted event is emitted on the no-op path.
+        assertEq(vm.getRecordedLogs().length, 0);
+    }
+
+    function test_execute_revertsWhenNotDispatched() public {
+        // Outside a protocol-dispatched call the transaction-context precompile yields no data, so `_actingActorId`
+        // resolves to bytes32(0) and execute rejects it. No `_mockActingActor` here on purpose.
+        _installSession(1);
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.NoActivePolicy.selector, bytes32(0)));
+        vm.prank(account);
+        manager.execute(address(policy), _action());
+    }
+
     // ── Config resolution ──
 
     function test_getPolicy_resolvesManagerAndCommitment() public {
@@ -187,6 +269,25 @@ contract PolicyManagerTest is AccountConfigurationTest {
         PolicyManager.PolicyBinding memory binding = _binding(salt);
         actorId = _sessionActorId(salt);
         _authorizePolicyActor(actorId, manager.commitmentOf(binding), expiry);
+        vm.prank(account);
+        manager.install(actorId, binding);
+    }
+
+    function _installSessionWithWindow(uint256 salt, uint40 validAfter, uint40 validUntil)
+        internal
+        returns (bytes32 actorId, bytes32 commitment)
+    {
+        PolicyManager.PolicyBinding memory binding = PolicyManager.PolicyBinding({
+            account: account,
+            policy: address(policy),
+            policyConfig: _config(),
+            validAfter: validAfter,
+            validUntil: validUntil,
+            salt: salt
+        });
+        actorId = _sessionActorId(salt);
+        commitment = manager.commitmentOf(binding);
+        _authorizePolicyActor(actorId, commitment);
         vm.prank(account);
         manager.install(actorId, binding);
     }

--- a/test/unit/examples/SessionPolicy.t.sol
+++ b/test/unit/examples/SessionPolicy.t.sol
@@ -57,7 +57,7 @@ contract SessionPolicyTest is AccountConfigurationTest {
 
     uint256 internal constant ROOT_PK = 0xA11CE;
     uint8 internal constant SCOPE_SENDER = 0x02;
-    uint8 internal constant POLICY_GATED = 0x01;
+    uint8 internal constant SCOPE_POLICY = 0x10;
     uint8 internal constant AUTHORIZE_ACTOR = 0x01;
 
     bytes4 internal constant TRANSFER = bytes4(keccak256("transfer(address,uint256)"));
@@ -387,6 +387,17 @@ contract SessionPolicyTest is AccountConfigurationTest {
         manager.install(actorId, binding);
     }
 
+    function test_install_revertsAnySelectorOnLimitedToken() public {
+        // A TokenLimit only tracks transfer/transferFrom/approve; anySelector would leave other methods untracked.
+        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
+        scopes[0] = _anySelectorScope(address(token));
+        (bytes32 actorId, PolicyManager.PolicyBinding memory binding) =
+            _prepareBinding(_config(_limit(address(token), 500e18, WEEK), scopes));
+        vm.expectRevert(abi.encodeWithSelector(SessionPolicy.AnySelectorOnLimitedToken.selector, address(token)));
+        vm.prank(account);
+        manager.install(actorId, binding);
+    }
+
     // ── Helpers ──
 
     function _mockActingActor(bytes32 actorId) internal {
@@ -492,7 +503,7 @@ contract SessionPolicyTest is AccountConfigurationTest {
         bytes32 commitment = manager.commitmentOf(binding);
 
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: SCOPE_SENDER, expiry: 0, policyType: POLICY_GATED
+            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0, nonceLane: 0
         });
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({

--- a/test/unit/examples/SessionPolicy.t.sol
+++ b/test/unit/examples/SessionPolicy.t.sol
@@ -398,7 +398,132 @@ contract SessionPolicyTest is AccountConfigurationTest {
         manager.install(actorId, binding);
     }
 
+    // ── Selector-length gating ──
+
+    function test_execute_revertsMissingSelectorForShortData() public {
+        // 1–3 bytes of calldata carry no usable selector, so the call is rejected rather than guessed.
+        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
+        scopes[0] = _anySelectorScope(address(target));
+        bytes32 actorId = _install(_config(_noLimits(), scopes));
+
+        _mockActingActor(actorId);
+        vm.expectRevert(SessionPolicy.MissingSelector.selector);
+        vm.prank(account);
+        manager.execute(address(policy), _action(address(target), 0, hex"010203"));
+    }
+
+    function test_execute_allowsEmptyCalldata() public {
+        // 0 bytes of calldata is a plain value call: it skips selector gating entirely.
+        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
+        scopes[0] = _anySelectorScope(bob);
+        bytes32 actorId = _install(_config(_noLimits(), scopes));
+
+        _execute(actorId, bob, 0, "");
+    }
+
+    // ── ERC-20 spend accounting edge cases ──
+
+    function test_execute_zeroAmountTransferSkipsSpend() public {
+        // A zero-value transfer on a limited token must not touch spend accounting (the library rejects zero spends).
+        (bytes32 actorId, bytes32 commitment) = _installWithCommitment(
+            _config(_limit(address(token), 500e18, WEEK), _erc20Scope(address(token), _noRecipients()))
+        );
+
+        _execute(actorId, address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 0)));
+
+        assertEq(policy.getCurrentSpend(commitment, address(token)).spend, 0);
+    }
+
+    function test_execute_revertsMalformedTransfer() public {
+        // A limited token pins the transfer selector; truncated transfer calldata (< 68 bytes) can't be decoded.
+        bytes32 actorId =
+            _install(_config(_limit(address(token), 500e18, WEEK), _erc20Scope(address(token), _noRecipients())));
+
+        _mockActingActor(actorId);
+        bytes memory malformed = abi.encodePacked(TRANSFER, bytes32(uint256(uint160(bob)))); // selector + 32 = 36 bytes
+        vm.expectRevert(abi.encodeWithSelector(SessionPolicy.MalformedTokenCall.selector, TRANSFER));
+        vm.prank(account);
+        manager.execute(address(policy), _action(address(token), 0, malformed));
+    }
+
+    function test_execute_revertsMalformedTransferFrom() public {
+        // Exercises the transferFrom decode branch: a pinned transferFrom selector with calldata < 100 bytes.
+        SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
+        rules[0] = SessionPolicy.SelectorRule({selector: TRANSFER_FROM, recipients: _noRecipients()});
+        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
+        scopes[0] = SessionPolicy.CallScope({target: address(token), selectorRules: rules});
+        bytes32 actorId = _install(_config(_limit(address(token), 500e18, WEEK), scopes));
+
+        _mockActingActor(actorId);
+        bytes memory malformed = abi.encodePacked(TRANSFER_FROM, bytes32(0), bytes32(0)); // selector + 64 = 68 < 100
+        vm.expectRevert(abi.encodeWithSelector(SessionPolicy.MalformedTokenCall.selector, TRANSFER_FROM));
+        vm.prank(account);
+        manager.execute(address(policy), _action(address(token), 0, malformed));
+    }
+
+    // ── Views ──
+
+    function test_views_reflectInstalledErc20Scope() public {
+        address[] memory recipients = new address[](1);
+        recipients[0] = bob;
+        (, bytes32 commitment) = _installWithCommitment(
+            _config(_limit(address(token), 500e18, WEEK), _erc20Scope(address(token), recipients))
+        );
+
+        (bool allowed, bool anySelector) = policy.isTargetAllowed(commitment, address(token));
+        assertTrue(allowed);
+        assertFalse(anySelector);
+
+        (bool selAllowed, bool recipientBound) = policy.getSelectorRule(commitment, address(token), TRANSFER);
+        assertTrue(selAllowed);
+        assertTrue(recipientBound);
+
+        assertTrue(policy.isRecipientAllowed(commitment, address(token), TRANSFER, bob));
+        assertFalse(policy.isRecipientAllowed(commitment, address(token), TRANSFER, mallory));
+
+        (bool set, uint160 allowance, uint40 period) = policy.getTokenLimit(commitment, address(token));
+        assertTrue(set);
+        assertEq(allowance, 500e18);
+        assertEq(period, WEEK);
+
+        assertEq(policy.getCurrentSpend(commitment, address(token)).spend, 0);
+    }
+
+    function test_views_reflectAnySelectorScopeAndOneTimeLimit() public {
+        (, bytes32 commitment) =
+            _installWithCommitment(_config(_limit(address(0), 1 ether, 0), _anySelectorScopes(address(target))));
+
+        (bool allowed, bool anySelector) = policy.isTargetAllowed(commitment, address(target));
+        assertTrue(allowed);
+        assertTrue(anySelector);
+
+        // Unlisted target resolves to the zero scope.
+        (bool otherAllowed,) = policy.isTargetAllowed(commitment, address(token));
+        assertFalse(otherAllowed);
+
+        // A one-time (period == 0) native cap is normalized to the never-resetting ONE_TIME period.
+        (bool set,, uint40 period) = policy.getTokenLimit(commitment, address(0));
+        assertTrue(set);
+        assertEq(period, type(uint40).max);
+    }
+
     // ── Helpers ──
+
+    bytes4 internal constant TRANSFER_FROM = bytes4(keccak256("transferFrom(address,address,uint256)"));
+
+    function _anySelectorScopes(address t) internal pure returns (SessionPolicy.CallScope[] memory scopes) {
+        scopes = new SessionPolicy.CallScope[](1);
+        scopes[0] = _anySelectorScope(t);
+    }
+
+    /// @dev Like {_install} but also returns the binding's commitment, for asserting on the commitment-keyed views.
+    function _installWithCommitment(bytes memory policyConfig) internal returns (bytes32 actorId, bytes32 commitment) {
+        PolicyManager.PolicyBinding memory binding;
+        (actorId, binding) = _prepareBinding(policyConfig);
+        commitment = manager.commitmentOf(binding);
+        vm.prank(account);
+        manager.install(actorId, binding);
+    }
 
     function _mockActingActor(bytes32 actorId) internal {
         vm.mockCall(

--- a/test/unit/examples/SessionPolicy.t.sol
+++ b/test/unit/examples/SessionPolicy.t.sol
@@ -502,9 +502,8 @@ contract SessionPolicyTest is AccountConfigurationTest {
         });
         bytes32 commitment = manager.commitmentOf(binding);
 
-        AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0, nonceLane: 0
-        });
+        AccountConfiguration.ActorConfig memory cfg =
+            AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0});
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({
             actorId: actorId,

--- a/test/unit/examples/SessionPolicyGas.t.sol
+++ b/test/unit/examples/SessionPolicyGas.t.sol
@@ -1,0 +1,396 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {console} from "forge-std/Test.sol";
+
+import {AccountConfiguration} from "../../../src/AccountConfiguration.sol";
+import {ITransactionContext, TX_CONTEXT_ADDRESS} from "../../../src/interfaces/ITransactionContext.sol";
+import {TRUSTED_EXECUTOR} from "../../../src/accounts/DefaultAccount.sol";
+
+import {PolicyManager} from "../../../src/examples/policies/PolicyManager.sol";
+import {SessionPolicy} from "../../../src/examples/policies/SessionPolicy.sol";
+
+import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
+import {SessionMockERC20, SessionMockTarget} from "./SessionPolicy.t.sol";
+
+/// @notice Gas benchmarks for the {SessionPolicy} / {PolicyManager} execution flows.
+///
+/// @dev Numbers are logged, not asserted, so this file never fails on chain-parameter drift; run with
+///      `forge test --mt test_gas -vv` to print the report. Each measurement wraps only the `manager.execute`
+///      call, so it captures the full production per-call path: manager dispatch (commitment + expiry + record
+///      reads), the policy hook, and the forwarded account `executeBatch` (including the ERC-20/native transfer).
+///
+///      Caveats when reading these:
+///        - The EIP-8130 transaction-context precompile is `vm.mockCall`-ed, so `_actingActorId`'s STATICCALL is
+///          approximated by Foundry's mock, not the real precompile cost.
+///        - "cold" cools (via `vm.cool`) every address the execute path touches before measuring, mirroring
+///          production where install ran in an earlier transaction so all contracts/slots are cold at execute
+///          time. "warm" is an immediate repeat call, isolating the marginal recompute cost. Production calls are
+///          effectively always cold, so the cold number is the representative one.
+///        - The per-flow `test_gas_execute_*` tests are authoritative: each runs in its own transaction. The
+///          `test_gas_summary` table is an at-a-glance overview and reads a few k low, because `vm.cool` resets
+///          access-list warmth but not EIP-2200 original-value (dirty-slot) pricing, which is fixed per tx.
+contract SessionPolicyGasTest is AccountConfigurationTest {
+    PolicyManager internal manager;
+    SessionPolicy internal policy;
+    SessionMockERC20 internal token;
+    SessionMockTarget internal target;
+
+    address internal account;
+    address internal bob = address(0xB0B);
+
+    uint256 internal constant ROOT_PK = 0xA11CE;
+    uint8 internal constant SCOPE_POLICY = 0x02;
+    uint8 internal constant AUTHORIZE_ACTOR = 0x01;
+
+    bytes4 internal constant TRANSFER = bytes4(keccak256("transfer(address,uint256)"));
+    uint40 internal constant WEEK = 7 days;
+
+    uint256 internal saltNonce;
+
+    function setUp() public override {
+        super.setUp();
+        vm.warp(1_700_000_000);
+
+        manager = new PolicyManager(address(accountConfiguration));
+        policy = new SessionPolicy(address(manager));
+        token = new SessionMockERC20();
+        target = new SessionMockTarget();
+
+        account = _createAccountWithRootAndManager();
+        token.mint(account, 1_000_000e18);
+        vm.deal(account, 100 ether);
+    }
+
+    // ── Install ──
+
+    function test_gas_install_limitAndSelectorScope() public {
+        (bytes32 actorId, PolicyManager.PolicyBinding memory binding) =
+            _prepareBinding(_config(_limit(address(token), 500e18, WEEK), _erc20Scope(address(token), _noRecipients())));
+
+        vm.prank(account);
+        uint256 g = gasleft();
+        manager.install(actorId, binding);
+        emit log_named_uint("install: 1 spend limit + 1 selector scope", g - gasleft());
+    }
+
+    // ── Execute: gating dimensions in isolation (no spend accounting) ──
+
+    function test_gas_execute_targetOnly_anySelector() public {
+        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
+        scopes[0] = _anySelectorScope(address(target));
+        bytes32 actorId = _install(_config(_noLimits(), scopes));
+
+        bytes memory ed = _action(address(target), 0, abi.encodeCall(SessionMockTarget.setValue, (42)));
+        emit log_named_uint("execute: target allowlist only (anySelector), cold", _measureCold(actorId, ed));
+        emit log_named_uint("execute: target allowlist only (anySelector), warm", _measure(actorId, ed));
+    }
+
+    function test_gas_execute_selectorGating() public {
+        SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
+        rules[0] =
+            SessionPolicy.SelectorRule({selector: SessionMockTarget.setValue.selector, recipients: _noRecipients()});
+        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
+        scopes[0] = SessionPolicy.CallScope({target: address(target), selectorRules: rules});
+        bytes32 actorId = _install(_config(_noLimits(), scopes));
+
+        bytes memory ed = _action(address(target), 0, abi.encodeCall(SessionMockTarget.setValue, (7)));
+        emit log_named_uint("execute: target + selector gating, cold", _measureCold(actorId, ed));
+        emit log_named_uint("execute: target + selector gating, warm", _measure(actorId, ed));
+    }
+
+    function test_gas_execute_recipientGating_noLimit() public {
+        address[] memory recipients = new address[](1);
+        recipients[0] = bob;
+        bytes32 actorId = _install(_config(_noLimits(), _erc20Scope(address(token), recipients)));
+
+        bytes memory ed = _action(address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 1e18)));
+        emit log_named_uint("execute: target + selector + recipient gating (no limit), cold", _measureCold(actorId, ed));
+        emit log_named_uint("execute: target + selector + recipient gating (no limit), warm", _measure(actorId, ed));
+    }
+
+    // ── Execute: spend-limit accounting (the only path with an SSTORE on the happy path) ──
+
+    function test_gas_execute_spendLimitOnly() public {
+        bytes32 actorId =
+            _install(_config(_limit(address(token), 500e18, WEEK), _erc20Scope(address(token), _noRecipients())));
+
+        // Cold: first spend allocates the period-usage slot (zero -> non-zero SSTORE).
+        bytes memory ed = _action(address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 1e18)));
+        emit log_named_uint("execute: spend limit only, cold (period alloc)", _measureCold(actorId, ed));
+        // Warm: same period, updates the existing slot (non-zero -> non-zero SSTORE).
+        emit log_named_uint("execute: spend limit only, warm (period update)", _measure(actorId, ed));
+    }
+
+    function test_gas_execute_spendLimit_plus_recipientGating() public {
+        address[] memory recipients = new address[](1);
+        recipients[0] = bob;
+        bytes32 actorId =
+            _install(_config(_limit(address(token), 500e18, WEEK), _erc20Scope(address(token), recipients)));
+
+        bytes memory ed = _action(address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 1e18)));
+        emit log_named_uint("execute: spend limit + recipient gating, cold", _measureCold(actorId, ed));
+        emit log_named_uint("execute: spend limit + recipient gating, warm", _measure(actorId, ed));
+    }
+
+    function test_gas_execute_nativeEthLimit() public {
+        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
+        scopes[0] = _anySelectorScope(bob);
+        bytes32 actorId = _install(_config(_limit(address(0), 10 ether, WEEK), scopes));
+
+        bytes memory ed = _action(bob, 0.1 ether, "");
+        emit log_named_uint("execute: native-ETH limit, cold (period alloc)", _measureCold(actorId, ed));
+        emit log_named_uint("execute: native-ETH limit, warm (period update)", _measure(actorId, ed));
+    }
+
+    // ── Summary table ──
+
+    function test_gas_summary() public {
+        console.log("");
+        console.log("=== EIP-8130 SessionPolicy / PolicyManager Gas Benchmark ===");
+        console.log("");
+        console.log("  Flow                                              Cold      Warm");
+        console.log("  ----------------------------------------------------------------");
+
+        // Each row deploys its own fresh mock target/token so storage values (e.g. `target.value`, token balances)
+        // never bleed across rows and change SSTORE zero/non-zero pricing — matching the standalone tests above.
+        {
+            SessionMockTarget t = new SessionMockTarget();
+            SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
+            scopes[0] = _anySelectorScope(address(t));
+            bytes32 a = _install(_config(_noLimits(), scopes));
+            _row(
+                "target allowlist only (anySelector) ",
+                a,
+                _action(address(t), 0, abi.encodeCall(SessionMockTarget.setValue, (42)))
+            );
+        }
+        {
+            SessionMockTarget t = new SessionMockTarget();
+            SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
+            rules[0] = SessionPolicy.SelectorRule({
+                selector: SessionMockTarget.setValue.selector, recipients: _noRecipients()
+            });
+            SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
+            scopes[0] = SessionPolicy.CallScope({target: address(t), selectorRules: rules});
+            bytes32 a = _install(_config(_noLimits(), scopes));
+            _row(
+                "target + selector gating            ",
+                a,
+                _action(address(t), 0, abi.encodeCall(SessionMockTarget.setValue, (7)))
+            );
+        }
+        {
+            address[] memory recipients = new address[](1);
+            recipients[0] = bob;
+            SessionMockERC20 tk = _freshToken();
+            bytes32 a = _install(_config(_noLimits(), _erc20Scope(address(tk), recipients)));
+            _row(
+                "target + selector + recipient       ",
+                a,
+                _action(address(tk), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 1e18)))
+            );
+        }
+        {
+            SessionMockERC20 tk = _freshToken();
+            bytes32 a = _install(_config(_limit(address(tk), 500e18, WEEK), _erc20Scope(address(tk), _noRecipients())));
+            _row(
+                "spend limit only (transfer)         ",
+                a,
+                _action(address(tk), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 1e18)))
+            );
+        }
+        {
+            address[] memory recipients = new address[](1);
+            recipients[0] = bob;
+            SessionMockERC20 tk = _freshToken();
+            bytes32 a = _install(_config(_limit(address(tk), 500e18, WEEK), _erc20Scope(address(tk), recipients)));
+            _row(
+                "spend limit + recipient gating      ",
+                a,
+                _action(address(tk), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 1e18)))
+            );
+        }
+        {
+            SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
+            scopes[0] = _anySelectorScope(bob);
+            bytes32 a = _install(_config(_limit(address(0), 10 ether, WEEK), scopes));
+            _row("native-ETH limit                    ", a, _action(bob, 0.1 ether, ""));
+        }
+
+        console.log("  ----------------------------------------------------------------");
+        console.log("");
+        console.log("  Cold = execute with all touched addresses cooled (~production: install in a prior tx)");
+        console.log("  Warm = immediate repeat call in the same tx (marginal recompute cost)");
+        console.log("  Path = manager dispatch + policy hook + account executeBatch + transfer");
+        console.log("  Note: overview only. The per-flow test_gas_execute_* tests each run in their own tx and are");
+        console.log("        the authoritative cold numbers; this table reads a few k low because vm.cool cannot");
+        console.log("        reset EIP-2200 original-value pricing mid-tx. Precompile is mocked.");
+        console.log("");
+    }
+
+    /// @dev A fresh mock ERC-20 minted to the account, so each flow's spend accounting starts from clean storage.
+    function _freshToken() internal returns (SessionMockERC20 tk) {
+        tk = new SessionMockERC20();
+        tk.mint(account, 1_000_000e18);
+    }
+
+    /// @dev Print one summary row: `label`, cold (all touched addresses cooled first, mirroring a production
+    ///      execute in a separate tx from install) and warm (immediate repeat) `execute` cost.
+    function _row(string memory label, bytes32 actorId, bytes memory ed) internal {
+        uint256 cold = _measureCold(actorId, ed);
+        uint256 warm = _measure(actorId, ed);
+        console.log(string.concat("  ", label, _pad(cold), "    ", _pad(warm)));
+    }
+
+    function _pad(uint256 n) internal pure returns (string memory) {
+        return _leftPad(vm.toString(n), 6);
+    }
+
+    function _leftPad(string memory s, uint256 width) internal pure returns (string memory) {
+        bytes memory b = bytes(s);
+        if (b.length >= width) return s;
+        bytes memory padded = new bytes(width);
+        uint256 offset = width - b.length;
+        for (uint256 i; i < width; i++) {
+            padded[i] = i < offset ? bytes1(" ") : b[i - offset];
+        }
+        return string(padded);
+    }
+
+    // ── Helpers ──
+
+    /// @dev Mock the acting actor, then measure gas consumed by a single `manager.execute`.
+    function _measure(bytes32 actorId, bytes memory executionData) internal returns (uint256 used) {
+        _mockActingActor(actorId);
+        vm.prank(account);
+        uint256 g = gasleft();
+        manager.execute(address(policy), executionData);
+        used = g - gasleft();
+    }
+
+    /// @dev Production-representative cold measurement: cool every address the execute path touches so their first
+    ///      access pays the EIP-2929 cold cost, as it would when execute runs in a separate tx from install.
+    function _measureCold(bytes32 actorId, bytes memory executionData) internal returns (uint256) {
+        _coolAll(executionData);
+        return _measure(actorId, executionData);
+    }
+
+    /// @dev Reset the warm/cold access state of every contract and account the execute path reads or calls. The call
+    ///      target is decoded from the action so this works for the per-row fresh mocks in the summary too.
+    function _coolAll(bytes memory executionData) internal {
+        vm.cool(account);
+        vm.cool(address(policy));
+        vm.cool(address(manager));
+        vm.cool(address(accountConfiguration));
+        vm.cool(bob);
+        SessionPolicy.Action memory action = abi.decode(executionData, (SessionPolicy.Action));
+        vm.cool(action.target);
+    }
+
+    function _mockActingActor(bytes32 actorId) internal {
+        vm.mockCall(
+            TX_CONTEXT_ADDRESS,
+            abi.encodeWithSelector(ITransactionContext.getTransactionSenderActorId.selector),
+            abi.encode(actorId)
+        );
+    }
+
+    function _action(address t, uint256 value, bytes memory data) internal pure returns (bytes memory) {
+        return abi.encode(SessionPolicy.Action({target: t, value: value, data: data}));
+    }
+
+    function _config(SessionPolicy.TokenLimit[] memory limits, SessionPolicy.CallScope[] memory scopes)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encode(SessionPolicy.Config({tokenLimits: limits, callScopes: scopes}));
+    }
+
+    function _noLimits() internal pure returns (SessionPolicy.TokenLimit[] memory) {
+        return new SessionPolicy.TokenLimit[](0);
+    }
+
+    function _limit(address tkn, uint256 lim, uint40 period)
+        internal
+        pure
+        returns (SessionPolicy.TokenLimit[] memory limits)
+    {
+        limits = new SessionPolicy.TokenLimit[](1);
+        limits[0] = SessionPolicy.TokenLimit({token: tkn, limit: lim, period: period});
+    }
+
+    function _noRecipients() internal pure returns (address[] memory) {
+        return new address[](0);
+    }
+
+    function _anySelectorScope(address t) internal pure returns (SessionPolicy.CallScope memory) {
+        return SessionPolicy.CallScope({target: t, selectorRules: new SessionPolicy.SelectorRule[](0)});
+    }
+
+    function _erc20Scope(address tkn, address[] memory recipients)
+        internal
+        pure
+        returns (SessionPolicy.CallScope[] memory scopes)
+    {
+        SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
+        rules[0] = SessionPolicy.SelectorRule({selector: TRANSFER, recipients: recipients});
+        scopes = new SessionPolicy.CallScope[](1);
+        scopes[0] = SessionPolicy.CallScope({target: tkn, selectorRules: rules});
+    }
+
+    function _createAccountWithRootAndManager() internal returns (address) {
+        AccountConfiguration.InitialActor memory root = AccountConfiguration.InitialActor({
+            actorId: bytes32(bytes20(vm.addr(ROOT_PK))),
+            authenticator: address(k1Authenticator),
+            scope: 0,
+            policyData: ""
+        });
+        AccountConfiguration.InitialActor memory mgr = AccountConfiguration.InitialActor({
+            actorId: bytes32(bytes20(address(manager))), authenticator: TRUSTED_EXECUTOR, scope: 0, policyData: ""
+        });
+
+        AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](2);
+        (actors[0], actors[1]) = root.actorId < mgr.actorId ? (root, mgr) : (mgr, root);
+
+        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
+        return accountConfiguration.createAccount(bytes32(0), bytecode, actors);
+    }
+
+    function _install(bytes memory policyConfig) internal returns (bytes32 actorId) {
+        PolicyManager.PolicyBinding memory binding;
+        (actorId, binding) = _prepareBinding(policyConfig);
+        vm.prank(account);
+        manager.install(actorId, binding);
+    }
+
+    function _prepareBinding(bytes memory policyConfig)
+        internal
+        returns (bytes32 actorId, PolicyManager.PolicyBinding memory binding)
+    {
+        actorId = keccak256(abi.encode("session", saltNonce++));
+        binding = PolicyManager.PolicyBinding({
+            account: account,
+            policy: address(policy),
+            policyConfig: policyConfig,
+            validAfter: 0,
+            validUntil: 0,
+            salt: saltNonce
+        });
+        bytes32 commitment = manager.commitmentOf(binding);
+
+        AccountConfiguration.ActorConfig memory cfg =
+            AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0});
+        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
+        changes[0] = AccountConfiguration.ActorChange({
+            actorId: actorId,
+            changeType: AUTHORIZE_ACTOR,
+            data: abi.encode(cfg, abi.encodePacked(address(manager), commitment))
+        });
+        uint64 chainId = uint64(block.chainid);
+        uint64 sequence = accountConfiguration.getChangeSequences(account).local;
+        bytes32 digest = _computeActorChangeBatchDigest(account, chainId, sequence, changes);
+        accountConfiguration.applySignedActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
+    }
+}


### PR DESCRIPTION
## Summary

Brings the reference `AccountConfiguration` (and the example accounts/authenticators) in line with the current EIP-8130 draft: https://github.com/chunter-cb/EIPs/pull/9

**Authorization model**
- Admin is the predicate `scope == 0x00`; config changes (`applySignedActorChanges`), account lock, delegation, and upgrades all require `scope == 0` — there is no separate CONFIG grant.
- Scope grants: `SENDER` (`0x01`), `POLICY` (`0x02`), `NONCE` (`0x04`), `SELF_PAYER` (`0x08`), `SPONSOR_PAYER` (`0x10`); `0x20/0x40/0x80` spare. Stored verbatim — `getActorConfig` / `authenticateActor` never normalize or mask.
- `POLICY` is gated initiation (gates the actor to its `manager` regardless of `SENDER`); it composes with `SELF_PAYER`, `SPONSOR_PAYER`, and `NONCE`.
- `PAYER` is split: `SELF_PAYER` authorizes self-pay (`payer == sender`); `SPONSOR_PAYER` authorizes sponsoring a different sender (`payer != sender`).
- ERC-1271 `verifySignature()` requires **operational authority** — admin, or `SENDER` without `POLICY` — not a dedicated grant (signing is an encoding of authority a `SENDER` key already holds via calls; `approve ≡ permit`). A `POLICY` actor is never operational and cannot sign.

**Actor policies**
- Policy slots (`policy_manager` / `policy_commitment`) are written iff `POLICY` is set. `policyData` is `manager(20) ‖ commitment(32)` (52 bytes when `POLICY` is set, empty otherwise); neither field need be nonzero.
- `authenticateActor` returns `(uint8 scope, address policyTarget)`. Granular getters: `getPolicy`, `getPolicyManager`, `getPolicyCommitment`.

**Account creation & import**
- `InitialActor` carries `actorId`, `authenticator`, `scope`, and `policyData`, all committed to the derived address and hashed into the import digest. Initial actors are non-expiring (`expiry = 0`); `manager = account` is expressible at import but not at create.

**Account lock**
- Signed, relayable, admin-authorized `applySignedLockChanges(account, op, unlockDelay, auth)` (op `1` = lock, `2` = unlock) replaces the caller-based `lock` / `initiateUnlock`. Local channel only: the digest binds `block.chainid` and the current `localSequence` (sign-current-then-increment, shared with local config changes), authenticated as admin (`scope == 0`).

**Delegate authenticator**
- The nested vouch stays **admin-only** (`scope == 0`), decoupled from the now-operational `verifySignature`, preserving non-escalation: a `SENDER` key on account B can produce a valid ERC-1271 signature for B but cannot vouch as a delegate on an account that delegates to B.

**ABI**
- Packed `ActorAuthorized` / `DelegationApplied` events, `uint256 chainId` on import / apply (chainId bound in the import digest).

## Test plan
- [x] `forge test` — 341 passing
- [x] `forge fmt --check`
- [ ] Spec review against EIP PR #9 for ABI parity
