### PR TITLE
refactor: extract shared Call type + IExecutor interface

### DIFF
--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -4,12 +4,7 @@ pragma solidity ^0.8.30;
 import {Receiver} from "solady/accounts/Receiver.sol";
 
 import {AccountConfiguration} from "../AccountConfiguration.sol";
-
-struct Call {
-    address target;
-    uint256 value;
-    bytes data;
-}
+import {Call, IExecutor} from "../interfaces/IExecutor.sol";
 
 /// @dev Sentinel `authenticator` value marking an actor as a trusted executor: an address (e.g. a PolicyManager,
 ///      EntryPoint, or relayer) authorized to drive execution on the account directly by matching `msg.sender`,
@@ -29,7 +24,7 @@ address constant TRUSTED_EXECUTOR = address(uint160(uint256(keccak256("trustedEx
 ///           - address(this) is always authorized (hardcoded) — covers 8130 self-call batches
 ///           - Trusted executors (PolicyManagers, relayers, EntryPoints) are registered as actors with
 ///             TRUSTED_EXECUTOR as the authenticator in AccountConfiguration
-contract DefaultAccount is Receiver {
+contract DefaultAccount is Receiver, IExecutor {
     AccountConfiguration public immutable ACCOUNT_CONFIGURATION;
 
     constructor(address accountConfiguration) {
@@ -40,7 +35,7 @@ contract DefaultAccount is Receiver {
     //  EXECUTION
     // ══════════════════════════════════════════════
 
-    function executeBatch(Call[] calldata calls) external virtual {
+    function executeBatch(Call[] calldata calls) external virtual override {
         require(_isAuthorizedCaller(msg.sender));
         for (uint256 i; i < calls.length; i++) {
             (bool success,) = calls[i].target.call{value: calls[i].value}(calls[i].data);

--- a/src/interfaces/IExecutor.sol
+++ b/src/interfaces/IExecutor.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @notice Canonical batched-call type for EIP-8130 account execution. Shared across every 8130 account so the
+///         protocol (direct dispatch), bundlers, tooling, and PolicyManagers all encode `executeBatch` calldata
+///         against one definition, rather than each contract re-declaring a structurally identical struct (which
+///         the compiler treats as a distinct, non-interchangeable type).
+struct Call {
+    address target;
+    uint256 value;
+    bytes data;
+}
+
+/// @notice Minimal execution surface every EIP-8130 account exposes. Declared as an interface so implementations
+///         living in other repositories (e.g. Base Account V2) can conform to the exact selector and `Call`
+///         layout the protocol and tooling expect, without inheriting any implementation or storage.
+interface IExecutor {
+    function executeBatch(Call[] calldata calls) external;
+}


### PR DESCRIPTION
## What

Extracts the `Call` struct out of `DefaultAccount.sol` into a new `src/interfaces/IExecutor.sol`, and has `DefaultAccount` implement `IExecutor`.

## Why

Every EIP-8130 account exposes the same execution surface (`executeBatch(Call[])`), and the protocol's direct dispatch, bundlers, SDKs, indexers, and PolicyManagers all encode calldata against that exact selector + `Call` layout. Today `Call` is declared inside `DefaultAccount` and re-declared structurally-identically elsewhere (e.g. the prototype for Base Account V2, which lives in a separate repo). Two identical-layout `Call` structs are distinct, non-interchangeable types to the compiler, which is a latent cross-repo interop hazard.

Publishing a tiny, dependency-free `IExecutor` interface + shared `Call` type gives downstream account implementations in other repos (notably **Base Account V2**) a single canonical ABI to import and conform to, with compiler-enforced conformance and zero implementation/storage coupling.

## Changes

- New `src/interfaces/IExecutor.sol`: `Call` struct + `IExecutor { executeBatch(Call[]) }`.
- `DefaultAccount` now imports `Call` from the interface and declares `is IExecutor` (compiler-enforced). `Call` is re-exported through `DefaultAccount`, so `DefaultHighRateAccount`, `UpgradeableAccount`, and `BackwardsCompatible4337Account` are unchanged.

## Not in scope / possible follow-ups

- No behavior change; no storage change.
- Could later grow `IExecutor` into an `IEIP8130Account` umbrella (single-call `execute`, an ERC-1271 reference) as the surface stabilizes, and/or add a stateless `ExecutorBase` abstract if logic-level sharing is desired.

## Testing

`forge test` — all 207 tests pass, no diffs in existing suites.
