### PR TITLE
tests: Improve fuzzing, line coverage, logical coverage, conventions

### DIFF
--- a/test/lib/AccountConfigurationTest.sol
+++ b/test/lib/AccountConfigurationTest.sol
@@ -3,11 +3,17 @@ pragma solidity ^0.8.30;
 
 import {Test} from "forge-std/Test.sol";
 
+import {Base64} from "openzeppelin/utils/Base64.sol";
+import {Math} from "openzeppelin/utils/math/Math.sol";
+import {P256} from "openzeppelin/utils/cryptography/P256.sol";
+import {WebAuthn} from "openzeppelin/utils/cryptography/WebAuthn.sol";
+
 import {AccountConfiguration} from "../../src/AccountConfiguration.sol";
+import {DefaultAccount} from "../../src/accounts/DefaultAccount.sol";
+import {DelegateAuthenticator} from "../../src/authenticators/DelegateAuthenticator.sol";
 import {IAuthenticator} from "../../src/interfaces/IAuthenticator.sol";
 import {P256Authenticator} from "../../src/authenticators/P256Authenticator.sol";
-import {DelegateAuthenticator} from "../../src/authenticators/DelegateAuthenticator.sol";
-import {DefaultAccount} from "../../src/accounts/DefaultAccount.sol";
+import {WebAuthnAuthenticator} from "../../src/authenticators/WebAuthnAuthenticator.sol";
 
 contract AccountConfigurationTest is Test {
     AccountConfiguration public accountConfiguration;
@@ -15,12 +21,14 @@ contract AccountConfigurationTest is Test {
     // K1_AUTHENTICATOR sentinel (address(1)); k1 auth blobs are K1_AUTHENTICATOR(20) || r‖s‖v.
     address public k1Authenticator;
     IAuthenticator public p256Authenticator;
+    IAuthenticator public webAuthnAuthenticator;
     IAuthenticator public delegateAuthenticator;
     address public defaultAccountImplementation;
 
-    /// @dev Test EntryPoint address. 4337 accounts authorize it by registering it as a TRUSTED_EXECUTOR actor
-    ///      (config-driven, revocable), not by hardcoding — tests seed it into the initial actor set at creation.
+    /// @dev Test EntryPoint address; tests register it as a TRUSTED_EXECUTOR actor in the initial actor set.
     address public constant ENTRY_POINT = address(0xEEEE);
+
+    // SECP256K1_ORDER (curve order n) is inherited from forge-std; _boundK1Pk bounds fuzzed keys to [1, n-1].
 
     bytes32 constant SIGNED_ACTOR_CHANGES_TYPEHASH = keccak256(
         "SignedActorChanges(address account,uint256 chainId,uint64 sequence,ActorChange[] actorChanges)"
@@ -33,6 +41,7 @@ contract AccountConfigurationTest is Test {
         accountConfiguration = new AccountConfiguration();
         k1Authenticator = accountConfiguration.K1_AUTHENTICATOR();
         p256Authenticator = IAuthenticator(new P256Authenticator());
+        webAuthnAuthenticator = IAuthenticator(new WebAuthnAuthenticator());
         delegateAuthenticator = IAuthenticator(new DelegateAuthenticator(address(accountConfiguration)));
         defaultAccountImplementation = address(new DefaultAccount(address(accountConfiguration)));
     }
@@ -74,8 +83,7 @@ contract AccountConfigurationTest is Test {
         return abi.encodePacked(r, s, v);
     }
 
-    /// @dev Build a canonical K1 auth blob: K1_AUTHENTICATOR(20) || r‖s‖v. This is the single secp256k1 encoding
-    ///      for the default EOA and every k1 actor; meaning (implicit owner vs scoped key) is decided by config.
+    /// @dev Build a canonical K1 auth blob: K1_AUTHENTICATOR(20) || r‖s‖v.
     function _buildK1Auth(uint256 pk, bytes32 digest) internal view returns (bytes memory) {
         bytes memory sig = _signDigest(pk, digest);
         return abi.encodePacked(k1Authenticator, sig);
@@ -105,5 +113,87 @@ contract AccountConfigurationTest is Test {
                 SIGNED_ACTOR_CHANGES_TYPEHASH, account, chainId, sequence, keccak256(abi.encodePacked(actorChangeHash))
             )
         );
+    }
+
+    // ── Fuzzed key bounding ──
+
+    /// @dev Bound a fuzzed seed to a valid secp256k1 private key in [1, n-1].
+    function _boundK1Pk(uint256 seed) internal pure returns (uint256) {
+        return bound(seed, 1, SECP256K1_ORDER - 1);
+    }
+
+    /// @dev Bound a fuzzed seed to a valid secp256r1 (P-256) private key in [1, n-1].
+    function _boundP256Pk(uint256 seed) internal pure returns (uint256) {
+        return bound(seed, 1, P256.N - 1);
+    }
+
+    // ── P-256 helpers (raw P256Authenticator: r‖s‖x‖y‖preHash = 129 bytes) ──
+
+    /// @dev P-256 public key coordinates for `pk`.
+    function _p256PubKey(uint256 pk) internal view returns (bytes32 x, bytes32 y) {
+        (uint256 ux, uint256 uy) = vm.publicKeyP256(pk);
+        (x, y) = (bytes32(ux), bytes32(uy));
+    }
+
+    /// @dev actorId for a P-256 / WebAuthn key = keccak256(x ‖ y).
+    function _p256ActorId(uint256 pk) internal view returns (bytes32) {
+        (bytes32 x, bytes32 y) = _p256PubKey(pk);
+        return keccak256(abi.encodePacked(x, y));
+    }
+
+    /// @dev Valid P256Authenticator data. s is normalized low-s so OZ P256.verify (which rejects high-s) accepts.
+    function _p256SignData(uint256 pk, bytes32 hash) internal view returns (bytes memory) {
+        (bytes32 x, bytes32 y) = _p256PubKey(pk);
+        (bytes32 r, bytes32 s) = vm.signP256(pk, hash);
+        s = bytes32(Math.min(uint256(s), P256.N - uint256(s)));
+        return abi.encodePacked(r, s, x, y, uint8(0));
+    }
+
+    /// @dev Malleable (high-s) variant of a valid P256 signature: s' = n - lowS > n/2. Must be rejected.
+    function _p256SignDataHighS(uint256 pk, bytes32 hash) internal view returns (bytes memory) {
+        (bytes32 x, bytes32 y) = _p256PubKey(pk);
+        (bytes32 r, bytes32 s) = vm.signP256(pk, hash);
+        uint256 lowS = Math.min(uint256(s), P256.N - uint256(s));
+        return abi.encodePacked(r, bytes32(P256.N - lowS), x, y, uint8(0));
+    }
+
+    // ── WebAuthn helpers (WebAuthnAuthenticator: abi.encode(WebAuthnAuth, x, y)) ──
+    //
+    // The WebAuthnAuthenticator calls WebAuthn.verify(challenge: abi.encode(hash), auth, x, y, requireUV: false).
+    // clientDataJSON prefix `{"type":"webauthn.get","challenge":"` fixes typeIndex = 1, challengeIndex = 23.
+
+    /// @dev Encoded authenticatorData: 32-byte rpIdHash ‖ 1-byte flags ‖ 4-byte counter (37 bytes, > 36 minimum).
+    function _webauthnAuthenticatorData(bytes1 flags) internal pure returns (bytes memory) {
+        return abi.encodePacked(bytes32(0), flags, bytes4(0));
+    }
+
+    function _webauthnClientDataJSON(bytes memory challenge) internal pure returns (string memory) {
+        return string.concat('{"type":"webauthn.get","challenge":"', Base64.encodeURL(challenge), '"}');
+    }
+
+    /// @dev Valid WebAuthnAuthenticator data with User-Present set (requireUV is false in the authenticator).
+    function _webauthnSignData(uint256 pk, bytes32 hash) internal view returns (bytes memory) {
+        return _webauthnSignData(pk, hash, WebAuthn.AUTH_DATA_FLAGS_UP);
+    }
+
+    /// @dev WebAuthnAuthenticator data with caller-chosen authenticator-data flags.
+    function _webauthnSignData(uint256 pk, bytes32 hash, bytes1 flags) internal view returns (bytes memory) {
+        (bytes32 x, bytes32 y) = _p256PubKey(pk);
+        bytes memory authenticatorData = _webauthnAuthenticatorData(flags);
+        string memory clientDataJSON = _webauthnClientDataJSON(abi.encode(hash));
+
+        bytes32 msgHash = sha256(abi.encodePacked(authenticatorData, sha256(bytes(clientDataJSON))));
+        (bytes32 r, bytes32 s) = vm.signP256(pk, msgHash);
+        s = bytes32(Math.min(uint256(s), P256.N - uint256(s)));
+
+        WebAuthn.WebAuthnAuth memory auth = WebAuthn.WebAuthnAuth({
+            r: r,
+            s: s,
+            challengeIndex: 23,
+            typeIndex: 1,
+            authenticatorData: authenticatorData,
+            clientDataJSON: clientDataJSON
+        });
+        return abi.encode(auth, x, y);
     }
 }

--- a/test/unit/AccountConfiguration/applyAccountChange.t.sol
+++ b/test/unit/AccountConfiguration/applyAccountChange.t.sol
@@ -4,8 +4,22 @@ pragma solidity ^0.8.30;
 import {AccountConfiguration} from "../../../src/AccountConfiguration.sol";
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 
+/// @notice Branch-complete, fuzz-by-default suite for the account lock surface: lock(uint16), initiateUnlock(),
+///         isLocked, getLockStatus, the onlyUnlocked modifier and _checkAndClearLock. lock/initiateUnlock act on
+///         msg.sender, so the account is pranked as itself; lock() is callable by any address as itself, so most
+///         lock-side tests prank an arbitrary fuzzed address. Tests that must drive an onlyUnlocked-guarded config
+///         path (applySignedActorChanges) create a real k1 account so the authenticated actor can change actors.
 contract AccountLockTest is AccountConfigurationTest {
-    uint256 constant ACTOR_PK = 300;
+    // ── Local fuzz-bound helpers ──
+
+    /// @dev Keep a fuzzed msg.sender out of the zero address, the system contract, and the forge-std cheatcode /
+    ///      console addresses so vm.prank drives a clean, code-free account acting as itself.
+    function _assumeSafeAccount(address account) internal view {
+        vm.assume(account != address(0));
+        vm.assume(account != address(accountConfiguration));
+        vm.assume(account != VM_ADDRESS);
+        vm.assume(account != CONSOLE);
+    }
 
     function _lockAccount(address account, uint16 unlockDelay) internal {
         vm.prank(account);
@@ -17,143 +31,347 @@ contract AccountLockTest is AccountConfigurationTest {
         accountConfiguration.initiateUnlock();
     }
 
-    // ── Lock lifecycle ──
-
-    function test_lockAccount() public {
-        (address account,) = _createK1Account(ACTOR_PK);
-
-        _lockAccount(account, 1 hours);
-
-        (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 unlockDelay) =
-            accountConfiguration.getLockStatus(account);
-        assertTrue(locked);
-        assertFalse(hasInitiatedUnlock);
-        assertEq(unlocksAt, type(uint40).max);
-        assertEq(unlockDelay, 1 hours);
+    /// @dev A single authorize-actor change granting an unrestricted k1 owner (scope 0, no expiry, no policy).
+    function _oneAuthorizeChange(bytes32 actorId)
+        internal
+        view
+        returns (AccountConfiguration.ActorChange[] memory changes)
+    {
+        changes = new AccountConfiguration.ActorChange[](1);
+        changes[0] = AccountConfiguration.ActorChange({
+            changeType: 0x01,
+            actorId: actorId,
+            data: abi.encode(
+                AccountConfiguration.ActorConfig({
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
+                }),
+                bytes("")
+            )
+        });
     }
 
-    function test_requestUnlock() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // REVERTS (source order: lock -> initiateUnlock -> onlyUnlocked on other functions)
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-        _lockAccount(account, 1 hours);
+    /// @notice lock(0) reverts ZeroUnlockDelay for any account acting as itself.
+    /// @dev Exercises the `unlockDelay == 0` guard in lock(); the onlyUnlocked prelude passes (fresh, unlocksAt == 0).
+    function test_lock_revert_zeroUnlockDelay(address account) public {
+        _assumeSafeAccount(account);
 
-        vm.warp(1000);
-        _initiateUnlock(account);
-
-        (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt,) = accountConfiguration.getLockStatus(account);
-        assertTrue(locked);
-        assertTrue(hasInitiatedUnlock);
-        assertEq(unlocksAt, 1000 + 1 hours);
+        vm.prank(account);
+        vm.expectRevert(AccountConfiguration.ZeroUnlockDelay.selector);
+        accountConfiguration.lock(0);
     }
 
-    function test_unlockAfterDelay() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice lock() reverts AccountIsLocked when the account is already hard-locked.
+    /// @dev Second lock hits onlyUnlocked -> _checkAndClearLock with unlocksAt == type(uint40).max (locked branch).
+    function test_lock_revert_whenAlreadyHardLocked(address account, uint16 firstDelay, uint16 secondDelay) public {
+        _assumeSafeAccount(account);
+        firstDelay = uint16(bound(firstDelay, 1, type(uint16).max));
+        secondDelay = uint16(bound(secondDelay, 1, type(uint16).max));
 
-        _lockAccount(account, 1 hours);
+        _lockAccount(account, firstDelay);
 
-        vm.warp(1000);
-        _initiateUnlock(account);
-
-        vm.warp(1000 + 1 hours);
-        assertFalse(accountConfiguration.isLocked(account));
+        vm.prank(account);
+        vm.expectRevert(AccountConfiguration.AccountIsLocked.selector);
+        accountConfiguration.lock(secondDelay);
     }
 
-    function test_unlockRevertsBeforeDelay() public {
-        (address account,) = _createK1Account(ACTOR_PK);
-
-        _lockAccount(account, 1 hours);
-
-        vm.warp(1000);
-        _initiateUnlock(account);
-
-        vm.warp(1000 + 30 minutes);
-        assertTrue(accountConfiguration.isLocked(account));
-    }
-
-    function test_unlockRevertsWithoutRequest() public {
-        (address account,) = _createK1Account(ACTOR_PK);
-
-        _lockAccount(account, 1 hours);
-
-        vm.warp(block.timestamp + 365 days);
-        assertTrue(accountConfiguration.isLocked(account));
-    }
-
-    function test_requestUnlockRevertsWhenNotLocked() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice initiateUnlock() reverts NotLocked when the account has never been locked (unlocksAt == 0).
+    /// @dev The `unlocksAt != type(uint40).max` guard fires on a fresh account whose unlocksAt is 0.
+    function test_initiateUnlock_revert_whenNeverLocked(address account) public {
+        _assumeSafeAccount(account);
 
         vm.prank(account);
         vm.expectRevert(AccountConfiguration.NotLocked.selector);
         accountConfiguration.initiateUnlock();
     }
 
-    function test_lockRevertsWhenAlreadyLocked() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice initiateUnlock() reverts NotLocked once an unlock has already been initiated.
+    /// @dev After initiateUnlock, unlocksAt is a finite timestamp (!= max), so a second initiateUnlock reverts.
+    function test_initiateUnlock_revert_whenUnlockAlreadyInitiated(address account, uint16 delay, uint256 t0) public {
+        _assumeSafeAccount(account);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+        t0 = bound(t0, 1, 1e9);
 
-        _lockAccount(account, 1 hours);
-
-        vm.prank(account);
-        vm.expectRevert(AccountConfiguration.AccountIsLocked.selector);
-        accountConfiguration.lock(2 hours);
-    }
-
-    function test_lockedAccountRejectsActorChanges() public {
-        (address account,) = _createK1Account(ACTOR_PK);
-
-        _lockAccount(account, 1 hours);
-
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
-        changes[0] = AccountConfiguration.ActorChange({
-            actorId: bytes32(bytes20(vm.addr(400))),
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
-
-        uint64 seq = accountConfiguration.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(ACTOR_PK, digest);
-
-        vm.expectRevert(AccountConfiguration.AccountIsLocked.selector);
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
-    }
-
-    // ── Full lifecycle ──
-
-    function test_fullLockUnlockCycle() public {
-        (address account,) = _createK1Account(ACTOR_PK);
-
-        _lockAccount(account, 1 hours);
-        (bool locked,,,) = accountConfiguration.getLockStatus(account);
-        assertTrue(locked);
-
-        vm.warp(1000);
+        _lockAccount(account, delay);
+        vm.warp(t0);
         _initiateUnlock(account);
 
-        vm.warp(1000 + 1 hours);
+        vm.prank(account);
+        vm.expectRevert(AccountConfiguration.NotLocked.selector);
+        accountConfiguration.initiateUnlock();
+    }
+
+    /// @notice applySignedActorChanges reverts AccountIsLocked while the target account is hard-locked.
+    /// @dev Exercises the onlyUnlocked modifier on a config-mutating path; the guard fires before any auth work.
+    function test_applySignedActorChanges_revert_whenLocked(uint256 pkSeed, uint16 delay) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+        (address account,) = _createK1Account(pk);
+
+        _lockAccount(account, delay);
+
+        AccountConfiguration.ActorChange[] memory changes = _oneAuthorizeChange(bytes32(bytes20(vm.addr(pk))));
+        uint64 chainId = uint64(block.chainid);
+        uint64 seq = accountConfiguration.getChangeSequences(account).local;
+        bytes32 digest = _computeActorChangeBatchDigest(account, chainId, seq, changes);
+        bytes memory auth = _buildK1Auth(pk, digest);
+
+        vm.expectRevert(AccountConfiguration.AccountIsLocked.selector);
+        accountConfiguration.applySignedActorChanges(account, chainId, changes, auth);
+    }
+
+    /// @notice importAccount reverts AccountIsLocked while the target account is hard-locked.
+    /// @dev The onlyUnlocked(account) modifier runs before the import body, so the lock guard is asserted in
+    ///      isolation on a second, distinct function (empty initialActors never reached).
+    function test_importAccount_revert_whenLocked(address account, uint16 delay) public {
+        _assumeSafeAccount(account);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+
+        _lockAccount(account, delay);
+
+        AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](0);
+        vm.expectRevert(AccountConfiguration.AccountIsLocked.selector);
+        accountConfiguration.importAccount(account, block.chainid, actors, "");
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // HAPPY PATHS / BRANCH COVERAGE
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice lock() hard-locks the account: unlocksAt == type(uint40).max and the delay is stored.
+    /// @dev getLockStatus reports locked, not-yet-initiated, sentinel unlocksAt and the stored delay; isLocked true.
+    function test_lock_success_setsHardLockStatus(address account, uint16 delay) public {
+        _assumeSafeAccount(account);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+
+        _lockAccount(account, delay);
+
+        (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 storedDelay) =
+            accountConfiguration.getLockStatus(account);
+        assertTrue(locked);
+        assertFalse(hasInitiatedUnlock);
+        assertEq(unlocksAt, type(uint40).max);
+        assertEq(storedDelay, delay);
+        assertTrue(accountConfiguration.isLocked(account));
+    }
+
+    /// @notice lock() emits AccountLocked(account, unlockDelay) exactly once. Sole assertion of this event.
+    function test_lock_success_emitsAccountLocked(address account, uint16 delay) public {
+        _assumeSafeAccount(account);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+
+        vm.expectEmit(true, false, false, true, address(accountConfiguration));
+        emit AccountConfiguration.AccountLocked(account, delay);
+        vm.prank(account);
+        accountConfiguration.lock(delay);
+    }
+
+    /// @notice An account can be re-locked after a prior unlock delay has fully elapsed.
+    /// @dev Drives _checkAndClearLock through its expiry-clear branch (block.timestamp >= unlocksAt, unlocksAt != 0):
+    ///      the stale timestamp is cleared to 0 and the fresh lock succeeds, hard-locking again with the new delay.
+    function test_lock_success_relockAfterUnlockExpired(
+        address account,
+        uint16 firstDelay,
+        uint16 secondDelay,
+        uint256 t0,
+        uint256 extra
+    ) public {
+        _assumeSafeAccount(account);
+        firstDelay = uint16(bound(firstDelay, 1, type(uint16).max));
+        secondDelay = uint16(bound(secondDelay, 1, type(uint16).max));
+        t0 = bound(t0, 1, 1e9);
+        extra = bound(extra, 0, 1e9);
+
+        _lockAccount(account, firstDelay);
+        vm.warp(t0);
+        _initiateUnlock(account);
+
+        vm.warp(t0 + firstDelay + extra); // at or past unlocksAt: account is unlocked
         assertFalse(accountConfiguration.isLocked(account));
 
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
-        changes[0] = AccountConfiguration.ActorChange({
-            actorId: bytes32(bytes20(vm.addr(500))),
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
+        _lockAccount(account, secondDelay);
 
+        (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 storedDelay) =
+            accountConfiguration.getLockStatus(account);
+        assertTrue(locked);
+        assertFalse(hasInitiatedUnlock);
+        assertEq(unlocksAt, type(uint40).max);
+        assertEq(storedDelay, secondDelay);
+    }
+
+    /// @notice initiateUnlock() sets unlocksAt = block.timestamp + delay and zeroes the stored delay.
+    /// @dev Before the delay elapses the account is still locked but now reports hasInitiatedUnlock; unlockDelay is 0.
+    function test_initiateUnlock_success_setsUnlocksAtAndClearsDelay(address account, uint16 delay, uint256 t0) public {
+        _assumeSafeAccount(account);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+        t0 = bound(t0, 1, 1e9);
+
+        _lockAccount(account, delay);
+        vm.warp(t0);
+        _initiateUnlock(account);
+
+        (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 storedDelay) =
+            accountConfiguration.getLockStatus(account);
+        assertTrue(locked); // block.timestamp (t0) < unlocksAt (t0 + delay)
+        assertTrue(hasInitiatedUnlock);
+        assertEq(unlocksAt, uint40(t0 + delay));
+        assertEq(storedDelay, 0);
+        assertTrue(accountConfiguration.isLocked(account));
+    }
+
+    /// @notice initiateUnlock() emits AccountUnlockInitiated(account, unlocksAt) exactly once. Sole assertion.
+    function test_initiateUnlock_success_emitsAccountUnlockInitiated(address account, uint16 delay, uint256 t0) public {
+        _assumeSafeAccount(account);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+        t0 = bound(t0, 1, 1e9);
+
+        _lockAccount(account, delay);
+        vm.warp(t0);
+
+        vm.expectEmit(true, false, false, true, address(accountConfiguration));
+        emit AccountConfiguration.AccountUnlockInitiated(account, uint40(t0 + delay));
+        vm.prank(account);
+        accountConfiguration.initiateUnlock();
+    }
+
+    /// @notice isLocked is false for an account that has never been locked (unlocksAt == 0).
+    function test_isLocked_success_falseWhenNeverLocked(address account, uint256 ts) public {
+        _assumeSafeAccount(account);
+        vm.warp(bound(ts, 1, 1e12));
+        assertFalse(accountConfiguration.isLocked(account));
+    }
+
+    /// @notice isLocked stays true for a hard-locked account at any reachable timestamp (unlocksAt == max sentinel).
+    function test_isLocked_success_trueWhileHardLocked(address account, uint16 delay, uint256 ts) public {
+        _assumeSafeAccount(account);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+
+        _lockAccount(account, delay);
+
+        vm.warp(bound(ts, 1, 1e12)); // any timestamp below the uint40 sentinel keeps block.timestamp < unlocksAt
+        assertTrue(accountConfiguration.isLocked(account));
+    }
+
+    /// @notice isLocked remains true after initiateUnlock while block.timestamp is strictly before unlocksAt.
+    function test_isLocked_success_trueBeforeUnlockDelayElapses(
+        address account,
+        uint16 delay,
+        uint256 t0,
+        uint256 within
+    ) public {
+        _assumeSafeAccount(account);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+        t0 = bound(t0, 1, 1e9);
+
+        _lockAccount(account, delay);
+        vm.warp(t0);
+        _initiateUnlock(account);
+
+        vm.warp(bound(within, t0, t0 + delay - 1)); // strictly before unlocksAt == t0 + delay
+        assertTrue(accountConfiguration.isLocked(account));
+    }
+
+    /// @notice isLocked flips to false once block.timestamp reaches or passes unlocksAt after an initiated unlock.
+    /// @dev Includes the exact boundary (extra == 0): isLocked is `block.timestamp < unlocksAt`, so == is unlocked.
+    function test_isLocked_success_falseAfterUnlockDelayElapses(
+        address account,
+        uint16 delay,
+        uint256 t0,
+        uint256 extra
+    ) public {
+        _assumeSafeAccount(account);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+        t0 = bound(t0, 1, 1e9);
+        extra = bound(extra, 0, 1e9);
+
+        _lockAccount(account, delay);
+        vm.warp(t0);
+        _initiateUnlock(account);
+
+        vm.warp(t0 + delay + extra); // at or past unlocksAt
+        assertFalse(accountConfiguration.isLocked(account));
+    }
+
+    /// @notice getLockStatus reports all-clear for a never-locked account: unlocked, not initiated, zeroed fields.
+    function test_getLockStatus_success_whenNeverLocked(address account) public view {
+        (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 unlockDelay) =
+            accountConfiguration.getLockStatus(account);
+        assertFalse(locked);
+        assertFalse(hasInitiatedUnlock);
+        assertEq(unlocksAt, 0);
+        assertEq(unlockDelay, 0);
+    }
+
+    /// @notice getLockStatus after the delay elapses (with no intervening onlyUnlocked call) still surfaces the
+    ///         initiated-unlock state: unlocked, but hasInitiatedUnlock true and unlocksAt unchanged.
+    /// @dev getLockStatus is a pure view: it never runs _checkAndClearLock, so the finite unlocksAt is not zeroed and
+    ///      the hasInitiatedUnlock branch (unlocksAt != 0 && != max) reports true even though the account is unlocked.
+    function test_getLockStatus_success_afterUnlockElapsedNotCleared(
+        address account,
+        uint16 delay,
+        uint256 t0,
+        uint256 extra
+    ) public {
+        _assumeSafeAccount(account);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+        t0 = bound(t0, 1, 1e9);
+        extra = bound(extra, 0, 1e9);
+
+        _lockAccount(account, delay);
+        vm.warp(t0);
+        _initiateUnlock(account);
+
+        vm.warp(t0 + delay + extra); // past unlocksAt, but no onlyUnlocked call to clear it
+
+        (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 storedDelay) =
+            accountConfiguration.getLockStatus(account);
+        assertFalse(locked);
+        assertTrue(hasInitiatedUnlock);
+        assertEq(unlocksAt, uint40(t0 + delay));
+        assertEq(storedDelay, 0);
+    }
+
+    /// @notice Full lock -> initiateUnlock -> warp-past -> config change cycle: once the delay elapses,
+    ///         _checkAndClearLock lets an onlyUnlocked config change through and the new actor is authorized.
+    /// @dev Drives the expiry-clear branch of _checkAndClearLock on the real applySignedActorChanges path.
+    function test_applySignedActorChanges_success_afterFullUnlockCycle(
+        uint256 pkSeed,
+        uint256 newActorSeed,
+        uint16 delay,
+        uint256 t0,
+        uint256 extra
+    ) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+        t0 = bound(t0, 1, 1e9);
+        extra = bound(extra, 0, 1e9);
+        (address account,) = _createK1Account(pk);
+
+        address newActor = address(uint160(bound(newActorSeed, 1, type(uint160).max)));
+        vm.assume(newActor != account);
+        vm.assume(newActor != vm.addr(pk));
+        bytes32 newActorId = bytes32(bytes20(newActor));
+
+        _lockAccount(account, delay);
+        vm.warp(t0);
+        _initiateUnlock(account);
+        vm.warp(t0 + delay + extra); // at or past unlocksAt: unlocked
+        assertFalse(accountConfiguration.isLocked(account));
+
+        AccountConfiguration.ActorChange[] memory changes = _oneAuthorizeChange(newActorId);
+        uint64 chainId = uint64(block.chainid);
         uint64 seq = accountConfiguration.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(ACTOR_PK, digest);
+        bytes32 digest = _computeActorChangeBatchDigest(account, chainId, seq, changes);
+        bytes memory auth = _buildK1Auth(pk, digest);
 
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
-        assertTrue(accountConfiguration.isActor(account, bytes32(bytes20(vm.addr(500)))));
+        accountConfiguration.applySignedActorChanges(account, chainId, changes, auth);
+
+        assertTrue(accountConfiguration.isActor(account, newActorId));
+        // The onlyUnlocked prelude cleared the stale unlock timestamp back to 0.
+        (,, uint40 unlocksAt,) = accountConfiguration.getLockStatus(account);
+        assertEq(unlocksAt, 0);
     }
 }

--- a/test/unit/AccountConfiguration/applyKeyChange.t.sol
+++ b/test/unit/AccountConfiguration/applyKeyChange.t.sol
@@ -5,292 +5,197 @@ import {AccountConfiguration} from "../../../src/AccountConfiguration.sol";
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 
 contract ApplyConfigChangeActorTest is AccountConfigurationTest {
-    uint256 constant ACTOR_PK = 200;
-    uint256 constant NEW_ACTOR_PK = 201;
+    /// @notice Authorizing a non-self actor registers it with the given authenticator and unrestricted scope.
+    function test_authorizeActor_success_unrestricted(uint256 pk, bytes32 actorId) public {
+        pk = _boundK1Pk(pk);
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
 
-    function test_authorizeActor() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+        AccountConfiguration.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), 0, 0, "");
+        _signApply(account, pk, ch);
 
-        address newSigner = vm.addr(NEW_ACTOR_PK);
-        bytes32 newActorId = bytes32(bytes20(newSigner));
-
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
-        changes[0] = AccountConfiguration.ActorChange({
-            actorId: newActorId,
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
-
-        uint64 seq = accountConfiguration.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(ACTOR_PK, digest);
-
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
-
-        AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, newActorId);
-        assertTrue(cfg.authenticator != address(0));
+        AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, actorId);
         assertEq(cfg.authenticator, address(k1Authenticator));
         assertEq(cfg.scope, 0x00);
     }
 
-    function test_authorizeActor_withScope() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice Authorizing an actor stores the requested non-zero scope verbatim.
+    function test_authorizeActor_success_withScope(uint256 pk, bytes32 actorId, uint8 scope) public {
+        pk = _boundK1Pk(pk);
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+        scope = uint8(bound(uint256(scope), 1, 255));
 
-        address newSigner = vm.addr(NEW_ACTOR_PK);
-        bytes32 newActorId = bytes32(bytes20(newSigner));
+        AccountConfiguration.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), scope, 0, "");
+        _signApply(account, pk, ch);
 
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
-        changes[0] = AccountConfiguration.ActorChange({
-            actorId: newActorId,
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x04, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
-
-        uint64 seq = accountConfiguration.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(ACTOR_PK, digest);
-
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
-
-        AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, newActorId);
+        AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, actorId);
         assertEq(cfg.authenticator, address(k1Authenticator));
-        assertEq(cfg.scope, 0x04);
+        assertEq(cfg.scope, scope);
     }
 
-    function test_revokeActor() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice Revoking a live non-self actor removes it from the account.
+    function test_revokeActor_success_removesActor(uint256 pk, bytes32 actorId) public {
+        pk = _boundK1Pk(pk);
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+        _authorizeActor(account, pk, actorId, address(k1Authenticator));
+        assertTrue(accountConfiguration.isActor(account, actorId));
 
-        address newSigner = vm.addr(NEW_ACTOR_PK);
-        bytes32 newActorId = bytes32(bytes20(newSigner));
-        _authorizeActor(account, ACTOR_PK, newActorId, address(k1Authenticator));
+        AccountConfiguration.ActorChange[] memory ch = new AccountConfiguration.ActorChange[](1);
+        ch[0] = AccountConfiguration.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
+        _signApply(account, pk, ch);
 
-        assertTrue(accountConfiguration.isActor(account, newActorId));
-
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
-        changes[0] = AccountConfiguration.ActorChange({actorId: newActorId, changeType: 0x02, data: ""});
-
-        uint64 seq = accountConfiguration.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(ACTOR_PK, digest);
-
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
-
-        assertFalse(accountConfiguration.isActor(account, newActorId));
+        assertFalse(accountConfiguration.isActor(account, actorId));
     }
 
-    function test_multipleOperationsInSingleChange() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice A batch of multiple authorize operations applies every element.
+    function test_applySignedActorChanges_success_multipleOperations(uint256 pk, bytes32 idA, bytes32 idB) public {
+        pk = _boundK1Pk(pk);
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(idA != ownerId && idA != bytes32(bytes20(account)));
+        vm.assume(idB != ownerId && idB != bytes32(bytes20(account)));
+        vm.assume(idA != idB);
 
-        bytes32 actor1 = bytes32(bytes20(vm.addr(300)));
-        bytes32 actor2 = bytes32(bytes20(vm.addr(301)));
+        AccountConfiguration.ActorChange[] memory ch = new AccountConfiguration.ActorChange[](2);
+        ch[0] = _authorizeChange(idA, address(k1Authenticator), 0, 0, "")[0];
+        ch[1] = _authorizeChange(idB, address(k1Authenticator), 0, 0, "")[0];
+        _signApply(account, pk, ch);
 
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](2);
-        changes[0] = AccountConfiguration.ActorChange({
-            actorId: actor1,
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
-        changes[1] = AccountConfiguration.ActorChange({
-            actorId: actor2,
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
-
-        uint64 seq = accountConfiguration.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(ACTOR_PK, digest);
-
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
-
-        assertTrue(accountConfiguration.isActor(account, actor1));
-        assertTrue(accountConfiguration.isActor(account, actor2));
+        assertTrue(accountConfiguration.isActor(account, idA));
+        assertTrue(accountConfiguration.isActor(account, idB));
     }
 
-    function test_sequenceIncrements() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice Each applied batch increments the account's local change sequence by one.
+    /// @dev createAccount initializes localSequence to 1 (the initialized flag), so the local channel starts at 1.
+    function test_applySignedActorChanges_success_sequenceIncrements(uint256 pk, bytes32 idA, bytes32 idB) public {
+        pk = _boundK1Pk(pk);
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(idA != ownerId && idA != bytes32(bytes20(account)));
+        vm.assume(idB != ownerId && idB != bytes32(bytes20(account)));
+        vm.assume(idA != idB);
 
-        // createAccount initializes localSequence to 1 (the initialized flag), so the local channel starts at 1.
         assertEq(accountConfiguration.getChangeSequences(account).local, 1);
 
-        _authorizeActor(account, ACTOR_PK, bytes32(bytes20(vm.addr(300))), address(k1Authenticator));
+        _authorizeActor(account, pk, idA, address(k1Authenticator));
         assertEq(accountConfiguration.getChangeSequences(account).local, 2);
 
-        _authorizeActor(account, ACTOR_PK, bytes32(bytes20(vm.addr(301))), address(k1Authenticator));
+        _authorizeActor(account, pk, idB, address(k1Authenticator));
         assertEq(accountConfiguration.getChangeSequences(account).local, 3);
     }
 
-    function test_revertsWhenLocked() public {
-        (address account,) = _createK1Account(ACTOR_PK);
-
+    /// @notice A hard-locked account rejects actor changes.
+    /// @dev The onlyUnlocked modifier fires before any authentication work.
+    function test_applySignedActorChanges_revert_whenLocked(uint256 pk, bytes32 actorId) public {
+        pk = _boundK1Pk(pk);
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
         _lockAccount(account);
 
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
-        changes[0] = AccountConfiguration.ActorChange({
-            actorId: bytes32(bytes20(vm.addr(300))),
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
-
-        uint64 seq = accountConfiguration.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(ACTOR_PK, digest);
-
-        vm.expectRevert();
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+        AccountConfiguration.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), 0, 0, "");
+        bytes memory auth = _authOver(account, pk, ch);
+        vm.expectRevert(AccountConfiguration.AccountIsLocked.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
     }
 
-    function test_anyActorCanAuthorize() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice Any authorized unrestricted actor, not only the owner, may authorize further actors.
+    function test_applySignedActorChanges_success_anyUnrestrictedActorAuthorizes(
+        uint256 ownerPk,
+        uint256 actorPk,
+        bytes32 targetId
+    ) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        actorPk = _boundK1Pk(actorPk);
+        vm.assume(ownerPk != actorPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+        vm.assume(targetId != ownerId && targetId != actorId && targetId != bytes32(bytes20(account)));
 
-        bytes32 secondActorId = bytes32(bytes20(vm.addr(NEW_ACTOR_PK)));
-        _authorizeActor(account, ACTOR_PK, secondActorId, address(k1Authenticator));
+        _authorizeActor(account, ownerPk, actorId, address(k1Authenticator));
 
-        bytes32 thirdActorId = bytes32(bytes20(vm.addr(302)));
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
-        changes[0] = AccountConfiguration.ActorChange({
-            actorId: thirdActorId,
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
-
-        uint64 seq = accountConfiguration.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(NEW_ACTOR_PK, digest);
-
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
-        assertTrue(accountConfiguration.isActor(account, thirdActorId));
+        AccountConfiguration.ActorChange[] memory ch = _authorizeChange(targetId, address(k1Authenticator), 0, 0, "");
+        _signApply(account, actorPk, ch);
+        assertTrue(accountConfiguration.isActor(account, targetId));
     }
 
-    function test_scopedActor_cannotAuthorizeWithoutConfigScope() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice An actor whose scope lacks the CONFIG bit cannot authorize actors.
+    /// @dev Reverts with UnauthorizedActorChange at the CONFIG-scope gate.
+    function test_applySignedActorChanges_revert_scopedActorWithoutConfigScope(
+        uint256 ownerPk,
+        uint256 actorPk,
+        uint8 scope,
+        bytes32 targetId
+    ) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        actorPk = _boundK1Pk(actorPk);
+        vm.assume(ownerPk != actorPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+        vm.assume(targetId != ownerId && targetId != actorId && targetId != bytes32(bytes20(account)));
+        uint8 config = accountConfiguration.SCOPE_CONFIG();
+        scope = uint8(bound(uint256(scope), 1, 255)) & ~config;
+        vm.assume(scope != 0);
 
-        address newSigner = vm.addr(NEW_ACTOR_PK);
-        bytes32 secondActorId = bytes32(bytes20(newSigner));
-        _authorizeActorWithScope(account, ACTOR_PK, secondActorId, address(k1Authenticator), 0x02);
+        _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), scope);
 
-        bytes32 thirdActorId = bytes32(bytes20(vm.addr(302)));
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
-        changes[0] = AccountConfiguration.ActorChange({
-            actorId: thirdActorId,
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
-
-        uint64 seq = accountConfiguration.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(NEW_ACTOR_PK, digest);
-
-        vm.expectRevert();
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+        AccountConfiguration.ActorChange[] memory ch = _authorizeChange(targetId, address(k1Authenticator), 0, 0, "");
+        bytes memory auth = _authOver(account, actorPk, ch);
+        vm.expectRevert(AccountConfiguration.UnauthorizedActorChange.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
     }
 
-    function test_scopedActor_canAuthorizeWithConfigScope() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice An actor whose scope includes the CONFIG bit may authorize actors.
+    function test_applySignedActorChanges_success_scopedActorWithConfigScope(
+        uint256 ownerPk,
+        uint256 actorPk,
+        uint8 extra,
+        bytes32 targetId
+    ) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        actorPk = _boundK1Pk(actorPk);
+        vm.assume(ownerPk != actorPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+        vm.assume(targetId != ownerId && targetId != actorId && targetId != bytes32(bytes20(account)));
+        uint8 scope = accountConfiguration.SCOPE_CONFIG() | (extra & 0x07);
 
-        address newSigner = vm.addr(NEW_ACTOR_PK);
-        bytes32 secondActorId = bytes32(bytes20(newSigner));
-        _authorizeActorWithScope(
-            account, ACTOR_PK, secondActorId, address(k1Authenticator), accountConfiguration.SCOPE_CONFIG()
-        );
+        _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), scope);
 
-        bytes32 thirdActorId = bytes32(bytes20(vm.addr(302)));
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
-        changes[0] = AccountConfiguration.ActorChange({
-            actorId: thirdActorId,
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
-
-        uint64 seq = accountConfiguration.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(NEW_ACTOR_PK, digest);
-
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
-        assertTrue(accountConfiguration.isActor(account, thirdActorId));
+        AccountConfiguration.ActorChange[] memory ch = _authorizeChange(targetId, address(k1Authenticator), 0, 0, "");
+        _signApply(account, actorPk, ch);
+        assertTrue(accountConfiguration.isActor(account, targetId));
     }
 
-    function test_reauthorizeNonSelfActor_upsertsInPlace() public {
-        // authorizeActor is an upsert: re-authorizing an already-configured (non-self) actor overwrites its config
-        // in place rather than reverting. Here the owner actor is re-scoped from unrestricted (0x00) to CONFIG.
-        (address account, bytes32 actorActorId) = _createK1Account(ACTOR_PK);
+    /// @notice Re-authorizing an already-configured non-self actor upserts its config in place.
+    /// @dev The owner actor is re-scoped from unrestricted to CONFIG rather than reverting.
+    function test_authorizeActor_success_reauthorizeUpsertsInPlace(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account, bytes32 ownerId) = _createK1Account(pk);
 
         uint8 newScope = accountConfiguration.SCOPE_CONFIG();
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
-        changes[0] = AccountConfiguration.ActorChange({
-            actorId: actorActorId,
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: newScope, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
+        AccountConfiguration.ActorChange[] memory ch =
+            _authorizeChange(ownerId, address(k1Authenticator), newScope, 0, "");
+        _signApply(account, pk, ch);
 
-        uint64 seq = accountConfiguration.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(ACTOR_PK, digest);
-
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
-
-        AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, actorActorId);
+        AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, ownerId);
         assertEq(cfg.scope, newScope);
         assertEq(cfg.authenticator, address(k1Authenticator));
     }
 
-    function test_reauthorizeLiveK1Self_rescopesWithoutPriorRevoke() public {
-        // Re-authorizing the inline k1 self is now an in-place upsert — no prior revoke required, even when the self
-        // is live with a non-trivial scope. (Previously this reverted unless the self was revoked or all-zero.)
-        uint256 eoaPk = 500;
+    /// @notice Re-authorizing a live inline k1 self is an in-place upsert with no prior revoke.
+    /// @dev Even a non-trivially-scoped live self can be re-scoped directly.
+    function test_selfActorId_success_reauthorizeLiveSelfRescopes(uint256 eoaPk) public {
+        eoaPk = _boundK1Pk(eoaPk);
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
 
-        // First: the implicit owner (all-zero inline, live) scopes the self to CONFIG so it can keep signing.
         uint8 configScope = accountConfiguration.SCOPE_CONFIG();
         _rescopeSelf(eoa, eoaPk, configScope);
         assertEq(accountConfiguration.getActorConfig(eoa, selfActorId).scope, configScope);
 
-        // Second: re-scope the now-live, non-trivially-scoped self again (no revoke in between).
         uint8 newScope = configScope | 0x02; // CONFIG | SENDER
         _rescopeSelf(eoa, eoaPk, newScope);
 
@@ -300,44 +205,32 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         assertTrue(accountConfiguration.isActor(eoa, selfActorId));
     }
 
-    function test_revertsOnRevokingNonExistentActor() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice Revoking an actor that was never authorized reverts.
+    function test_revokeActor_revert_nonExistentActor(uint256 pk, bytes32 actorId) public {
+        pk = _boundK1Pk(pk);
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
 
-        bytes32 nonExistentActorId = bytes32(bytes20(vm.addr(999)));
-
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
-        changes[0] = AccountConfiguration.ActorChange({actorId: nonExistentActorId, changeType: 0x02, data: ""});
-
-        uint64 seq = accountConfiguration.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(ACTOR_PK, digest);
-
+        AccountConfiguration.ActorChange[] memory ch = new AccountConfiguration.ActorChange[](1);
+        ch[0] = AccountConfiguration.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
+        bytes memory auth = _authOver(account, pk, ch);
         vm.expectRevert();
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
     }
 
-    function test_revertsWithInvalidSignature() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice A batch signed by a key that is not an actor on the account reverts.
+    function test_applySignedActorChanges_revert_invalidSignature(uint256 pk, uint256 wrongPk, bytes32 actorId) public {
+        pk = _boundK1Pk(pk);
+        wrongPk = _boundK1Pk(wrongPk);
+        vm.assume(vm.addr(pk) != vm.addr(wrongPk));
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(vm.addr(wrongPk) != account);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
 
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
-        changes[0] = AccountConfiguration.ActorChange({
-            actorId: bytes32(bytes20(vm.addr(300))),
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
-
-        uint64 seq = accountConfiguration.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-
-        bytes memory badAuth = _buildK1Auth(999, digest);
-
+        AccountConfiguration.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), 0, 0, "");
+        bytes memory badAuth = _authOver(account, wrongPk, ch);
         vm.expectRevert();
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, badAuth);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, badAuth);
     }
 
     // ── Implicit EOA (registered by default) ──
@@ -346,57 +239,42 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
     // that is authorized with unrestricted scope when the config slot
     // is empty. No createAccount/importAccount needed.
 
-    function test_implicitEOA_canSignActorChanges() public {
-        uint256 eoaPk = 500;
+    /// @notice A never-created EOA can sign actor changes via its implicit self key.
+    function test_applySignedActorChanges_success_implicitEoaSigner(uint256 eoaPk, bytes32 actorId) public {
+        eoaPk = _boundK1Pk(eoaPk);
         address eoa = vm.addr(eoaPk);
-        bytes32 newActorId = bytes32(bytes20(vm.addr(501)));
+        vm.assume(actorId != bytes32(bytes20(eoa)));
 
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
-        changes[0] = AccountConfiguration.ActorChange({
-            actorId: newActorId,
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
-
-        uint64 seq = accountConfiguration.getChangeSequences(eoa).local;
-        bytes32 digest = _computeActorChangeBatchDigest(eoa, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(eoaPk, digest);
-
-        accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), changes, auth);
-        assertTrue(accountConfiguration.isActor(eoa, newActorId));
+        _signApply(eoa, eoaPk, _authorizeChange(actorId, address(k1Authenticator), 0, 0, ""));
+        assertTrue(accountConfiguration.isActor(eoa, actorId));
     }
 
-    function test_implicitEOA_canRevokeItselfViaFlag() public {
-        uint256 eoaPk = 500;
+    /// @notice The implicit EOA self key can be revoked via the default-EOA flag using another key.
+    /// @dev A revoked default EOA reports an all-zero config.
+    function test_selfActorId_success_implicitEoaRevokesSelfViaFlag(uint256 eoaPk, uint256 newPk) public {
+        eoaPk = _boundK1Pk(eoaPk);
+        newPk = _boundK1Pk(newPk);
+        vm.assume(eoaPk != newPk);
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
-
+        bytes32 newActorId = bytes32(bytes20(vm.addr(newPk)));
+        vm.assume(newActorId != selfActorId);
         assertTrue(accountConfiguration.isActor(eoa, selfActorId));
 
-        // Add a second key first using implicit EOA auth
-        bytes32 newActorId = bytes32(bytes20(vm.addr(501)));
         _implicitAuthorizeActor(eoa, eoaPk, newActorId, address(k1Authenticator));
-
-        // Revoke self-actorId using the new explicit key (sets the default-EOA revoke flag)
-        _revokeActor(eoa, 501, selfActorId);
+        _revokeActor(eoa, newPk, selfActorId);
 
         assertFalse(accountConfiguration.isActor(eoa, selfActorId));
         assertTrue(accountConfiguration.isActor(eoa, newActorId));
 
-        // A revoked default EOA reports as an all-zero (empty) config — no sentinel.
         AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(eoa, selfActorId);
         assertEq(cfg.authenticator, address(0));
         assertEq(cfg.scope, 0);
     }
 
-    function test_implicitEOA_liveReportsAsEcrecoverOwner() public view {
-        // A live default EOA (no createAccount, flag unset) synthesizes a native ecrecover owner config.
-        uint256 eoaPk = 500;
+    /// @notice A live default EOA reports a synthesized K1 owner config for its self-actorId.
+    function test_selfActorId_success_liveReportsAsK1Owner(uint256 eoaPk) public view {
+        eoaPk = _boundK1Pk(eoaPk);
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
 
@@ -405,79 +283,56 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         assertEq(cfg.scope, 0);
     }
 
-    function test_selfActorId_canScopeViaK1() public {
-        // The account's own key can be downgraded to a scoped actor by authorizing the self-actorId as a K1 actor.
-        // With a single k1 path the config alone decides the scope, so there is no implicit full-owner escape.
-        uint256 eoaPk = 500;
+    /// @notice The account's own key can be downgraded to a scoped actor via the self-actorId.
+    /// @dev With a single k1 path the config alone decides the scope; there is no implicit full-owner escape.
+    function test_selfActorId_success_scopeViaK1(uint256 eoaPk, uint8 scope, bytes32 hash) public {
+        eoaPk = _boundK1Pk(eoaPk);
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
+        scope = uint8(bound(uint256(scope), 1, 255));
         assertTrue(accountConfiguration.isActor(eoa, selfActorId));
 
-        _implicitAuthorizeActorWithScope(eoa, eoaPk, selfActorId, address(k1Authenticator), 0x02);
+        _implicitAuthorizeActorWithScope(eoa, eoaPk, selfActorId, address(k1Authenticator), scope);
 
         assertTrue(accountConfiguration.isActor(eoa, selfActorId));
         AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(eoa, selfActorId);
         assertEq(cfg.authenticator, address(k1Authenticator));
-        assertEq(cfg.scope, 0x02);
+        assertEq(cfg.scope, scope);
 
-        // The same key now authenticates with its downgraded scope (0x02), never full owner (0x00).
-        bytes32 hash = keccak256("scoped self");
-        (uint8 scope,,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
-        assertEq(scope, 0x02);
+        (uint8 outScope,,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        assertEq(outScope, scope);
     }
 
-    function test_selfActorId_doubleAuthorizeReverts() public {
-        // Once the self-actorId has an explicit entry it cannot be re-authorized without revoking first.
-        uint256 eoaPk = 500;
+    /// @notice A self key scoped without the CONFIG bit can no longer authorize, including re-authorizing itself.
+    /// @dev Reverts with UnauthorizedActorChange: the downgraded self fails the CONFIG-scope gate.
+    function test_selfActorId_revert_scopedSelfCannotReauthorize(uint256 eoaPk, uint8 scope) public {
+        eoaPk = _boundK1Pk(eoaPk);
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
+        uint8 config = accountConfiguration.SCOPE_CONFIG();
+        scope = uint8(bound(uint256(scope), 1, 255)) & ~config;
+        vm.assume(scope != 0);
 
-        _implicitAuthorizeActorWithScope(eoa, eoaPk, selfActorId, address(k1Authenticator), 0x02);
+        _implicitAuthorizeActorWithScope(eoa, eoaPk, selfActorId, address(k1Authenticator), scope);
 
-        // Second authorize for the same actorId reverts (existing entry). Signed by the now-scoped self key.
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
-        changes[0] = AccountConfiguration.ActorChange({
-            actorId: selfActorId,
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: 0x00, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
-        uint64 seq = accountConfiguration.getChangeSequences(eoa).local;
-        bytes32 digest = _computeActorChangeBatchDigest(eoa, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(eoaPk, digest);
-
-        vm.expectRevert();
-        accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), changes, auth);
+        AccountConfiguration.ActorChange[] memory ch =
+            _authorizeChange(selfActorId, accountConfiguration.K1_AUTHENTICATOR(), 0, 0, "");
+        bytes memory auth = _authOver(eoa, eoaPk, ch);
+        vm.expectRevert(AccountConfiguration.UnauthorizedActorChange.selector);
+        accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), ch, auth);
     }
 
-    function test_implicitEOA_crossChainActorChange() public {
-        uint256 eoaPk = 500;
+    /// @notice A never-created EOA can apply a multichain (chainId 0) actor change via its implicit self key.
+    function test_applySignedActorChanges_success_multichainImplicitEoa(uint256 eoaPk, bytes32 actorId) public {
+        eoaPk = _boundK1Pk(eoaPk);
         address eoa = vm.addr(eoaPk);
-        bytes32 newActorId = bytes32(bytes20(vm.addr(501)));
+        vm.assume(actorId != bytes32(bytes20(eoa)));
 
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
-        changes[0] = AccountConfiguration.ActorChange({
-            actorId: newActorId,
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
-
-        // chainId=0 for multichain
+        AccountConfiguration.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), 0, 0, "");
         uint64 seq = accountConfiguration.getChangeSequences(eoa).multichain;
-        bytes32 digest = _computeActorChangeBatchDigest(eoa, 0, seq, changes);
-        bytes memory auth = _buildK1Auth(eoaPk, digest);
-
-        accountConfiguration.applySignedActorChanges(eoa, 0, changes, auth);
-        assertTrue(accountConfiguration.isActor(eoa, newActorId));
+        bytes32 digest = _computeActorChangeBatchDigest(eoa, 0, seq, ch);
+        accountConfiguration.applySignedActorChanges(eoa, 0, ch, _buildK1Auth(eoaPk, digest));
+        assertTrue(accountConfiguration.isActor(eoa, actorId));
     }
 
     // ── Default EOA self-actorId semantics ──
@@ -488,25 +343,26 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
     // path. The flag is never cleared, so a managed self-actorId is operated through its explicit entry/prefix.
     // createAccount and importAccount disable the implicit default EOA by default.
 
-    function test_selfActorId_revokedByDefaultOnCreate() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice createAccount disables the implicit default EOA, so the self-actorId is not a live actor.
+    function test_selfActorId_success_revokedByDefaultOnCreate(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
         bytes32 selfActorId = bytes32(bytes20(account));
 
-        // createAccount disables the default EOA, so the self-actorId is not a live actor.
         assertFalse(accountConfiguration.isActor(account, selfActorId));
-
         AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, selfActorId);
         assertEq(cfg.authenticator, address(0));
         assertEq(cfg.scope, 0);
     }
 
-    function test_selfActorId_reEnableOnCreatedAccount() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice An owner re-enables the default EOA by authorizing the self-actorId with the owner shape.
+    function test_selfActorId_success_reEnableOnCreatedAccount(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
         bytes32 selfActorId = bytes32(bytes20(account));
         assertFalse(accountConfiguration.isActor(account, selfActorId));
 
-        // An owner re-enables the default EOA by authorizing the self-actorId with the canonical owner shape.
-        _authorizeActor(account, ACTOR_PK, selfActorId, accountConfiguration.K1_AUTHENTICATOR());
+        _authorizeActor(account, pk, selfActorId, accountConfiguration.K1_AUTHENTICATOR());
 
         assertTrue(accountConfiguration.isActor(account, selfActorId));
         AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, selfActorId);
@@ -514,226 +370,492 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         assertEq(cfg.scope, 0);
     }
 
-    function test_selfActorId_revokeThenReEnable() public {
-        // An EOA account (not created) starts with a live default EOA.
-        uint256 eoaPk = 500;
+    /// @notice A revoked default EOA can be re-enabled by authorizing the self-actorId as a native k1 owner.
+    /// @dev While revoked the own key cannot authenticate; after re-enable it resolves via the explicit self config.
+    function test_selfActorId_success_revokeThenReEnable(uint256 eoaPk, uint256 newPk, bytes32 hash) public {
+        eoaPk = _boundK1Pk(eoaPk);
+        newPk = _boundK1Pk(newPk);
+        vm.assume(eoaPk != newPk);
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
+        bytes32 newActorId = bytes32(bytes20(vm.addr(newPk)));
+        vm.assume(newActorId != selfActorId);
         assertTrue(accountConfiguration.isActor(eoa, selfActorId));
 
-        // Add a second key, then revoke the default EOA via the flag.
-        bytes32 newActorId = bytes32(bytes20(vm.addr(501)));
         _implicitAuthorizeActor(eoa, eoaPk, newActorId, address(k1Authenticator));
-        _revokeActor(eoa, 501, selfActorId);
+        _revokeActor(eoa, newPk, selfActorId);
         assertFalse(accountConfiguration.isActor(eoa, selfActorId));
 
-        // The default EOA can no longer authenticate while revoked: its own k1 sig finds no config and the flag
-        // disables the implicit full-owner fallback.
-        bytes32 hash = keccak256("while revoked");
         vm.expectRevert();
         accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
 
-        // Re-enable by authorizing the self-actorId as a native k1 owner using the second key.
-        _authorizeActor(eoa, 501, selfActorId, accountConfiguration.K1_AUTHENTICATOR());
+        _authorizeActor(eoa, newPk, selfActorId, accountConfiguration.K1_AUTHENTICATOR());
         assertTrue(accountConfiguration.isActor(eoa, selfActorId));
 
-        // The own key is a full owner again — now resolved through its explicit self config (the flag stays set, so
-        // it is the config, not the implicit fallback, that authorizes it).
         (uint8 scope,,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(scope, 0);
     }
 
-    function test_e2e_eoaToPasskeyThenReEnableK1() public {
-        // Full lifecycle: use the default EOA, hand the account to a "passkey", then re-enable the K1 key.
-        //
-        // The new owner is registered through an authenticator (K1 here as a stand-in for a passkey/P256 device
-        // key); the revoke-self + re-enable-self mechanics are authenticator-agnostic, so a real passkey owner
-        // behaves identically — only changes[0].data.authenticator differs.
-        uint256 eoaPk = 500; // the account's own K1 key (the default EOA)
+    /// @notice Full lifecycle: default EOA hands the account to a device key, then re-enables the K1 key.
+    /// @dev The revoke-self + re-enable-self mechanics are authenticator-agnostic; K1 stands in for a passkey here.
+    function test_selfActorId_success_eoaToPasskeyLifecycle(uint256 eoaPk, uint256 devicePk, bytes32 hash) public {
+        eoaPk = _boundK1Pk(eoaPk);
+        devicePk = _boundK1Pk(devicePk);
+        vm.assume(eoaPk != devicePk);
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
-
-        uint256 devicePk = 600; // the "passkey" device key
         bytes32 deviceActorId = bytes32(bytes20(vm.addr(devicePk)));
+        vm.assume(deviceActorId != selfActorId);
 
-        // ── Phase 0: the default EOA is live and authenticates with its own k1 signature (implicit full owner). ──
+        // Phase 0: the default EOA is live and authenticates with its own k1 signature.
         assertTrue(accountConfiguration.isActor(eoa, selfActorId));
-        bytes32 h0 = keccak256("phase 0");
-        (uint8 scope0,,) = accountConfiguration.authenticateActor(eoa, h0, _buildK1Auth(eoaPk, h0));
+        (uint8 scope0,,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(scope0, 0);
 
-        // ── Phase 1: in one batch signed by the EOA, add the passkey as a full owner and revoke the default EOA. ──
+        // Phase 1: in one batch signed by the EOA, add the device key as a full owner and revoke the default EOA.
         AccountConfiguration.ActorChange[] memory switchChanges = new AccountConfiguration.ActorChange[](2);
-        switchChanges[0] = AccountConfiguration.ActorChange({
-            actorId: deviceActorId,
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
+        switchChanges[0] = _authorizeChange(deviceActorId, address(k1Authenticator), 0, 0, "")[0];
         switchChanges[1] = AccountConfiguration.ActorChange({actorId: selfActorId, changeType: 0x02, data: ""});
+        _signApply(eoa, eoaPk, switchChanges);
 
-        uint64 seq1 = accountConfiguration.getChangeSequences(eoa).local;
-        bytes32 d1 = _computeActorChangeBatchDigest(eoa, uint64(block.chainid), seq1, switchChanges);
-        accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), switchChanges, _buildK1Auth(eoaPk, d1));
-
-        // The EOA is now disabled; the passkey is the live owner.
         assertFalse(accountConfiguration.isActor(eoa, selfActorId));
         assertTrue(accountConfiguration.isActor(eoa, deviceActorId));
-
-        bytes32 h1 = keccak256("phase 1");
         vm.expectRevert();
-        accountConfiguration.authenticateActor(eoa, h1, _buildK1Auth(eoaPk, h1));
-        (uint8 scope1,,) = accountConfiguration.authenticateActor(eoa, h1, _buildK1Auth(devicePk, h1));
+        accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (uint8 scope1,,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(devicePk, hash));
         assertEq(scope1, 0);
 
-        // ── Phase 2: the passkey re-enables the K1 key by authorizing the self-actorId as a native k1 owner. ──
-        AccountConfiguration.ActorChange[] memory reEnable = new AccountConfiguration.ActorChange[](1);
-        reEnable[0] = AccountConfiguration.ActorChange({
-            actorId: selfActorId,
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: 0x00, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
+        // Phase 2: the device key re-enables the K1 key by authorizing the self-actorId as a native k1 owner.
+        AccountConfiguration.ActorChange[] memory reEnable =
+            _authorizeChange(selfActorId, accountConfiguration.K1_AUTHENTICATOR(), 0, 0, "");
+        _signApply(eoa, devicePk, reEnable);
 
-        uint64 seq2 = accountConfiguration.getChangeSequences(eoa).local;
-        bytes32 d2 = _computeActorChangeBatchDigest(eoa, uint64(block.chainid), seq2, reEnable);
-        accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), reEnable, _buildK1Auth(devicePk, d2));
-
-        // The K1 key is a full owner again — now resolved through its explicit self config rather than the
-        // implicit fallback (the flag is never cleared), so the same k1 signature authenticates.
         assertTrue(accountConfiguration.isActor(eoa, selfActorId));
-        bytes32 h2 = keccak256("phase 2");
-        (uint8 scope2,,) = accountConfiguration.authenticateActor(eoa, h2, _buildK1Auth(eoaPk, h2));
+        (uint8 scope2,,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(scope2, 0);
     }
 
-    function test_selfActorId_batchRevokeViaFlag() public {
-        // EOA account: add a key and revoke the default EOA in a single batch signed by the default EOA.
-        uint256 eoaPk = 500;
+    /// @notice A single batch signed by the default EOA can add a key and revoke the default EOA together.
+    function test_selfActorId_success_batchRevokeViaFlag(uint256 eoaPk, uint256 newPk) public {
+        eoaPk = _boundK1Pk(eoaPk);
+        newPk = _boundK1Pk(newPk);
+        vm.assume(eoaPk != newPk);
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
+        bytes32 newActorId = bytes32(bytes20(vm.addr(newPk)));
+        vm.assume(newActorId != selfActorId);
 
-        bytes32 newActorId = bytes32(bytes20(vm.addr(NEW_ACTOR_PK)));
-
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](2);
-        changes[0] = AccountConfiguration.ActorChange({
-            actorId: newActorId,
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
-        changes[1] = AccountConfiguration.ActorChange({actorId: selfActorId, changeType: 0x02, data: ""});
-
-        uint64 seq = accountConfiguration.getChangeSequences(eoa).local;
-        bytes32 digest = _computeActorChangeBatchDigest(eoa, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(eoaPk, digest);
-
-        accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), changes, auth);
+        AccountConfiguration.ActorChange[] memory ch = new AccountConfiguration.ActorChange[](2);
+        ch[0] = _authorizeChange(newActorId, address(k1Authenticator), 0, 0, "")[0];
+        ch[1] = AccountConfiguration.ActorChange({actorId: selfActorId, changeType: 0x02, data: ""});
+        _signApply(eoa, eoaPk, ch);
 
         assertFalse(accountConfiguration.isActor(eoa, selfActorId));
         assertTrue(accountConfiguration.isActor(eoa, newActorId));
 
-        // A revoked default EOA reports as an all-zero (empty) config — no sentinel.
         AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(eoa, selfActorId);
         assertEq(cfg.authenticator, address(0));
         assertEq(cfg.scope, 0);
     }
 
-    function test_selfActorId_revokedCannotSignActorChanges() public {
-        // EOA account: default EOA adds a second key, then revokes itself.
-        uint256 eoaPk = 500;
+    /// @notice A revoked default EOA can no longer sign actor changes, but a still-active key can.
+    /// @dev The revoked self signature reverts; the second key's signature over the same digest applies.
+    function test_selfActorId_revert_revokedCannotSign(uint256 eoaPk, uint256 newPk, bytes32 targetId) public {
+        eoaPk = _boundK1Pk(eoaPk);
+        newPk = _boundK1Pk(newPk);
+        vm.assume(eoaPk != newPk);
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
+        bytes32 newActorId = bytes32(bytes20(vm.addr(newPk)));
+        vm.assume(newActorId != selfActorId);
+        vm.assume(targetId != selfActorId && targetId != newActorId);
 
-        bytes32 newActorId = bytes32(bytes20(vm.addr(NEW_ACTOR_PK)));
         _implicitAuthorizeActor(eoa, eoaPk, newActorId, address(k1Authenticator));
-        _revokeActor(eoa, NEW_ACTOR_PK, selfActorId);
+        _revokeActor(eoa, newPk, selfActorId);
 
-        bytes32 thirdActorId = bytes32(bytes20(vm.addr(302)));
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
-        changes[0] = AccountConfiguration.ActorChange({
-            actorId: thirdActorId,
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
-
+        AccountConfiguration.ActorChange[] memory ch = _authorizeChange(targetId, address(k1Authenticator), 0, 0, "");
         uint64 seq = accountConfiguration.getChangeSequences(eoa).local;
-        bytes32 digest = _computeActorChangeBatchDigest(eoa, uint64(block.chainid), seq, changes);
-
-        // The revoked default EOA can no longer authenticate.
-        vm.expectRevert();
-        accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), changes, _buildK1Auth(eoaPk, digest));
-
-        // But the still-active second key can sign.
-        accountConfiguration.applySignedActorChanges(
-            eoa, uint64(block.chainid), changes, _buildK1Auth(NEW_ACTOR_PK, digest)
-        );
-        assertTrue(accountConfiguration.isActor(eoa, thirdActorId));
-    }
-
-    function test_revokedKey_cannotSignActorChanges() public {
-        (address account,) = _createK1Account(ACTOR_PK);
-
-        bytes32 newActorId = bytes32(bytes20(vm.addr(NEW_ACTOR_PK)));
-        _authorizeActor(account, ACTOR_PK, newActorId, address(k1Authenticator));
-
-        // Revoke the initial key
-        _revokeActor(account, NEW_ACTOR_PK, bytes32(bytes20(vm.addr(ACTOR_PK))));
-
-        // Attempt to sign an actor change with the revoked key
-        bytes32 thirdActorId = bytes32(bytes20(vm.addr(302)));
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
-        changes[0] = AccountConfiguration.ActorChange({
-            actorId: thirdActorId,
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
-
-        uint64 seq = accountConfiguration.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
+        bytes32 digest = _computeActorChangeBatchDigest(eoa, uint64(block.chainid), seq, ch);
 
         vm.expectRevert();
-        accountConfiguration.applySignedActorChanges(
-            account, uint64(block.chainid), changes, _buildK1Auth(ACTOR_PK, digest)
-        );
+        accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), ch, _buildK1Auth(eoaPk, digest));
+
+        accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), ch, _buildK1Auth(newPk, digest));
+        assertTrue(accountConfiguration.isActor(eoa, targetId));
     }
 
-    function test_nonSelfActor_revokeDeletesSlot() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice A revoked signer key can no longer authorize actor changes.
+    function test_applySignedActorChanges_revert_revokedSignerKey(uint256 ownerPk, uint256 newPk, bytes32 targetId)
+        public
+    {
+        ownerPk = _boundK1Pk(ownerPk);
+        newPk = _boundK1Pk(newPk);
+        vm.assume(ownerPk != newPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        bytes32 newActorId = bytes32(bytes20(vm.addr(newPk)));
+        vm.assume(newActorId != ownerId && newActorId != bytes32(bytes20(account)));
+        vm.assume(targetId != ownerId && targetId != newActorId && targetId != bytes32(bytes20(account)));
 
-        bytes32 newActorId = bytes32(bytes20(vm.addr(NEW_ACTOR_PK)));
-        _authorizeActor(account, ACTOR_PK, newActorId, address(k1Authenticator));
+        _authorizeActor(account, ownerPk, newActorId, address(k1Authenticator));
+        _revokeActor(account, newPk, ownerId);
 
-        _revokeActor(account, ACTOR_PK, newActorId);
+        AccountConfiguration.ActorChange[] memory ch = _authorizeChange(targetId, address(k1Authenticator), 0, 0, "");
+        bytes memory auth = _authOver(account, ownerPk, ch);
+        vm.expectRevert();
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+    }
 
-        AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, newActorId);
+    /// @notice Revoking a non-self actor deletes its config slot.
+    function test_revokeActor_success_deletesSlot(uint256 pk, bytes32 actorId) public {
+        pk = _boundK1Pk(pk);
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+        _authorizeActor(account, pk, actorId, address(k1Authenticator));
+
+        _revokeActor(account, pk, actorId);
+
+        AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, actorId);
         assertEq(cfg.authenticator, address(0));
         assertEq(cfg.scope, 0);
     }
 
+    // ── Fuzzed reverts and branch coverage ──
+
+    /// @notice applySignedActorChanges reverts for a chainId that is neither 0 (multichain) nor the current chain.
+    /// @dev Exercises the `chainId != 0 && chainId != block.chainid` guard on the actor-change path.
+    function test_applySignedActorChanges_revert_invalidChainId(uint256 pk, uint256 badChainId) public {
+        pk = _boundK1Pk(pk);
+        badChainId = bound(badChainId, 1, type(uint64).max);
+        vm.assume(badChainId != block.chainid);
+        (address account,) = _createK1Account(pk);
+
+        AccountConfiguration.ActorChange[] memory changes =
+            _authorizeChange(bytes32(bytes20(vm.addr(0xBEEF))), address(k1Authenticator), 0, 0, "");
+        bytes memory auth = _buildK1Auth(pk, _computeActorChangeBatchDigest(account, uint64(badChainId), 0, changes));
+
+        vm.expectRevert(AccountConfiguration.InvalidChainId.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(badChainId), changes, auth);
+    }
+
+    /// @notice Replaying an identical (changes, auth) pair fails once the sequence is consumed.
+    /// @dev The replay recomputes the digest at seq+1, so the stale signature recovers a non-actor and reverts.
+    function test_applySignedActorChanges_revert_replay(uint256 pk, bytes32 actorId) public {
+        pk = _boundK1Pk(pk);
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        AccountConfiguration.ActorChange[] memory changes =
+            _authorizeChange(actorId, address(k1Authenticator), 0, 0, "");
+        bytes memory auth = _authOver(account, pk, changes);
+
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+
+        vm.expectRevert();
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+    }
+
+    /// @notice A changeType outside {authorize, revoke} reverts with UnknownChangeType (after the CONFIG gate).
+    function test_applySignedActorChanges_revert_unknownChangeType(uint256 pk, uint8 changeType) public {
+        pk = _boundK1Pk(pk);
+        vm.assume(changeType != 0x01 && changeType != 0x02);
+        (address account,) = _createK1Account(pk);
+
+        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
+        changes[0] = AccountConfiguration.ActorChange({
+            actorId: bytes32(bytes20(vm.addr(0xBEEF))), changeType: changeType, data: ""
+        });
+
+        bytes memory auth = _authOver(account, pk, changes);
+        vm.expectRevert(AccountConfiguration.UnknownChangeType.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+    }
+
+    /// @notice The CONFIG gate: an authenticated actor may change actors iff scope==0 or scope has the CONFIG bit.
+    /// @dev Fuzzes the signer's scope across the whole byte and asserts success/revert on the exact predicate.
+    function test_applySignedActorChanges_configGate_acrossScopes(
+        uint256 ownerPk,
+        uint256 signerPk,
+        uint8 signerScope,
+        bytes32 targetId
+    ) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        signerPk = _boundK1Pk(signerPk);
+        vm.assume(ownerPk != signerPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        bytes32 signerId = bytes32(bytes20(vm.addr(signerPk)));
+        vm.assume(signerId != ownerId && signerId != bytes32(bytes20(account)));
+        vm.assume(targetId != ownerId && targetId != signerId && targetId != bytes32(bytes20(account)));
+
+        uint8 config = accountConfiguration.SCOPE_CONFIG();
+        _authorizeActorWithScope(account, ownerPk, signerId, address(k1Authenticator), signerScope);
+
+        AccountConfiguration.ActorChange[] memory ch = _authorizeChange(targetId, address(k1Authenticator), 0, 0, "");
+        if (signerScope == 0 || signerScope & config != 0) {
+            _signApply(account, signerPk, ch);
+            assertTrue(accountConfiguration.isActor(account, targetId));
+        } else {
+            bytes memory auth = _authOver(account, signerPk, ch);
+            vm.expectRevert(AccountConfiguration.UnauthorizedActorChange.selector);
+            accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+        }
+    }
+
+    /// @notice Authorizing with a zero authenticator reverts with InvalidAuthenticator.
+    function test_authorizeActor_revert_invalidAuthenticator(uint256 pk, bytes32 actorId) public {
+        pk = _boundK1Pk(pk);
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        AccountConfiguration.ActorChange[] memory ch = _authorizeChange(actorId, address(0), 0, 0, "");
+        bytes memory auth = _authOver(account, pk, ch);
+        vm.expectRevert(AccountConfiguration.InvalidAuthenticator.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+    }
+
+    /// @notice A policy-bearing actor with scope 0 reverts with InvalidPolicyScope.
+    function test_authorizeActor_revert_invalidPolicyScope_zeroScope(uint256 pk, bytes32 actorId) public {
+        pk = _boundK1Pk(pk);
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        AccountConfiguration.ActorChange[] memory ch =
+            _authorizeChange(actorId, address(k1Authenticator), 0, 0x01, _validPolicyData());
+        bytes memory auth = _authOver(account, pk, ch);
+        vm.expectRevert(AccountConfiguration.InvalidPolicyScope.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+    }
+
+    /// @notice A policy-bearing actor whose scope includes the CONFIG bit reverts with InvalidPolicyScope.
+    function test_authorizeActor_revert_invalidPolicyScope_configScope(uint256 pk, bytes32 actorId, uint8 extra)
+        public
+    {
+        pk = _boundK1Pk(pk);
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+        uint8 scope = accountConfiguration.SCOPE_CONFIG() | (extra & 0x07);
+
+        AccountConfiguration.ActorChange[] memory ch =
+            _authorizeChange(actorId, address(k1Authenticator), scope, 0x01, _validPolicyData());
+        bytes memory auth = _authOver(account, pk, ch);
+        vm.expectRevert(AccountConfiguration.InvalidPolicyScope.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+    }
+
+    /// @notice policyType==NONE with non-empty policyData reverts with InvalidPolicyData.
+    function test_authorizeActor_revert_invalidPolicyData_noneWithData(uint256 pk, bytes32 actorId, bytes memory data)
+        public
+    {
+        pk = _boundK1Pk(pk);
+        vm.assume(data.length != 0);
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        AccountConfiguration.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), 0, 0, data);
+        bytes memory auth = _authOver(account, pk, ch);
+        vm.expectRevert(AccountConfiguration.InvalidPolicyData.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+    }
+
+    /// @notice A gated actor whose policyData is not exactly 52 bytes reverts with InvalidPolicyData.
+    function test_authorizeActor_revert_invalidPolicyData_gatedWrongLength(
+        uint256 pk,
+        bytes32 actorId,
+        bytes memory data
+    ) public {
+        pk = _boundK1Pk(pk);
+        vm.assume(data.length != 52);
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        AccountConfiguration.ActorChange[] memory ch =
+            _authorizeChange(actorId, address(k1Authenticator), 0x02, 0x01, data);
+        bytes memory auth = _authOver(account, pk, ch);
+        vm.expectRevert(AccountConfiguration.InvalidPolicyData.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+    }
+
+    /// @notice A gated actor with a zero policy manager reverts with InvalidPolicyData.
+    function test_authorizeActor_revert_invalidPolicyData_zeroManager(uint256 pk, bytes32 actorId, bytes32 commitment)
+        public
+    {
+        pk = _boundK1Pk(pk);
+        vm.assume(commitment != bytes32(0));
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        bytes memory data = abi.encodePacked(bytes20(address(0)), commitment);
+        AccountConfiguration.ActorChange[] memory ch =
+            _authorizeChange(actorId, address(k1Authenticator), 0x02, 0x01, data);
+        bytes memory auth = _authOver(account, pk, ch);
+        vm.expectRevert(AccountConfiguration.InvalidPolicyData.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+    }
+
+    /// @notice A gated actor with a zero policy commitment reverts with InvalidPolicyData.
+    function test_authorizeActor_revert_invalidPolicyData_zeroCommitment(uint256 pk, bytes32 actorId, address manager)
+        public
+    {
+        pk = _boundK1Pk(pk);
+        vm.assume(manager != address(0));
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        bytes memory data = abi.encodePacked(bytes20(manager), bytes32(0));
+        AccountConfiguration.ActorChange[] memory ch =
+            _authorizeChange(actorId, address(k1Authenticator), 0x02, 0x01, data);
+        bytes memory auth = _authOver(account, pk, ch);
+        vm.expectRevert(AccountConfiguration.InvalidPolicyData.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+    }
+
+    /// @notice Duplicate actorIds within one batch apply sequentially (last operation wins).
+    function test_applySignedActorChanges_success_duplicateActorIdInBatch(uint256 pk, bytes32 actorId) public {
+        pk = _boundK1Pk(pk);
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        // [authorize A, revoke A] → A ends not live.
+        AccountConfiguration.ActorChange[] memory ch = new AccountConfiguration.ActorChange[](2);
+        ch[0] = _authorizeChange(actorId, address(k1Authenticator), 0, 0, "")[0];
+        ch[1] = AccountConfiguration.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
+        _signApply(account, pk, ch);
+        assertFalse(accountConfiguration.isActor(account, actorId));
+
+        // Pre-authorize, then [revoke A, authorize A] → A ends live.
+        _authorizeActor(account, pk, actorId, address(k1Authenticator));
+        AccountConfiguration.ActorChange[] memory ch2 = new AccountConfiguration.ActorChange[](2);
+        ch2[0] = AccountConfiguration.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
+        ch2[1] = _authorizeChange(actorId, address(k1Authenticator), 0, 0, "")[0];
+        _signApply(account, pk, ch2);
+        assertTrue(accountConfiguration.isActor(account, actorId));
+    }
+
+    /// @notice A CONFIG-scoped signer may revoke itself mid-batch; the scope gate is evaluated once, pre-loop.
+    function test_applySignedActorChanges_success_signerRevokesSelfMidBatch(
+        uint256 ownerPk,
+        uint256 signerPk,
+        bytes32 bId
+    ) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        signerPk = _boundK1Pk(signerPk);
+        vm.assume(ownerPk != signerPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        bytes32 signerId = bytes32(bytes20(vm.addr(signerPk)));
+        vm.assume(signerId != ownerId && signerId != bytes32(bytes20(account)));
+        vm.assume(bId != ownerId && bId != signerId && bId != bytes32(bytes20(account)));
+
+        _authorizeActorWithScope(
+            account, ownerPk, signerId, address(k1Authenticator), accountConfiguration.SCOPE_CONFIG()
+        );
+
+        AccountConfiguration.ActorChange[] memory ch = new AccountConfiguration.ActorChange[](2);
+        ch[0] = AccountConfiguration.ActorChange({actorId: signerId, changeType: 0x02, data: ""});
+        ch[1] = _authorizeChange(bId, address(k1Authenticator), 0, 0, "")[0];
+        _signApply(account, signerPk, ch);
+
+        assertFalse(accountConfiguration.isActor(account, signerId));
+        assertTrue(accountConfiguration.isActor(account, bId));
+    }
+
+    /// @notice Self-actorId flip: k1 self → non-k1 (p256) self → k1 self; the non-k1 config replaces then is replaced.
+    function test_selfActorId_success_flipFlopK1NonK1(uint256 eoaPk, uint256 adminPk) public {
+        eoaPk = _boundK1Pk(eoaPk);
+        adminPk = _boundK1Pk(adminPk);
+        vm.assume(eoaPk != adminPk);
+        address eoa = vm.addr(eoaPk);
+        bytes32 selfId = bytes32(bytes20(eoa));
+        bytes32 adminId = bytes32(bytes20(vm.addr(adminPk)));
+        vm.assume(adminId != selfId);
+
+        // Implicit self authorizes an admin with CONFIG scope to drive the flips.
+        _implicitAuthorizeActorWithScope(
+            eoa, eoaPk, adminId, address(k1Authenticator), accountConfiguration.SCOPE_CONFIG()
+        );
+
+        // Flip self → non-k1 (p256): sets the revoke flag, stores the non-k1 self config; k1 self dies.
+        _authorizeActorWithScope(eoa, adminPk, selfId, address(p256Authenticator), 0x02);
+        assertEq(accountConfiguration.getActorConfig(eoa, selfId).authenticator, address(p256Authenticator));
+        bytes32 h = keccak256("flip");
+        vm.expectRevert();
+        accountConfiguration.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
+
+        // Flip self → k1 owner: deletes the non-k1 config, restores inline k1 (flag cleared); k1 self lives again.
+        _authorizeActor(eoa, adminPk, selfId, accountConfiguration.K1_AUTHENTICATOR());
+        assertEq(
+            accountConfiguration.getActorConfig(eoa, selfId).authenticator, accountConfiguration.K1_AUTHENTICATOR()
+        );
+        (uint8 scope,,) = accountConfiguration.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
+        assertEq(scope, 0);
+    }
+
+    /// @notice A happy-path authorize emits ActorAuthorized once with the correct account and actorId.
+    function test_applySignedActorChanges_success_emitsActorAuthorized(uint256 pk, bytes32 actorId) public {
+        pk = _boundK1Pk(pk);
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        AccountConfiguration.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), 0, 0, "");
+        vm.expectEmit(true, true, false, false, address(accountConfiguration));
+        emit AccountConfiguration.ActorAuthorized(account, actorId, "");
+        _signApply(account, pk, ch);
+    }
+
+    /// @notice A happy-path revoke emits ActorRevoked once with the correct account and actorId.
+    function test_applySignedActorChanges_success_emitsActorRevoked(uint256 pk, bytes32 actorId) public {
+        pk = _boundK1Pk(pk);
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+        _authorizeActor(account, pk, actorId, address(k1Authenticator));
+
+        AccountConfiguration.ActorChange[] memory ch = new AccountConfiguration.ActorChange[](1);
+        ch[0] = AccountConfiguration.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
+        vm.expectEmit(true, true, false, true, address(accountConfiguration));
+        emit AccountConfiguration.ActorRevoked(account, actorId);
+        _signApply(account, pk, ch);
+    }
+
     // ── Helpers ──
+
+    /// @dev Build a one-element authorize batch with a full ActorConfig + policyData (expiry fixed at 0).
+    function _authorizeChange(bytes32 actorId, address auth, uint8 scope, uint8 policyType, bytes memory policyData)
+        internal
+        pure
+        returns (AccountConfiguration.ActorChange[] memory changes)
+    {
+        changes = new AccountConfiguration.ActorChange[](1);
+        changes[0] = AccountConfiguration.ActorChange({
+            actorId: actorId,
+            changeType: 0x01,
+            data: abi.encode(
+                AccountConfiguration.ActorConfig({
+                    authenticator: auth, scope: scope, expiry: 0, policyType: policyType
+                }),
+                policyData
+            )
+        });
+    }
+
+    /// @dev Owner/actor signature over a batch at the current local sequence.
+    function _authOver(address account, uint256 pk, AccountConfiguration.ActorChange[] memory changes)
+        internal
+        view
+        returns (bytes memory)
+    {
+        uint64 seq = accountConfiguration.getChangeSequences(account).local;
+        return _buildK1Auth(pk, _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes));
+    }
+
+    /// @dev Sign (with pk) and apply a batch on the local chain.
+    function _signApply(address account, uint256 pk, AccountConfiguration.ActorChange[] memory changes) internal {
+        accountConfiguration.applySignedActorChanges(
+            account, uint64(block.chainid), changes, _authOver(account, pk, changes)
+        );
+    }
+
+    /// @dev A well-formed 52-byte gated policyData (non-zero manager ‖ non-zero commitment).
+    function _validPolicyData() internal pure returns (bytes memory) {
+        return abi.encodePacked(bytes20(uint160(0x1234)), bytes32(uint256(0x5678)));
+    }
 
     /// @dev Authorize/overwrite the EOA's own inline k1 self-actorId with the given scope, signed by the EOA key.
     function _rescopeSelf(address eoa, uint256 eoaPk, uint8 scope) internal {

--- a/test/unit/AccountConfiguration/authenticate.t.sol
+++ b/test/unit/AccountConfiguration/authenticate.t.sol
@@ -4,305 +4,746 @@ pragma solidity ^0.8.30;
 import {AccountConfiguration} from "../../../src/AccountConfiguration.sol";
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 
+/// @notice Fuzzed, branch-complete suite for the authentication paths of AccountConfiguration:
+///         authenticateActor -> _authenticate -> {_authenticateK1, IAuthenticator} -> _recoverSigner, plus the
+///         verifySignature / getActorConfig / getPolicy / isActor views that read the same actor resolution.
+///
+///         Source-order revert coverage (as declared / hit through authenticateActor):
+///           1. InvalidAuthLength      authenticateActor: auth.length < 20
+///           2. AuthenticationFailed   _authenticate: non-K1 IAuthenticator returns bytes32(0)
+///           3. AuthenticatorMismatch  _authenticate (non-K1) / _authenticateK1: stored authenticator != presented
+///           4. ActorExpired           inline self (_authenticateK1), non-self K1, and non-self non-K1 paths
+///           5. DefaultEoaRevoked      _authenticateK1: recovered == account with the revoke flag set
+///           6. InvalidSignature       _recoverSigner: bad length / high-s / non-canonical v / zero recovery
+///
+///         The authentication functions are `view` and emit no events, so there are no event assertions here;
+///         events (ActorAuthorized / ActorRevoked) belong to the applyKeyChange suite that drives the config writes.
 contract AuthenticateTest is AccountConfigurationTest {
-    uint256 constant ACTOR_PK = 400;
+    uint8 constant SCOPE_SIGNER = 0x01;
+    uint8 constant SCOPE_SENDER = 0x02;
+    uint8 constant SCOPE_PAYER = 0x04;
+    uint8 constant SCOPE_CONFIG = 0x08;
 
-    function test_authenticate_validK1() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // REVERTS (source order)
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-        bytes32 hash = keccak256("authenticate me");
-        bytes memory auth = _buildK1Auth(ACTOR_PK, hash);
+    // ── 1. InvalidAuthLength: authenticateActor, auth.length < 20 ──
 
-        (uint8 scope,,) = accountConfiguration.authenticateActor(account, hash, auth);
-        assertEq(scope, uint8(0x00));
-    }
+    /// @notice Any auth blob shorter than the 20-byte authenticator prefix reverts before slicing the selector.
+    /// @dev Fuzzes the full [0,19] length range and byte content plus the account/hash; hits the length guard.
+    function test_authenticateActor_revert_invalidAuthLength(
+        address account,
+        bytes32 hash,
+        uint256 lenSeed,
+        uint256 fillSeed
+    ) public {
+        uint256 len = bound(lenSeed, 0, 19);
+        bytes memory auth = new bytes(len);
+        for (uint256 i; i < len; ++i) {
+            auth[i] = bytes1(uint8(uint256(keccak256(abi.encode(fillSeed, i)))));
+        }
 
-    function test_authenticate_wrongSignature() public {
-        (address account,) = _createK1Account(ACTOR_PK);
-
-        bytes32 hash = keccak256("authenticate me");
-        // Sign with pk 999 — authenticator recovers wrong address, config mismatch
-        bytes memory auth = _buildK1Auth(999, hash);
-
-        vm.expectRevert();
+        vm.expectRevert(AccountConfiguration.InvalidAuthLength.selector);
         accountConfiguration.authenticateActor(account, hash, auth);
     }
 
-    function test_authenticate_unregisteredActor() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    // ── 2. AuthenticationFailed: non-K1 IAuthenticator returns bytes32(0) ──
 
-        bytes32 hash = keccak256("authenticate me");
-        // Sign with pk 999 (not registered on this account)
-        bytes memory auth = _buildK1Auth(999, hash);
+    /// @notice A well-formed P-256 blob whose signature is over a different hash resolves actorId 0 and reverts.
+    /// @dev The P256Authenticator returns bytes32(0) on a failed verify (never reverts on a well-formed sig), so
+    ///      _authenticate hits `revert AuthenticationFailed`. Reverts before any account SLOAD, so account is free.
+    function test_authenticateActor_revert_authenticationFailed_p256(
+        address account,
+        uint256 pkSeed,
+        bytes32 hash,
+        bytes32 wrongHash
+    ) public {
+        vm.assume(hash != wrongHash);
+        uint256 pk = _boundP256Pk(pkSeed);
+        bytes memory auth = abi.encodePacked(address(p256Authenticator), _p256SignData(pk, hash));
 
-        vm.expectRevert();
+        vm.expectRevert(AccountConfiguration.AuthenticationFailed.selector);
+        accountConfiguration.authenticateActor(account, wrongHash, auth);
+    }
+
+    /// @notice A valid WebAuthn assertion presented against a different hash also resolves actorId 0 and reverts.
+    /// @dev Same AuthenticationFailed branch through a distinct IAuthenticator (challenge != abi.encode(wrongHash)).
+    function test_authenticateActor_revert_authenticationFailed_webAuthn(
+        address account,
+        uint256 pkSeed,
+        bytes32 hash,
+        bytes32 wrongHash
+    ) public {
+        vm.assume(hash != wrongHash);
+        uint256 pk = _boundP256Pk(pkSeed);
+        bytes memory auth = abi.encodePacked(address(webAuthnAuthenticator), _webauthnSignData(pk, hash));
+
+        vm.expectRevert(AccountConfiguration.AuthenticationFailed.selector);
+        accountConfiguration.authenticateActor(account, wrongHash, auth);
+    }
+
+    // ── 3. AuthenticatorMismatch: stored actor authenticator != presented ──
+
+    /// @notice A K1 signature recovering to a key that is neither the account nor a registered actor mismatches.
+    /// @dev _authenticateK1: recovered != account, `_actorConfig[actorId].authenticator == 0 != K1` -> mismatch.
+    function test_authenticateActor_revert_authenticatorMismatch_k1Unregistered(
+        uint256 ownerSeed,
+        uint256 strangerSeed,
+        bytes32 hash
+    ) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 strangerPk = _boundK1Pk(strangerSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(strangerPk));
+
+        (address account,) = _createK1Account(ownerPk);
+        // A CREATE2 account can never equal a recoverable EOA, so the stranger takes the non-self K1 actor branch.
+        vm.assume(vm.addr(strangerPk) != account);
+
+        vm.expectRevert(AccountConfiguration.AuthenticatorMismatch.selector);
+        accountConfiguration.authenticateActor(account, hash, _buildK1Auth(strangerPk, hash));
+    }
+
+    /// @notice A valid P-256 signature for a key that was never authorized on the account mismatches.
+    /// @dev _authenticate (non-K1): actorId resolves, but `_actorConfig[actorId].authenticator == 0 != p256`.
+    function test_authenticateActor_revert_authenticatorMismatch_p256Unregistered(
+        address account,
+        uint256 pkSeed,
+        bytes32 hash
+    ) public {
+        uint256 pk = _boundP256Pk(pkSeed);
+        bytes memory auth = abi.encodePacked(address(p256Authenticator), _p256SignData(pk, hash));
+
+        vm.expectRevert(AccountConfiguration.AuthenticatorMismatch.selector);
         accountConfiguration.authenticateActor(account, hash, auth);
     }
 
-    function test_authenticate_revokedActor() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice A key registered under the P-256 authenticator, presented via the WebAuthn authenticator, mismatches.
+    /// @dev Both authenticators derive actorId = keccak256(x‖y), so the actorId resolves but the stored authenticator
+    ///      (p256) differs from the presented one (webAuthn).
+    function test_authenticateActor_revert_authenticatorMismatch_crossAuthenticator(
+        uint256 ownerSeed,
+        uint256 pkSeed,
+        bytes32 hash
+    ) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 pk = _boundP256Pk(pkSeed);
 
-        address newSigner = vm.addr(401);
-        bytes32 newActorId = bytes32(bytes20(newSigner));
-        _authorizeActor(account, ACTOR_PK, newActorId, address(k1Authenticator));
+        (address account,) = _createK1Account(ownerPk);
+        _authorizeActorWithScope(account, ownerPk, _p256ActorId(pk), address(p256Authenticator), 0x00);
 
-        _revokeActor(account, ACTOR_PK, newActorId);
+        // Present the same key through WebAuthn: actorId matches, presented authenticator does not.
+        bytes memory auth = abi.encodePacked(address(webAuthnAuthenticator), _webauthnSignData(pk, hash));
 
-        bytes32 hash = keccak256("after revoke");
-        bytes memory revokedAuth = _buildK1Auth(401, hash);
-
-        vm.expectRevert();
-        accountConfiguration.authenticateActor(account, hash, revokedAuth);
-
-        // Original actor should still work
-        accountConfiguration.authenticateActor(account, hash, _buildK1Auth(ACTOR_PK, hash));
+        vm.expectRevert(AccountConfiguration.AuthenticatorMismatch.selector);
+        accountConfiguration.authenticateActor(account, hash, auth);
     }
 
-    function test_authenticate_differentAccounts() public {
-        (address account1,) = _createK1AccountWithSalt(ACTOR_PK, bytes32(uint256(1)));
-        (address account2,) = _createK1AccountWithSalt(ACTOR_PK, bytes32(uint256(2)));
+    /// @notice After a K1 actor is revoked its config is cleared, so re-presenting its signature mismatches.
+    /// @dev Revoke deletes `_actorConfig[actorId]`, leaving authenticator == 0 != K1 on the non-self K1 path.
+    function test_authenticateActor_revert_authenticatorMismatch_revokedActor(
+        uint256 ownerSeed,
+        uint256 actorSeed,
+        bytes32 hash
+    ) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 actorPk = _boundK1Pk(actorSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(actorPk));
 
-        bytes32 hash = keccak256("cross-account test");
-        bytes memory auth = _buildK1Auth(ACTOR_PK, hash);
+        (address account,) = _createK1Account(ownerPk);
+        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), 0x00);
+        _revokeActor(account, ownerPk, actorId);
 
-        accountConfiguration.authenticateActor(account1, hash, auth);
-        accountConfiguration.authenticateActor(account2, hash, auth);
+        vm.expectRevert(AccountConfiguration.AuthenticatorMismatch.selector);
+        accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
     }
 
-    function test_authenticate_expiredActor_reverts() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    // ── 4. ActorExpired: inline self, non-self K1, and non-self non-K1 ──
 
-        uint256 sessionPk = 401;
+    /// @notice The inline self key expires: once block.timestamp passes defaultEOAExpiry the self path reverts.
+    /// @dev _authenticateK1 inline-self branch (recovered == account, flag unset) hits the expiry guard.
+    function test_authenticateActor_revert_actorExpired_inlineSelf(
+        uint256 eoaSeed,
+        uint48 expirySeed,
+        uint256 warpSeed,
+        bytes32 hash
+    ) public {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
+        address eoa = vm.addr(eoaPk);
+        bytes32 selfActorId = bytes32(bytes20(eoa));
+
+        uint48 expiry = uint48(bound(uint256(expirySeed), 1, uint256(type(uint48).max) - 1));
+        // Authorize the self-actorId as a scoped-0 K1 actor carrying an expiry (re-enables the inline self).
+        _authorizeActorWithExpiry(eoa, eoaPk, selfActorId, address(k1Authenticator), expiry);
+
+        vm.warp(uint256(expiry) + bound(warpSeed, 1, 1_000_000));
+        vm.expectRevert(AccountConfiguration.ActorExpired.selector);
+        accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+    }
+
+    /// @notice A non-self K1 session actor expires and can no longer authenticate.
+    /// @dev _authenticateK1 non-self branch (config.expiry != 0 && block.timestamp > expiry).
+    function test_authenticateActor_revert_actorExpired_nonSelfK1(
+        uint256 ownerSeed,
+        uint256 sessionSeed,
+        uint48 expirySeed,
+        uint256 warpSeed,
+        bytes32 hash
+    ) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 sessionPk = _boundK1Pk(sessionSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(sessionPk));
+
+        (address account,) = _createK1Account(ownerPk);
         bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
-        uint48 expiry = uint48(block.timestamp + 1 hours);
-        _authorizeActorWithExpiry(account, ACTOR_PK, sessionActorId, address(k1Authenticator), expiry);
+        uint48 expiry = uint48(bound(uint256(expirySeed), 1, uint256(type(uint48).max) - 1));
+        _authorizeActorWithExpiry(account, ownerPk, sessionActorId, address(k1Authenticator), expiry);
 
-        bytes32 hash = keccak256("expiry test");
-
-        // Before expiry: valid.
-        accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
-
-        // At expiry boundary (block.timestamp == expiry): still valid.
-        vm.warp(expiry);
-        accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
-
-        // Past expiry: authentication fails.
-        vm.warp(uint256(expiry) + 1);
+        vm.warp(uint256(expiry) + bound(warpSeed, 1, 1_000_000));
         vm.expectRevert(AccountConfiguration.ActorExpired.selector);
         accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
     }
 
-    function test_authenticate_zeroExpiry_neverExpires() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice A non-self P-256 actor expires and can no longer authenticate.
+    /// @dev _authenticate (non-K1) expiry guard: exercises the ActorExpired branch outside the K1 path.
+    function test_authenticateActor_revert_actorExpired_nonSelfP256(
+        uint256 ownerSeed,
+        uint256 pkSeed,
+        uint48 expirySeed,
+        uint256 warpSeed,
+        bytes32 hash
+    ) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 pk = _boundP256Pk(pkSeed);
 
-        uint256 sessionPk = 401;
-        bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
-        _authorizeActorWithExpiry(account, ACTOR_PK, sessionActorId, address(k1Authenticator), 0);
+        (address account,) = _createK1Account(ownerPk);
+        uint48 expiry = uint48(bound(uint256(expirySeed), 1, uint256(type(uint48).max) - 1));
+        _authorizeActorWithExpiry(account, ownerPk, _p256ActorId(pk), address(p256Authenticator), expiry);
 
-        bytes32 hash = keccak256("no expiry test");
-        vm.warp(block.timestamp + 3650 days);
-        accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
+        vm.warp(uint256(expiry) + bound(warpSeed, 1, 1_000_000));
+        bytes memory auth = abi.encodePacked(address(p256Authenticator), _p256SignData(pk, hash));
+
+        vm.expectRevert(AccountConfiguration.ActorExpired.selector);
+        accountConfiguration.authenticateActor(account, hash, auth);
     }
 
-    function test_getActorConfig_returnsAuthenticatorAndScopes() public {
-        (address account, bytes32 actorId) = _createK1Account(ACTOR_PK);
+    // ── 5. DefaultEoaRevoked: recovered == account with the revoke flag set ──
 
-        AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, actorId);
-        assertEq(cfg.authenticator, address(k1Authenticator));
-        assertEq(cfg.scope, 0x00);
-    }
-
-    function test_getActorConfig_returnsZeroForUnknownActor() public {
-        (address account,) = _createK1Account(ACTOR_PK);
-
-        bytes32 unknownActorId = bytes32(bytes20(vm.addr(999)));
-        AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, unknownActorId);
-        assertEq(cfg.authenticator, address(0));
-        assertEq(cfg.scope, 0);
-    }
-
-    function test_authenticate_scopedActor_succeeds() public {
-        (address account,) = _createK1Account(ACTOR_PK);
-
-        address newSigner = vm.addr(401);
-        bytes32 newActorId = bytes32(bytes20(newSigner));
-        _authorizeActorWithScope(account, ACTOR_PK, newActorId, address(k1Authenticator), 0x01);
-
-        bytes32 hash = keccak256("scoped authenticate");
-        bytes memory auth = _buildK1Auth(401, hash);
-
-        (uint8 scope,,) = accountConfiguration.authenticateActor(account, hash, auth);
-        assertEq(scope, uint8(0x01));
-    }
-
-    function test_authenticate_unrestrictedScope() public {
-        (address account,) = _createK1Account(ACTOR_PK);
-
-        address newSigner = vm.addr(401);
-        bytes32 newActorId = bytes32(bytes20(newSigner));
-        _authorizeActorWithScope(account, ACTOR_PK, newActorId, address(k1Authenticator), 0x00);
-
-        bytes32 hash = keccak256("unrestricted");
-        bytes memory auth = _buildK1Auth(401, hash);
-
-        (uint8 scope,,) = accountConfiguration.authenticateActor(account, hash, auth);
-        assertEq(scope, uint8(0x00));
-    }
-
-    // ── Implicit EOA (registered by default) ──
-
-    function test_authenticate_implicitEOA() public {
-        uint256 eoaPk = 500;
-        address eoa = vm.addr(eoaPk);
-
-        bytes32 hash = keccak256("implicit eoa authenticate");
-        bytes memory auth = _buildK1Auth(eoaPk, hash);
-
-        // No createAccount or importAccount — the EOA is implicitly authorized
-        (uint8 scope,,) = accountConfiguration.authenticateActor(eoa, hash, auth);
-        assertEq(scope, 0);
-    }
-
-    function test_authenticate_implicitEOA_isActorReturnsTrue() public {
-        uint256 eoaPk = 500;
-        address eoa = vm.addr(eoaPk);
-
-        assertTrue(accountConfiguration.isActor(eoa, bytes32(bytes20(eoa))));
-    }
-
-    function test_authenticate_implicitEOA_nonSelfActorIdNotImplicit() public {
-        uint256 eoaPk = 500;
-        address eoa = vm.addr(eoaPk);
-
-        // A random actorId that isn't bytes32(bytes20(eoa)) should NOT be implicit
-        bytes32 randomActorId = bytes32(bytes20(vm.addr(999)));
-        assertFalse(accountConfiguration.isActor(eoa, randomActorId));
-    }
-
-    function test_authenticate_implicitEOA_revokedByFlag() public {
-        uint256 eoaPk = 500;
+    /// @notice After the self-actorId is revoked, the account's own K1 key can no longer authenticate.
+    /// @dev Revoking the self-actorId sets FLAG_REVOKE_DEFAULT_EOA; _authenticateK1 reverts on the flag check.
+    function test_authenticateActor_revert_defaultEoaRevoked_afterSelfRevoke(uint256 eoaSeed, bytes32 hash) public {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
 
-        // Implicit EOA signs to add a second key
-        bytes32 newActorId = bytes32(bytes20(vm.addr(501)));
-        _implicitAuthorizeActor(eoa, eoaPk, newActorId, address(k1Authenticator));
+        // The implicit self (unrestricted) signs a batch revoking its own self-actorId; auth precedes the revoke.
+        _revokeActor(eoa, eoaPk, selfActorId);
 
-        // Revoke the self-actorId (sets the default-EOA revoke flag) using the new explicit key
-        _revokeActor(eoa, 501, selfActorId);
-
-        assertFalse(accountConfiguration.isActor(eoa, selfActorId));
-
-        // Implicit path is now blocked
-        bytes32 hash = keccak256("after revoke");
         vm.expectRevert(AccountConfiguration.DefaultEoaRevoked.selector);
         accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
     }
 
-    function test_authenticate_selfActorScopedDowngradesOwnKey() public {
-        // Scoping the account's own key (self-actorId as an explicit k1 actor) downgrades it: the same key now
-        // authenticates with the reduced scope. There is a single k1 path, so there is no implicit full-owner
-        // escape — the config alone decides the scope.
-        uint256 eoaPk = 500;
+    /// @notice Authorizing the self-actorId to a non-K1 authenticator disables the inline K1 self (mutual exclusion).
+    /// @dev The non-K1 self path sets FLAG_REVOKE_DEFAULT_EOA, so a subsequent self K1 signature is DefaultEoaRevoked.
+    function test_authenticateActor_revert_defaultEoaRevoked_afterNonK1SelfAuthorize(uint256 eoaSeed, bytes32 hash)
+        public
+    {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
 
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
-        changes[0] = AccountConfiguration.ActorChange({
-            actorId: selfActorId,
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: 0x02, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
-        uint64 seq = accountConfiguration.getChangeSequences(eoa).local;
-        bytes32 digest = _computeActorChangeBatchDigest(eoa, uint64(block.chainid), seq, changes);
-        accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), changes, _buildK1Auth(eoaPk, digest));
+        // Implicit self authorizes itself to a non-K1 authenticator (P256), flipping the mutual-exclusion flag.
+        _authorizeActorWithScope(eoa, eoaPk, selfActorId, address(p256Authenticator), 0x00);
 
-        // The own key now returns the downgraded scope (0x02), never full owner (0x00).
-        bytes32 hash = keccak256("scoped self auth");
-        (uint8 scope,,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
-        assertEq(scope, 0x02);
+        vm.expectRevert(AccountConfiguration.DefaultEoaRevoked.selector);
+        accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
     }
 
-    function test_authenticate_explicitEOA_nonSelfActor() public {
-        uint256 eoaPk = 500;
-        address eoa = vm.addr(eoaPk);
+    // ── 6. InvalidSignature: _recoverSigner (length / high-s / v / zero recovery) ──
 
-        uint256 bobPk = 501;
-        bytes32 bobActorId = bytes32(bytes20(vm.addr(bobPk)));
-        _implicitAuthorizeActor(eoa, eoaPk, bobActorId, accountConfiguration.K1_AUTHENTICATOR());
+    /// @notice A K1 auth whose signature payload is not exactly 65 bytes reverts on the length guard.
+    /// @dev _recoverSigner: `data.length != 65`; data == auth[20:], so the auth blob is K1(20) ‖ <len != 65>.
+    function test_authenticateActor_revert_invalidSignature_badLength(
+        address account,
+        bytes32 hash,
+        uint256 lenSeed,
+        uint256 fillSeed
+    ) public {
+        uint256 len = bound(lenSeed, 0, 200);
+        vm.assume(len != 65);
+        bytes memory data = new bytes(len);
+        for (uint256 i; i < len; ++i) {
+            data[i] = bytes1(uint8(uint256(keccak256(abi.encode(fillSeed, i)))));
+        }
+        bytes memory auth = abi.encodePacked(k1Authenticator, data);
 
-        bytes32 hash = keccak256("explicit non-self actor");
-        (uint8 scope,,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(bobPk, hash));
-        assertEq(scope, 0);
+        vm.expectRevert(AccountConfiguration.InvalidSignature.selector);
+        accountConfiguration.authenticateActor(account, hash, auth);
     }
 
-    function test_authenticate_unregisteredK1KeyFails() public {
-        // A k1 signature from a key that is neither the account itself nor a registered actor fails. (A k1 sig from
-        // the account's own key would instead resolve to the implicit default EOA — covered elsewhere.)
-        uint256 eoaPk = 500;
+    /// @notice The high-s (EIP-2 malleable) twin of a canonical signature is rejected.
+    /// @dev _recoverSigner: `s > SECP256K1_HALF_ORDER`. vm.sign returns low-s, so n - s is always high-s; v flipped
+    ///      to model the malleability attack that recovers the same address.
+    function test_authenticateActor_revert_invalidSignature_highS(uint256 eoaSeed, bytes32 hash) public {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
 
-        bytes32 hash = keccak256("unregistered k1 key");
-        vm.expectRevert();
-        accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(999, hash));
-    }
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(eoaPk, hash);
+        bytes32 highS = bytes32(SECP256K1_ORDER - uint256(s));
+        uint8 flippedV = v == 27 ? 28 : 27;
+        bytes memory auth = abi.encodePacked(k1Authenticator, r, highS, flippedV);
 
-    function test_authenticate_unknownAuthenticatorPrefixReverts() public {
-        uint256 eoaPk = 500;
-        address eoa = vm.addr(eoaPk);
-
-        bytes32 hash = keccak256("unknown authenticator prefix");
-        // An authenticator address with no code cannot resolve an actor, so authentication reverts.
-        bytes memory auth = abi.encodePacked(address(type(uint160).max));
-
-        vm.expectRevert();
+        vm.expectRevert(AccountConfiguration.InvalidSignature.selector);
         accountConfiguration.authenticateActor(eoa, hash, auth);
     }
 
-    // ── EIP-2 signature malleability ──
-
-    function test_authenticate_rejectsHighSMalleability() public {
-        uint256 eoaPk = 500;
+    /// @notice A recovery id outside {27, 28} is rejected even with a canonical low-s signature.
+    /// @dev _recoverSigner: `v != 27 && v != 28`. Low-s keeps the high-s guard from firing first.
+    function test_authenticateActor_revert_invalidSignature_badV(uint256 eoaSeed, bytes32 hash, uint8 vSeed) public {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
-        bytes32 hash = keccak256("malleability");
-
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(eoaPk, hash);
-
-        // The canonical (low-s) signature authenticates.
-        accountConfiguration.authenticateActor(eoa, hash, abi.encodePacked(k1Authenticator, r, s, v));
-
-        // Its high-s twin (s' = n - s, v flipped) recovers the same address but is rejected per EIP-2.
-        uint256 n = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141;
-        bytes32 highS = bytes32(n - uint256(s));
-        uint8 flippedV = v == 27 ? 28 : 27;
-
-        vm.expectRevert(AccountConfiguration.InvalidSignature.selector);
-        accountConfiguration.authenticateActor(eoa, hash, abi.encodePacked(k1Authenticator, r, highS, flippedV));
-    }
-
-    function test_authenticate_rejectsNonCanonicalV() public {
-        uint256 eoaPk = 500;
-        address eoa = vm.addr(eoaPk);
-        bytes32 hash = keccak256("bad v");
+        vm.assume(vSeed != 27 && vSeed != 28);
 
         (, bytes32 r, bytes32 s) = vm.sign(eoaPk, hash);
+        bytes memory auth = abi.encodePacked(k1Authenticator, r, s, vSeed);
 
-        // v outside {27, 28} is rejected.
         vm.expectRevert(AccountConfiguration.InvalidSignature.selector);
-        accountConfiguration.authenticateActor(eoa, hash, abi.encodePacked(k1Authenticator, r, s, uint8(29)));
+        accountConfiguration.authenticateActor(eoa, hash, auth);
     }
 
-    // ── Helpers ──
+    /// @notice A signature that ecrecovers to address(0) (r == 0) is rejected as a zero recovery.
+    /// @dev _recoverSigner passes length/high-s/v guards (s low, v = 27) but r == 0 -> ecrecover == 0 ->
+    ///      _authenticateK1 reverts on `recovered == address(0)`.
+    function test_authenticateActor_revert_invalidSignature_zeroRecovery(address account, bytes32 hash, uint256 sSeed)
+        public
+    {
+        uint256 s = bound(sSeed, 1, (SECP256K1_ORDER - 1) / 2); // canonical low-s so only the r == 0 guard bites
+        bytes memory auth = abi.encodePacked(k1Authenticator, bytes32(0), bytes32(s), uint8(27));
 
-    function _authorizeActor(address account, uint256 pk, bytes32 newActorId, address authenticator) internal {
-        _authorizeActorWithScope(account, pk, newActorId, authenticator, 0x00);
+        vm.expectRevert(AccountConfiguration.InvalidSignature.selector);
+        accountConfiguration.authenticateActor(account, hash, auth);
     }
 
+    // ── Unknown authenticator: a selector with no deployed code cannot resolve an actor ──
+
+    /// @notice A non-K1 authenticator address with no deployed code reverts (empty returndata fails the decode).
+    /// @dev Exercises the external-call branch of _authenticate against a codeless authenticator.
+    function test_authenticateActor_revert_unknownAuthenticatorNoCode(
+        address account,
+        address authenticator,
+        bytes32 hash,
+        bytes calldata data
+    ) public {
+        vm.assume(uint160(authenticator) > uint160(k1Authenticator)); // not the K1 branch, not address(0)
+        vm.assume(authenticator.code.length == 0);
+        bytes memory auth = abi.encodePacked(authenticator, data);
+
+        vm.expectRevert();
+        accountConfiguration.authenticateActor(account, hash, auth);
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // HAPPY / BRANCH
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice A never-created EOA authenticates via the implicit self key as a full owner (all-zero inline config).
+    /// @dev _authenticateK1 inline-self branch: recovered == account, flag unset, expiry 0 -> (0, 0, address(0)).
+    function test_authenticateActor_success_implicitEoaSelf(uint256 eoaSeed, bytes32 hash) public view {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
+        address eoa = vm.addr(eoaPk);
+
+        (uint8 scope, uint8 policyType, address policyTarget) =
+            accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+
+        assertEq(scope, uint8(0x00));
+        assertEq(policyType, uint8(0x00));
+        assertEq(policyTarget, address(0));
+    }
+
+    /// @notice A registered non-self K1 owner (scope 0) authenticates on a created account.
+    /// @dev _authenticateK1 non-self branch: config.authenticator == K1, expiry 0 -> returns the stored scope.
+    function test_authenticateActor_success_registeredK1Actor(uint256 ownerSeed, uint256 actorSeed, bytes32 hash)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 actorPk = _boundK1Pk(actorSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(actorPk));
+
+        (address account,) = _createK1Account(ownerPk);
+        vm.assume(vm.addr(actorPk) != account);
+        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), 0x00);
+
+        (uint8 scope,,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        assertEq(scope, uint8(0x00));
+    }
+
+    /// @notice A registered P-256 actor authenticates via the non-K1 authenticator path.
+    /// @dev _authenticate (non-K1) success: IAuthenticator resolves actorId, config.authenticator == p256.
+    function test_authenticateActor_success_p256Actor(uint256 ownerSeed, uint256 pkSeed, uint8 scopeSeed, bytes32 hash)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 pk = _boundP256Pk(pkSeed);
+        uint8 scope = uint8(bound(uint256(scopeSeed), 0, 255));
+
+        (address account,) = _createK1Account(ownerPk);
+        _authorizeActorWithScope(account, ownerPk, _p256ActorId(pk), address(p256Authenticator), scope);
+
+        bytes memory auth = abi.encodePacked(address(p256Authenticator), _p256SignData(pk, hash));
+        (uint8 outScope,,) = accountConfiguration.authenticateActor(account, hash, auth);
+        assertEq(outScope, scope);
+    }
+
+    /// @notice A registered WebAuthn actor authenticates via the non-K1 authenticator path.
+    /// @dev Same non-K1 success branch through the WebAuthn authenticator; actorId = keccak256(x‖y).
+    function test_authenticateActor_success_webAuthnActor(
+        uint256 ownerSeed,
+        uint256 pkSeed,
+        uint8 scopeSeed,
+        bytes32 hash
+    ) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 pk = _boundP256Pk(pkSeed);
+        uint8 scope = uint8(bound(uint256(scopeSeed), 0, 255));
+
+        (address account,) = _createK1Account(ownerPk);
+        _authorizeActorWithScope(account, ownerPk, _p256ActorId(pk), address(webAuthnAuthenticator), scope);
+
+        bytes memory auth = abi.encodePacked(address(webAuthnAuthenticator), _webauthnSignData(pk, hash));
+        (uint8 outScope,,) = accountConfiguration.authenticateActor(account, hash, auth);
+        assertEq(outScope, scope);
+    }
+
+    /// @notice A scoped K1 actor authenticates and surfaces exactly its stored scope.
+    /// @dev Fuzzes the full non-zero scope space to prove passthrough of the scope byte (no SIGNER special-casing).
+    function test_authenticateActor_success_scopedActorReturnsScope(
+        uint256 ownerSeed,
+        uint256 actorSeed,
+        uint8 scopeSeed,
+        bytes32 hash
+    ) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 actorPk = _boundK1Pk(actorSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(actorPk));
+        uint8 scope = uint8(bound(uint256(scopeSeed), 1, 255));
+
+        (address account,) = _createK1Account(ownerPk);
+        vm.assume(vm.addr(actorPk) != account);
+        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), scope);
+
+        (uint8 outScope,,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        assertEq(outScope, scope);
+    }
+
+    /// @notice An explicitly registered unrestricted (scope 0) non-self K1 actor authenticates as a full owner.
+    /// @dev Distinguishes the explicit scope-0 upsert from the implicit-self path; both resolve to scope 0.
+    function test_authenticateActor_success_unrestrictedScope(uint256 ownerSeed, uint256 actorSeed, bytes32 hash)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 actorPk = _boundK1Pk(actorSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(actorPk));
+
+        (address account,) = _createK1Account(ownerPk);
+        vm.assume(vm.addr(actorPk) != account);
+        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), 0x00);
+
+        (uint8 scope,,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        assertEq(scope, uint8(0x00));
+    }
+
+    /// @notice A zero-expiry actor never expires, even far in the future.
+    /// @dev expiry == 0 short-circuits the expiry guard on the non-self K1 path regardless of warp.
+    function test_authenticateActor_success_zeroExpiryNeverExpires(
+        uint256 ownerSeed,
+        uint256 sessionSeed,
+        uint256 warpSeed,
+        bytes32 hash
+    ) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 sessionPk = _boundK1Pk(sessionSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(sessionPk));
+
+        (address account,) = _createK1Account(ownerPk);
+        vm.assume(vm.addr(sessionPk) != account);
+        _authorizeActorWithExpiry(account, ownerPk, bytes32(bytes20(vm.addr(sessionPk))), address(k1Authenticator), 0);
+
+        vm.warp(block.timestamp + bound(warpSeed, 1, 3650 days));
+        (uint8 scope,,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
+        assertEq(scope, uint8(0x00));
+    }
+
+    /// @notice An actor at exactly its expiry timestamp is still valid (guard is strict `>`).
+    /// @dev Warps to block.timestamp == expiry on the non-self K1 path and expects success.
+    function test_authenticateActor_success_atExpiryBoundary(
+        uint256 ownerSeed,
+        uint256 sessionSeed,
+        uint48 expirySeed,
+        bytes32 hash
+    ) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 sessionPk = _boundK1Pk(sessionSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(sessionPk));
+
+        (address account,) = _createK1Account(ownerPk);
+        vm.assume(vm.addr(sessionPk) != account);
+        uint48 expiry = uint48(bound(uint256(expirySeed), block.timestamp + 1, uint256(type(uint48).max)));
+        _authorizeActorWithExpiry(
+            account, ownerPk, bytes32(bytes20(vm.addr(sessionPk))), address(k1Authenticator), expiry
+        );
+
+        vm.warp(expiry);
+        (uint8 scope,,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
+        assertEq(scope, uint8(0x00));
+    }
+
+    /// @notice A policy-gated actor surfaces its scope, policy sub-type byte, and resolved policy target (manager).
+    /// @dev _resolvePolicyTarget returns the stored manager; the commitment is not returned here (execution-time read).
+    function test_authenticateActor_success_gatedActorReturnsScopePolicyTarget(
+        uint256 ownerSeed,
+        uint256 sessionSeed,
+        uint8 scopeSeed,
+        uint8 policyTypeSeed,
+        address manager,
+        bytes32 commitment,
+        bytes32 hash
+    ) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 sessionPk = _boundK1Pk(sessionSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(sessionPk));
+        vm.assume(manager != address(0));
+        vm.assume(commitment != bytes32(0));
+        // A policy-bearing actor must be scope-restricted (non-zero) without CONFIG scope.
+        uint8 scope = uint8(bound(uint256(scopeSeed), 1, 7));
+        uint8 policyType = uint8(bound(uint256(policyTypeSeed), 1, 255));
+
+        (address account,) = _createK1Account(ownerPk);
+        vm.assume(vm.addr(sessionPk) != account);
+        bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
+        _authorizeGatedActor(account, ownerPk, sessionActorId, scope, policyType, manager, commitment);
+
+        (uint8 outScope, uint8 outPolicyType, address outTarget) =
+            accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
+
+        assertEq(outScope, scope);
+        assertEq(outPolicyType, policyType);
+        assertEq(outTarget, manager);
+    }
+
+    /// @notice An ungated actor authenticates with a zero policy sub-type and a zero policy target.
+    /// @dev policyType == POLICY_NONE short-circuits _resolvePolicyTarget to address(0).
+    function test_authenticateActor_success_ungatedActorReturnsZeroPolicy(uint256 eoaSeed, bytes32 hash) public view {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
+        address eoa = vm.addr(eoaPk);
+
+        (uint8 scope, uint8 policyType, address policyTarget) =
+            accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+
+        assertEq(scope, uint8(0x00));
+        assertEq(policyType, uint8(0x00));
+        assertEq(policyTarget, address(0));
+    }
+
+    /// @notice Scoping the account's own key downgrades it: the inline self returns the reduced scope, never owner.
+    /// @dev There is a single K1 path, so the config alone decides the scope — no implicit full-owner escape.
+    function test_authenticateActor_success_selfScopedDowngrade(uint256 eoaSeed, uint8 scopeSeed, bytes32 hash) public {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
+        address eoa = vm.addr(eoaPk);
+        bytes32 selfActorId = bytes32(bytes20(eoa));
+        uint8 scope = uint8(bound(uint256(scopeSeed), 1, 255));
+
+        _authorizeActorWithScope(eoa, eoaPk, selfActorId, address(k1Authenticator), scope);
+
+        (uint8 outScope,,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        assertEq(outScope, scope);
+    }
+
+    /// @notice A second explicit K1 owner (non-self actorId) registered on an EOA authenticates independently.
+    /// @dev Non-self K1 branch on an EIP-7702-style EOA that still has its implicit self live.
+    function test_authenticateActor_success_explicitNonSelfEoaActor(uint256 eoaSeed, uint256 bobSeed, bytes32 hash)
+        public
+    {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
+        uint256 bobPk = _boundK1Pk(bobSeed);
+        address eoa = vm.addr(eoaPk);
+        vm.assume(vm.addr(bobPk) != eoa);
+
+        _implicitAuthorizeActor(eoa, eoaPk, bytes32(bytes20(vm.addr(bobPk))), address(k1Authenticator));
+
+        (uint8 scope,,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(bobPk, hash));
+        assertEq(scope, uint8(0x00));
+    }
+
+    /// @notice The same owner key authenticates on two distinct accounts derived from different salts.
+    /// @dev Confirms actor resolution is keyed per-account; a valid owner sig is not cross-account fungible by luck.
+    function test_authenticateActor_success_crossAccount(uint256 ownerSeed, bytes32 saltA, bytes32 saltB, bytes32 hash)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        vm.assume(saltA != saltB);
+
+        (address accountA,) = _createK1AccountWithSalt(ownerPk, saltA);
+        (address accountB,) = _createK1AccountWithSalt(ownerPk, saltB);
+        vm.assume(accountA != accountB);
+
+        bytes memory auth = _buildK1Auth(ownerPk, hash);
+        (uint8 scopeA,,) = accountConfiguration.authenticateActor(accountA, hash, auth);
+        (uint8 scopeB,,) = accountConfiguration.authenticateActor(accountB, hash, auth);
+        assertEq(scopeA, uint8(0x00));
+        assertEq(scopeB, uint8(0x00));
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // verifySignature (SIGNER gate)
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice verifySignature returns true iff the resolved actor's scope is unrestricted or carries SCOPE_SIGNER.
+    /// @dev Fuzzes the full scope space [0,255] and asserts the boolean equals `scope == 0 || scope & SIGNER != 0`,
+    ///      proving the SIGNER gate across every scope combination.
+    function test_verifySignature_success_signerGateAcrossScopes(
+        uint256 ownerSeed,
+        uint256 actorSeed,
+        uint8 scopeSeed,
+        bytes32 hash
+    ) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 actorPk = _boundK1Pk(actorSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(actorPk));
+        uint8 scope = uint8(bound(uint256(scopeSeed), 0, 255));
+
+        (address account,) = _createK1Account(ownerPk);
+        vm.assume(vm.addr(actorPk) != account);
+        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), scope);
+
+        bool expected = scope == 0 || scope & SCOPE_SIGNER != 0;
+        assertEq(accountConfiguration.verifySignature(account, hash, _buildK1Auth(actorPk, hash)), expected);
+    }
+
+    /// @notice verifySignature returns false when authentication fails outright (unregistered signer).
+    /// @dev authenticateActor reverts (AuthenticatorMismatch) and the try/catch collapses it to false.
+    function test_verifySignature_success_falseOnUnauthenticated(uint256 ownerSeed, uint256 strangerSeed, bytes32 hash)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 strangerPk = _boundK1Pk(strangerSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(strangerPk));
+
+        (address account,) = _createK1Account(ownerPk);
+        vm.assume(vm.addr(strangerPk) != account);
+
+        assertFalse(accountConfiguration.verifySignature(account, hash, _buildK1Auth(strangerPk, hash)));
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // getPolicy / getActorConfig / isActor (actor-resolution views)
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice getPolicy resolves a gated actor's sub-type, manager, and signed commitment.
+    /// @dev Non-zero policyType returns (policyType, manager, commitment) from the policy keyspace.
+    function test_getPolicy_success_gatedActor(
+        uint256 ownerSeed,
+        uint256 sessionSeed,
+        uint8 scopeSeed,
+        uint8 policyTypeSeed,
+        address manager,
+        bytes32 commitment
+    ) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 sessionPk = _boundK1Pk(sessionSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(sessionPk));
+        vm.assume(manager != address(0));
+        vm.assume(commitment != bytes32(0));
+        uint8 scope = uint8(bound(uint256(scopeSeed), 1, 7));
+        uint8 policyType = uint8(bound(uint256(policyTypeSeed), 1, 255));
+
+        (address account,) = _createK1Account(ownerPk);
+        bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
+        _authorizeGatedActor(account, ownerPk, sessionActorId, scope, policyType, manager, commitment);
+
+        (uint8 outPolicyType, address outTarget, bytes32 outCommitment) =
+            accountConfiguration.getPolicy(account, sessionActorId);
+        assertEq(outPolicyType, policyType);
+        assertEq(outTarget, manager);
+        assertEq(outCommitment, commitment);
+    }
+
+    /// @notice getPolicy returns the zero policy for an ungated actor.
+    /// @dev policyType == POLICY_NONE returns (0, address(0), bytes32(0)).
+    function test_getPolicy_success_ungatedActor(uint256 ownerSeed, uint256 actorSeed) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 actorPk = _boundK1Pk(actorSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(actorPk));
+
+        (address account,) = _createK1Account(ownerPk);
+        vm.assume(vm.addr(actorPk) != account);
+        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), 0x00);
+
+        (uint8 policyType, address target, bytes32 commitment) = accountConfiguration.getPolicy(account, actorId);
+        assertEq(policyType, uint8(0x00));
+        assertEq(target, address(0));
+        assertEq(commitment, bytes32(0));
+    }
+
+    /// @notice getActorConfig returns a registered actor's authenticator and scope verbatim.
+    /// @dev The initial owner is stored with the K1 authenticator and scope 0.
+    function test_getActorConfig_success_returnsAuthenticatorAndScope(uint256 ownerSeed) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        (address account, bytes32 actorId) = _createK1Account(ownerPk);
+
+        AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, actorId);
+        assertEq(cfg.authenticator, address(k1Authenticator));
+        assertEq(cfg.scope, uint8(0x00));
+    }
+
+    /// @notice getActorConfig returns the empty config for an unknown actor.
+    /// @dev No _actorConfig entry and not the (live) self-actorId -> all-zero config.
+    function test_getActorConfig_success_returnsZeroForUnknownActor(uint256 ownerSeed, bytes32 unknownActorId) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        (address account, bytes32 actorId) = _createK1Account(ownerPk);
+        vm.assume(unknownActorId != actorId);
+        vm.assume(unknownActorId != bytes32(bytes20(account)));
+
+        AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, unknownActorId);
+        assertEq(cfg.authenticator, address(0));
+        assertEq(cfg.scope, uint8(0x00));
+    }
+
+    /// @notice isActor reports the implicit self-actorId of a never-created EOA as live.
+    /// @dev No _actorConfig entry, actorId == self, flag unset -> true.
+    function test_isActor_success_implicitEoaTrue(uint256 eoaSeed) public view {
+        address eoa = vm.addr(_boundK1Pk(eoaSeed));
+        assertTrue(accountConfiguration.isActor(eoa, bytes32(bytes20(eoa))));
+    }
+
+    /// @notice isActor reports a non-self actorId on a never-created EOA as not live.
+    /// @dev A random actorId != bytes32(bytes20(eoa)) has no inline home and no _actorConfig entry -> false.
+    function test_isActor_success_nonSelfActorIdNotImplicit(uint256 eoaSeed, bytes32 randomActorId) public view {
+        address eoa = vm.addr(_boundK1Pk(eoaSeed));
+        vm.assume(randomActorId != bytes32(bytes20(eoa)));
+        assertFalse(accountConfiguration.isActor(eoa, randomActorId));
+    }
+
+    /// @notice isActor reports the self-actorId as not live after the self key has been revoked.
+    /// @dev Revoking the self-actorId sets the revoke flag, so the inline self no longer counts as an actor.
+    function test_isActor_success_falseAfterSelfRevoke(uint256 eoaSeed) public {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
+        address eoa = vm.addr(eoaPk);
+        bytes32 selfActorId = bytes32(bytes20(eoa));
+
+        _revokeActor(eoa, eoaPk, selfActorId);
+
+        assertFalse(accountConfiguration.isActor(eoa, selfActorId));
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // HELPERS
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @dev Authorize `newActorId` under `authenticator` with `scope` (no expiry, no policy), signed by `pk`.
+    ///      For the self-actorId with the K1 authenticator this drives the inline-self home; for any other
+    ///      authenticator on the self-actorId it drives the mutually-exclusive non-K1 self home.
     function _authorizeActorWithScope(
         address account,
         uint256 pk,
@@ -324,11 +765,10 @@ contract AuthenticateTest is AccountConfigurationTest {
 
         uint64 seq = accountConfiguration.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(pk, digest);
-
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));
     }
 
+    /// @dev Authorize `newActorId` under `authenticator` with the given `expiry` (scope 0, no policy), signed by `pk`.
     function _authorizeActorWithExpiry(
         address account,
         uint256 pk,
@@ -350,42 +790,25 @@ contract AuthenticateTest is AccountConfigurationTest {
 
         uint64 seq = accountConfiguration.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(pk, digest);
-
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));
     }
 
+    /// @dev Authorize `newActorId` under `authenticator` as an unrestricted owner (scope 0), signed by `pk`.
+    function _implicitAuthorizeActor(address account, uint256 pk, bytes32 newActorId, address authenticator) internal {
+        _authorizeActorWithScope(account, pk, newActorId, authenticator, 0x00);
+    }
+
+    /// @dev Revoke `actorId` from `account`, signed by `pk`.
     function _revokeActor(address account, uint256 pk, bytes32 actorId) internal {
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
 
         uint64 seq = accountConfiguration.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(pk, digest);
-
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));
     }
 
-    function _implicitAuthorizeActor(address account, uint256 pk, bytes32 newActorId, address authenticator) internal {
-        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
-        changes[0] = AccountConfiguration.ActorChange({
-            actorId: newActorId,
-            changeType: 0x01,
-            data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: authenticator, scope: 0x00, expiry: 0, policyType: 0x00
-                }),
-                bytes("")
-            )
-        });
-
-        uint64 seq = accountConfiguration.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(pk, digest);
-
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
-    }
-
+    /// @dev Authorize a K1 policy-gated actor: manager[20] || commitment[32] policy data, signed by the owner `pk`.
     function _authorizeGatedActor(
         address account,
         uint256 ownerPk,
@@ -412,36 +835,5 @@ contract AuthenticateTest is AccountConfigurationTest {
         accountConfiguration.applySignedActorChanges(
             account, uint64(block.chainid), changes, _buildK1Auth(ownerPk, digest)
         );
-    }
-
-    /// @notice authenticate surfaces the actor's full authorization: scope, the reserved policyType byte, and the
-    ///         resolved policy target (the manager); the commitment stays an execution-time read.
-    function test_authenticate_returnsScopePolicyTypeAndTarget() public {
-        (address account,) = _createK1Account(ACTOR_PK);
-
-        uint256 sessionPk = 410;
-        bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
-        address policyManager = address(0xB0B);
-        _authorizeGatedActor(account, ACTOR_PK, sessionActorId, 0x02, 0x01, policyManager, keccak256("commit"));
-
-        bytes32 hash = keccak256("gated authenticate");
-        (uint8 scope, uint8 policyType, address policyTarget) =
-            accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
-
-        assertEq(scope, uint8(0x02));
-        assertEq(policyType, uint8(0x01));
-        assertEq(policyTarget, policyManager);
-    }
-
-    function test_authenticate_ungatedActorReturnsZeroPolicy() public {
-        (address account,) = _createK1Account(ACTOR_PK);
-
-        bytes32 hash = keccak256("ungated authenticate");
-        (uint8 scope, uint8 policyType, address policyTarget) =
-            accountConfiguration.authenticateActor(account, hash, _buildK1Auth(ACTOR_PK, hash));
-
-        assertEq(scope, uint8(0x00));
-        assertEq(policyType, uint8(0x00));
-        assertEq(policyTarget, address(0));
     }
 }

--- a/test/unit/AccountConfiguration/createAccount.t.sol
+++ b/test/unit/AccountConfiguration/createAccount.t.sol
@@ -4,7 +4,13 @@ pragma solidity ^0.8.30;
 import {AccountConfiguration} from "../../../src/AccountConfiguration.sol";
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 
+/// @dev Fully fuzzed, branch-complete suite for AccountConfiguration.createAccount and the pure/view
+///      machinery it drives: computeAddress, _buildDeploymentCode, _computeEffectiveSalt / _computeActorsCommitment,
+///      and _initializeAccount. Reverts are ordered to mirror createAccount's source control flow; happy paths and
+///      the computeAddress determinism/sensitivity checks follow.
 contract CreateAccountTest is AccountConfigurationTest {
+    // ── local builders ──
+
     function _initialActor(bytes32 actorId, address authenticator)
         internal
         pure
@@ -13,83 +19,89 @@ contract CreateAccountTest is AccountConfigurationTest {
         return AccountConfiguration.InitialActor({actorId: actorId, authenticator: authenticator});
     }
 
-    function test_createAccount_singleK1Actor(uint256 pk) public {
-        pk = bound(pk, 1, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140);
-        address actor = vm.addr(pk);
-        bytes32 actorId = bytes32(bytes20(actor));
-
-        AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](1);
+    /// @dev A one-element k1 actor set with a caller-chosen actorId. actorId must be strictly > 0 (the sort guard
+    ///      seeds previousActorId at 0 and rejects the first id if it is <= 0).
+    function _oneK1Actor(bytes32 actorId) internal view returns (AccountConfiguration.InitialActor[] memory actors) {
+        actors = new AccountConfiguration.InitialActor[](1);
         actors[0] = _initialActor(actorId, address(k1Authenticator));
-
-        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
-        address account = accountConfiguration.createAccount(bytes32(0), bytecode, actors);
-
-        assertTrue(account != address(0));
-        assertTrue(account.code.length > 0);
-        assertTrue(accountConfiguration.isActor(account, actorId));
     }
 
-    function test_createAccount_multipleActors() public {
-        address actor1 = vm.addr(1);
-        address actor2 = vm.addr(2);
-
-        bytes32 actorId1 = bytes32(bytes20(actor1));
-        bytes32 actorId2 = bytes32(bytes20(actor2));
-
-        AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](2);
-        if (actorId1 < actorId2) {
-            actors[0] = _initialActor(actorId1, address(k1Authenticator));
-            actors[1] = _initialActor(actorId2, address(k1Authenticator));
-        } else {
-            actors[0] = _initialActor(actorId2, address(k1Authenticator));
-            actors[1] = _initialActor(actorId1, address(k1Authenticator));
+    /// @dev Deterministically materialize a strictly-ascending k1 actor set of `count` address-shaped actorIds
+    ///      (low 12 bytes zero, mirroring a real k1 actorId = bytes32(bytes20(signer))). Ascending uint160 base+i
+    ///      maps to ascending bytes32, so no in-Solidity sort is needed. base >= 1 keeps the first id > 0.
+    function _ascendingK1Actors(uint256 count, uint256 base)
+        internal
+        view
+        returns (AccountConfiguration.InitialActor[] memory actors)
+    {
+        actors = new AccountConfiguration.InitialActor[](count);
+        for (uint256 i; i < count; i++) {
+            bytes32 actorId = bytes32(bytes20(address(uint160(base + i))));
+            actors[i] = _initialActor(actorId, address(k1Authenticator));
         }
-
-        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
-        address account = accountConfiguration.createAccount(bytes32(0), bytecode, actors);
-
-        assertTrue(account != address(0));
-        assertTrue(accountConfiguration.isActor(account, actorId1));
-        assertTrue(accountConfiguration.isActor(account, actorId2));
     }
 
-    function test_createAccount_deterministicAddress() public {
-        address actor = vm.addr(1);
-        bytes32 actorId = bytes32(bytes20(actor));
-
-        AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](1);
-        actors[0] = _initialActor(actorId, address(k1Authenticator));
-
-        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
-        address predicted = accountConfiguration.computeAddress(bytes32(0), bytecode, actors);
-        address actual = accountConfiguration.createAccount(bytes32(0), bytecode, actors);
-
-        assertEq(predicted, actual);
+    /// @dev Arbitrary valid runtime bytecode of a fuzzed length/content. The deployment header only CODECOPY+RETURNs
+    ///      these bytes as runtime code (never executes them), so any content deploys as long as it is under the
+    ///      EIP-170 runtime cap and does not lead with 0xEF (EIP-3541).
+    function _validBytecode(uint256 lenSeed, bytes32 contentSeed) internal pure returns (bytes memory bc) {
+        uint256 len = bound(lenSeed, 1, 2048);
+        bc = new bytes(len);
+        for (uint256 i; i < len; i++) {
+            bc[i] = bytes1(uint8(uint256(keccak256(abi.encodePacked(contentSeed, i)))));
+        }
+        if (bc[0] == 0xEF) bc[0] = 0x00; // EIP-3541: leading 0xEF is rejected as runtime code
     }
 
-    function test_createAccount_revertsOnDuplicate() public {
-        address actor = vm.addr(1);
-        bytes32 actorId = bytes32(bytes20(actor));
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // REVERTS (source-execution order)
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-        AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](1);
-        actors[0] = _initialActor(actorId, address(k1Authenticator));
+    /// @notice Verifies createAccount reverts when bytecode length exceeds the 0xFFFF encodable maximum
+    /// @dev _buildDeploymentCode (reached first, via computeAddress) reverts BytecodeTooLarge for n > 0xFFFF
+    function test_createAccount_revert_bytecodeTooLarge(uint256 lenSeed, bytes1 fill, bytes32 salt) public {
+        uint256 len = bound(lenSeed, 0x10000, 0x10000 + 64);
+        bytes memory bytecode = new bytes(len);
+        bytecode[0] = fill;
 
-        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
-        accountConfiguration.createAccount(bytes32(0), bytecode, actors);
+        AccountConfiguration.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(1))));
+
+        vm.expectRevert(AccountConfiguration.BytecodeTooLarge.selector);
+        accountConfiguration.createAccount(salt, bytecode, actors);
+    }
+
+    /// @notice Verifies re-creating an account at an address that already holds 8130 state reverts
+    /// @dev localSequence is set to 1 on first create and doubles as the initialized flag; the guard trips on retry
+    function test_createAccount_revert_alreadyInitialized(uint256 pk, bytes32 salt, uint256 lenSeed, bytes32 content)
+        public
+    {
+        pk = _boundK1Pk(pk);
+        AccountConfiguration.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(pk))));
+        bytes memory bytecode = _validBytecode(lenSeed, content);
+
+        accountConfiguration.createAccount(salt, bytecode, actors);
 
         vm.expectRevert(AccountConfiguration.AlreadyInitialized.selector);
-        accountConfiguration.createAccount(bytes32(0), bytecode, actors);
+        accountConfiguration.createAccount(salt, bytecode, actors);
     }
 
-    function test_createAccount_revertsWithUnsortedActors() public {
-        address actor1 = vm.addr(1);
-        address actor2 = vm.addr(2);
+    /// @notice Verifies createAccount reverts when the initial actor set is empty
+    /// @dev _initializeAccount rejects a zero-length initialActors with NoInitialActors before any actor is written
+    function test_createAccount_revert_noInitialActors(bytes32 salt, uint256 lenSeed, bytes32 content) public {
+        AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](0);
+        bytes memory bytecode = _validBytecode(lenSeed, content);
 
-        bytes32 actorId1 = bytes32(bytes20(actor1));
-        bytes32 actorId2 = bytes32(bytes20(actor2));
+        vm.expectRevert(AccountConfiguration.NoInitialActors.selector);
+        accountConfiguration.createAccount(salt, bytecode, actors);
+    }
 
-        bytes32 smaller = actorId1 < actorId2 ? actorId1 : actorId2;
-        bytes32 larger = actorId1 < actorId2 ? actorId2 : actorId1;
+    /// @notice Verifies createAccount reverts when initial actors are not in strictly ascending actorId order
+    /// @dev Exercises the `<` side of the `actorId <= previousActorId` guard: a larger id precedes a smaller one
+    function test_createAccount_revert_actorsNotSorted(bytes32 idA, bytes32 idB, bytes32 salt) public {
+        vm.assume(idA != 0 && idB != 0);
+        vm.assume(idA != idB);
+        bytes32 smaller = idA < idB ? idA : idB;
+        bytes32 larger = idA < idB ? idB : idA;
 
         AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](2);
         actors[0] = _initialActor(larger, address(k1Authenticator));
@@ -97,67 +109,155 @@ contract CreateAccountTest is AccountConfigurationTest {
 
         bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
         vm.expectRevert(AccountConfiguration.ActorsNotSortedOrDuplicate.selector);
-        accountConfiguration.createAccount(bytes32(0), bytecode, actors);
+        accountConfiguration.createAccount(salt, bytecode, actors);
     }
 
-    function test_createAccount_revertsWithNoActors() public {
-        AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](0);
+    /// @notice Verifies createAccount reverts when the initial actor set contains a duplicate actorId
+    /// @dev Exercises the `==` side of the `actorId <= previousActorId` guard: two equal ids in one set
+    function test_createAccount_revert_actorsDuplicate(bytes32 id, bytes32 salt) public {
+        vm.assume(id != 0);
+
+        AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](2);
+        actors[0] = _initialActor(id, address(k1Authenticator));
+        actors[1] = _initialActor(id, address(k1Authenticator));
+
         bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
-
-        vm.expectRevert(AccountConfiguration.NoInitialActors.selector);
-        accountConfiguration.createAccount(bytes32(0), bytecode, actors);
+        vm.expectRevert(AccountConfiguration.ActorsNotSortedOrDuplicate.selector);
+        accountConfiguration.createAccount(salt, bytecode, actors);
     }
 
-    function test_createAccount_revertsWithZeroAuthenticator() public {
-        bytes32 actorId = bytes32(uint256(1));
+    /// @notice Verifies createAccount reverts when an initial actor names an authenticator below the K1 sentinel
+    /// @dev _authorizeActor rejects authenticator < K1_AUTHENTICATOR; the only such value is address(0)
+    function test_createAccount_revert_invalidAuthenticator(bytes32 actorId, bytes32 salt) public {
+        vm.assume(actorId != 0);
 
         AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](1);
         actors[0] = _initialActor(actorId, address(0));
 
         bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
         vm.expectRevert(AccountConfiguration.InvalidAuthenticator.selector);
-        accountConfiguration.createAccount(bytes32(0), bytecode, actors);
+        accountConfiguration.createAccount(salt, bytecode, actors);
     }
 
-    /// @notice Regression: oversized bytecode makes the underlying CREATE2 fail (EIP-170). The deploy-return check
-    ///         must revert the whole call so no initialized-but-codeless account is left behind (the "orphaned
-    ///         config" bad state). Before the fix, the CREATE2 result was swallowed and the state writes persisted.
-    function test_createAccount_revertsOnFailedDeployment_noOrphanedState() public {
-        address actor = vm.addr(1);
-        bytes32 actorId = bytes32(bytes20(actor));
+    /// @notice Verifies createAccount reverts when CREATE2 rejects the runtime code for a leading 0xEF byte
+    /// @dev EIP-3541: a 0xEF-prefixed runtime code makes CREATE2 return address(0), tripping AccountDeploymentFailed
+    function test_createAccount_revert_deploymentFailedLeadingEF(uint256 lenSeed, bytes32 content, bytes32 salt)
+        public
+    {
+        uint256 len = bound(lenSeed, 1, 512);
+        bytes memory bytecode = new bytes(len);
+        bytecode[0] = 0xEF;
+        for (uint256 i = 1; i < len; i++) {
+            bytecode[i] = bytes1(uint8(uint256(keccak256(abi.encodePacked(content, i)))));
+        }
 
-        AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](1);
-        actors[0] = _initialActor(actorId, address(k1Authenticator));
+        AccountConfiguration.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(1))));
 
-        // Runtime code beginning with 0xEF is rejected by EIP-3541, so the CREATE2 returns address(0).
+        vm.expectRevert(AccountConfiguration.AccountDeploymentFailed.selector);
+        accountConfiguration.createAccount(salt, bytecode, actors);
+    }
+
+    /// @notice A failed CREATE2 unwinds every state write, leaving no initialized-but-codeless account
+    /// @dev Leading-0xEF runtime code makes CREATE2 return address(0), which must revert the whole call. Verifies no
+    ///      code, no local sequence, and no actor persist, and that a retry re-attempts the deploy (and fails again)
+    ///      rather than reverting AlreadyInitialized.
+    function test_createAccount_revert_deploymentFailedNoOrphanedState(uint256 pk, bytes32 salt) public {
+        pk = _boundK1Pk(pk);
+        bytes32 actorId = bytes32(bytes20(vm.addr(pk)));
+
+        AccountConfiguration.InitialActor[] memory actors = _oneK1Actor(actorId);
         bytes memory bytecode = hex"EF";
 
-        address predicted = accountConfiguration.computeAddress(bytes32(0), bytecode, actors);
+        address predicted = accountConfiguration.computeAddress(salt, bytecode, actors);
 
         vm.expectRevert(AccountConfiguration.AccountDeploymentFailed.selector);
-        accountConfiguration.createAccount(bytes32(0), bytecode, actors);
+        accountConfiguration.createAccount(salt, bytecode, actors);
 
-        // No code and no orphaned 8130 state: the account remains fully uninitialized.
         assertEq(predicted.code.length, 0);
         assertEq(accountConfiguration.getChangeSequences(predicted).local, 0);
+        assertEq(accountConfiguration.getChangeSequences(predicted).multichain, 0);
         assertFalse(accountConfiguration.isActor(predicted, actorId));
 
-        // Because the state writes were unwound, the re-init guard was NOT tripped: retrying re-attempts the deploy
-        // (and fails again on the same oversized bytecode) rather than reverting with AlreadyInitialized, which is
-        // exactly what the pre-fix orphaned-state bug would have produced.
+        // The writes were unwound, so the re-init guard is not tripped: the retry re-attempts the deploy and fails
+        // again on the same invalid bytecode rather than reverting AlreadyInitialized.
         vm.expectRevert(AccountConfiguration.AccountDeploymentFailed.selector);
-        accountConfiguration.createAccount(bytes32(0), bytecode, actors);
+        accountConfiguration.createAccount(salt, bytecode, actors);
     }
 
-    function test_createAccount_unrestrictedInitialActor() public {
-        address actor = vm.addr(1);
-        bytes32 actorId = bytes32(bytes20(actor));
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // HAPPY PATHS
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice Verifies a single-K1-actor account deploys with code and registers the actor as live
+    /// @dev Canonical clone bytecode; fuzzed key and salt confirm the property holds across the actor/salt space
+    function test_createAccount_success_singleK1Actor(uint256 pk, bytes32 salt) public {
+        pk = _boundK1Pk(pk);
+        bytes32 actorId = bytes32(bytes20(vm.addr(pk)));
+
+        AccountConfiguration.InitialActor[] memory actors = _oneK1Actor(actorId);
+        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
+
+        address account = accountConfiguration.createAccount(salt, bytecode, actors);
+
+        assertTrue(account != address(0));
+        assertGt(account.code.length, 0);
+        assertTrue(accountConfiguration.isActor(account, actorId));
+    }
+
+    /// @notice Verifies an account with many sorted initial actors deploys and registers every actor as live
+    /// @dev Fuzzes the actor count and the ascending id base, exercising the _initializeAccount authorization loop
+    ///      and _computeActorsCommitment over a multi-element set
+    function test_createAccount_success_multipleActors(uint256 count, uint256 base, bytes32 salt) public {
+        count = bound(count, 2, 8);
+        base = bound(base, 1, type(uint160).max - count);
+
+        AccountConfiguration.InitialActor[] memory actors = _ascendingK1Actors(count, base);
+        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
+
+        address account = accountConfiguration.createAccount(salt, bytecode, actors);
+
+        assertGt(account.code.length, 0);
+        for (uint256 i; i < count; i++) {
+            assertTrue(accountConfiguration.isActor(account, actors[i].actorId));
+        }
+    }
+
+    /// @notice Verifies any non-zero authenticator address is accepted and stored verbatim on the initial actor
+    /// @dev Fuzzes the authenticator address (the `authenticator >= K1_AUTHENTICATOR` accept side) and asserts
+    ///      getActorConfig round-trips it as an unrestricted owner
+    function test_createAccount_success_fuzzedAuthenticatorAddress(address authenticator, bytes32 actorId, bytes32 salt)
+        public
+    {
+        vm.assume(authenticator != address(0));
+        // Keep actorId away from the self-actorId shape (low 12 bytes non-zero) so it routes to the generic actor
+        // home rather than the inline-self path, which would report the K1 sentinel instead of the fuzzed address.
+        vm.assume(uint96(uint256(actorId)) != 0);
 
         AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](1);
-        actors[0] = _initialActor(actorId, address(k1Authenticator));
-
+        actors[0] = _initialActor(actorId, authenticator);
         bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
-        address account = accountConfiguration.createAccount(bytes32(0), bytecode, actors);
+
+        address account = accountConfiguration.createAccount(salt, bytecode, actors);
+
+        AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, actorId);
+        assertEq(cfg.authenticator, authenticator);
+        assertEq(cfg.scope, 0x00);
+        assertEq(cfg.expiry, 0);
+        assertEq(cfg.policyType, 0x00);
+        assertTrue(accountConfiguration.isActor(account, actorId));
+    }
+
+    /// @notice Verifies initial actors are unrestricted owners and the account is initialized with safe lock defaults
+    /// @dev Initial actors are structurally scope 0 / no expiry / no policy; localSequence is 1 and the account is
+    ///      unlocked with a zeroed unlock schedule
+    function test_createAccount_success_unrestrictedInitialActor(uint256 pk, bytes32 salt) public {
+        pk = _boundK1Pk(pk);
+        bytes32 actorId = bytes32(bytes20(vm.addr(pk)));
+
+        AccountConfiguration.InitialActor[] memory actors = _oneK1Actor(actorId);
+        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
+
+        address account = accountConfiguration.createAccount(salt, bytecode, actors);
 
         AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, actorId);
         assertEq(cfg.authenticator, address(k1Authenticator));
@@ -165,8 +265,8 @@ contract CreateAccountTest is AccountConfigurationTest {
         assertEq(cfg.expiry, 0);
         assertEq(cfg.policyType, 0x00);
 
-        // Created accounts are marked initialized (localSequence == 1).
         assertEq(accountConfiguration.getChangeSequences(account).local, 1);
+        assertEq(accountConfiguration.getChangeSequences(account).multichain, 0);
 
         (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 unlockDelay) =
             accountConfiguration.getLockStatus(account);
@@ -176,17 +276,155 @@ contract CreateAccountTest is AccountConfigurationTest {
         assertEq(unlockDelay, 0);
     }
 
-    function test_createAccount_differentSaltsProduceDifferentAddresses() public {
-        address actor = vm.addr(1);
-        bytes32 actorId = bytes32(bytes20(actor));
+    /// @notice Verifies createAccount marks the account's implicit secp256k1 self key revoked by default
+    /// @dev FLAG_REVOKE_DEFAULT_EOA is set on create (quantum-safe default), so the self-actorId is not a live actor
+    ///      absent an explicit self initial actor
+    function test_createAccount_success_defaultEoaRevokedByDefault(uint256 pk, bytes32 salt) public {
+        pk = _boundK1Pk(pk);
+        bytes32 actorId = bytes32(bytes20(vm.addr(pk)));
 
-        AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](1);
-        actors[0] = _initialActor(actorId, address(k1Authenticator));
-
+        AccountConfiguration.InitialActor[] memory actors = _oneK1Actor(actorId);
         bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
-        address addr1 = accountConfiguration.computeAddress(bytes32(uint256(1)), bytecode, actors);
-        address addr2 = accountConfiguration.computeAddress(bytes32(uint256(2)), bytecode, actors);
 
-        assertTrue(addr1 != addr2);
+        address account = accountConfiguration.createAccount(salt, bytecode, actors);
+
+        // The account's own self-actorId is not the seeded actor, so the inline k1 self stays disabled.
+        vm.assume(bytes32(bytes20(account)) != actorId);
+        assertFalse(accountConfiguration.isActor(account, bytes32(bytes20(account))));
+    }
+
+    /// @notice Verifies arbitrary valid runtime bytecode of a fuzzed length/content deploys successfully
+    /// @dev The deployment header CODECOPY+RETURNs the bytes as runtime code without executing them, so any EIP-170-
+    ///      sized, non-0xEF-leading payload deploys; the deployed code length matches the requested bytecode length
+    function test_createAccount_success_arbitraryBytecode(uint256 lenSeed, bytes32 content, uint256 pk, bytes32 salt)
+        public
+    {
+        pk = _boundK1Pk(pk);
+        AccountConfiguration.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(pk))));
+        bytes memory bytecode = _validBytecode(lenSeed, content);
+
+        address account = accountConfiguration.createAccount(salt, bytecode, actors);
+
+        assertEq(account.code.length, bytecode.length);
+    }
+
+    /// @notice Verifies bytecode of exactly 0xFFFF bytes is accepted (the encodable maximum is inclusive)
+    /// @dev Lower side of the BytecodeTooLarge boundary: _buildDeploymentCode rejects only `n > 0xFFFF`, so 0xFFFF
+    ///      passes the size check and deploys. Foundry disables the EIP-170 runtime code-size limit in tests, so the
+    ///      65535-byte runtime code deploys rather than failing — the assertion here is purely that BytecodeTooLarge
+    ///      is NOT reached at the boundary, complementing the n == 0x10000 revert test above.
+    function test_createAccount_success_bytecodeAtEncodableMax(bytes32 salt) public {
+        bytes memory bytecode = new bytes(0xFFFF); // zero-filled: EIP-3541-clean (no leading 0xEF)
+
+        AccountConfiguration.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(1))));
+
+        address account = accountConfiguration.createAccount(salt, bytecode, actors);
+        assertEq(account.code.length, 0xFFFF);
+    }
+
+    /// @notice Verifies createAccount emits AccountCreated once with the account, user salt, and bytecode hash
+    /// @dev Sole assertion of this event; the codeHash argument is keccak256 of the raw user bytecode, not the header
+    function test_createAccount_success_emitsAccountCreated(uint256 pk, bytes32 salt, uint256 lenSeed, bytes32 content)
+        public
+    {
+        pk = _boundK1Pk(pk);
+        AccountConfiguration.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(pk))));
+        bytes memory bytecode = _validBytecode(lenSeed, content);
+
+        address predicted = accountConfiguration.computeAddress(salt, bytecode, actors);
+
+        vm.expectEmit(true, false, false, true, address(accountConfiguration));
+        emit AccountConfiguration.AccountCreated(predicted, salt, keccak256(bytecode));
+        accountConfiguration.createAccount(salt, bytecode, actors);
+    }
+
+    /// @notice Verifies the deployed account address equals the counterfactual computeAddress for fuzzed inputs
+    /// @dev CREATE2 determinism across salt, bytecode, and actor set; the predicted address holds code post-deploy
+    function test_createAccount_success_deterministicAddress(uint256 pk, bytes32 salt, uint256 lenSeed, bytes32 content)
+        public
+    {
+        pk = _boundK1Pk(pk);
+        AccountConfiguration.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(pk))));
+        bytes memory bytecode = _validBytecode(lenSeed, content);
+
+        address predicted = accountConfiguration.computeAddress(salt, bytecode, actors);
+        address actual = accountConfiguration.createAccount(salt, bytecode, actors);
+
+        assertEq(actual, predicted);
+        assertGt(predicted.code.length, 0);
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // computeAddress (pure/view: _buildDeploymentCode + _computeEffectiveSalt + _computeActorsCommitment)
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice Verifies computeAddress reverts for bytecode larger than the 0xFFFF encodable maximum
+    /// @dev computeAddress -> _buildDeploymentCode reverts BytecodeTooLarge for n > 0xFFFF, independent of create
+    function test_computeAddress_revert_bytecodeTooLarge(uint256 lenSeed, bytes1 fill, bytes32 salt) public {
+        uint256 len = bound(lenSeed, 0x10000, 0x10000 + 64);
+        bytes memory bytecode = new bytes(len);
+        bytecode[0] = fill;
+
+        AccountConfiguration.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(1))));
+
+        vm.expectRevert(AccountConfiguration.BytecodeTooLarge.selector);
+        accountConfiguration.computeAddress(salt, bytecode, actors);
+    }
+
+    /// @notice Verifies computeAddress accepts bytecode of exactly 0xFFFF bytes without reverting
+    /// @dev Config-independent proof that the BytecodeTooLarge boundary is exclusive: computeAddress runs
+    ///      _buildDeploymentCode but never deploys, so 0xFFFF returns an address while n == 0x10000 reverts (above)
+    function test_computeAddress_success_bytecodeAtEncodableMax(bytes32 salt) public view {
+        bytes memory bytecode = new bytes(0xFFFF);
+        AccountConfiguration.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(1))));
+
+        address predicted = accountConfiguration.computeAddress(salt, bytecode, actors);
+        assertTrue(predicted != address(0));
+    }
+
+    /// @notice Verifies distinct user salts produce distinct counterfactual addresses for the same actors/bytecode
+    /// @dev _computeEffectiveSalt folds userSalt into the CREATE2 salt, so salt is address-determining
+    function test_computeAddress_success_differentSalts(uint256 pk, bytes32 saltA, bytes32 saltB) public view {
+        vm.assume(saltA != saltB);
+        pk = _boundK1Pk(pk);
+        AccountConfiguration.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(pk))));
+        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
+
+        address addrA = accountConfiguration.computeAddress(saltA, bytecode, actors);
+        address addrB = accountConfiguration.computeAddress(saltB, bytecode, actors);
+
+        assertTrue(addrA != addrB);
+    }
+
+    /// @notice Verifies a different initial actor set yields a different address for the same salt and bytecode
+    /// @dev _computeActorsCommitment binds the packed actor set into the effective salt, so the actor set is
+    ///      address-determining
+    function test_computeAddress_success_actorSetSensitivity(bytes32 salt, bytes32 idA, bytes32 idB) public view {
+        vm.assume(idA != 0 && idB != 0 && idA != idB);
+        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
+
+        address addrA = accountConfiguration.computeAddress(salt, bytecode, _oneK1Actor(idA));
+        address addrB = accountConfiguration.computeAddress(salt, bytecode, _oneK1Actor(idB));
+
+        assertTrue(addrA != addrB);
+    }
+
+    /// @notice Verifies different bytecode yields a different address for the same salt and actor set
+    /// @dev computeAddress hashes _buildDeploymentCode(bytecode); a distinct codeHash moves the CREATE2 address
+    function test_computeAddress_success_bytecodeSensitivity(uint256 pk, bytes32 salt, uint256 lenSeed, bytes32 content)
+        public
+        view
+    {
+        pk = _boundK1Pk(pk);
+        AccountConfiguration.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(pk))));
+
+        bytes memory bytecodeA = _validBytecode(lenSeed, content);
+        bytes memory bytecodeB = _computeERC1167Bytecode(defaultAccountImplementation);
+        vm.assume(keccak256(bytecodeA) != keccak256(bytecodeB));
+
+        address addrA = accountConfiguration.computeAddress(salt, bytecodeA, actors);
+        address addrB = accountConfiguration.computeAddress(salt, bytecodeB, actors);
+
+        assertTrue(addrA != addrB);
     }
 }

--- a/test/unit/AccountConfiguration/importAccount.t.sol
+++ b/test/unit/AccountConfiguration/importAccount.t.sol
@@ -6,7 +6,8 @@ import {ECDSA} from "openzeppelin/utils/cryptography/ECDSA.sol";
 import {AccountConfiguration} from "../../../src/AccountConfiguration.sol";
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 
-/// @dev Minimal ERC-1271 wallet that validates an owner ECDSA signature over the presented hash.
+/// @dev Minimal ERC-1271 wallet that validates an owner ECDSA signature over the presented hash. Returns the
+///      0x1626ba7e magic for a valid owner signature and 0xFFFFFFFF otherwise (the wrong-selector branch).
 contract MockERC1271Wallet {
     address public immutable owner;
 
@@ -20,10 +21,36 @@ contract MockERC1271Wallet {
     }
 }
 
+/// @dev ERC-1271 wallet whose isValidSignature always reverts. Drives the `!success` term of the import
+///      signature predicate (staticcall fails).
+contract RevertingERC1271Wallet {
+    function isValidSignature(bytes32, bytes calldata) external pure returns (bytes4) {
+        revert("no");
+    }
+}
+
+/// @dev ERC-1271 wallet that returns non-32-byte returndata (4 bytes here, containing the magic). Drives the
+///      `result.length != 32` term even though the leading word would decode to the magic.
+contract ShortReturnERC1271Wallet {
+    function isValidSignature(bytes32, bytes calldata) external pure returns (bytes4) {
+        assembly ("memory-safe") {
+            mstore(0x00, 0x1626ba7e00000000000000000000000000000000000000000000000000000000)
+            return(0x00, 4)
+        }
+    }
+}
+
+/// @dev Fully fuzzed, branch-complete suite for AccountConfiguration.importAccount and the pure digest machinery it
+///      drives (_computeImportDigest), plus the _initializeAccount reverts it inherits. Reverts are ordered to
+///      mirror importAccount's source control flow (onlyUnlocked → InvalidChainId → AlreadyInitialized →
+///      InvalidImportSignature → _initializeAccount reverts); happy/branch paths follow.
 contract ImportAccountTest is AccountConfigurationTest {
-    // Independent reimplementation of the contract's typed import digest (see _computeImportDigest). The digest retains
-    // the full Actor/ActorConfig typehash structure; for imported (always unrestricted) actors the config fields are
-    // zero and policyData is empty.
+    // ERC-1271 magic value (matches AccountConfiguration.ERC1271_SELECTOR).
+    bytes4 constant ERC1271_MAGIC = 0x1626ba7e;
+
+    // Independent reimplementation of the contract's typed import digest (see _computeImportDigest). The digest
+    // retains the full Actor/ActorConfig typehash structure; for imported (always unrestricted) actors the config
+    // fields are zero and policyData is empty.
     bytes32 constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
         "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint8 policyType)"
     );
@@ -32,6 +59,8 @@ contract ImportAccountTest is AccountConfigurationTest {
     );
     bytes32 constant ACTORCONFIG_TYPEHASH =
         keccak256("ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint8 policyType)");
+
+    // ── digest helpers ──
 
     /// @dev Convenience: bind the digest to the current chain (the common per-chain import).
     function _computeImportDigest(address account, AccountConfiguration.InitialActor[] memory initialActors)
@@ -64,6 +93,8 @@ contract ImportAccountTest is AccountConfigurationTest {
         );
     }
 
+    // ── actor-set builders ──
+
     function _singleUnrestrictedActor(address signer)
         internal
         view
@@ -75,65 +106,113 @@ contract ImportAccountTest is AccountConfigurationTest {
         });
     }
 
-    function test_importAccount_validSignature() public {
-        uint256 ownerPk = 700;
-        MockERC1271Wallet wallet = new MockERC1271Wallet(vm.addr(ownerPk));
+    /// @dev A strictly-ascending k1 actor set of `count` address-shaped actorIds (mirroring a real k1 actorId =
+    ///      bytes32(bytes20(signer))). Ascending uint160 base+i maps to ascending bytes32, so no sort is needed.
+    function _ascendingK1Actors(uint256 count, uint256 base)
+        internal
+        view
+        returns (AccountConfiguration.InitialActor[] memory actors)
+    {
+        actors = new AccountConfiguration.InitialActor[](count);
+        for (uint256 i; i < count; i++) {
+            actors[i] = AccountConfiguration.InitialActor({
+                actorId: bytes32(bytes20(address(uint160(base + i)))), authenticator: address(k1Authenticator)
+            });
+        }
+    }
+
+    /// @dev chainId is fuzzed over its two accepted domains: 0 (multichain) or the current chain (local).
+    function _acceptedChainId(bool multichain) internal view returns (uint256) {
+        return multichain ? 0 : block.chainid;
+    }
+
+    /// @dev Deploy a MockERC1271Wallet owned by vm.addr(ownerPk) and return it with a valid import signature over the
+    ///      given actors/chainId. The signature is a raw 65-byte r‖s‖v ECDSA blob (what ERC-1271 recover expects).
+    function _walletAndSig(uint256 ownerPk, uint256 chainId, AccountConfiguration.InitialActor[] memory actors)
+        internal
+        returns (MockERC1271Wallet wallet, bytes memory sig)
+    {
+        wallet = new MockERC1271Wallet(vm.addr(ownerPk));
+        bytes32 digest = _computeImportDigest(address(wallet), chainId, actors);
+        sig = _signDigest(ownerPk, digest);
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // REVERTS (source-execution order)
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice Verifies importAccount reverts when the account is hard-locked (onlyUnlocked runs before all else).
+    /// @dev lock() sets unlocksAt = type(uint40).max, so the account stays locked regardless of warp; any non-zero
+    ///      unlock delay locks it. The onlyUnlocked modifier trips before the chainId/sequence/signature checks.
+    function test_importAccount_revert_accountIsLocked(uint256 ownerSeed, uint16 delay, bool multichain) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        vm.assume(delay != 0);
 
         AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(vm.addr(ownerPk));
-        bytes32 digest = _computeImportDigest(address(wallet), actors);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPk, digest);
+        uint256 chainId = _acceptedChainId(multichain);
+        (MockERC1271Wallet wallet, bytes memory sig) = _walletAndSig(ownerPk, chainId, actors);
 
-        accountConfiguration.importAccount(address(wallet), uint64(block.chainid), actors, abi.encodePacked(r, s, v));
+        vm.prank(address(wallet));
+        accountConfiguration.lock(delay);
 
-        assertEq(accountConfiguration.getChangeSequences(address(wallet)).local, 1);
-        assertTrue(accountConfiguration.isActor(address(wallet), bytes32(bytes20(vm.addr(ownerPk)))));
+        vm.expectRevert(AccountConfiguration.AccountIsLocked.selector);
+        accountConfiguration.importAccount(address(wallet), chainId, actors, sig);
     }
 
-    function test_importAccount_revertsOnBadSignature() public {
-        uint256 ownerPk = 700;
-        MockERC1271Wallet wallet = new MockERC1271Wallet(vm.addr(ownerPk));
+    /// @notice Verifies importAccount reverts for a chainId that is neither 0 (multichain) nor the current chain.
+    /// @dev Exercises the `chainId != 0 && chainId != block.chainid` guard, which runs before any signature work.
+    function test_importAccount_revert_invalidChainId(uint256 ownerSeed, uint256 chainIdSeed) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        vm.assume(chainIdSeed != 0 && chainIdSeed != block.chainid);
 
         AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(vm.addr(ownerPk));
-        bytes32 digest = _computeImportDigest(address(wallet), actors);
-        // Sign with a different key so the wallet rejects the signature.
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(701, digest);
+        (MockERC1271Wallet wallet, bytes memory sig) = _walletAndSig(ownerPk, chainIdSeed, actors);
 
-        vm.expectRevert();
-        accountConfiguration.importAccount(address(wallet), uint64(block.chainid), actors, abi.encodePacked(r, s, v));
+        vm.expectRevert(AccountConfiguration.InvalidChainId.selector);
+        accountConfiguration.importAccount(address(wallet), chainIdSeed, actors, sig);
     }
 
-    function test_importAccount_revertsOnReimport() public {
-        uint256 ownerPk = 700;
-        MockERC1271Wallet wallet = new MockERC1271Wallet(vm.addr(ownerPk));
+    /// @notice Verifies importAccount reverts on an already-created account (localSequence == 1).
+    /// @dev A created account is initialized (localSequence doubles as the initialized flag), so the first
+    ///      AlreadyInitialized disjunct trips before the signature is ever checked (empty sig suffices).
+    function test_importAccount_revert_alreadyInitialized_createdAccount(uint256 pkSeed, bool multichain) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        (address account,) = _createK1Account(pk);
+
+        AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(vm.addr(pk));
+        uint256 chainId = _acceptedChainId(multichain);
+
+        vm.expectRevert(AccountConfiguration.AlreadyInitialized.selector);
+        accountConfiguration.importAccount(account, chainId, actors, "");
+    }
+
+    /// @notice Verifies a second importAccount on the same account reverts (localSequence == 1 after first import).
+    /// @dev The re-init guard blocks re-import, which would otherwise re-open a stale key.
+    function test_importAccount_revert_alreadyInitialized_reimport(uint256 ownerSeed, bool multichain) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 chainId = _acceptedChainId(multichain);
 
         AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(vm.addr(ownerPk));
-        bytes32 digest = _computeImportDigest(address(wallet), actors);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPk, digest);
-        bytes memory sig = abi.encodePacked(r, s, v);
+        (MockERC1271Wallet wallet, bytes memory sig) = _walletAndSig(ownerPk, chainId, actors);
 
-        accountConfiguration.importAccount(address(wallet), uint64(block.chainid), actors, sig);
+        accountConfiguration.importAccount(address(wallet), chainId, actors, sig);
 
-        vm.expectRevert();
-        accountConfiguration.importAccount(address(wallet), uint64(block.chainid), actors, sig);
+        vm.expectRevert(AccountConfiguration.AlreadyInitialized.selector);
+        accountConfiguration.importAccount(address(wallet), chainId, actors, sig);
     }
 
-    function test_importAccount_revertsOnCreatedAccount() public {
-        // A created account is already initialized (localSequence == 1), so it cannot be imported.
-        (address account,) = _createK1Account(900);
-
-        AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(vm.addr(901));
-        vm.expectRevert();
-        accountConfiguration.importAccount(account, uint64(block.chainid), actors, "");
-    }
-
-    function test_importAccount_revertsAfterGlobalChange() public {
-        // A code-less 8130 EOA can apply a *global* (chainId 0) actor change signed by its implicit default EOA.
-        // That advances the multichain channel while localSequence stays 0. Import must still be blocked: the gate
-        // now requires *both* sequence channels empty, so an account that has already established 8130 state on the
-        // multichain channel cannot be bootstrapped via import (which would re-open the old key).
-        uint256 eoaPk = 700;
+    /// @notice Verifies importAccount reverts when the multichain channel is non-zero even though localSequence == 0.
+    /// @dev A code-less 8130 EOA can apply a *global* (chainId 0) actor change signed by its implicit default EOA,
+    ///      advancing multichainSequence while localSequence stays 0. Import must still be blocked: the gate requires
+    ///      *both* sequence channels empty, so this exercises the `|| multichainSequence != 0` disjunct.
+    function test_importAccount_revert_alreadyInitialized_afterMultichainChange(uint256 eoaSeed, uint256 deviceSeed)
+        public
+    {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
+        uint256 devicePk = _boundK1Pk(deviceSeed);
         address eoa = vm.addr(eoaPk);
-        address device = vm.addr(701);
+        address device = vm.addr(devicePk);
+        vm.assume(eoa != device);
 
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({
@@ -154,89 +233,305 @@ contract ImportAccountTest is AccountConfigurationTest {
         assertEq(accountConfiguration.getChangeSequences(eoa).multichain, 1);
         assertEq(accountConfiguration.getChangeSequences(eoa).local, 0);
 
-        // Import is gated even though localSequence == 0, because the multichain channel is non-zero.
         AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(device);
         bytes32 importDigest = _computeImportDigest(eoa, actors);
-        vm.expectRevert();
+        vm.expectRevert(AccountConfiguration.AlreadyInitialized.selector);
         accountConfiguration.importAccount(eoa, uint64(block.chainid), actors, _buildK1Auth(eoaPk, importDigest));
     }
 
-    function test_importAccount_revertsWhenLocked() public {
-        uint256 ownerPk = 700;
+    /// @notice Verifies importAccount reverts when the ERC-1271 signer is wrong (magic value not returned).
+    /// @dev Signing with a key other than the wallet owner makes isValidSignature return 0xFFFFFFFF (32-byte
+    ///      returndata), tripping the `abi.decode(result,(bytes4)) != ERC1271_SELECTOR` term.
+    function test_importAccount_revert_invalidImportSignature_wrongSigner(
+        uint256 ownerSeed,
+        uint256 wrongSeed,
+        bool multichain
+    ) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 wrongPk = _boundK1Pk(wrongSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(wrongPk));
+
         MockERC1271Wallet wallet = new MockERC1271Wallet(vm.addr(ownerPk));
-
-        vm.prank(address(wallet));
-        accountConfiguration.lock(1 hours);
-
         AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(vm.addr(ownerPk));
-        bytes32 digest = _computeImportDigest(address(wallet), actors);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPk, digest);
+        uint256 chainId = _acceptedChainId(multichain);
+        bytes32 digest = _computeImportDigest(address(wallet), chainId, actors);
+        bytes memory sig = _signDigest(wrongPk, digest);
 
-        vm.expectRevert();
-        accountConfiguration.importAccount(address(wallet), uint64(block.chainid), actors, abi.encodePacked(r, s, v));
+        vm.expectRevert(AccountConfiguration.InvalidImportSignature.selector);
+        accountConfiguration.importAccount(address(wallet), chainId, actors, sig);
     }
 
-    function test_importAccount_allowsDelegatedAccount() public {
-        // EIP-7702 delegated accounts are no longer rejected: the delegate-indicator check has been removed, so
-        // import is gated solely by the ERC-1271 signature against the (delegated) account's authorization logic.
-        uint256 ownerPk = 700;
+    /// @notice Verifies importAccount reverts when the account's isValidSignature reverts (staticcall fails).
+    /// @dev Exercises the `!success` term of the import signature predicate.
+    function test_importAccount_revert_invalidImportSignature_staticcallReverts(uint256 ownerSeed, bool multichain)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        RevertingERC1271Wallet wallet = new RevertingERC1271Wallet();
+
+        AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(vm.addr(ownerPk));
+        uint256 chainId = _acceptedChainId(multichain);
+        bytes32 digest = _computeImportDigest(address(wallet), chainId, actors);
+        bytes memory sig = _signDigest(ownerPk, digest);
+
+        vm.expectRevert(AccountConfiguration.InvalidImportSignature.selector);
+        accountConfiguration.importAccount(address(wallet), chainId, actors, sig);
+    }
+
+    /// @notice Verifies importAccount reverts against a code-less account (staticcall returns empty returndata).
+    /// @dev A plain EOA has no code, so the staticcall succeeds with zero-length returndata, tripping the
+    ///      `result.length != 32` term (the natural "account has no ERC-1271 implementation" case).
+    function test_importAccount_revert_invalidImportSignature_noCode(uint256 accountSeed, bool multichain) public {
+        uint256 accountPk = _boundK1Pk(accountSeed);
+        address account = vm.addr(accountPk);
+
+        AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(account);
+        uint256 chainId = _acceptedChainId(multichain);
+        bytes32 digest = _computeImportDigest(account, chainId, actors);
+        bytes memory sig = _signDigest(accountPk, digest);
+
+        vm.expectRevert(AccountConfiguration.InvalidImportSignature.selector);
+        accountConfiguration.importAccount(account, chainId, actors, sig);
+    }
+
+    /// @notice Verifies importAccount reverts when isValidSignature returns non-32-byte returndata.
+    /// @dev The wallet returns 4 bytes (the magic word truncated), so the `result.length != 32` term trips before
+    ///      any decode, distinguishing the length guard from the selector guard.
+    function test_importAccount_revert_invalidImportSignature_wrongReturnLength(uint256 ownerSeed, bool multichain)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        ShortReturnERC1271Wallet wallet = new ShortReturnERC1271Wallet();
+
+        AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(vm.addr(ownerPk));
+        uint256 chainId = _acceptedChainId(multichain);
+        bytes32 digest = _computeImportDigest(address(wallet), chainId, actors);
+        bytes memory sig = _signDigest(ownerPk, digest);
+
+        vm.expectRevert(AccountConfiguration.InvalidImportSignature.selector);
+        accountConfiguration.importAccount(address(wallet), chainId, actors, sig);
+    }
+
+    /// @notice Verifies importAccount reverts with NoInitialActors when the actor set is empty.
+    /// @dev The signature check (over the empty-actor digest) passes first, so this exercises the _initializeAccount
+    ///      `initialActors.length == 0` guard reached only after a valid ERC-1271 signature.
+    function test_importAccount_revert_noInitialActors(uint256 ownerSeed, bool multichain) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](0);
+        uint256 chainId = _acceptedChainId(multichain);
+        (MockERC1271Wallet wallet, bytes memory sig) = _walletAndSig(ownerPk, chainId, actors);
+
+        vm.expectRevert(AccountConfiguration.NoInitialActors.selector);
+        accountConfiguration.importAccount(address(wallet), chainId, actors, sig);
+    }
+
+    /// @notice Verifies importAccount reverts when initial actors are not strictly ascending by actorId.
+    /// @dev Exercises the `<` side of the `actorId <= previousActorId` guard in _initializeAccount, reached after a
+    ///      valid import signature over the (unsorted) actor set.
+    function test_importAccount_revert_actorsNotSorted(uint256 ownerSeed, bytes32 idA, bytes32 idB, bool multichain)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        vm.assume(idA != 0 && idB != 0 && idA != idB);
+        bytes32 smaller = idA < idB ? idA : idB;
+        bytes32 larger = idA < idB ? idB : idA;
+
+        AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](2);
+        actors[0] = AccountConfiguration.InitialActor({actorId: larger, authenticator: address(k1Authenticator)});
+        actors[1] = AccountConfiguration.InitialActor({actorId: smaller, authenticator: address(k1Authenticator)});
+
+        uint256 chainId = _acceptedChainId(multichain);
+        (MockERC1271Wallet wallet, bytes memory sig) = _walletAndSig(ownerPk, chainId, actors);
+
+        vm.expectRevert(AccountConfiguration.ActorsNotSortedOrDuplicate.selector);
+        accountConfiguration.importAccount(address(wallet), chainId, actors, sig);
+    }
+
+    /// @notice Verifies importAccount reverts when the initial actor set contains a duplicate actorId.
+    /// @dev Exercises the `==` side of the `actorId <= previousActorId` guard, again reached only after a valid
+    ///      import signature.
+    function test_importAccount_revert_actorsDuplicate(uint256 ownerSeed, bytes32 id, bool multichain) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        vm.assume(id != 0);
+
+        AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](2);
+        actors[0] = AccountConfiguration.InitialActor({actorId: id, authenticator: address(k1Authenticator)});
+        actors[1] = AccountConfiguration.InitialActor({actorId: id, authenticator: address(k1Authenticator)});
+
+        uint256 chainId = _acceptedChainId(multichain);
+        (MockERC1271Wallet wallet, bytes memory sig) = _walletAndSig(ownerPk, chainId, actors);
+
+        vm.expectRevert(AccountConfiguration.ActorsNotSortedOrDuplicate.selector);
+        accountConfiguration.importAccount(address(wallet), chainId, actors, sig);
+    }
+
+    /// @notice Verifies importAccount reverts when an initial actor names an authenticator below the K1 sentinel.
+    /// @dev _authorizeActor rejects authenticator < K1_AUTHENTICATOR; address(0) is the only such value. Reached
+    ///      after a valid import signature over the (address(0)-authenticator) actor set.
+    function test_importAccount_revert_invalidAuthenticator(uint256 ownerSeed, bytes32 actorId, bool multichain)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        vm.assume(actorId != 0);
+
+        AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](1);
+        actors[0] = AccountConfiguration.InitialActor({actorId: actorId, authenticator: address(0)});
+
+        uint256 chainId = _acceptedChainId(multichain);
+        (MockERC1271Wallet wallet, bytes memory sig) = _walletAndSig(ownerPk, chainId, actors);
+
+        vm.expectRevert(AccountConfiguration.InvalidAuthenticator.selector);
+        accountConfiguration.importAccount(address(wallet), chainId, actors, sig);
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // HAPPY / BRANCH PATHS
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice Verifies a valid local-chain (chainId == block.chainid) import via an ERC-1271 wallet succeeds.
+    /// @dev Sets localSequence to 1 and registers the imported actor as live.
+    function test_importAccount_success_validSignatureLocalChain(uint256 ownerSeed) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(vm.addr(ownerPk));
+        (MockERC1271Wallet wallet, bytes memory sig) = _walletAndSig(ownerPk, block.chainid, actors);
+
+        accountConfiguration.importAccount(address(wallet), block.chainid, actors, sig);
+
+        assertEq(accountConfiguration.getChangeSequences(address(wallet)).local, 1);
+        assertTrue(accountConfiguration.isActor(address(wallet), bytes32(bytes20(vm.addr(ownerPk)))));
+    }
+
+    /// @notice Verifies a chainId == 0 (multichain) import signature authorizes import and still sets localSequence.
+    /// @dev The multichain branch of the chainId gate: import is valid on any chain, yet localSequence is set to 1
+    ///      (the local initialized flag) while the multichain channel stays 0 — the source always writes local.
+    function test_importAccount_success_multichainSignature(uint256 ownerSeed) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(vm.addr(ownerPk));
+        (MockERC1271Wallet wallet, bytes memory sig) = _walletAndSig(ownerPk, 0, actors);
+
+        accountConfiguration.importAccount(address(wallet), 0, actors, sig);
+
+        assertEq(accountConfiguration.getChangeSequences(address(wallet)).local, 1);
+        assertEq(accountConfiguration.getChangeSequences(address(wallet)).multichain, 0);
+        assertTrue(accountConfiguration.isActor(address(wallet), bytes32(bytes20(vm.addr(ownerPk)))));
+    }
+
+    /// @notice Verifies importAccount emits AccountImported(account) exactly once on the happy path.
+    /// @dev The event is asserted here (and only here) per the one-event-per-test convention.
+    function test_importAccount_success_emitsAccountImported(uint256 ownerSeed, bool multichain) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(vm.addr(ownerPk));
+        uint256 chainId = _acceptedChainId(multichain);
+        (MockERC1271Wallet wallet, bytes memory sig) = _walletAndSig(ownerPk, chainId, actors);
+
+        vm.expectEmit(true, true, true, true, address(accountConfiguration));
+        emit AccountConfiguration.AccountImported(address(wallet));
+        accountConfiguration.importAccount(address(wallet), chainId, actors, sig);
+    }
+
+    /// @notice Verifies FLAG_REVOKE_DEFAULT_EOA is set after import (the implicit default-EOA self key is disabled).
+    /// @dev With the flag set and no explicit self actor, the account's own self-actorId is not a live actor.
+    function test_importAccount_success_defaultEoaRevokedFlagSet(uint256 ownerSeed, bool multichain) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(vm.addr(ownerPk));
+        uint256 chainId = _acceptedChainId(multichain);
+        (MockERC1271Wallet wallet, bytes memory sig) = _walletAndSig(ownerPk, chainId, actors);
+
+        accountConfiguration.importAccount(address(wallet), chainId, actors, sig);
+
+        // The implicit default EOA (self-actorId) is disabled by default on import.
+        assertFalse(accountConfiguration.isActor(address(wallet), bytes32(bytes20(address(wallet)))));
+        AccountConfiguration.ActorConfig memory selfConfig =
+            accountConfiguration.getActorConfig(address(wallet), bytes32(bytes20(address(wallet))));
+        assertEq(selfConfig.authenticator, address(0));
+    }
+
+    /// @notice Verifies every imported actor is live and registered as an unrestricted k1 owner.
+    /// @dev Exercises the multi-actor branch of _computeImportDigest and _initializeAccount: each actor reports via
+    ///      isActor and getActorConfig with authenticator == K1, scope 0, no expiry, no policy.
+    function test_importAccount_success_importedActorsLive(uint256 ownerSeed, uint256 countSeed, uint256 baseSeed)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 count = bound(countSeed, 1, 8);
+        // Keep the ascending block clear of 0 and clear of the low address range that could collide with sentinels.
+        uint256 base = bound(baseSeed, 1000, type(uint32).max);
+
+        AccountConfiguration.InitialActor[] memory actors = _ascendingK1Actors(count, base);
+        (MockERC1271Wallet wallet, bytes memory sig) = _walletAndSig(ownerPk, block.chainid, actors);
+
+        accountConfiguration.importAccount(address(wallet), block.chainid, actors, sig);
+
+        assertEq(accountConfiguration.getChangeSequences(address(wallet)).local, 1);
+        for (uint256 i; i < count; i++) {
+            bytes32 actorId = actors[i].actorId;
+            assertTrue(accountConfiguration.isActor(address(wallet), actorId));
+            AccountConfiguration.ActorConfig memory config =
+                accountConfiguration.getActorConfig(address(wallet), actorId);
+            assertEq(config.authenticator, address(k1Authenticator));
+            assertEq(config.scope, 0);
+            assertEq(config.expiry, 0);
+            assertEq(config.policyType, 0);
+        }
+    }
+
+    /// @notice Verifies an EIP-7702 delegated account can be imported (delegate-indicator check removed).
+    /// @dev Import is gated solely by the ERC-1271 signature against the delegated account's authorization logic; the
+    ///      distinct device actor is registered and the implicit default EOA is disabled by default on import.
+    function test_importAccount_success_delegatedAccount(uint256 ownerSeed, uint256 deviceSeed) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 devicePk = _boundK1Pk(deviceSeed);
         address eoa = vm.addr(ownerPk);
+        address device = vm.addr(devicePk);
+        vm.assume(eoa != device);
+
         MockERC1271Wallet impl = new MockERC1271Wallet(eoa);
         // Delegate the EOA's code to the ERC-1271 implementation (code = 0xef0100 || delegate).
         vm.etch(eoa, abi.encodePacked(hex"ef0100", address(impl)));
 
-        // Register a distinct device key as the initial actor.
-        address device = vm.addr(701);
-        AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](1);
-        actors[0] = AccountConfiguration.InitialActor({
-            actorId: bytes32(bytes20(device)), authenticator: address(k1Authenticator)
-        });
-
+        AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(device);
         bytes32 digest = _computeImportDigest(eoa, actors);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPk, digest);
+        bytes memory sig = _signDigest(ownerPk, digest);
 
-        accountConfiguration.importAccount(eoa, uint64(block.chainid), actors, abi.encodePacked(r, s, v));
+        accountConfiguration.importAccount(eoa, uint64(block.chainid), actors, sig);
 
         assertEq(accountConfiguration.getChangeSequences(eoa).local, 1);
         assertTrue(accountConfiguration.isActor(eoa, bytes32(bytes20(device))));
-        // The implicit default EOA is disabled by default on import.
         assertFalse(accountConfiguration.isActor(eoa, bytes32(bytes20(eoa))));
     }
 
-    function test_importAccount_7702_selfSignDisablesEoa() public {
-        // A real EIP-7702 EOA delegated to DefaultAccount self-imports using its own (default-EOA) k1 signature.
-        // That implicit full-owner path is the only authenticator available at import time, so this pins the
-        // ordering invariant: the ERC-1271 check must run before the flag is set, and the default EOA is disabled
-        // only after import succeeds.
-        uint256 eoaPk = 700;
+    /// @notice Verifies a real EIP-7702 EOA delegated to DefaultAccount can self-import with its own k1 signature.
+    /// @dev The implicit full-owner path is the only authenticator available at import time, pinning the ordering
+    ///      invariant: the ERC-1271 check runs before the flag is set, and the default EOA is disabled only after
+    ///      import succeeds (its own k1 sig then finds no config and the flag disables the full-owner fallback).
+    function test_importAccount_success_7702_selfSignDisablesEoa(uint256 eoaSeed, uint256 deviceSeed) public {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
+        uint256 devicePk = _boundK1Pk(deviceSeed);
         address eoa = vm.addr(eoaPk);
+        address device = vm.addr(devicePk);
+        vm.assume(eoa != device);
         vm.etch(eoa, abi.encodePacked(hex"ef0100", defaultAccountImplementation));
 
-        address device = vm.addr(701);
-        AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](1);
-        actors[0] = AccountConfiguration.InitialActor({
-            actorId: bytes32(bytes20(device)), authenticator: address(k1Authenticator)
-        });
-
+        AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(device);
         bytes32 digest = _computeImportDigest(eoa, actors);
         // Canonical k1 auth blob: K1_AUTHENTICATOR || signature, signed by the EOA's own key (the implicit owner).
         accountConfiguration.importAccount(eoa, uint64(block.chainid), actors, _buildK1Auth(eoaPk, digest));
 
         assertEq(accountConfiguration.getChangeSequences(eoa).local, 1);
         assertTrue(accountConfiguration.isActor(eoa, bytes32(bytes20(device))));
-        // The implicit default EOA is disabled after import: its own k1 sig now finds no config and the flag
-        // disables the full-owner fallback.
         assertFalse(accountConfiguration.isActor(eoa, bytes32(bytes20(eoa))));
+
+        // The implicit default EOA is disabled after import: its own k1 sig now finds no config.
         bytes32 h = keccak256("post import");
-        vm.expectRevert();
+        vm.expectRevert(AccountConfiguration.DefaultEoaRevoked.selector);
         accountConfiguration.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
     }
 
-    function test_importAccount_7702_keepKeyViaExplicitSelfActor() public {
-        // A live 7702 EOA that wants to keep using its key past import lists the self-actorId as an explicit k1
-        // owner. Import disables the implicit full-owner fallback (sets the flag), but the same key stays a full
-        // owner through its explicit self config — lossless, no extra import option needed.
-        uint256 eoaPk = 700;
+    /// @notice Verifies a live 7702 EOA that lists its self-actorId as an explicit k1 owner keeps its key past import.
+    /// @dev Import disables the implicit full-owner fallback (sets the flag), but the same key stays a full owner
+    ///      through its explicit self config — lossless, resolved via the explicit config rather than the fallback.
+    function test_importAccount_success_7702_keepKeyViaExplicitSelfActor(uint256 eoaSeed) public {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
         vm.etch(eoa, abi.encodePacked(hex"ef0100", defaultAccountImplementation));
 
@@ -252,39 +547,10 @@ contract ImportAccountTest is AccountConfigurationTest {
         // The self-actorId is a live explicit owner.
         assertTrue(accountConfiguration.isActor(eoa, bytes32(bytes20(eoa))));
 
-        // The same key still authenticates as a full owner — now resolved through its explicit self config rather
-        // than the (disabled) implicit fallback.
+        // The same key still authenticates as a full owner — now via its explicit self config, not the (disabled)
+        // implicit fallback.
         bytes32 h = keccak256("post import");
         (uint8 scope,,) = accountConfiguration.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
         assertEq(scope, 0);
-    }
-
-    function test_importAccount_multichainSignatureValid() public {
-        // A chainId == 0 import signature authorizes import on any chain (mirrors the multichain actor-change path).
-        uint256 ownerPk = 700;
-        MockERC1271Wallet wallet = new MockERC1271Wallet(vm.addr(ownerPk));
-
-        AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(vm.addr(ownerPk));
-        bytes32 digest = _computeImportDigest(address(wallet), 0, actors);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPk, digest);
-
-        accountConfiguration.importAccount(address(wallet), 0, actors, abi.encodePacked(r, s, v));
-
-        assertEq(accountConfiguration.getChangeSequences(address(wallet)).local, 1);
-        assertTrue(accountConfiguration.isActor(address(wallet), bytes32(bytes20(vm.addr(ownerPk)))));
-    }
-
-    function test_importAccount_revertsOnForeignChainId() public {
-        // A chainId that is neither 0 nor the current chain is rejected before any signature work.
-        uint256 ownerPk = 700;
-        MockERC1271Wallet wallet = new MockERC1271Wallet(vm.addr(ownerPk));
-        uint256 foreignChainId = block.chainid + 1;
-
-        AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(vm.addr(ownerPk));
-        bytes32 digest = _computeImportDigest(address(wallet), foreignChainId, actors);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPk, digest);
-
-        vm.expectRevert(AccountConfiguration.InvalidChainId.selector);
-        accountConfiguration.importAccount(address(wallet), foreignChainId, actors, abi.encodePacked(r, s, v));
     }
 }

--- a/test/unit/AccountConfiguration/policyAccessors.t.sol
+++ b/test/unit/AccountConfiguration/policyAccessors.t.sol
@@ -4,238 +4,705 @@ pragma solidity ^0.8.30;
 import {AccountConfiguration} from "../../../src/AccountConfiguration.sol";
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 
-/// @notice Unit tests for the granular policy accessors `getPolicyCommitment` and `getPolicyManager`, plus
-///         regression coverage for the `getPolicy` aggregate. The granular accessors are the single-SLOAD reads
-///         intended for the per-tx validation hot path of a policy manager invoked by the protocol-dispatched
-///         8130 tx; the aggregate is the convenience read for off-chain consumers.
+/// @notice Fully-fuzzed unit tests for the policy accessors on `AccountConfiguration`:
+///           - `getPolicy(account, actorId)`           — off-chain aggregate: (policyType, manager, commitment)
+///           - `getPolicyCommitment(account, actorId)` — single-SLOAD hot-path read
+///           - `getPolicyManager(account, actorId)`    — single-SLOAD hot-path read
+///           - `_resolvePolicyTarget(...)`             — internal; exercised via `authenticateActor`'s policyTarget
+///
+///         All four are `view`; there are no events to assert. Every test fuzzes its inputs (managers, commitments,
+///         actorIds, keys, scopes, and the non-zero policyType byte). A policy-bearing (gated) actor requires a
+///         non-zero manager and non-zero commitment (else `_slicePolicy` reverts `InvalidPolicyData`) and a
+///         scope-restricted, non-CONFIG scope (else `_authorizeActor` reverts `InvalidPolicyScope`) — so gated
+///         fuzzing bounds manager/commitment to non-zero and scope to [1,7] (any non-zero value with the 0x08
+///         CONFIG bit clear).
+///
+///         Branch map covered:
+///           getPolicy line ~528  stored.authenticator != 0            -> explicit-actor home (gated + ungated)
+///           getPolicy line ~531  else-if actorId==self && !revoked    -> inline-k1-self home (true; false via revoke)
+///           getPolicy line ~535  else                                  -> unknown actor / revoked self
+///           getPolicy line ~537  policyType == POLICY_NONE early-return -> both sides (gated vs ungated/none)
+///           _resolvePolicyTarget line ~887 policyType == NONE           -> both sides (returns 0 vs returns manager)
 contract PolicyAccessorsTest is AccountConfigurationTest {
-    uint256 internal constant ROOT_PK = 200;
-    uint256 internal constant SESSION_PK = 201;
-    uint256 internal constant EOA_PK = 500;
-
+    uint8 internal constant SCOPE_SIGNER = 0x01;
     uint8 internal constant SCOPE_SENDER = 0x02;
+    uint8 internal constant SCOPE_PAYER = 0x04;
+    uint8 internal constant SCOPE_CONFIG = 0x08;
+
+    uint8 internal constant POLICY_NONE = 0x00;
     uint8 internal constant POLICY_GATED = 0x01;
+
     uint8 internal constant AUTHORIZE_ACTOR = 0x01;
     uint8 internal constant REVOKE_ACTOR = 0x02;
 
-    address internal constant DUMMY_MANAGER = address(0xCAFE);
-    bytes32 internal constant DUMMY_COMMITMENT = bytes32(uint256(0xC0FFEE));
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // getPolicy — explicit (non-self) actor home  (stored.authenticator != 0)
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    // ── Explicit-actor home (non-self actor with policy) ──
+    /// @notice A gated non-self actor: getPolicy returns (policyType, manager, commitment) and the aggregate agrees
+    ///         with the granular accessors. Covers the explicit-actor home and the `policyType != NONE` tail.
+    function test_getPolicy_success_explicitGatedActor(
+        uint256 rootSeed,
+        bytes32 actorId,
+        uint8 scopeSeed,
+        uint8 policyTypeSeed,
+        uint256 managerSeed,
+        uint256 commitmentSeed
+    ) public {
+        uint256 rootPk = _boundK1Pk(rootSeed);
+        (address account,) = _createK1Account(rootPk);
+        actorId = _boundExplicitActorId(account, rootPk, actorId);
 
-    function test_getPolicyCommitment_explicitActor_returnsCommitment() public {
-        (address account,) = _createK1Account(ROOT_PK);
-        bytes32 sessionActorId = bytes32(bytes20(vm.addr(SESSION_PK)));
-        _authorizePolicyActor(account, ROOT_PK, sessionActorId, DUMMY_MANAGER, DUMMY_COMMITMENT);
+        uint8 scope = _boundGatedScope(scopeSeed);
+        uint8 policyType = _boundPolicyType(policyTypeSeed);
+        address manager = _boundNonZeroAddress(managerSeed);
+        bytes32 commitment = _boundNonZeroWord(commitmentSeed);
 
-        assertEq(accountConfiguration.getPolicyCommitment(account, sessionActorId), DUMMY_COMMITMENT);
+        _authorizePolicyActor(account, rootPk, actorId, scope, policyType, manager, commitment);
+
+        (uint8 outType, address outManager, bytes32 outCommitment) = accountConfiguration.getPolicy(account, actorId);
+        assertEq(outType, policyType);
+        assertEq(outManager, manager);
+        assertEq(outCommitment, commitment);
+        // Aggregate agrees with the single-SLOAD granular accessors.
+        assertEq(outManager, accountConfiguration.getPolicyManager(account, actorId));
+        assertEq(outCommitment, accountConfiguration.getPolicyCommitment(account, actorId));
     }
 
-    function test_getPolicyManager_explicitActor_returnsManager() public {
-        (address account,) = _createK1Account(ROOT_PK);
-        bytes32 sessionActorId = bytes32(bytes20(vm.addr(SESSION_PK)));
-        _authorizePolicyActor(account, ROOT_PK, sessionActorId, DUMMY_MANAGER, DUMMY_COMMITMENT);
+    /// @notice A non-self actor authorized with policyType == NONE: getPolicy short-circuits to (0, 0, 0). Covers
+    ///         the explicit-actor home reaching the `policyType == POLICY_NONE` early-return (line ~537, true side).
+    function test_getPolicy_success_ungatedExplicitActor_returnsNone(uint256 rootSeed, bytes32 actorId) public {
+        uint256 rootPk = _boundK1Pk(rootSeed);
+        (address account,) = _createK1Account(rootPk);
+        actorId = _boundExplicitActorId(account, rootPk, actorId);
 
-        assertEq(accountConfiguration.getPolicyManager(account, sessionActorId), DUMMY_MANAGER);
+        _authorizeUngatedActor(account, rootPk, actorId, address(k1Authenticator));
+
+        (uint8 outType, address outManager, bytes32 outCommitment) = accountConfiguration.getPolicy(account, actorId);
+        assertEq(outType, POLICY_NONE);
+        assertEq(outManager, address(0));
+        assertEq(outCommitment, bytes32(0));
     }
 
-    function test_getPolicy_explicitActor_aggregateMatchesGranular() public {
-        (address account,) = _createK1Account(ROOT_PK);
-        bytes32 sessionActorId = bytes32(bytes20(vm.addr(SESSION_PK)));
-        _authorizePolicyActor(account, ROOT_PK, sessionActorId, DUMMY_MANAGER, DUMMY_COMMITMENT);
-
-        (uint8 policyType, address target, bytes32 commitment) = accountConfiguration.getPolicy(account, sessionActorId);
-        assertEq(policyType, POLICY_GATED);
-        assertEq(target, accountConfiguration.getPolicyManager(account, sessionActorId));
-        assertEq(commitment, accountConfiguration.getPolicyCommitment(account, sessionActorId));
-    }
-
-    // ── Inline-k1 self home (self-actorId K1 with policy) ──
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // getPolicy — inline-k1-self home  (else-if actorId == self && !revoked)
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     //
-    // The inline-k1 self lives in AccountState (scope/policyType/expiry), but the policy *manager* and
-    // *commitment* are keyed by actorId in the shared keyspace — so the granular accessors must work
-    // identically to the explicit-actor home. This branch is the one `getPolicy` reaches via its `else if`.
+    // The inline-k1 self stores scope/policyType/expiry in AccountState, but manager/commitment live in the shared
+    // actorId-keyed keyspace — so the accessors must resolve identically to the explicit-actor home. This is the
+    // branch getPolicy reaches through its `else if`.
 
-    function test_getPolicyCommitment_inlineSelf_returnsCommitment() public {
-        address eoa = vm.addr(EOA_PK);
+    /// @notice A gated inline-k1 self: getPolicy returns (policyType, manager, commitment) and agrees with the
+    ///         granular accessors. Covers the inline-self home (else-if true) and the `policyType != NONE` tail.
+    function test_getPolicy_success_inlineSelfGatedActor(
+        uint256 eoaSeed,
+        uint8 scopeSeed,
+        uint8 policyTypeSeed,
+        uint256 managerSeed,
+        uint256 commitmentSeed
+    ) public {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
+        address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
 
-        _authorizeInlineSelfWithPolicy(eoa, EOA_PK, DUMMY_MANAGER, DUMMY_COMMITMENT);
+        uint8 scope = _boundGatedScope(scopeSeed);
+        uint8 policyType = _boundPolicyType(policyTypeSeed);
+        address manager = _boundNonZeroAddress(managerSeed);
+        bytes32 commitment = _boundNonZeroWord(commitmentSeed);
 
-        assertEq(accountConfiguration.getPolicyCommitment(eoa, selfActorId), DUMMY_COMMITMENT);
+        _authorizeInlineSelfWithPolicy(eoa, eoaPk, scope, policyType, manager, commitment);
+
+        (uint8 outType, address outManager, bytes32 outCommitment) = accountConfiguration.getPolicy(eoa, selfActorId);
+        assertEq(outType, policyType);
+        assertEq(outManager, manager);
+        assertEq(outCommitment, commitment);
+        assertEq(outManager, accountConfiguration.getPolicyManager(eoa, selfActorId));
+        assertEq(outCommitment, accountConfiguration.getPolicyCommitment(eoa, selfActorId));
     }
 
-    function test_getPolicyManager_inlineSelf_returnsManager() public {
-        address eoa = vm.addr(EOA_PK);
+    /// @notice A fresh EOA's implicit self (full owner, policyType == NONE): getPolicy short-circuits to (0, 0, 0).
+    ///         Covers the inline-self home (else-if true, no _actorConfig, not revoked) reaching the
+    ///         `policyType == POLICY_NONE` early-return (line ~537, true side) from the inline home.
+    function test_getPolicy_success_inlineSelfUngated_returnsNone(uint256 eoaSeed) public view {
+        address eoa = vm.addr(_boundK1Pk(eoaSeed));
         bytes32 selfActorId = bytes32(bytes20(eoa));
 
-        _authorizeInlineSelfWithPolicy(eoa, EOA_PK, DUMMY_MANAGER, DUMMY_COMMITMENT);
-
-        assertEq(accountConfiguration.getPolicyManager(eoa, selfActorId), DUMMY_MANAGER);
+        (uint8 outType, address outManager, bytes32 outCommitment) = accountConfiguration.getPolicy(eoa, selfActorId);
+        assertEq(outType, POLICY_NONE);
+        assertEq(outManager, address(0));
+        assertEq(outCommitment, bytes32(0));
     }
 
-    function test_getPolicy_inlineSelf_aggregateMatchesGranular() public {
-        address eoa = vm.addr(EOA_PK);
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // getPolicy — else branch  (unknown actor / revoked self)
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice An unknown (never-authorized, non-self) actor: getPolicy takes the else branch and returns (0, 0, 0).
+    ///         No account is created, so this is a pure view over empty state.
+    function test_getPolicy_success_unknownActor_returnsNone(address account, bytes32 actorId) public view {
+        vm.assume(actorId != bytes32(bytes20(account))); // stay off the inline-self else-if
+
+        (uint8 outType, address outManager, bytes32 outCommitment) = accountConfiguration.getPolicy(account, actorId);
+        assertEq(outType, POLICY_NONE);
+        assertEq(outManager, address(0));
+        assertEq(outCommitment, bytes32(0));
+    }
+
+    /// @notice A gated inline self that is then revoked: getPolicy takes the else branch (self actorId, but
+    ///         `!_isDefaultEoaRevoked` is false) and returns (0, 0, 0). Covers the false side of the else-if's
+    ///         `!revoked` sub-condition.
+    function test_getPolicy_success_revokedInlineSelf_returnsNone(
+        uint256 eoaSeed,
+        uint256 ownerSeed,
+        uint8 scopeSeed,
+        uint8 policyTypeSeed,
+        uint256 managerSeed,
+        uint256 commitmentSeed
+    ) public {
+        (address eoa, uint256 ownerPk) = _seedGatedInlineSelfWithSpareOwner(
+            eoaSeed, ownerSeed, scopeSeed, policyTypeSeed, managerSeed, commitmentSeed
+        );
         bytes32 selfActorId = bytes32(bytes20(eoa));
 
-        _authorizeInlineSelfWithPolicy(eoa, EOA_PK, DUMMY_MANAGER, DUMMY_COMMITMENT);
+        // Revoke the (downgraded) self via the spare unrestricted owner; the policy-scoped self cannot sign config.
+        _revokeActor(eoa, ownerPk, selfActorId);
 
-        (uint8 policyType, address target, bytes32 commitment) = accountConfiguration.getPolicy(eoa, selfActorId);
-        assertEq(policyType, POLICY_GATED);
-        assertEq(target, accountConfiguration.getPolicyManager(eoa, selfActorId));
-        assertEq(commitment, accountConfiguration.getPolicyCommitment(eoa, selfActorId));
+        (uint8 outType, address outManager, bytes32 outCommitment) = accountConfiguration.getPolicy(eoa, selfActorId);
+        assertEq(outType, POLICY_NONE);
+        assertEq(outManager, address(0));
+        assertEq(outCommitment, bytes32(0));
     }
 
-    // ── Zero cases (invariant: zero accessor return iff no policy) ──
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // getPolicyManager / getPolicyCommitment — single-SLOAD granular reads
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    function test_getPolicyAccessors_ungatedActor_returnsZero() public {
-        // An actor with policyType == POLICY_NONE never has manager/commitment set (per _authorizeActor's
-        // conditional writes), so the accessors must return zero for it.
-        (address account,) = _createK1Account(ROOT_PK);
-        bytes32 newActorId = bytes32(bytes20(vm.addr(SESSION_PK)));
-        _authorizeUngatedActor(account, ROOT_PK, newActorId, address(k1Authenticator));
+    function test_getPolicyManager_success_explicitGatedActor(
+        uint256 rootSeed,
+        bytes32 actorId,
+        uint8 scopeSeed,
+        uint8 policyTypeSeed,
+        uint256 managerSeed,
+        uint256 commitmentSeed
+    ) public {
+        uint256 rootPk = _boundK1Pk(rootSeed);
+        (address account,) = _createK1Account(rootPk);
+        actorId = _boundExplicitActorId(account, rootPk, actorId);
 
-        assertEq(accountConfiguration.getPolicyCommitment(account, newActorId), bytes32(0));
-        assertEq(accountConfiguration.getPolicyManager(account, newActorId), address(0));
+        address manager = _boundNonZeroAddress(managerSeed);
+        _authorizePolicyActor(
+            account,
+            rootPk,
+            actorId,
+            _boundGatedScope(scopeSeed),
+            _boundPolicyType(policyTypeSeed),
+            manager,
+            _boundNonZeroWord(commitmentSeed)
+        );
+
+        assertEq(accountConfiguration.getPolicyManager(account, actorId), manager);
     }
 
-    function test_getPolicyAccessors_unknownActor_returnsZero() public {
-        (address account,) = _createK1Account(ROOT_PK);
-        bytes32 unknownActorId = bytes32(bytes20(vm.addr(999)));
+    function test_getPolicyCommitment_success_explicitGatedActor(
+        uint256 rootSeed,
+        bytes32 actorId,
+        uint8 scopeSeed,
+        uint8 policyTypeSeed,
+        uint256 managerSeed,
+        uint256 commitmentSeed
+    ) public {
+        uint256 rootPk = _boundK1Pk(rootSeed);
+        (address account,) = _createK1Account(rootPk);
+        actorId = _boundExplicitActorId(account, rootPk, actorId);
 
-        assertEq(accountConfiguration.getPolicyCommitment(account, unknownActorId), bytes32(0));
-        assertEq(accountConfiguration.getPolicyManager(account, unknownActorId), address(0));
+        bytes32 commitment = _boundNonZeroWord(commitmentSeed);
+        _authorizePolicyActor(
+            account,
+            rootPk,
+            actorId,
+            _boundGatedScope(scopeSeed),
+            _boundPolicyType(policyTypeSeed),
+            _boundNonZeroAddress(managerSeed),
+            commitment
+        );
+
+        assertEq(accountConfiguration.getPolicyCommitment(account, actorId), commitment);
     }
 
-    function test_getPolicyAccessors_clearedOnRevoke() public {
-        (address account,) = _createK1Account(ROOT_PK);
-        bytes32 sessionActorId = bytes32(bytes20(vm.addr(SESSION_PK)));
-        _authorizePolicyActor(account, ROOT_PK, sessionActorId, DUMMY_MANAGER, DUMMY_COMMITMENT);
+    function test_getPolicyManager_success_inlineSelfGatedActor(
+        uint256 eoaSeed,
+        uint8 scopeSeed,
+        uint8 policyTypeSeed,
+        uint256 managerSeed,
+        uint256 commitmentSeed
+    ) public {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
+        address eoa = vm.addr(eoaPk);
+        bytes32 selfActorId = bytes32(bytes20(eoa));
+
+        address manager = _boundNonZeroAddress(managerSeed);
+        _authorizeInlineSelfWithPolicy(
+            eoa,
+            eoaPk,
+            _boundGatedScope(scopeSeed),
+            _boundPolicyType(policyTypeSeed),
+            manager,
+            _boundNonZeroWord(commitmentSeed)
+        );
+
+        assertEq(accountConfiguration.getPolicyManager(eoa, selfActorId), manager);
+    }
+
+    function test_getPolicyCommitment_success_inlineSelfGatedActor(
+        uint256 eoaSeed,
+        uint8 scopeSeed,
+        uint8 policyTypeSeed,
+        uint256 managerSeed,
+        uint256 commitmentSeed
+    ) public {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
+        address eoa = vm.addr(eoaPk);
+        bytes32 selfActorId = bytes32(bytes20(eoa));
+
+        bytes32 commitment = _boundNonZeroWord(commitmentSeed);
+        _authorizeInlineSelfWithPolicy(
+            eoa,
+            eoaPk,
+            _boundGatedScope(scopeSeed),
+            _boundPolicyType(policyTypeSeed),
+            _boundNonZeroAddress(managerSeed),
+            commitment
+        );
+
+        assertEq(accountConfiguration.getPolicyCommitment(eoa, selfActorId), commitment);
+    }
+
+    /// @notice An ungated actor never has manager/commitment written (per `_authorizeActor`'s conditional writes),
+    ///         so both granular accessors return zero.
+    function test_getPolicyManager_success_ungatedActor_returnsZero(uint256 rootSeed, bytes32 actorId) public {
+        uint256 rootPk = _boundK1Pk(rootSeed);
+        (address account,) = _createK1Account(rootPk);
+        actorId = _boundExplicitActorId(account, rootPk, actorId);
+
+        _authorizeUngatedActor(account, rootPk, actorId, address(k1Authenticator));
+
+        assertEq(accountConfiguration.getPolicyManager(account, actorId), address(0));
+    }
+
+    function test_getPolicyCommitment_success_ungatedActor_returnsZero(uint256 rootSeed, bytes32 actorId) public {
+        uint256 rootPk = _boundK1Pk(rootSeed);
+        (address account,) = _createK1Account(rootPk);
+        actorId = _boundExplicitActorId(account, rootPk, actorId);
+
+        _authorizeUngatedActor(account, rootPk, actorId, address(k1Authenticator));
+
+        assertEq(accountConfiguration.getPolicyCommitment(account, actorId), bytes32(0));
+    }
+
+    /// @notice An unknown actor's granular slots are empty: both accessors return zero over untouched state.
+    function test_getPolicyManager_success_unknownActor_returnsZero(address account, bytes32 actorId) public view {
+        assertEq(accountConfiguration.getPolicyManager(account, actorId), address(0));
+    }
+
+    function test_getPolicyCommitment_success_unknownActor_returnsZero(address account, bytes32 actorId) public view {
+        assertEq(accountConfiguration.getPolicyCommitment(account, actorId), bytes32(0));
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // Lifecycle — invariant: granular slots non-zero iff policyType non-zero
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice Revoking an explicit gated actor clears both policy slots (`_revokeActor` deletes them).
+    function test_getPolicyAccessors_success_clearedOnRevoke(
+        uint256 rootSeed,
+        bytes32 actorId,
+        uint8 scopeSeed,
+        uint8 policyTypeSeed,
+        uint256 managerSeed,
+        uint256 commitmentSeed
+    ) public {
+        uint256 rootPk = _boundK1Pk(rootSeed);
+        (address account,) = _createK1Account(rootPk);
+        actorId = _boundExplicitActorId(account, rootPk, actorId);
+
+        address manager = _boundNonZeroAddress(managerSeed);
+        bytes32 commitment = _boundNonZeroWord(commitmentSeed);
+        _authorizePolicyActor(
+            account, rootPk, actorId, _boundGatedScope(scopeSeed), _boundPolicyType(policyTypeSeed), manager, commitment
+        );
 
         // Live first.
-        assertEq(accountConfiguration.getPolicyCommitment(account, sessionActorId), DUMMY_COMMITMENT);
-        assertEq(accountConfiguration.getPolicyManager(account, sessionActorId), DUMMY_MANAGER);
+        assertEq(accountConfiguration.getPolicyManager(account, actorId), manager);
+        assertEq(accountConfiguration.getPolicyCommitment(account, actorId), commitment);
 
-        // Revoke clears both slots in _revokeActor.
-        _revokeActor(account, ROOT_PK, sessionActorId);
+        _revokeActor(account, rootPk, actorId);
 
-        assertEq(accountConfiguration.getPolicyCommitment(account, sessionActorId), bytes32(0));
-        assertEq(accountConfiguration.getPolicyManager(account, sessionActorId), address(0));
+        assertEq(accountConfiguration.getPolicyManager(account, actorId), address(0));
+        assertEq(accountConfiguration.getPolicyCommitment(account, actorId), bytes32(0));
     }
 
-    function test_getPolicyAccessors_clearedOnInlineSelfRevoke() public {
-        // Inline self with a policy → revoke → granular accessors return zero. Verifies the cleanup applies to
-        // the shared (actorId-keyed) keyspace from the inline-self home too.
-        address eoa = vm.addr(EOA_PK);
+    /// @notice Revoking a gated inline self clears the shared (actorId-keyed) policy slots too.
+    function test_getPolicyAccessors_success_clearedOnInlineSelfRevoke(
+        uint256 eoaSeed,
+        uint256 ownerSeed,
+        uint8 scopeSeed,
+        uint8 policyTypeSeed,
+        uint256 managerSeed,
+        uint256 commitmentSeed
+    ) public {
+        (address eoa, uint256 ownerPk) = _seedGatedInlineSelfWithSpareOwner(
+            eoaSeed, ownerSeed, scopeSeed, policyTypeSeed, managerSeed, commitmentSeed
+        );
         bytes32 selfActorId = bytes32(bytes20(eoa));
 
-        // Pre-authorize a separate unrestricted-owner key. Once we downgrade the self-actorId to
-        // SCOPE_SENDER + policy below, it no longer carries SCOPE_CONFIG and can't sign the revoke.
-        bytes32 ownerActorId = bytes32(bytes20(vm.addr(SESSION_PK)));
-        _authorizeUngatedActor(eoa, EOA_PK, ownerActorId, address(k1Authenticator));
+        // Live first.
+        assertTrue(accountConfiguration.getPolicyManager(eoa, selfActorId) != address(0));
+        assertTrue(accountConfiguration.getPolicyCommitment(eoa, selfActorId) != bytes32(0));
 
-        _authorizeInlineSelfWithPolicy(eoa, EOA_PK, DUMMY_MANAGER, DUMMY_COMMITMENT);
-        assertEq(accountConfiguration.getPolicyCommitment(eoa, selfActorId), DUMMY_COMMITMENT);
+        _revokeActor(eoa, ownerPk, selfActorId);
 
-        // Revoke self via the unrestricted owner key — the downgraded self can no longer authorize changes.
-        _revokeActor(eoa, SESSION_PK, selfActorId);
-
-        assertEq(accountConfiguration.getPolicyCommitment(eoa, selfActorId), bytes32(0));
         assertEq(accountConfiguration.getPolicyManager(eoa, selfActorId), address(0));
+        assertEq(accountConfiguration.getPolicyCommitment(eoa, selfActorId), bytes32(0));
     }
 
-    function test_getPolicyAccessors_clearedOnReauthorizeToNone() public {
-        // Upsert path: re-authorizing a policy-bearing actor down to POLICY_NONE must clear both policy slots, so no
-        // stale (manager, commitment) leaks and the "commitment non-zero iff policyType non-zero" invariant holds.
-        (address account,) = _createK1Account(ROOT_PK);
-        bytes32 sessionActorId = bytes32(bytes20(vm.addr(SESSION_PK)));
+    /// @notice Re-authorizing a gated actor down to POLICY_NONE clears both policy slots (no stale leak) and the
+    ///         config's policyType/scope fall to zero.
+    function test_getPolicyAccessors_success_clearedOnReauthorizeToNone(
+        uint256 rootSeed,
+        bytes32 actorId,
+        uint8 scopeSeed,
+        uint8 policyTypeSeed,
+        uint256 managerSeed,
+        uint256 commitmentSeed
+    ) public {
+        uint256 rootPk = _boundK1Pk(rootSeed);
+        (address account,) = _createK1Account(rootPk);
+        actorId = _boundExplicitActorId(account, rootPk, actorId);
 
-        _authorizePolicyActor(account, ROOT_PK, sessionActorId, DUMMY_MANAGER, DUMMY_COMMITMENT);
-        assertEq(accountConfiguration.getPolicyCommitment(account, sessionActorId), DUMMY_COMMITMENT);
-        assertEq(accountConfiguration.getPolicyManager(account, sessionActorId), DUMMY_MANAGER);
+        _authorizePolicyActor(
+            account,
+            rootPk,
+            actorId,
+            _boundGatedScope(scopeSeed),
+            _boundPolicyType(policyTypeSeed),
+            _boundNonZeroAddress(managerSeed),
+            _boundNonZeroWord(commitmentSeed)
+        );
 
         // Overwrite the same actor as ungated (policyType == POLICY_NONE).
-        _authorizeUngatedActor(account, ROOT_PK, sessionActorId, address(k1Authenticator));
+        _authorizeUngatedActor(account, rootPk, actorId, address(k1Authenticator));
 
-        assertEq(accountConfiguration.getPolicyCommitment(account, sessionActorId), bytes32(0));
-        assertEq(accountConfiguration.getPolicyManager(account, sessionActorId), address(0));
-        AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, sessionActorId);
-        assertEq(cfg.policyType, 0x00);
-        assertEq(cfg.scope, 0x00);
+        assertEq(accountConfiguration.getPolicyManager(account, actorId), address(0));
+        assertEq(accountConfiguration.getPolicyCommitment(account, actorId), bytes32(0));
+        AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, actorId);
+        assertEq(cfg.policyType, POLICY_NONE);
+        assertEq(cfg.scope, uint8(0x00));
     }
 
-    function test_getPolicyAccessors_updatedOnReauthorizeToNewManager() public {
-        // Upsert to a *different* (manager, commitment) must replace, not merge.
-        (address account,) = _createK1Account(ROOT_PK);
-        bytes32 sessionActorId = bytes32(bytes20(vm.addr(SESSION_PK)));
+    /// @notice Re-authorizing a gated actor to a *different* (manager, commitment) replaces rather than merges.
+    function test_getPolicyAccessors_success_updatedOnReauthorizeToNewManager(
+        uint256 rootSeed,
+        bytes32 actorId,
+        uint8 scopeSeed,
+        uint8 policyTypeSeed,
+        uint256 managerSeed,
+        uint256 commitmentSeed,
+        uint256 newManagerSeed,
+        uint256 newCommitmentSeed
+    ) public {
+        uint256 rootPk = _boundK1Pk(rootSeed);
+        (address account,) = _createK1Account(rootPk);
+        actorId = _boundExplicitActorId(account, rootPk, actorId);
 
-        _authorizePolicyActor(account, ROOT_PK, sessionActorId, DUMMY_MANAGER, DUMMY_COMMITMENT);
+        uint8 scope = _boundGatedScope(scopeSeed);
+        uint8 policyType = _boundPolicyType(policyTypeSeed);
+        address manager = _boundNonZeroAddress(managerSeed);
+        bytes32 commitment = _boundNonZeroWord(commitmentSeed);
+        address newManager = _boundNonZeroAddress(newManagerSeed);
+        bytes32 newCommitment = _boundNonZeroWord(newCommitmentSeed);
+        // Make the update observable.
+        vm.assume(newManager != manager);
+        vm.assume(newCommitment != commitment);
 
-        address newManager = address(0xBEEF);
-        bytes32 newCommitment = bytes32(uint256(0xD00D));
-        _authorizePolicyActor(account, ROOT_PK, sessionActorId, newManager, newCommitment);
+        _authorizePolicyActor(account, rootPk, actorId, scope, policyType, manager, commitment);
+        _authorizePolicyActor(account, rootPk, actorId, scope, policyType, newManager, newCommitment);
 
-        assertEq(accountConfiguration.getPolicyManager(account, sessionActorId), newManager);
-        assertEq(accountConfiguration.getPolicyCommitment(account, sessionActorId), newCommitment);
+        assertEq(accountConfiguration.getPolicyManager(account, actorId), newManager);
+        assertEq(accountConfiguration.getPolicyCommitment(account, actorId), newCommitment);
     }
 
-    // ── Isolation (correct mapping key derivation) ──
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // Isolation — correct (account, actorId) mapping-key derivation
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    function test_getPolicyAccessors_isolatedAcrossActors() public {
-        (address account,) = _createK1Account(ROOT_PK);
-        bytes32 actorA = bytes32(bytes20(vm.addr(SESSION_PK)));
-        bytes32 actorB = bytes32(bytes20(vm.addr(SESSION_PK + 1)));
+    /// @notice Two distinct actors on the same account keep independent (manager, commitment): no cross-actor leak.
+    function test_getPolicyAccessors_success_isolatedAcrossActors(
+        uint256 rootSeed,
+        bytes32 actorA,
+        bytes32 actorB,
+        uint8 scopeSeed,
+        uint8 policyTypeSeed,
+        uint256 managerSeedA,
+        uint256 commitmentSeedA,
+        uint256 managerSeedB,
+        uint256 commitmentSeedB
+    ) public {
+        uint256 rootPk = _boundK1Pk(rootSeed);
+        (address account,) = _createK1Account(rootPk);
+        actorA = _boundExplicitActorId(account, rootPk, actorA);
+        actorB = _boundExplicitActorId(account, rootPk, actorB);
+        vm.assume(actorA != actorB);
 
-        address managerA = address(0xAAAA);
-        address managerB = address(0xBBBB);
-        bytes32 commitmentA = bytes32(uint256(0xA));
-        bytes32 commitmentB = bytes32(uint256(0xB));
+        uint8 scope = _boundGatedScope(scopeSeed);
+        uint8 policyType = _boundPolicyType(policyTypeSeed);
+        address managerA = _boundNonZeroAddress(managerSeedA);
+        bytes32 commitmentA = _boundNonZeroWord(commitmentSeedA);
+        address managerB = _boundNonZeroAddress(managerSeedB);
+        bytes32 commitmentB = _boundNonZeroWord(commitmentSeedB);
 
-        _authorizePolicyActor(account, ROOT_PK, actorA, managerA, commitmentA);
-        _authorizePolicyActor(account, ROOT_PK, actorB, managerB, commitmentB);
+        _authorizePolicyActor(account, rootPk, actorA, scope, policyType, managerA, commitmentA);
+        _authorizePolicyActor(account, rootPk, actorB, scope, policyType, managerB, commitmentB);
 
-        assertEq(accountConfiguration.getPolicyCommitment(account, actorA), commitmentA);
         assertEq(accountConfiguration.getPolicyManager(account, actorA), managerA);
-        assertEq(accountConfiguration.getPolicyCommitment(account, actorB), commitmentB);
+        assertEq(accountConfiguration.getPolicyCommitment(account, actorA), commitmentA);
         assertEq(accountConfiguration.getPolicyManager(account, actorB), managerB);
+        assertEq(accountConfiguration.getPolicyCommitment(account, actorB), commitmentB);
     }
 
-    function test_getPolicyAccessors_isolatedAcrossAccounts() public {
-        // Same actorId across two distinct accounts must yield distinct commitments — verifies the
-        // `(account, actorId)` argument convention resolves the correct nested mapping slot (the inner
-        // mapping is keyed by account, not the outer actorId mapping alone).
-        (address accountA,) = _createK1AccountWithSalt(ROOT_PK, bytes32(uint256(1)));
-        (address accountB,) = _createK1AccountWithSalt(ROOT_PK, bytes32(uint256(2)));
+    /// @notice The same actorId across two distinct accounts resolves to distinct (manager, commitment) — the inner
+    ///         mapping is keyed by account, so nothing leaks across accounts.
+    function test_getPolicyAccessors_success_isolatedAcrossAccounts(
+        uint256 rootSeed,
+        bytes32 saltA,
+        bytes32 saltB,
+        bytes32 sharedActorId,
+        uint8 scopeSeed,
+        uint8 policyTypeSeed,
+        uint256 managerSeedA,
+        uint256 commitmentSeedA,
+        uint256 managerSeedB,
+        uint256 commitmentSeedB
+    ) public {
+        vm.assume(saltA != saltB);
+        uint256 rootPk = _boundK1Pk(rootSeed);
+        (address accountA,) = _createK1AccountWithSalt(rootPk, saltA);
+        (address accountB,) = _createK1AccountWithSalt(rootPk, saltB);
+        bytes32 rootActorId = bytes32(bytes20(vm.addr(rootPk)));
+        // Keep the shared actorId a non-self, non-owner explicit actor on both accounts.
+        vm.assume(sharedActorId != rootActorId);
+        vm.assume(sharedActorId != bytes32(bytes20(accountA)));
+        vm.assume(sharedActorId != bytes32(bytes20(accountB)));
 
-        bytes32 sharedActorId = bytes32(bytes20(vm.addr(SESSION_PK)));
+        uint8 scope = _boundGatedScope(scopeSeed);
+        uint8 policyType = _boundPolicyType(policyTypeSeed);
+        address managerA = _boundNonZeroAddress(managerSeedA);
+        bytes32 commitmentA = _boundNonZeroWord(commitmentSeedA);
+        address managerB = _boundNonZeroAddress(managerSeedB);
+        bytes32 commitmentB = _boundNonZeroWord(commitmentSeedB);
 
-        address managerA = address(0xAAAA);
-        address managerB = address(0xBBBB);
-        bytes32 commitmentA = bytes32(uint256(0xA));
-        bytes32 commitmentB = bytes32(uint256(0xB));
+        _authorizePolicyActor(accountA, rootPk, sharedActorId, scope, policyType, managerA, commitmentA);
+        _authorizePolicyActor(accountB, rootPk, sharedActorId, scope, policyType, managerB, commitmentB);
 
-        _authorizePolicyActor(accountA, ROOT_PK, sharedActorId, managerA, commitmentA);
-        _authorizePolicyActor(accountB, ROOT_PK, sharedActorId, managerB, commitmentB);
-
-        assertEq(accountConfiguration.getPolicyCommitment(accountA, sharedActorId), commitmentA);
         assertEq(accountConfiguration.getPolicyManager(accountA, sharedActorId), managerA);
-        assertEq(accountConfiguration.getPolicyCommitment(accountB, sharedActorId), commitmentB);
+        assertEq(accountConfiguration.getPolicyCommitment(accountA, sharedActorId), commitmentA);
         assertEq(accountConfiguration.getPolicyManager(accountB, sharedActorId), managerB);
+        assertEq(accountConfiguration.getPolicyCommitment(accountB, sharedActorId), commitmentB);
     }
 
-    // ── Helpers ──
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // _resolvePolicyTarget — internal, surfaced as `policyTarget` from authenticateActor
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    //
+    // `_resolvePolicyTarget(account, actorId, policyType)` returns address(0) when policyType == NONE, else the
+    // stored manager. `authenticateActor` returns it verbatim as its third value, so we drive both branches there.
 
-    /// @dev Authorize a non-self actor with a gated (policyType=POLICY_GATED) policy bound to (manager, commitment).
-    ///      Signed by the root key, which is the unrestricted-owner k1 actor installed by `_createK1Account`.
+    /// @notice A gated non-self actor authenticates; policyTarget resolves to the stored manager (policyType != NONE
+    ///         branch). Also equals the granular getPolicyManager read.
+    function test_resolvePolicyTarget_success_gatedExplicitActor_returnsManager(
+        uint256 rootSeed,
+        uint256 sessionSeed,
+        uint8 scopeSeed,
+        uint8 policyTypeSeed,
+        uint256 managerSeed,
+        uint256 commitmentSeed,
+        bytes32 hash
+    ) public {
+        uint256 rootPk = _boundK1Pk(rootSeed);
+        uint256 sessionPk = _boundK1Pk(sessionSeed);
+        vm.assume(vm.addr(rootPk) != vm.addr(sessionPk));
+
+        (address account,) = _createK1Account(rootPk);
+        vm.assume(vm.addr(sessionPk) != account); // stay off the inline-self path
+        bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
+
+        uint8 policyType = _boundPolicyType(policyTypeSeed);
+        address manager = _boundNonZeroAddress(managerSeed);
+        _authorizePolicyActor(
+            account,
+            rootPk,
+            sessionActorId,
+            _boundGatedScope(scopeSeed),
+            policyType,
+            manager,
+            _boundNonZeroWord(commitmentSeed)
+        );
+
+        (uint8 outScope, uint8 outPolicyType, address policyTarget) =
+            accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
+        assertTrue(outScope != 0);
+        assertEq(outPolicyType, policyType);
+        assertEq(policyTarget, manager);
+        assertEq(policyTarget, accountConfiguration.getPolicyManager(account, sessionActorId));
+    }
+
+    /// @notice An ungated non-self actor authenticates; policyType == NONE short-circuits _resolvePolicyTarget to
+    ///         address(0) (the NONE branch).
+    function test_resolvePolicyTarget_success_ungatedActor_returnsZero(
+        uint256 rootSeed,
+        uint256 sessionSeed,
+        bytes32 hash
+    ) public {
+        uint256 rootPk = _boundK1Pk(rootSeed);
+        uint256 sessionPk = _boundK1Pk(sessionSeed);
+        vm.assume(vm.addr(rootPk) != vm.addr(sessionPk));
+
+        (address account,) = _createK1Account(rootPk);
+        vm.assume(vm.addr(sessionPk) != account);
+        bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
+
+        _authorizeUngatedActor(account, rootPk, sessionActorId, address(k1Authenticator));
+
+        (, uint8 outPolicyType, address policyTarget) =
+            accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
+        assertEq(outPolicyType, POLICY_NONE);
+        assertEq(policyTarget, address(0));
+    }
+
+    /// @notice A gated inline self authenticates; policyTarget resolves to the stored manager via the inline home.
+    function test_resolvePolicyTarget_success_inlineSelfGated_returnsManager(
+        uint256 eoaSeed,
+        uint8 scopeSeed,
+        uint8 policyTypeSeed,
+        uint256 managerSeed,
+        uint256 commitmentSeed,
+        bytes32 hash
+    ) public {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
+        address eoa = vm.addr(eoaPk);
+        bytes32 selfActorId = bytes32(bytes20(eoa));
+
+        uint8 policyType = _boundPolicyType(policyTypeSeed);
+        address manager = _boundNonZeroAddress(managerSeed);
+        _authorizeInlineSelfWithPolicy(
+            eoa, eoaPk, _boundGatedScope(scopeSeed), policyType, manager, _boundNonZeroWord(commitmentSeed)
+        );
+
+        (, uint8 outPolicyType, address policyTarget) =
+            accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        assertEq(outPolicyType, policyType);
+        assertEq(policyTarget, manager);
+        assertEq(policyTarget, accountConfiguration.getPolicyManager(eoa, selfActorId));
+    }
+
+    /// @notice A fresh EOA (implicit full owner, policyType == NONE) authenticates; _resolvePolicyTarget returns
+    ///         address(0) via the NONE branch, over untouched state.
+    function test_resolvePolicyTarget_success_inlineSelfFullOwner_returnsZero(uint256 eoaSeed, bytes32 hash)
+        public
+        view
+    {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
+        address eoa = vm.addr(eoaPk);
+
+        (uint8 outScope, uint8 outPolicyType, address policyTarget) =
+            accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        assertEq(outScope, uint8(0x00));
+        assertEq(outPolicyType, POLICY_NONE);
+        assertEq(policyTarget, address(0));
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // Fuzz-input bounding helpers
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @dev A policy-bearing actor's scope: non-zero and without the CONFIG bit — i.e. [1,7]. Any value in that
+    ///      range satisfies `_authorizeActor`'s `scope != 0 && scope & SCOPE_CONFIG == 0` guard.
+    function _boundGatedScope(uint8 seed) internal pure returns (uint8) {
+        return uint8(bound(uint256(seed), 1, 7));
+    }
+
+    /// @dev A non-zero policy sub-type byte. The protocol treats any non-zero policyType as gated; the specific
+    ///      value is opaque and reserved for manager semantics, so fuzzing the full [1,255] range is valid.
+    function _boundPolicyType(uint8 seed) internal pure returns (uint8) {
+        return uint8(bound(uint256(seed), 1, 255));
+    }
+
+    /// @dev A non-zero policy manager address (`_slicePolicy` rejects a zero manager for a gated actor).
+    function _boundNonZeroAddress(uint256 seed) internal pure returns (address) {
+        return address(uint160(bound(seed, 1, type(uint160).max)));
+    }
+
+    /// @dev A non-zero policy commitment word (`_slicePolicy` rejects a zero commitment for a gated actor).
+    function _boundNonZeroWord(uint256 seed) internal pure returns (bytes32) {
+        return bytes32(bound(seed, 1, type(uint256).max));
+    }
+
+    /// @dev Constrain a fuzzed actorId to a non-self, non-owner explicit-actor key on `account`: distinct from the
+    ///      self-actorId (which would route to the inline-self home) and from the root owner's actorId (which would
+    ///      overwrite the owner). actorId is otherwise an opaque bytes32 the protocol does not format-check.
+    function _boundExplicitActorId(address account, uint256 rootPk, bytes32 actorId) internal pure returns (bytes32) {
+        vm.assume(actorId != bytes32(bytes20(account)));
+        vm.assume(actorId != bytes32(bytes20(vm.addr(rootPk))));
+        return actorId;
+    }
+
+    /// @dev Seed a gated inline-k1 self plus a spare unrestricted owner able to sign a later self-revoke. Returns
+    ///      (eoa, spareOwnerPk). The self is downgraded to a policy scope (no CONFIG bit) and thus cannot sign
+    ///      config changes, so the spare owner is what revokes it.
+    function _seedGatedInlineSelfWithSpareOwner(
+        uint256 eoaSeed,
+        uint256 ownerSeed,
+        uint8 scopeSeed,
+        uint8 policyTypeSeed,
+        uint256 managerSeed,
+        uint256 commitmentSeed
+    ) internal returns (address eoa, uint256 ownerPk) {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
+        ownerPk = _boundK1Pk(ownerSeed);
+        vm.assume(vm.addr(eoaPk) != vm.addr(ownerPk));
+        eoa = vm.addr(eoaPk);
+        bytes32 ownerActorId = bytes32(bytes20(vm.addr(ownerPk)));
+        vm.assume(ownerActorId != bytes32(bytes20(eoa)));
+
+        // Pre-authorize the spare unrestricted owner (signed by the still-full-owner self).
+        _authorizeUngatedActor(eoa, eoaPk, ownerActorId, address(k1Authenticator));
+
+        // Downgrade the self to a gated policy actor (signed by the still-full-owner self).
+        _authorizeInlineSelfWithPolicy(
+            eoa,
+            eoaPk,
+            _boundGatedScope(scopeSeed),
+            _boundPolicyType(policyTypeSeed),
+            _boundNonZeroAddress(managerSeed),
+            _boundNonZeroWord(commitmentSeed)
+        );
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // Actor-change helpers (signed applySignedActorChanges wrappers)
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @dev Authorize a non-self actor with a gated policy bound to (manager, commitment), signed by the root owner.
     function _authorizePolicyActor(
         address account,
         uint256 rootPk,
         bytes32 actorId,
+        uint8 scope,
+        uint8 policyType,
         address policyManager,
         bytes32 commitment
     ) internal {
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: SCOPE_SENDER, expiry: 0, policyType: POLICY_GATED
+            authenticator: address(k1Authenticator), scope: scope, expiry: 0, policyType: policyType
         });
         bytes memory policyData = abi.encodePacked(policyManager, commitment);
 
@@ -251,19 +718,20 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         );
     }
 
-    /// @dev Authorize the EOA's self-actorId as a scoped k1 actor carrying a policy. The EOA is not
-    ///      createAccount'd, so the implicit default-EOA owner (all-zero inline) signs the change; the resulting
-    ///      authorization lives in the inline-k1 self home (`_accountState`), with (manager, commitment) in the
-    ///      shared actorId-keyed keyspace.
-    function _authorizeInlineSelfWithPolicy(address eoa, uint256 eoaPk, address policyManager, bytes32 commitment)
-        internal
-    {
+    /// @dev Authorize the EOA's self-actorId as a scoped k1 actor carrying a gated policy. The EOA is not
+    ///      createAccount'd, so the implicit default-EOA owner signs the change; the authorization lives in the
+    ///      inline-k1 self home (`_accountState`) with (manager, commitment) in the shared actorId-keyed keyspace.
+    function _authorizeInlineSelfWithPolicy(
+        address eoa,
+        uint256 eoaPk,
+        uint8 scope,
+        uint8 policyType,
+        address policyManager,
+        bytes32 commitment
+    ) internal {
         bytes32 selfActorId = bytes32(bytes20(eoa));
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: accountConfiguration.K1_AUTHENTICATOR(),
-            scope: SCOPE_SENDER,
-            expiry: 0,
-            policyType: POLICY_GATED
+            authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: scope, expiry: 0, policyType: policyType
         });
         bytes memory policyData = abi.encodePacked(policyManager, commitment);
 
@@ -277,6 +745,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), changes, _buildK1Auth(eoaPk, digest));
     }
 
+    /// @dev Authorize an ungated (scope 0, policyType NONE) actor under `authenticator`, signed by `pk`.
     function _authorizeUngatedActor(address account, uint256 pk, bytes32 newActorId, address authenticator) internal {
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({
@@ -294,6 +763,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));
     }
 
+    /// @dev Revoke `actorId` from `account`, signed by `pk`.
     function _revokeActor(address account, uint256 pk, bytes32 actorId) internal {
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({actorId: actorId, changeType: REVOKE_ACTOR, data: ""});

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -5,6 +5,8 @@ import {DefaultAccount, Call} from "../../../src/accounts/DefaultAccount.sol";
 import {AccountConfiguration} from "../../../src/AccountConfiguration.sol";
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 
+/// @dev Minimal call target: a payable state setter and an unconditional reverter, used to exercise both the
+///      success and failure legs of the low-level call inside executeBatch.
 contract MockTarget {
     uint256 public value;
 
@@ -19,6 +21,18 @@ contract MockTarget {
 
 contract DefaultAccountTest is AccountConfigurationTest {
     uint256 constant ACTOR_PK = 100;
+
+    // ERC-1271 magic values returned by isValidSignature.
+    bytes4 constant ERC1271_MAGIC = 0x1626ba7e;
+    bytes4 constant ERC1271_FAIL = 0xFFFFFFFF;
+
+    // Scope bits: SIGNER gates isValidSignature; SENDER is a non-signing scope.
+    uint8 constant SCOPE_SIGNER = 0x01;
+    uint8 constant SCOPE_SENDER = 0x02;
+
+    // TRUSTED_EXECUTOR sentinel: the authenticator value that marks an actor as a direct-execution caller.
+    address constant TRUSTED_EXECUTOR = address(uint160(uint256(keccak256("trustedExecutor"))));
+
     MockTarget public target;
 
     function setUp() public override {
@@ -31,98 +45,357 @@ contract DefaultAccountTest is AccountConfigurationTest {
         calls[0] = Call(t, v, d);
     }
 
-    // ── Caller management ──
-
-    function test_selfIsAlwaysAuthorized() public {
-        (address account,) = _createK1Account(ACTOR_PK);
-        assertTrue(DefaultAccount(payable(account)).isAuthorizedCaller(account));
+    /// @dev Authorize an actor with unrestricted scope on `account`, signed by `pk`.
+    function _authorizeActor(address account, uint256 pk, bytes32 newActorId, address authenticator) internal {
+        _authorizeActorWithScope(account, pk, newActorId, authenticator, 0x00);
     }
 
-    // ── executeBatch ──
+    /// @dev Authorize an actor with a given scope, signed by `pk`. Used to register both TRUSTED_EXECUTOR actors and
+    ///      scoped k1 actors from the account owner.
+    function _authorizeActorWithScope(
+        address account,
+        uint256 pk,
+        bytes32 newActorId,
+        address authenticator,
+        uint8 scope
+    ) internal {
+        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
+        changes[0] = AccountConfiguration.ActorChange({
+            actorId: newActorId,
+            changeType: 0x01,
+            data: abi.encode(
+                AccountConfiguration.ActorConfig({
+                    authenticator: authenticator, scope: scope, expiry: 0, policyType: 0x00
+                }),
+                bytes("")
+            )
+        });
 
-    function test_executeBatch_success() public {
+        uint64 seq = accountConfiguration.getChangeSequences(account).local;
+        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
+        bytes memory auth = _buildK1Auth(pk, digest);
+
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+    }
+
+    // ══════════════════════════════════════════════
+    //  executeBatch — reverts (source order)
+    // ══════════════════════════════════════════════
+
+    /// @notice Any caller that is neither the account itself nor a registered trusted executor reverts.
+    /// @dev Exercises the false leg of `require(_isAuthorizedCaller(msg.sender))`; fuzzes caller/value/data.
+    function test_executeBatch_revert_unauthorizedCaller(address caller, uint256 value, bytes calldata data) public {
+        (address account,) = _createK1Account(ACTOR_PK);
+        vm.assume(caller != account);
+        value = bound(value, 0, type(uint128).max);
+
+        vm.prank(caller);
+        vm.expectRevert();
+        DefaultAccount(payable(account)).executeBatch(_singleCall(address(target), value, data));
+    }
+
+    /// @notice The account owner's own EOA key holder cannot drive executeBatch directly.
+    /// @dev The owner is a k1 actor (authenticator == K1), not TRUSTED_EXECUTOR, so _isAuthorizedCaller is false.
+    function test_executeBatch_revert_ownerEoaCallerUnauthorized(uint256 pkSeed) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        (address account,) = _createK1Account(pk);
+        address owner = vm.addr(pk);
+        vm.assume(owner != account);
+
+        vm.prank(owner);
+        vm.expectRevert();
+        DefaultAccount(payable(account))
+            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (1))));
+    }
+
+    /// @notice A registered actor whose authenticator is K1 (not the TRUSTED_EXECUTOR sentinel) cannot call.
+    /// @dev Only the TRUSTED_EXECUTOR sentinel authorizes calls; an ordinary k1 actor does not.
+    function test_executeBatch_revert_nonExecutorActorCaller(uint256 actorSeed) public {
+        (address account,) = _createK1Account(ACTOR_PK);
+
+        uint256 actorPk = _boundK1Pk(actorSeed);
+        address actor = vm.addr(actorPk);
+        vm.assume(actor != account && actor != vm.addr(ACTOR_PK));
+
+        // Register `actor` as an ordinary k1 actor (authenticator == K1_AUTHENTICATOR), NOT a trusted executor.
+        _authorizeActor(account, ACTOR_PK, bytes32(bytes20(actor)), k1Authenticator);
+
+        vm.prank(actor);
+        vm.expectRevert();
+        DefaultAccount(payable(account))
+            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (1))));
+    }
+
+    /// @notice A failing inner call aborts the whole batch.
+    /// @dev Exercises the false leg of `require(success)`; fuzzes the ETH value carried by the failing call.
+    function test_executeBatch_revert_failedInnerCall(uint256 value) public {
+        (address account,) = _createK1Account(ACTOR_PK);
+        value = bound(value, 0, 1e24);
+        vm.deal(account, value);
+
+        vm.prank(account);
+        vm.expectRevert();
+        DefaultAccount(payable(account))
+            .executeBatch(_singleCall(address(target), value, abi.encodeCall(MockTarget.reverting, ())));
+    }
+
+    /// @notice A failed call late in the batch rolls back state written by earlier successful calls.
+    /// @dev The whole executeBatch reverts, so the earlier setValue is rolled back.
+    function test_executeBatch_revert_failedInnerCallRollsBackPriorState(uint256 v) public {
+        (address account,) = _createK1Account(ACTOR_PK);
+        v = bound(v, 1, type(uint256).max); // non-zero so the rollback assertion is meaningful
+
+        Call[] memory calls = new Call[](2);
+        calls[0] = Call(address(target), 0, abi.encodeCall(MockTarget.setValue, (v)));
+        calls[1] = Call(address(target), 0, abi.encodeCall(MockTarget.reverting, ()));
+
+        vm.prank(account);
+        vm.expectRevert();
+        DefaultAccount(payable(account)).executeBatch(calls);
+
+        assertEq(target.value(), 0);
+    }
+
+    // ══════════════════════════════════════════════
+    //  executeBatch — happy paths
+    // ══════════════════════════════════════════════
+
+    /// @notice An empty calls array succeeds without entering the loop body.
+    /// @dev Covers the loop-not-entered branch: authorization passes and no inner call is made.
+    function test_executeBatch_success_emptyCalls() public {
+        (address account,) = _createK1Account(ACTOR_PK);
+
+        Call[] memory calls = new Call[](0);
+        vm.prank(account);
+        DefaultAccount(payable(account)).executeBatch(calls);
+
+        assertEq(target.value(), 0);
+    }
+
+    /// @notice The account calling itself executes a single inner call.
+    /// @dev Covers the `caller == address(this)` authorization branch and one successful loop iteration.
+    function test_executeBatch_success_selfCaller(uint256 v) public {
         (address account,) = _createK1Account(ACTOR_PK);
 
         vm.prank(account);
         DefaultAccount(payable(account))
-            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (42))));
+            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (v))));
 
-        assertEq(target.value(), 42);
+        assertEq(target.value(), v);
     }
 
-    function test_executeBatch_withETHValue() public {
+    /// @notice Executing a call that forwards ETH transfers the value to the target.
+    /// @dev Fuzzes the forwarded amount bounded to the account balance; confirms `call{value:}` wiring.
+    function test_executeBatch_success_withETHValue(uint256 amount) public {
         (address account,) = _createK1Account(ACTOR_PK);
-        vm.deal(account, 1 ether);
+        amount = bound(amount, 0, 1e30);
+        vm.deal(account, amount);
 
         vm.prank(account);
         DefaultAccount(payable(account))
-            .executeBatch(_singleCall(address(target), 0.5 ether, abi.encodeCall(MockTarget.setValue, (1))));
+            .executeBatch(_singleCall(address(target), amount, abi.encodeCall(MockTarget.setValue, (7))));
 
-        assertEq(address(target).balance, 0.5 ether);
+        assertEq(address(target).balance, amount);
+        assertEq(account.balance, 0);
+        assertEq(target.value(), 7);
     }
 
-    function test_executeBatch_multipleCalls() public {
+    /// @notice A batch with multiple calls executes every element in order.
+    /// @dev Covers the loop iterating more than once across two distinct targets with fuzzed values.
+    function test_executeBatch_success_multipleCalls(uint256 a, uint256 b) public {
         (address account,) = _createK1Account(ACTOR_PK);
+        a = bound(a, 0, 1e27);
+        b = bound(b, 0, 1e27);
+        vm.deal(account, a + b);
+
         MockTarget target2 = new MockTarget();
 
         Call[] memory calls = new Call[](2);
-        calls[0] = Call(address(target), 0, abi.encodeCall(MockTarget.setValue, (10)));
-        calls[1] = Call(address(target2), 0, abi.encodeCall(MockTarget.setValue, (20)));
+        calls[0] = Call(address(target), a, abi.encodeCall(MockTarget.setValue, (10)));
+        calls[1] = Call(address(target2), b, abi.encodeCall(MockTarget.setValue, (20)));
 
         vm.prank(account);
         DefaultAccount(payable(account)).executeBatch(calls);
 
         assertEq(target.value(), 10);
         assertEq(target2.value(), 20);
+        assertEq(address(target).balance, a);
+        assertEq(address(target2).balance, b);
     }
 
-    function test_executeBatch_revertsFromUnauthorizedCaller() public {
+    /// @notice A registered TRUSTED_EXECUTOR actor may drive execution directly by matching msg.sender.
+    /// @dev Covers the config-driven authorization branch: getActorConfig(...).authenticator == TRUSTED_EXECUTOR.
+    function test_executeBatch_success_trustedExecutor(uint256 execSeed, uint256 v) public {
         (address account,) = _createK1Account(ACTOR_PK);
 
-        vm.prank(address(0xdead));
-        vm.expectRevert();
+        address executor = address(uint160(bound(execSeed, 10, type(uint160).max)));
+        vm.assume(executor != account && executor != vm.addr(ACTOR_PK));
+
+        // The owner signs an actor change registering `executor` with the TRUSTED_EXECUTOR authenticator.
+        _authorizeActor(account, ACTOR_PK, bytes32(bytes20(executor)), TRUSTED_EXECUTOR);
+
+        vm.prank(executor);
         DefaultAccount(payable(account))
-            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (1))));
+            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (v))));
+
+        assertEq(target.value(), v);
     }
 
-    function test_executeBatch_revertsOnFailedCall() public {
+    /// @notice A call to a target with no code succeeds (the low-level call returns success).
+    /// @dev executeBatch does not verify the target has code, so codeless targets return success.
+    function test_executeBatch_success_callToCodelessTarget(address t) public {
         (address account,) = _createK1Account(ACTOR_PK);
+        vm.assume(uint160(t) > 0xffff); // stay clear of all precompiles (which may revert on arbitrary calldata)
+        vm.assume(t != account && t != address(vm) && t.code.length == 0);
 
         vm.prank(account);
-        vm.expectRevert();
-        DefaultAccount(payable(account))
-            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.reverting, ())));
+        DefaultAccount(payable(account)).executeBatch(_singleCall(t, 0, abi.encodeCall(MockTarget.setValue, (1))));
+
+        assertEq(t.code.length, 0);
     }
 
-    // ── isValidSignature ──
+    // ══════════════════════════════════════════════
+    //  isValidSignature — failure returns (0xFFFFFFFF)
+    // ══════════════════════════════════════════════
 
-    function test_isValidSignature_validK1() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice A signature from a key that is not a registered actor returns the failure magic value.
+    /// @dev authenticateActor reverts (AuthenticatorMismatch/DefaultEoaRevoked), caught by verifySignature -> false.
+    function test_isValidSignature_success_returnsFailureForWrongKey(uint256 ownerSeed, uint256 wrongSeed, bytes32 hash)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 wrongPk = _boundK1Pk(wrongSeed);
+        (address account,) = _createK1Account(ownerPk);
+        vm.assume(vm.addr(wrongPk) != vm.addr(ownerPk) && vm.addr(wrongPk) != account);
 
-        bytes32 hash = keccak256("validate me");
-        bytes memory authData = _buildK1Auth(ACTOR_PK, hash);
+        bytes memory authData = _buildK1Auth(wrongPk, hash);
 
         bytes4 result = DefaultAccount(payable(account)).isValidSignature(hash, authData);
-        assertEq(result, bytes4(0x1626ba7e));
+        assertEq(result, ERC1271_FAIL);
     }
 
-    function test_isValidSignature_invalidSignature() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice A valid signature from an actor holding a non-signing scope returns the failure magic value.
+    /// @dev verifySignature is false when scope != 0 and SCOPE_SIGNER is unset (here SCOPE_SENDER only).
+    function test_isValidSignature_success_returnsFailureForNonSignerScope(
+        uint256 ownerSeed,
+        uint256 actorSeed,
+        bytes32 hash
+    ) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        (address account,) = _createK1Account(ownerPk);
 
-        bytes32 hash = keccak256("validate me");
-        bytes memory authData = _buildK1Auth(999, hash);
+        uint256 actorPk = _boundK1Pk(actorSeed);
+        address actor = vm.addr(actorPk);
+        vm.assume(actor != vm.addr(ownerPk) && actor != account);
+
+        // Authorize the actor with SENDER scope only — it can act but cannot validate signatures.
+        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(actor)), k1Authenticator, SCOPE_SENDER);
+
+        bytes memory authData = _buildK1Auth(actorPk, hash);
 
         bytes4 result = DefaultAccount(payable(account)).isValidSignature(hash, authData);
-        assertEq(result, bytes4(0xFFFFFFFF));
+        assertEq(result, ERC1271_FAIL);
     }
 
-    function test_isValidSignature_unknownActorId() public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice A signature blob shorter than the 20-byte authenticator prefix returns the failure magic value.
+    /// @dev authenticateActor reverts InvalidAuthLength, which verifySignature catches and reports as false.
+    function test_isValidSignature_success_returnsFailureForShortSignature(
+        uint256 ownerSeed,
+        uint8 lenSeed,
+        bytes32 hash
+    ) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        (address account,) = _createK1Account(ownerPk);
 
-        bytes32 hash = keccak256("validate me");
-        bytes memory authData = _buildK1Auth(999, hash);
+        uint256 len = bound(lenSeed, 0, 19);
+        bytes memory shortSig = new bytes(len);
+
+        bytes4 result = DefaultAccount(payable(account)).isValidSignature(hash, shortSig);
+        assertEq(result, ERC1271_FAIL);
+    }
+
+    // ══════════════════════════════════════════════
+    //  isValidSignature — success returns (0x1626ba7e)
+    // ══════════════════════════════════════════════
+
+    /// @notice A valid signature from the unrestricted owner returns the ERC-1271 magic value.
+    /// @dev verifySignature is true because the owner actor has scope == 0 (unrestricted). Fuzzes key and hash.
+    function test_isValidSignature_success_validK1Owner(uint256 pkSeed, bytes32 hash) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        (address account,) = _createK1Account(pk);
+
+        bytes memory authData = _buildK1Auth(pk, hash);
 
         bytes4 result = DefaultAccount(payable(account)).isValidSignature(hash, authData);
-        assertEq(result, bytes4(0xFFFFFFFF));
+        assertEq(result, ERC1271_MAGIC);
+    }
+
+    /// @notice A valid signature from an actor explicitly scoped SCOPE_SIGNER returns the magic value.
+    /// @dev Covers the `scope & SCOPE_SIGNER != 0` leg of verifySignature (as opposed to the scope == 0 leg).
+    function test_isValidSignature_success_scopedSignerActor(uint256 ownerSeed, uint256 actorSeed, bytes32 hash)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        (address account,) = _createK1Account(ownerPk);
+
+        uint256 actorPk = _boundK1Pk(actorSeed);
+        address actor = vm.addr(actorPk);
+        vm.assume(actor != vm.addr(ownerPk) && actor != account);
+
+        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(actor)), k1Authenticator, SCOPE_SIGNER);
+
+        bytes memory authData = _buildK1Auth(actorPk, hash);
+
+        bytes4 result = DefaultAccount(payable(account)).isValidSignature(hash, authData);
+        assertEq(result, ERC1271_MAGIC);
+    }
+
+    // ══════════════════════════════════════════════
+    //  isAuthorizedCaller
+    // ══════════════════════════════════════════════
+
+    /// @notice The account is always authorized to call itself.
+    /// @dev Covers the hardcoded `caller == address(this)` branch. Fuzzes the owner key to vary the account.
+    function test_isAuthorizedCaller_success_self(uint256 pkSeed) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        (address account,) = _createK1Account(pk);
+
+        assertTrue(DefaultAccount(payable(account)).isAuthorizedCaller(account));
+    }
+
+    /// @notice A registered TRUSTED_EXECUTOR actor is reported as authorized.
+    /// @dev Covers the config-driven true branch: getActorConfig(...).authenticator == TRUSTED_EXECUTOR.
+    function test_isAuthorizedCaller_success_trustedExecutor(uint256 execSeed) public {
+        (address account,) = _createK1Account(ACTOR_PK);
+
+        address executor = address(uint160(bound(execSeed, 10, type(uint160).max)));
+        vm.assume(executor != account && executor != vm.addr(ACTOR_PK));
+
+        _authorizeActor(account, ACTOR_PK, bytes32(bytes20(executor)), TRUSTED_EXECUTOR);
+
+        assertTrue(DefaultAccount(payable(account)).isAuthorizedCaller(executor));
+    }
+
+    /// @notice A registered k1 actor (authenticator != TRUSTED_EXECUTOR) is not an authorized caller.
+    /// @dev Covers the config-driven false branch: a configured actor whose authenticator is the K1 sentinel.
+    function test_isAuthorizedCaller_success_k1ActorNotAuthorized(uint256 actorSeed) public {
+        (address account,) = _createK1Account(ACTOR_PK);
+
+        uint256 actorPk = _boundK1Pk(actorSeed);
+        address actor = vm.addr(actorPk);
+        vm.assume(actor != account && actor != vm.addr(ACTOR_PK));
+
+        _authorizeActor(account, ACTOR_PK, bytes32(bytes20(actor)), k1Authenticator);
+
+        assertFalse(DefaultAccount(payable(account)).isAuthorizedCaller(actor));
+    }
+
+    /// @notice An arbitrary unregistered caller is not authorized.
+    /// @dev Covers the config-driven false branch for an empty config (authenticator == address(0)). Fuzzes caller.
+    function test_isAuthorizedCaller_success_randomCallerNotAuthorized(address caller) public {
+        (address account,) = _createK1Account(ACTOR_PK);
+        vm.assume(caller != account);
+
+        assertFalse(DefaultAccount(payable(account)).isAuthorizedCaller(caller));
     }
 }

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -4,126 +4,165 @@ pragma solidity ^0.8.30;
 import {AccountConfiguration} from "../../../src/AccountConfiguration.sol";
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 
+/// @notice Fuzzed, branch-complete test suite for DelegateAuthenticator.authenticate.
+///
+///         Source data layout: delegate_address(20) ‖ nested_authenticator(20) ‖ nested_data.
+///         Guards, in source-execution order (all bare `require`, so assert with vm.expectRevert()):
+///           1. require(data.length >= 40)
+///           2. require(nestedAuthenticator != address(this))   // blocks 1-hop recursion
+///           3. require(ACCOUNT_CONFIGURATION.verifySignature(delegate, hash, nestedAuth))
+///         On success returns actorId = bytes32(bytes20(delegate)).
+///
+///         verifySignature(delegate, hash, nestedAuth) is true iff the nested auth resolves to a live
+///         actor on `delegate` whose scope is unrestricted (0x00) or carries SCOPE_SIGNER.
 contract DelegateAuthenticatorTest is AccountConfigurationTest {
-    uint256 constant DELEGATE_PK = 42;
-    uint256 constant DELEGATOR_PK = 43;
+    uint8 constant SCOPE_SIGNER = 0x01;
+    uint8 constant SCOPE_SENDER = 0x02;
+    uint8 constant SCOPE_PAYER = 0x04;
+    uint8 constant SCOPE_CONFIG = 0x08;
+    uint8 constant AUTHORIZE_ACTOR = 0x01;
 
-    function test_authenticate_validDelegation() public {
-        (address delegateAccount,) = _createK1Account(DELEGATE_PK);
+    // ── Guard 1: require(data.length >= 40) ──
 
-        address delegateSigner = vm.addr(DELEGATOR_PK);
-        bytes32 delegatorActorId = bytes32(bytes20(delegateSigner));
-        bytes32 delegateRefActorId = bytes32(bytes20(delegateAccount));
-
-        AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](2);
-        if (delegatorActorId < delegateRefActorId) {
-            actors[0] =
-                AccountConfiguration.InitialActor({actorId: delegatorActorId, authenticator: address(k1Authenticator)});
-            actors[1] = AccountConfiguration.InitialActor({
-                actorId: delegateRefActorId, authenticator: address(delegateAuthenticator)
-            });
-        } else {
-            actors[0] = AccountConfiguration.InitialActor({
-                actorId: delegateRefActorId, authenticator: address(delegateAuthenticator)
-            });
-            actors[1] =
-                AccountConfiguration.InitialActor({actorId: delegatorActorId, authenticator: address(k1Authenticator)});
+    /// @dev Any data shorter than 40 bytes reverts before the delegate/nested slices are read.
+    ///      Fuzzes the full [0,39] length range (including the 39-byte boundary) and the byte content.
+    function test_authenticate_revert_dataTooShort(bytes32 hash, uint256 lenSeed, uint256 fillSeed) public {
+        uint256 len = bound(lenSeed, 0, 39);
+        bytes memory data = new bytes(len);
+        for (uint256 i; i < len; i++) {
+            data[i] = bytes1(uint8(uint256(keccak256(abi.encode(fillSeed, i)))));
         }
 
-        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
-        accountConfiguration.createAccount(bytes32(uint256(1)), bytecode, actors);
-
-        bytes32 hash = keccak256("delegate test");
-        bytes memory delegateSig = _signDigest(DELEGATE_PK, hash);
-
-        // Nested auth: k1Authenticator(20) || sig
-        bytes memory nestedAuth = abi.encodePacked(address(k1Authenticator), delegateSig);
-        // delegate data: delegate_address(20) || nestedAuth
-        bytes memory data = abi.encodePacked(delegateAccount, nestedAuth);
-
-        bytes32 actorId = delegateAuthenticator.authenticate(hash, data);
-        assertEq(actorId, delegateRefActorId);
+        vm.expectRevert();
+        delegateAuthenticator.authenticate(hash, data);
     }
 
-    function test_authenticate_revertsOnTooShortData() public {
-        bytes32 hash = keccak256("test");
+    // ── Guard 2: require(nestedAuthenticator != address(this)) — 1-hop recursion block ──
+
+    /// @dev A nested authenticator equal to the DelegateAuthenticator itself is rejected regardless of
+    ///      delegate address or trailing nested data (data is >= 40 bytes so guard 1 passes first).
+    function test_authenticate_revert_selfNestedAuthenticator(address delegate, bytes32 hash, bytes calldata tail)
+        public
+    {
+        address self = address(delegateAuthenticator);
+        bytes memory data = abi.encodePacked(delegate, self, tail);
+        assertGe(data.length, 40);
 
         vm.expectRevert();
-        delegateAuthenticator.authenticate(hash, hex"");
+        delegateAuthenticator.authenticate(hash, data);
     }
 
-    function test_authenticate_revertsOnUnauthorizedNestedActor() public {
-        (address delegateAccount,) = _createK1Account(DELEGATE_PK);
+    // ── Guard 3: require(verifySignature(...)) ──
 
-        bytes32 hash = keccak256("test");
+    /// @dev A well-formed k1 nested auth whose recovered signer is not an actor on the delegate account
+    ///      makes verifySignature return false (authenticateActor reverts, caught as false).
+    function test_authenticate_revert_invalidNestedSignature(uint256 ownerSeed, uint256 wrongSeed, bytes32 hash)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 wrongPk = _boundK1Pk(wrongSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(wrongPk));
 
-        bytes memory fakeSig = _signDigest(999, hash);
-        // Nested auth with wrong signer — authenticator recovers wrong address
-        bytes memory nestedAuth = abi.encodePacked(address(k1Authenticator), fakeSig);
+        (address delegateAccount,) = _createK1Account(ownerPk);
+
+        // Signature by a key that is not authorized on the delegate account.
+        bytes memory nestedAuth = abi.encodePacked(k1Authenticator, _signDigest(wrongPk, hash));
         bytes memory data = abi.encodePacked(delegateAccount, nestedAuth);
 
         vm.expectRevert();
         delegateAuthenticator.authenticate(hash, data);
     }
 
-    function test_authenticate_revertsOnDoubleDelegate() public {
-        (address accountA,) = _createK1Account(DELEGATE_PK);
+    /// @dev The nested signature is valid for account A's owner, but the delegate passed is account B, where
+    ///      that signer is not an actor. Confirms the delegate address scopes verification: verifySignature
+    ///      returns false and guard 3 reverts.
+    function test_authenticate_revert_delegateMismatch(uint256 ownerASeed, uint256 ownerBSeed, bytes32 hash) public {
+        uint256 ownerAPk = _boundK1Pk(ownerASeed);
+        uint256 ownerBPk = _boundK1Pk(ownerBSeed);
+        vm.assume(vm.addr(ownerAPk) != vm.addr(ownerBPk));
 
-        bytes32 delegateRefA = bytes32(bytes20(accountA));
-        AccountConfiguration.InitialActor[] memory actorsB = new AccountConfiguration.InitialActor[](1);
-        actorsB[0] =
-            AccountConfiguration.InitialActor({actorId: delegateRefA, authenticator: address(delegateAuthenticator)});
-        bytes memory bytecodeB = _computeERC1167Bytecode(defaultAccountImplementation);
-        address accountB = accountConfiguration.createAccount(bytes32(uint256(10)), bytecodeB, actorsB);
+        (address accountA,) = _createK1AccountWithSalt(ownerAPk, bytes32(uint256(1)));
+        (address accountB,) = _createK1AccountWithSalt(ownerBPk, bytes32(uint256(2)));
+        vm.assume(accountA != accountB);
 
-        bytes32 hash = keccak256("double delegate test");
-        bytes memory k1Sig = _signDigest(DELEGATE_PK, hash);
+        // Valid owner-A signature, but delegate = account B (owner A is not an actor on B).
+        bytes memory nestedAuth = abi.encodePacked(k1Authenticator, _signDigest(ownerAPk, hash));
+        bytes memory data = abi.encodePacked(accountB, nestedAuth);
 
-        // Single-hop B → A: should work
-        bytes memory nestedAuth = abi.encodePacked(address(k1Authenticator), k1Sig);
-        bytes memory singleHopData = abi.encodePacked(accountA, nestedAuth);
-        bytes32 actorId = delegateAuthenticator.authenticate(hash, singleHopData);
-        assertEq(actorId, delegateRefA);
-
-        // Double-hop: try to use accountB as delegate — 1-hop limit triggers
-        bytes memory doubleHopData = abi.encodePacked(accountB, nestedAuth);
-        vm.expectRevert();
-        delegateAuthenticator.authenticate(hash, doubleHopData);
-    }
-
-    function test_authenticate_revertsWhenNestedSignerLacksSignatureScope() public {
-        // Account B: unrestricted owner (DELEGATE_PK) plus a second key scoped to PAYER only.
-        (address delegateAccount,) = _createK1Account(DELEGATE_PK);
-        _authorizeScopedK1Actor(delegateAccount, DELEGATE_PK, DELEGATOR_PK, SCOPE_PAYER);
-
-        bytes32 hash = keccak256("scoped delegate test");
-        // The PAYER-only key is a valid, bound actor on B, but lacks SIGNATURE scope.
-        bytes memory nestedAuth = abi.encodePacked(address(k1Authenticator), _signDigest(DELEGATOR_PK, hash));
-        bytes memory data = abi.encodePacked(delegateAccount, nestedAuth);
-
-        // Delegation now gates SCOPE_SIGNER (verifySignature), so a non-SIGNATURE key must revert.
         vm.expectRevert();
         delegateAuthenticator.authenticate(hash, data);
     }
 
-    function test_authenticate_succeedsWhenNestedSignerHasSignatureScope() public {
-        (address delegateAccount,) = _createK1Account(DELEGATE_PK);
-        _authorizeScopedK1Actor(delegateAccount, DELEGATE_PK, DELEGATOR_PK, SCOPE_SIGNER);
+    /// @dev A nested signer that is a live actor on the delegate account but holds a non-zero scope lacking
+    ///      SCOPE_SIGNER (e.g. PAYER/SENDER/CONFIG combinations) fails verifySignature and guard 3 reverts.
+    function test_authenticate_revert_nestedSignerLacksSignerScope(
+        uint256 ownerSeed,
+        uint256 signerSeed,
+        uint8 scopeSeed,
+        bytes32 hash
+    ) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 signerPk = _boundK1Pk(signerSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(signerPk));
 
-        bytes32 hash = keccak256("scoped delegate test");
-        bytes memory nestedAuth = abi.encodePacked(address(k1Authenticator), _signDigest(DELEGATOR_PK, hash));
+        // Non-zero scope with the SIGNER bit cleared → verifySignature must return false.
+        uint8 scope = uint8(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_SIGNER;
+        vm.assume(scope != 0);
+
+        (address delegateAccount,) = _createK1Account(ownerPk);
+        _authorizeScopedK1Actor(delegateAccount, ownerPk, signerPk, scope);
+
+        bytes memory nestedAuth = abi.encodePacked(k1Authenticator, _signDigest(signerPk, hash));
+        bytes memory data = abi.encodePacked(delegateAccount, nestedAuth);
+
+        vm.expectRevert();
+        delegateAuthenticator.authenticate(hash, data);
+    }
+
+    // ── Happy paths ──
+
+    /// @dev An unrestricted (scope 0x00) initial owner passes verifySignature via the `scope == 0` branch;
+    ///      authenticate returns actorId = bytes32(bytes20(delegate)).
+    function test_authenticate_success_unrestrictedNestedSigner(uint256 ownerSeed, bytes32 hash) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        (address delegateAccount,) = _createK1Account(ownerPk);
+
+        bytes memory nestedAuth = abi.encodePacked(k1Authenticator, _signDigest(ownerPk, hash));
         bytes memory data = abi.encodePacked(delegateAccount, nestedAuth);
 
         bytes32 actorId = delegateAuthenticator.authenticate(hash, data);
         assertEq(actorId, bytes32(bytes20(delegateAccount)));
     }
 
-    uint8 constant SCOPE_SIGNER = 0x01;
-    uint8 constant SCOPE_PAYER = 0x04;
-    uint8 constant AUTHORIZE_ACTOR = 0x01;
+    /// @dev A scoped actor whose scope carries the SCOPE_SIGNER bit passes verifySignature via the
+    ///      `scope & SCOPE_SIGNER != 0` branch; authenticate returns actorId = bytes32(bytes20(delegate)).
+    function test_authenticate_success_signerScopedNestedSigner(
+        uint256 ownerSeed,
+        uint256 signerSeed,
+        uint8 scopeSeed,
+        bytes32 hash
+    ) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 signerPk = _boundK1Pk(signerSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(signerPk));
 
-    /// @dev Authorizes a new K1 actor (`newPk`) with `scope` on `account`, signed by the
-    ///      unrestricted owner (`ownerPk`) via applySignedActorChanges on the local chain.
+        // Any scope with the SIGNER bit set (always non-zero) → verifySignature true via the SIGNER branch.
+        uint8 scope = uint8(bound(uint256(scopeSeed), 0, 255)) | SCOPE_SIGNER;
+
+        (address delegateAccount,) = _createK1Account(ownerPk);
+        _authorizeScopedK1Actor(delegateAccount, ownerPk, signerPk, scope);
+
+        bytes memory nestedAuth = abi.encodePacked(k1Authenticator, _signDigest(signerPk, hash));
+        bytes memory data = abi.encodePacked(delegateAccount, nestedAuth);
+
+        bytes32 actorId = delegateAuthenticator.authenticate(hash, data);
+        assertEq(actorId, bytes32(bytes20(delegateAccount)));
+    }
+
+    // ── Helpers ──
+
+    /// @dev Authorizes a new K1 actor (`newPk`) with `scope` on `account`, signed by the unrestricted
+    ///      owner (`ownerPk`) via applySignedActorChanges on the local chain.
     function _authorizeScopedK1Actor(address account, uint256 ownerPk, uint256 newPk, uint8 scope) internal {
         AccountConfiguration.ActorConfig memory config = AccountConfiguration.ActorConfig({
             authenticator: address(k1Authenticator), scope: scope, expiry: 0, policyType: 0

--- a/test/unit/authenticators/P256Authenticator.t.sol
+++ b/test/unit/authenticators/P256Authenticator.t.sol
@@ -1,76 +1,235 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {Math} from "openzeppelin/utils/math/Math.sol";
+import {P256} from "openzeppelin/utils/cryptography/P256.sol";
+
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 
+/// @notice P256Authenticator tests. Data layout: r(32) ‖ s(32) ‖ x(32) ‖ y(32) ‖ preHash(1) = 129 bytes.
+///         The authenticator reverts on wrong length, returns actorId = keccak256(x‖y) on a valid signature, and
+///         returns bytes32(0) on any verification failure (it never reverts on a bad-but-well-formed signature).
 contract P256AuthenticatorTest is AccountConfigurationTest {
-    uint256 constant P256_PK = 0xdead00000000000000000000000000000000000000000000000000000000beef;
+    // ── revert: length guard (require(data.length == 129)) ──
 
-    function _p256ActorId(uint256 pk) internal returns (bytes32 actorId, bytes32 pubX, bytes32 pubY) {
-        (uint256 x, uint256 y) = vm.publicKeyP256(pk);
-        pubX = bytes32(x);
-        pubY = bytes32(y);
-        actorId = keccak256(abi.encodePacked(pubX, pubY));
-    }
-
-    function _p256SignData(uint256 pk, bytes32 hash) internal returns (bytes memory) {
-        (bytes32 pubX, bytes32 pubY) = (bytes32(0), bytes32(0));
-        {
-            (uint256 x, uint256 y) = vm.publicKeyP256(pk);
-            pubX = bytes32(x);
-            pubY = bytes32(y);
-        }
-        (bytes32 r, bytes32 s) = vm.signP256(pk, hash);
-        return abi.encodePacked(r, s, pubX, pubY, uint8(0));
-    }
-
-    function test_authenticate_validSignature() public {
-        (bytes32 expectedActorId,,) = _p256ActorId(P256_PK);
-        bytes32 hash = keccak256("test p256 message");
-        bytes memory data = _p256SignData(P256_PK, hash);
-
-        bytes32 actorId = p256Authenticator.authenticate(hash, data);
-        assertEq(actorId, expectedActorId);
-    }
-
-    function test_authenticate_wrongHash() public {
-        bytes32 hash = keccak256("test p256 message");
-        bytes32 wrongHash = keccak256("wrong message");
-        bytes memory data = _p256SignData(P256_PK, hash);
-
-        bytes32 actorId = p256Authenticator.authenticate(wrongHash, data);
-        assertEq(actorId, bytes32(0));
-    }
-
-    function test_authenticate_revertsWithWrongDataLength() public {
-        bytes32 hash = keccak256("test");
-
+    /// @notice Reverts for any calldata whose length is not exactly 129 bytes.
+    /// @dev Fuzz confirms no length other than 129 is accepted; bare require reverts with empty data.
+    function test_authenticate_revert_wrongDataLength(bytes memory data) public {
+        vm.assume(data.length != 129);
         vm.expectRevert();
-        p256Authenticator.authenticate(hash, hex"deadbeef");
+        p256Authenticator.authenticate(keccak256("h"), data);
     }
 
-    function test_authenticate_exactlyRequires129Bytes() public {
-        (bytes32 expectedActorId,,) = _p256ActorId(P256_PK);
-        bytes32 hash = keccak256("test");
-        bytes memory data = _p256SignData(P256_PK, hash);
+    /// @notice Reverts at exactly one byte short (128).
+    /// @dev Boundary below the required length.
+    function test_authenticate_revert_length128(uint256 pk, bytes32 hash) public {
+        pk = _boundP256Pk(pk);
+        bytes memory data = _p256SignData(pk, hash);
+        bytes memory short = new bytes(128);
+        for (uint256 i; i < 128; ++i) {
+            short[i] = data[i];
+        }
+        vm.expectRevert();
+        p256Authenticator.authenticate(hash, short);
+    }
 
-        assertEq(data.length, 129);
+    /// @notice Reverts at exactly one byte long (130).
+    /// @dev Boundary above the required length.
+    function test_authenticate_revert_length130(uint256 pk, bytes32 hash) public {
+        pk = _boundP256Pk(pk);
+        bytes memory data = abi.encodePacked(_p256SignData(pk, hash), uint8(0));
+        assertEq(data.length, 130);
+        vm.expectRevert();
+        p256Authenticator.authenticate(hash, data);
+    }
+
+    // ── success: valid signature returns actorId ──
+
+    /// @notice A valid P-256 signature over `hash` returns keccak256(x‖y).
+    /// @dev Fuzzes the key and the message; low-s normalized so OZ P256.verify accepts.
+    function test_authenticate_success_validSignatureReturnsActorId(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        bytes memory data = _p256SignData(pk, hash);
+
         bytes32 actorId = p256Authenticator.authenticate(hash, data);
-        assertEq(actorId, expectedActorId);
+
+        assertEq(actorId, _p256ActorId(pk));
+        assertTrue(actorId != bytes32(0));
     }
 
-    function test_authenticate_differentPrivateKeys() public {
-        uint256 pk2 = 0x1234000000000000000000000000000000000000000000000000000000005678;
-        (bytes32 actorId1,,) = _p256ActorId(P256_PK);
-        (bytes32 actorId2,,) = _p256ActorId(pk2);
+    /// @notice actorId is exactly keccak256(x‖y) of the signing key.
+    /// @dev A change to this derivation would rebind every existing P-256 actor's identity.
+    function test_authenticate_success_actorIdIsKeccakOfPubKey(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        (bytes32 x, bytes32 y) = _p256PubKey(pk);
+        bytes memory data = _p256SignData(pk, hash);
 
-        assertTrue(actorId1 != actorId2);
+        assertEq(p256Authenticator.authenticate(hash, data), keccak256(abi.encodePacked(x, y)));
+    }
 
-        bytes32 hash = keccak256("test");
-        bytes memory data1 = _p256SignData(P256_PK, hash);
-        bytes memory data2 = _p256SignData(pk2, hash);
+    /// @notice Distinct keys produce distinct actorIds for the same message.
+    /// @dev Guards against actorId collisions across keys.
+    function test_authenticate_success_distinctKeysDistinctActorIds(uint256 pk1, uint256 pk2, bytes32 hash)
+        public
+        view
+    {
+        pk1 = _boundP256Pk(pk1);
+        pk2 = _boundP256Pk(pk2);
+        vm.assume(pk1 != pk2);
 
-        assertEq(p256Authenticator.authenticate(hash, data1), actorId1);
-        assertEq(p256Authenticator.authenticate(hash, data2), actorId2);
+        bytes32 id1 = p256Authenticator.authenticate(hash, _p256SignData(pk1, hash));
+        bytes32 id2 = p256Authenticator.authenticate(hash, _p256SignData(pk2, hash));
+
+        assertTrue(id1 != id2);
+    }
+
+    /// @notice The trailing preHash byte is not validated; any value still authenticates.
+    /// @dev Documents that data[128] is inert in this implementation.
+    function test_authenticate_success_preHashByteIgnored(uint256 pk, bytes32 hash, uint8 preByte) public view {
+        pk = _boundP256Pk(pk);
+        (bytes32 x, bytes32 y) = _p256PubKey(pk);
+        (bytes32 r, bytes32 s) = vm.signP256(pk, hash);
+        s = bytes32(Math.min(uint256(s), P256.N - uint256(s)));
+        bytes memory data = abi.encodePacked(r, s, x, y, preByte);
+
+        assertEq(p256Authenticator.authenticate(hash, data), _p256ActorId(pk));
+    }
+
+    // ── success: verification failures return bytes32(0) (no revert) ──
+
+    /// @notice Returns zero when the signature is over a different hash.
+    /// @dev Signature bound to message: verifying a different hash must fail.
+    function test_authenticate_success_wrongHashReturnsZero(uint256 pk, bytes32 hash, bytes32 wrongHash) public view {
+        pk = _boundP256Pk(pk);
+        vm.assume(hash != wrongHash);
+        bytes memory data = _p256SignData(pk, hash);
+
+        assertEq(p256Authenticator.authenticate(wrongHash, data), bytes32(0));
+    }
+
+    /// @notice Returns zero for a high-s (malleable) signature.
+    /// @dev OZ P256.verify rejects s > n/2; a mirrored signature must not authenticate.
+    function test_authenticate_success_highSReturnsZero(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        bytes memory data = _p256SignDataHighS(pk, hash);
+
+        assertEq(p256Authenticator.authenticate(hash, data), bytes32(0));
+    }
+
+    /// @notice Returns zero when s == 0.
+    /// @dev Degenerate scalar must be rejected by the verifier.
+    function test_authenticate_success_zeroSReturnsZero(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        (bytes32 x, bytes32 y) = _p256PubKey(pk);
+        (bytes32 r,) = vm.signP256(pk, hash);
+        bytes memory data = abi.encodePacked(r, bytes32(0), x, y, uint8(0));
+
+        assertEq(p256Authenticator.authenticate(hash, data), bytes32(0));
+    }
+
+    /// @notice Returns zero when r == 0.
+    /// @dev Degenerate scalar must be rejected by the verifier.
+    function test_authenticate_success_zeroRReturnsZero(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        (bytes32 x, bytes32 y) = _p256PubKey(pk);
+        (, bytes32 s) = vm.signP256(pk, hash);
+        s = bytes32(Math.min(uint256(s), P256.N - uint256(s)));
+        bytes memory data = abi.encodePacked(bytes32(0), s, x, y, uint8(0));
+
+        assertEq(p256Authenticator.authenticate(hash, data), bytes32(0));
+    }
+
+    /// @notice Returns zero when r or s equals the curve order n.
+    /// @dev Out-of-range scalars must be rejected.
+    function test_authenticate_success_scalarEqualsOrderReturnsZero(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        (bytes32 x, bytes32 y) = _p256PubKey(pk);
+
+        bytes memory rEqN = abi.encodePacked(bytes32(P256.N), bytes32(uint256(1)), x, y, uint8(0));
+        assertEq(p256Authenticator.authenticate(hash, rEqN), bytes32(0));
+
+        bytes memory sEqN = abi.encodePacked(bytes32(uint256(1)), bytes32(P256.N), x, y, uint8(0));
+        assertEq(p256Authenticator.authenticate(hash, sEqN), bytes32(0));
+    }
+
+    /// @notice Returns zero when the signature is valid but paired with a different public key.
+    /// @dev The verifier binds signature to the supplied key; substituting a foreign key must fail.
+    function test_authenticate_success_wrongPubKeyReturnsZero(uint256 pk, uint256 pk2, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        pk2 = _boundP256Pk(pk2);
+        vm.assume(pk != pk2);
+
+        (bytes32 r, bytes32 s) = vm.signP256(pk, hash);
+        s = bytes32(Math.min(uint256(s), P256.N - uint256(s)));
+        (bytes32 x2, bytes32 y2) = _p256PubKey(pk2);
+        bytes memory data = abi.encodePacked(r, s, x2, y2, uint8(0));
+
+        assertEq(p256Authenticator.authenticate(hash, data), bytes32(0));
+    }
+
+    /// @notice Returns zero for a public key that is not a point on the P-256 curve.
+    /// @dev Off-curve keys must never authenticate.
+    function test_authenticate_success_offCurvePubKeyReturnsZero(uint256 pk, bytes32 hash, bytes32 badX, bytes32 badY)
+        public
+        view
+    {
+        pk = _boundP256Pk(pk);
+        // Exclude the (astronomically unlikely) case that (badX, badY) is actually on-curve for this signature.
+        (bytes32 r, bytes32 s) = vm.signP256(pk, hash);
+        s = bytes32(Math.min(uint256(s), P256.N - uint256(s)));
+        bytes memory data = abi.encodePacked(r, s, badX, badY, uint8(0));
+
+        assertEq(p256Authenticator.authenticate(hash, data), bytes32(0));
+    }
+
+    /// @notice Returns zero for the zero public key (0,0) and never leaks keccak256(0,0) as an actorId.
+    /// @dev (0,0) is the uninitialized-key value; accepting it would let an unset credential authenticate.
+    function test_authenticate_success_zeroPubKeyReturnsZero(bytes32 hash, bytes32 r, bytes32 s) public view {
+        bytes memory data = abi.encodePacked(r, s, bytes32(0), bytes32(0), uint8(0));
+
+        bytes32 actorId = p256Authenticator.authenticate(hash, data);
+        assertEq(actorId, bytes32(0));
+        assertTrue(actorId != keccak256(abi.encodePacked(bytes32(0), bytes32(0))));
+    }
+
+    /// @notice Returns zero for out-of-field public-key coordinates (x = y = 2^256-1).
+    /// @dev Exercises the verifier's public-key range validation.
+    function test_authenticate_success_maxCoordsReturnZero(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        (bytes32 r, bytes32 s) = vm.signP256(pk, hash);
+        s = bytes32(Math.min(uint256(s), P256.N - uint256(s)));
+        bytes memory data = abi.encodePacked(r, s, bytes32(type(uint256).max), bytes32(type(uint256).max), uint8(0));
+
+        assertEq(p256Authenticator.authenticate(hash, data), bytes32(0));
+    }
+
+    /// @notice Returns zero for an all-zero 129-byte blob (r = s = x = y = 0).
+    /// @dev Length is valid so no revert; every scalar/coordinate is degenerate.
+    function test_authenticate_success_allZeroBlobReturnsZero(bytes32 hash) public view {
+        bytes memory data = new bytes(129);
+        assertEq(p256Authenticator.authenticate(hash, data), bytes32(0));
+    }
+
+    /// @notice Returns zero when s is just above the low-s cutoff (n/2 + 1).
+    /// @dev Tightens the malleability boundary beyond the high-s mirror; s just over n/2 must be rejected.
+    function test_authenticate_success_sJustAboveHalfOrderReturnsZero(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        (bytes32 x, bytes32 y) = _p256PubKey(pk);
+        bytes memory data = abi.encodePacked(bytes32(uint256(1)), bytes32(P256.N / 2 + 1), x, y, uint8(0));
+
+        assertEq(p256Authenticator.authenticate(hash, data), bytes32(0));
+    }
+
+    /// @notice Returns zero when r or s exceeds the curve order n.
+    /// @dev Out-of-range scalars (> n, not just == n) must be rejected.
+    function test_authenticate_success_scalarAboveOrderReturnsZero(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        (bytes32 x, bytes32 y) = _p256PubKey(pk);
+
+        bytes memory rHi = abi.encodePacked(bytes32(P256.N + 1), bytes32(uint256(1)), x, y, uint8(0));
+        assertEq(p256Authenticator.authenticate(hash, rHi), bytes32(0));
+
+        bytes memory sHi = abi.encodePacked(bytes32(uint256(1)), bytes32(P256.N + 1), x, y, uint8(0));
+        assertEq(p256Authenticator.authenticate(hash, sHi), bytes32(0));
     }
 }

--- a/test/unit/authenticators/WebAuthnAuthenticator.t.sol
+++ b/test/unit/authenticators/WebAuthnAuthenticator.t.sol
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Base64} from "openzeppelin/utils/Base64.sol";
+import {Math} from "openzeppelin/utils/math/Math.sol";
+import {P256} from "openzeppelin/utils/cryptography/P256.sol";
+import {WebAuthn} from "openzeppelin/utils/cryptography/WebAuthn.sol";
+
+import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
+
+/// @notice WebAuthnAuthenticator tests. The authenticator decodes abi.encode(WebAuthnAuth, x, y), derives
+///         actorId = keccak256(x‖y), and calls WebAuthn.verify(challenge: abi.encode(hash), auth, x, y,
+///         requireUV: false). It returns bytes32(0) on any verification failure and reverts only when the calldata
+///         cannot be abi-decoded into the expected tuple.
+contract WebAuthnAuthenticatorTest is AccountConfigurationTest {
+    // ── revert: undecodable calldata ──
+
+    /// @notice Reverts when calldata is too short to abi-decode into (WebAuthnAuth, bytes32, bytes32).
+    /// @dev The authenticator does not wrap abi.decode; malformed input propagates as a revert.
+    function test_authenticate_revert_truncatedData(uint256 len) public {
+        len = bound(len, 0, 95); // top-level head needs 3 words (offset + x + y); < 96 cannot decode
+        bytes memory data = new bytes(len);
+        vm.expectRevert();
+        p256WebAuthnAuthenticate(keccak256("h"), data);
+    }
+
+    // ── success: valid assertion returns actorId ──
+
+    /// @notice A valid WebAuthn assertion over `hash` returns keccak256(x‖y).
+    /// @dev Fuzzes key and message; User-Present set, low-s normalized.
+    function test_authenticate_success_validReturnsActorId(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        bytes memory data = _webauthnSignData(pk, hash);
+
+        bytes32 actorId = webAuthnAuthenticator.authenticate(hash, data);
+
+        assertEq(actorId, _p256ActorId(pk));
+        assertTrue(actorId != bytes32(0));
+    }
+
+    /// @notice actorId is exactly keccak256(x‖y) of the credential public key.
+    /// @dev A change to this derivation would rebind every existing credential's identity.
+    function test_authenticate_success_actorIdIsKeccakOfPubKey(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        (bytes32 x, bytes32 y) = _p256PubKey(pk);
+
+        assertEq(
+            webAuthnAuthenticator.authenticate(hash, _webauthnSignData(pk, hash)), keccak256(abi.encodePacked(x, y))
+        );
+    }
+
+    /// @notice Distinct credentials produce distinct actorIds.
+    /// @dev Guards against actorId collisions across credentials.
+    function test_authenticate_success_distinctKeysDistinctActorIds(uint256 pk1, uint256 pk2, bytes32 hash)
+        public
+        view
+    {
+        pk1 = _boundP256Pk(pk1);
+        pk2 = _boundP256Pk(pk2);
+        vm.assume(pk1 != pk2);
+
+        bytes32 id1 = webAuthnAuthenticator.authenticate(hash, _webauthnSignData(pk1, hash));
+        bytes32 id2 = webAuthnAuthenticator.authenticate(hash, _webauthnSignData(pk2, hash));
+
+        assertTrue(id1 != id2);
+    }
+
+    /// @notice A User-Verified assertion also authenticates (authenticator sets requireUV = false).
+    /// @dev UP|UV must succeed given requireUV is false.
+    function test_authenticate_success_userVerifiedAlsoAuthenticates(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        bytes memory data = _webauthnSignData(pk, hash, WebAuthn.AUTH_DATA_FLAGS_UP | WebAuthn.AUTH_DATA_FLAGS_UV);
+
+        assertEq(webAuthnAuthenticator.authenticate(hash, data), _p256ActorId(pk));
+    }
+
+    /// @notice Backup-eligible + backed-up assertion authenticates (BE=1, BS=1 is a valid state).
+    /// @dev Confirms the BE/BS consistency check permits the fully-backed-up state.
+    function test_authenticate_success_backupEligibleAndStateAuthenticates(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        bytes1 flags = WebAuthn.AUTH_DATA_FLAGS_UP | WebAuthn.AUTH_DATA_FLAGS_BE | WebAuthn.AUTH_DATA_FLAGS_BS;
+        bytes memory data = _webauthnSignData(pk, hash, flags);
+
+        assertEq(webAuthnAuthenticator.authenticate(hash, data), _p256ActorId(pk));
+    }
+
+    // ── success: verification failures return bytes32(0) ──
+
+    /// @notice Returns zero when the challenge in clientDataJSON does not match the authenticated hash.
+    /// @dev Assertion is built for `hash` but verified against `wrongHash`; challenge check must fail.
+    function test_authenticate_success_wrongHashReturnsZero(uint256 pk, bytes32 hash, bytes32 wrongHash) public view {
+        pk = _boundP256Pk(pk);
+        vm.assume(hash != wrongHash);
+        bytes memory data = _webauthnSignData(pk, hash);
+
+        assertEq(webAuthnAuthenticator.authenticate(wrongHash, data), bytes32(0));
+    }
+
+    /// @notice Returns zero when the User-Present bit is not set.
+    /// @dev UP is mandatory even when requireUV is false.
+    function test_authenticate_success_userPresentNotSetReturnsZero(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        // Only UV set (no UP).
+        bytes memory data = _webauthnSignData(pk, hash, WebAuthn.AUTH_DATA_FLAGS_UV);
+
+        assertEq(webAuthnAuthenticator.authenticate(hash, data), bytes32(0));
+    }
+
+    /// @notice Returns zero when backed-up (BS=1) without backup-eligibility (BE=0).
+    /// @dev BE/BS consistency: BS=1 requires BE=1.
+    function test_authenticate_success_backupStateWithoutEligibilityReturnsZero(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        bytes memory data = _webauthnSignData(pk, hash, WebAuthn.AUTH_DATA_FLAGS_UP | WebAuthn.AUTH_DATA_FLAGS_BS);
+
+        assertEq(webAuthnAuthenticator.authenticate(hash, data), bytes32(0));
+    }
+
+    /// @notice Returns zero when clientDataJSON type is not "webauthn.get".
+    /// @dev A "webauthn.create" ceremony must not authenticate an assertion.
+    function test_authenticate_success_wrongTypeReturnsZero(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        (bytes32 x, bytes32 y) = _p256PubKey(pk);
+        bytes memory authData = _webauthnAuthenticatorData(WebAuthn.AUTH_DATA_FLAGS_UP);
+        string memory clientDataJSON =
+            string.concat('{"type":"webauthn.create","challenge":"', Base64.encodeURL(abi.encode(hash)), '"}');
+
+        bytes32 msgHash = sha256(abi.encodePacked(authData, sha256(bytes(clientDataJSON))));
+        (bytes32 r, bytes32 s) = vm.signP256(pk, msgHash);
+        s = bytes32(Math.min(uint256(s), P256.N - uint256(s)));
+
+        WebAuthn.WebAuthnAuth memory auth = WebAuthn.WebAuthnAuth({
+            r: r,
+            s: s,
+            challengeIndex: 25, // shifted by 2 vs "webauthn.get" prefix; type check fails first regardless
+            typeIndex: 1,
+            authenticatorData: authData,
+            clientDataJSON: clientDataJSON
+        });
+
+        assertEq(webAuthnAuthenticator.authenticate(hash, abi.encode(auth, x, y)), bytes32(0));
+    }
+
+    /// @notice Returns zero for a high-s (malleable) signature.
+    /// @dev WebAuthn.verify delegates to P256.verify, which rejects s > n/2.
+    function test_authenticate_success_highSReturnsZero(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        (bytes32 x, bytes32 y) = _p256PubKey(pk);
+        bytes memory authData = _webauthnAuthenticatorData(WebAuthn.AUTH_DATA_FLAGS_UP);
+        string memory clientDataJSON = _webauthnClientDataJSON(abi.encode(hash));
+
+        bytes32 msgHash = sha256(abi.encodePacked(authData, sha256(bytes(clientDataJSON))));
+        (bytes32 r, bytes32 s) = vm.signP256(pk, msgHash);
+        uint256 lowS = Math.min(uint256(s), P256.N - uint256(s));
+
+        WebAuthn.WebAuthnAuth memory auth = WebAuthn.WebAuthnAuth({
+            r: r,
+            s: bytes32(P256.N - lowS), // high-s
+            challengeIndex: 23,
+            typeIndex: 1,
+            authenticatorData: authData,
+            clientDataJSON: clientDataJSON
+        });
+
+        assertEq(webAuthnAuthenticator.authenticate(hash, abi.encode(auth, x, y)), bytes32(0));
+    }
+
+    /// @notice Returns zero when a valid signature is paired with a different public key.
+    /// @dev Signature binds to the supplied credential key; substituting a foreign key must fail.
+    function test_authenticate_success_wrongPubKeyReturnsZero(uint256 pk, uint256 pk2, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        pk2 = _boundP256Pk(pk2);
+        vm.assume(pk != pk2);
+
+        bytes memory authData = _webauthnAuthenticatorData(WebAuthn.AUTH_DATA_FLAGS_UP);
+        string memory clientDataJSON = _webauthnClientDataJSON(abi.encode(hash));
+        bytes32 msgHash = sha256(abi.encodePacked(authData, sha256(bytes(clientDataJSON))));
+        (bytes32 r, bytes32 s) = vm.signP256(pk, msgHash);
+        s = bytes32(Math.min(uint256(s), P256.N - uint256(s)));
+        (bytes32 x2, bytes32 y2) = _p256PubKey(pk2);
+
+        WebAuthn.WebAuthnAuth memory auth = WebAuthn.WebAuthnAuth({
+            r: r, s: s, challengeIndex: 23, typeIndex: 1, authenticatorData: authData, clientDataJSON: clientDataJSON
+        });
+
+        assertEq(webAuthnAuthenticator.authenticate(hash, abi.encode(auth, x2, y2)), bytes32(0));
+    }
+
+    /// @notice Returns zero when authenticatorData is too short (<= 36 bytes).
+    /// @dev verify checks the length before indexing the flags byte; short data fails cleanly without reverting.
+    function test_authenticate_success_shortAuthenticatorDataReturnsZero(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        (bytes32 x, bytes32 y) = _p256PubKey(pk);
+        bytes memory authData = new bytes(36); // one byte short of the 37-byte minimum
+        string memory clientDataJSON = _webauthnClientDataJSON(abi.encode(hash));
+        bytes32 msgHash = sha256(abi.encodePacked(authData, sha256(bytes(clientDataJSON))));
+        (bytes32 r, bytes32 s) = vm.signP256(pk, msgHash);
+        s = bytes32(Math.min(uint256(s), P256.N - uint256(s)));
+
+        WebAuthn.WebAuthnAuth memory auth = WebAuthn.WebAuthnAuth({
+            r: r, s: s, challengeIndex: 23, typeIndex: 1, authenticatorData: authData, clientDataJSON: clientDataJSON
+        });
+
+        assertEq(webAuthnAuthenticator.authenticate(hash, abi.encode(auth, x, y)), bytes32(0));
+    }
+
+    /// @notice Returns zero for the zero public key (0,0); never leaks keccak256(0,0) as an actorId.
+    /// @dev (0,0) is the uninitialized-key value; accepting it would let an unset credential authenticate.
+    function test_authenticate_success_zeroPubKeyReturnsZero(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        bytes memory authData = _webauthnAuthenticatorData(WebAuthn.AUTH_DATA_FLAGS_UP);
+        string memory clientDataJSON = _webauthnClientDataJSON(abi.encode(hash));
+        bytes32 msgHash = sha256(abi.encodePacked(authData, sha256(bytes(clientDataJSON))));
+        (bytes32 r, bytes32 s) = vm.signP256(pk, msgHash);
+        s = bytes32(Math.min(uint256(s), P256.N - uint256(s)));
+
+        WebAuthn.WebAuthnAuth memory auth = WebAuthn.WebAuthnAuth({
+            r: r, s: s, challengeIndex: 23, typeIndex: 1, authenticatorData: authData, clientDataJSON: clientDataJSON
+        });
+
+        bytes32 actorId = webAuthnAuthenticator.authenticate(hash, abi.encode(auth, bytes32(0), bytes32(0)));
+        assertEq(actorId, bytes32(0));
+        assertTrue(actorId != keccak256(abi.encodePacked(bytes32(0), bytes32(0))));
+    }
+
+    /// @notice Returns zero when typeIndex is tampered out of bounds.
+    /// @dev typeIndex/challengeIndex are caller-supplied and NOT signed material; a garbage index must not
+    ///      produce a false accept (and must not revert).
+    function test_authenticate_success_tamperedTypeIndexReturnsZero(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        (bytes32 x, bytes32 y) = _p256PubKey(pk);
+        bytes memory authData = _webauthnAuthenticatorData(WebAuthn.AUTH_DATA_FLAGS_UP);
+        string memory clientDataJSON = _webauthnClientDataJSON(abi.encode(hash));
+        bytes32 msgHash = sha256(abi.encodePacked(authData, sha256(bytes(clientDataJSON))));
+        (bytes32 r, bytes32 s) = vm.signP256(pk, msgHash);
+        s = bytes32(Math.min(uint256(s), P256.N - uint256(s)));
+
+        WebAuthn.WebAuthnAuth memory auth = WebAuthn.WebAuthnAuth({
+            r: r,
+            s: s,
+            challengeIndex: 23,
+            typeIndex: type(uint256).max,
+            authenticatorData: authData,
+            clientDataJSON: clientDataJSON
+        });
+
+        assertEq(webAuthnAuthenticator.authenticate(hash, abi.encode(auth, x, y)), bytes32(0));
+    }
+
+    /// @notice Returns zero when challengeIndex is tampered out of bounds.
+    /// @dev An overflowing challengeIndex slice must yield a mismatch, not a revert.
+    function test_authenticate_success_tamperedChallengeIndexReturnsZero(uint256 pk, bytes32 hash) public view {
+        pk = _boundP256Pk(pk);
+        (bytes32 x, bytes32 y) = _p256PubKey(pk);
+        bytes memory authData = _webauthnAuthenticatorData(WebAuthn.AUTH_DATA_FLAGS_UP);
+        string memory clientDataJSON = _webauthnClientDataJSON(abi.encode(hash));
+        bytes32 msgHash = sha256(abi.encodePacked(authData, sha256(bytes(clientDataJSON))));
+        (bytes32 r, bytes32 s) = vm.signP256(pk, msgHash);
+        s = bytes32(Math.min(uint256(s), P256.N - uint256(s)));
+
+        WebAuthn.WebAuthnAuth memory auth = WebAuthn.WebAuthnAuth({
+            r: r,
+            s: s,
+            challengeIndex: type(uint256).max,
+            typeIndex: 1,
+            authenticatorData: authData,
+            clientDataJSON: clientDataJSON
+        });
+
+        assertEq(webAuthnAuthenticator.authenticate(hash, abi.encode(auth, x, y)), bytes32(0));
+    }
+
+    /// @dev Forwards to webAuthnAuthenticator.authenticate; used by the truncated-data revert test.
+    function p256WebAuthnAuthenticate(bytes32 hash, bytes memory data) internal view returns (bytes32) {
+        return webAuthnAuthenticator.authenticate(hash, data);
+    }
+}


### PR DESCRIPTION
## Summary
Fuzz-by-default hardening pass over the audit-scope contracts: `AccountConfiguration`, `DefaultAccount`, and the P256 / WebAuthn / Delegate authenticators. **Tests only — no `src/` changes.**

- Adds a full `WebAuthnAuthenticator` unit suite (the contract was previously untested).
- Expands revert/branch coverage across `AccountConfiguration`'s `authenticate`, `applyKeyChange`, `createAccount`, `importAccount`, `applyAccountChange`, and policy-accessor paths.
- Converts the legacy concrete `applyKeyChange` tests to the `test_{fn}_{revert|success}_{scenario}` convention with fuzzed inputs, matching the rest of the suite.
- Tightens test NatSpec/comments to callsite-focused specifications.

## Coverage (main `9c37e50` → this branch)
Measured with `forge coverage --report summary --ir-minimum`. Per-contract line/statement denominators are stable across runs, so deltas are exact.

| Contract | Lines | Statements | Branches* |
|---|---|---|---|
| AccountConfiguration.sol | 93.56% → **98.71%** | 89.21% → **98.73%** | 65.08% → **98.41%** |
| WebAuthnAuthenticator.sol | 0% → **100%** | 0% → **100%** | 0% → **100%** |
| DefaultAccount.sol | 100% (hardened) | 100% | — |
| P256Authenticator.sol | 100% (hardened) | 100% | — |
| DelegateAuthenticator.sol | 100% (hardened) | 100% | — |

\* The project's `via_ir` setting forces `--ir-minimum` coverage, which under-reports branch % on small contracts; line/statement are the reliable signal.

## Verification
- `forge test` → **322 passing, 0 failed**
- `forge fmt --check` → clean

## Out of scope (follow-ups)
- Pinning the 3 remaining uncovered `AccountConfiguration` lines/1 branch (defensive/unreachable — needs confirmation).
- Pre-existing test-naming drift in unrelated files (`UpgradeableAccount`, `BackwardsCompatible4337Account`, `SessionPolicy`, `PolicyManager`) — left untouched to keep this diff scoped.
