### PR TITLE
docs: update/add/stylize NatSpec for core EIP-8130 contracts

### DIFF
--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -12,11 +12,13 @@ contract AccountConfiguration {
     // STRUCTS
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
+    /// @notice Per-account replay counters for signed changes.
     struct ChangeSequences {
         uint64 multichain; // chain_id 0
         uint64 local; // chain_id == block.chainid; starts at 1 once initialized (created/imported), 0 = uninitialized
     }
 
+    /// @notice An actor's authorization: authenticator, scope, expiry, and policy sub-type.
     struct ActorConfig {
         address authenticator;
         uint8 scope;
@@ -24,12 +26,13 @@ contract AccountConfiguration {
         uint8 policyType; // 0x00 = none; any non-zero = gated to stored manager (value interpreted by the manager)
     }
 
-    // Minimal actor used for account creation and import (always unrestricted: scope=0x00, policyType=0x00, no expiry).
+    /// @notice Minimal actor for account creation and import (always unrestricted: scope 0x00, no expiry, no policy).
     struct InitialActor {
         bytes32 actorId;
         address authenticator;
     }
 
+    /// @notice A full actor record: identifier, config, and policy data.
     struct Actor {
         bytes32 actorId;
         ActorConfig config;
@@ -37,12 +40,15 @@ contract AccountConfiguration {
         bytes policyData;
     }
 
+    /// @notice A single authorize/revoke operation within a signed batch.
     struct ActorChange {
         uint8 changeType; // 0x01 = authorizeActor, 0x02 = revokeActor
         bytes32 actorId;
         bytes data; // operation-specific: ActorConfig || policyData for authorize, empty for revoke
     }
 
+    /// @notice Per-account packed state: sequences, lock status, and the inline home for the account's k1 self key.
+    ///
     /// @dev Packed into a single storage slot (exactly 32 bytes).
     ///      localSequence > 0 doubles as the account initialized flag.
     ///      The defaultEOA* fields are the inline home for the account's own secp256k1 ("self") key — the actor whose
@@ -68,29 +74,33 @@ contract AccountConfiguration {
 
     bytes4 constant ERC1271_SELECTOR = bytes4(keccak256("isValidSignature(bytes32,bytes)"));
 
-    /// @dev Typehash for the importAccount ERC-1271 signature, NOT compliant with EIP-712 to mitigate phishing
-    ///      attacks. Bound to the current chainId so an import signature cannot be replayed on another chain.
-    ///      Initial actors are hashed structurally via ACTOR_TYPEHASH / ACTORCONFIG_TYPEHASH below.
+    /// @notice Typehash binding an importAccount signature to its salt, chainId, and initial actor set.
+    ///
+    /// @dev NOT compliant with EIP-712, to mitigate eth_signTypedData phishing. Bound to the current chainId so an
+    ///      import signature cannot be replayed on another chain. Initial actors are hashed structurally via
+    ///      ACTOR_TYPEHASH / ACTORCONFIG_TYPEHASH below.
     bytes32 public constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
         "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint8 policyType)"
     );
 
-    /// @dev Per-actor typehash used to structurally hash each Actor within an ActorInitialization import digest.
+    /// @notice Typehash used to structurally hash each Actor within an ActorInitialization import digest.
     bytes32 public constant ACTOR_TYPEHASH = keccak256(
         "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint8 policyType)"
     );
 
-    /// @dev Per-config typehash used to structurally hash an Actor's ActorConfig within an import digest.
+    /// @notice Typehash used to structurally hash an Actor's ActorConfig within an import digest.
     bytes32 public constant ACTORCONFIG_TYPEHASH =
         keccak256("ActorConfig(address authenticator,uint8 scope,uint48 expiry,uint8 policyType)");
 
-    /// @dev Typehash for signed actor changes, NOT compliant with EIP-712 to mitigate phishing attacks.
+    /// @notice Typehash binding a signed actor-change batch to its account, chainId, and sequence.
+    ///
+    /// @dev NOT compliant with EIP-712, to mitigate phishing attacks.
     bytes32 public constant SIGNED_ACTOR_CHANGES_TYPEHASH = keccak256(
         "SignedActorChanges(address account,uint256 chainId,uint64 sequence,ActorChange[] actorChanges)"
         "ActorChange(uint8 changeType,bytes32 actorId,bytes data)"
     );
 
-    /// @dev Per-change typehash used to structurally hash each ActorChange within a SignedActorChanges batch.
+    /// @notice Typehash used to structurally hash each ActorChange within a SignedActorChanges batch.
     bytes32 public constant ACTORCHANGE_TYPEHASH =
         keccak256("ActorChange(uint8 changeType,bytes32 actorId,bytes data)");
 
@@ -167,75 +177,100 @@ contract AccountConfiguration {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     /// @notice Emitted when an actor is authorized (created or updated).
-    /// @param actorData Tightly packed authorization surface, mirroring the storage/wire packing:
-    ///        authenticator(20) || scope(1) || expiry(6) || policyType(1) — 28 bytes — and, only when
-    ///        policyType != 0x00, followed by the resolved policy gate: manager(20) || commitment(32).
-    ///        So the payload is 28 bytes for an unrestricted/ungated actor and 80 bytes for a policy-gated one;
-    ///        no zero policy words are emitted when there is no policy.
+    ///
+    /// @param account The account whose actor was authorized.
+    /// @param actorId The authorized actor's identifier.
+    /// @param actorData Tightly packed authorization surface mirroring the storage/wire packing:
+    ///        authenticator(20) || scope(1) || expiry(6) || policyType(1) = 28 bytes, and, only when
+    ///        policyType != 0x00, followed by the resolved policy gate manager(20) || commitment(32). So the
+    ///        payload is 28 bytes for an ungated actor and 80 bytes for a policy-gated one.
     event ActorAuthorized(address indexed account, bytes32 indexed actorId, bytes actorData);
 
+    /// @notice Emitted when an actor is revoked from an account.
+    ///
+    /// @param account The account whose actor was revoked.
+    /// @param actorId The revoked actor's identifier.
     event ActorRevoked(address indexed account, bytes32 indexed actorId);
 
+    /// @notice Emitted when a new account is created.
+    ///
+    /// @param account The created account address.
+    /// @param userSalt The caller-chosen salt used in the address derivation.
+    /// @param codeHash The keccak256 of the account's deployment bytecode.
     event AccountCreated(address indexed account, bytes32 userSalt, bytes32 codeHash);
 
+    /// @notice Emitted when an existing account is imported into management.
+    ///
+    /// @param account The imported account address.
     event AccountImported(address indexed account);
 
     /// @notice Protocol-injected receipt log for successful EIP-8130 delegation updates (not emitted in EVM).
+    ///
+    /// @param account The account whose delegation was updated.
+    /// @param target The delegation target.
     event DelegationApplied(address indexed account, address target);
 
+    /// @notice Emitted when an account is locked.
+    ///
+    /// @param account The locked account.
+    /// @param unlockDelay The configured unlock delay in seconds.
     event AccountLocked(address indexed account, uint16 unlockDelay);
 
+    /// @notice Emitted when an account's unlock is initiated.
+    ///
+    /// @param account The account whose unlock was initiated.
+    /// @param unlocksAt The timestamp at which the account will unlock.
     event AccountUnlockInitiated(address indexed account, uint40 unlocksAt);
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // ERRORS
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @dev An account address argument was the zero address.
+    /// @notice An account address argument was the zero address.
     error ZeroAccount();
-    /// @dev The account already has EIP-8130 state, so it cannot be created or imported again.
+    /// @notice The account already has EIP-8130 state, so it cannot be created or imported again.
     error AlreadyInitialized();
-    /// @dev The operation is not permitted while the account is locked.
+    /// @notice The operation is not permitted while the account is locked.
     error AccountIsLocked();
-    /// @dev The signed chainId is neither 0 (multichain) nor the current chain.
+    /// @notice The signed chainId is neither 0 (multichain) nor the current chain.
     error InvalidChainId();
-    /// @dev The authenticated actor lacks the scope required to change actors.
+    /// @notice The authenticated actor lacks the scope required to change actors.
     error UnauthorizedActorChange();
-    /// @dev An ActorChange carried an unrecognized changeType.
+    /// @notice An ActorChange carried an unrecognized changeType.
     error UnknownChangeType();
-    /// @dev The importAccount ERC-1271 signature check did not return the magic value.
+    /// @notice The importAccount ERC-1271 signature check did not return the magic value.
     error InvalidImportSignature();
-    /// @dev lock() was called with a zero unlock delay.
+    /// @notice lock() was called with a zero unlock delay.
     error ZeroUnlockDelay();
-    /// @dev initiateUnlock() was called when the account was not in the locked (unlocksAt == max) state.
+    /// @notice initiateUnlock() was called when the account was not in the locked (unlocksAt == max) state.
     error NotLocked();
-    /// @dev The auth blob is shorter than the 20-byte authenticator selector prefix.
+    /// @notice The auth blob is shorter than the 20-byte authenticator selector prefix.
     error InvalidAuthLength();
-    /// @dev createAccount/importAccount was called with an empty initialActors set.
+    /// @notice createAccount/importAccount was called with an empty initialActors set.
     error NoInitialActors();
-    /// @dev initialActors are not strictly ascending by actorId (unsorted or duplicated).
+    /// @notice initialActors are not strictly ascending by actorId (unsorted or duplicated).
     error ActorsNotSortedOrDuplicate();
-    /// @dev An actor config named an authenticator below the K1 sentinel (i.e. address(0)).
+    /// @notice An actor config named an authenticator below the K1 sentinel (i.e. address(0)).
     error InvalidAuthenticator();
-    /// @dev A policy-bearing actor must be scope-restricted and must not hold change-actors scope.
+    /// @notice A policy-bearing actor must be scope-restricted and must not hold change-actors scope.
     error InvalidPolicyScope();
-    /// @dev The policyData length or embedded manager/commitment did not match the policyType.
+    /// @notice The policyData length or embedded manager/commitment did not match the policyType.
     error InvalidPolicyData();
-    /// @dev The referenced actor is not currently authorized on the account.
+    /// @notice The referenced actor is not currently authorized on the account.
     error UnknownActor();
-    /// @dev An authenticator resolved a zero actorId (authentication failed).
+    /// @notice An authenticator resolved a zero actorId (authentication failed).
     error AuthenticationFailed();
-    /// @dev The resolved actor is not bound to the presented authenticator.
+    /// @notice The resolved actor is not bound to the presented authenticator.
     error AuthenticatorMismatch();
-    /// @dev The actor's expiry has passed.
+    /// @notice The actor's expiry has passed.
     error ActorExpired();
-    /// @dev The signature was malformed: bad length, non-canonical v, high-s, or a zero recovery.
+    /// @notice The signature was malformed: bad length, non-canonical v, high-s, or a zero recovery.
     error InvalidSignature();
-    /// @dev The account's default (implicit/scoped) EOA key has been revoked.
+    /// @notice The account's default (implicit/scoped) EOA key has been revoked.
     error DefaultEoaRevoked();
-    /// @dev The provided account bytecode exceeds the maximum encodable length.
+    /// @notice The provided account bytecode exceeds the maximum encodable length.
     error BytecodeTooLarge();
-    /// @dev CREATE2 did not deploy code at the expected account address (e.g. bytecode too large per EIP-170,
+    /// @notice CREATE2 did not deploy code at the expected account address (e.g. bytecode too large per EIP-170,
     ///      leading 0xEF byte per EIP-3541, or out of gas). Reverting unwinds all state writes so no orphaned
     ///      EIP-8130 configuration is left behind.
     error AccountDeploymentFailed();
@@ -276,9 +311,22 @@ contract AccountConfiguration {
     // FUNCTIONS
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice Deploy a new account with its initial actors. Initial actors bootstrap account ownership and are always
-    ///         registered as unrestricted owners (scope = 0x00, no expiry, no policy); scoped keys and session-key
-    ///         policies are added afterwards via applySignedActorChanges. Lock state is initialized to safe defaults.
+    /// @notice Deploys a new account with its initial actors, which are always registered as unrestricted owners
+    ///         (scope 0x00, no expiry, no policy); scoped keys and session-key policies are added afterwards via
+    ///         applySignedActorChanges. The implicit default-EOA key is disabled on creation.
+    ///
+    /// @dev Reverts with BytecodeTooLarge when `bytecode` exceeds the maximum encodable length.
+    /// @dev Reverts with AlreadyInitialized when the account already has EIP-8130 state.
+    /// @dev Reverts with NoInitialActors when `initialActors` is empty.
+    /// @dev Reverts with ActorsNotSortedOrDuplicate when `initialActors` is not strictly ascending by actorId.
+    /// @dev Reverts with InvalidAuthenticator when an initial actor names a zero authenticator.
+    /// @dev Reverts with AccountDeploymentFailed when CREATE2 does not deploy code at the expected address.
+    ///
+    /// @param userSalt Caller-chosen salt mixed into the CREATE2 address derivation.
+    /// @param bytecode Account deployment bytecode to CREATE2 at the derived address.
+    /// @param initialActors Bootstrap owners, strictly ascending by actorId; each becomes an unrestricted owner.
+    ///
+    /// @return account The deployed account address.
     function createAccount(bytes32 userSalt, bytes calldata bytecode, InitialActor[] calldata initialActors)
         external
         returns (address account)
@@ -320,11 +368,23 @@ contract AccountConfiguration {
         emit AccountCreated(account, userSalt, keccak256(bytecode));
     }
 
-    /// @notice Import an existing account to AccountConfiguration management.
-    /// @dev Verifies via ERC-1271. Accounts must have bytecode.
-    /// @dev Custom hash used to partially mitigate phishing attacks on eth_signTypedData.
-    /// @param chainId Replay domain of the import signature, mirroring applySignedActorChanges: 0 = multichain
-    ///        (valid on every chain), otherwise it must equal the current chain.
+    /// @notice Imports an existing account (which must have bytecode) into AccountConfiguration management via an
+    ///         ERC-1271 signature over a typed import digest. The implicit default-EOA key is disabled after import.
+    ///
+    /// @dev Uses a custom (non-EIP-712) digest to partially mitigate eth_signTypedData phishing.
+    /// @dev Reverts with AccountIsLocked when the account is locked.
+    /// @dev Reverts with InvalidChainId when `chainId` is neither 0 (multichain) nor the current chain.
+    /// @dev Reverts with AlreadyInitialized when the account already has EIP-8130 state.
+    /// @dev Reverts with InvalidImportSignature when the account's ERC-1271 check does not return the magic value.
+    /// @dev Reverts with NoInitialActors when `initialActors` is empty.
+    /// @dev Reverts with ActorsNotSortedOrDuplicate when `initialActors` is not strictly ascending by actorId.
+    /// @dev Reverts with InvalidAuthenticator when an initial actor names a zero authenticator.
+    ///
+    /// @param account The account being imported.
+    /// @param chainId Replay domain of the import signature: 0 = multichain (valid on every chain), otherwise it
+    ///        must equal the current chain.
+    /// @param initialActors Bootstrap owners, strictly ascending by actorId; each becomes an unrestricted owner.
+    /// @param signature ERC-1271 signature the account validates over the import digest.
     function importAccount(
         address account,
         uint256 chainId,
@@ -357,10 +417,23 @@ contract AccountConfiguration {
         emit AccountImported(account);
     }
 
-    /// @notice Apply a batch of signed actor changes (authorize/revoke) to an account's configuration.
-    /// @dev Authenticates `auth` against the account's actors and requires the resolved actor to be unrestricted
-    ///      (scope 0) or to hold SCOPE_CONFIG. Replay is bound by chainId (0 = multichain, else the current
-    ///      chain) and a monotonic per-account sequence consumed on each call.
+    /// @notice Applies a batch of signed actor changes (authorize/revoke) to an account's configuration.
+    ///
+    /// @dev Authorized when the authenticated actor is unrestricted (scope 0) or holds SCOPE_CONFIG. Replay is
+    ///      bound by `chainId` and a monotonic per-account sequence consumed on each call.
+    /// @dev Reverts with AccountIsLocked when the account is locked.
+    /// @dev Reverts with InvalidChainId when `chainId` is neither 0 (multichain) nor the current chain.
+    /// @dev Reverts with InvalidAuthLength, InvalidSignature, AuthenticationFailed, AuthenticatorMismatch,
+    ///      ActorExpired, or DefaultEoaRevoked when `auth` fails to authenticate a live actor.
+    /// @dev Reverts with UnauthorizedActorChange when the authenticated actor lacks CONFIG scope.
+    /// @dev Reverts with UnknownChangeType when a change carries an unrecognized changeType.
+    /// @dev Reverts with InvalidAuthenticator, InvalidPolicyScope, or InvalidPolicyData on a malformed authorize.
+    /// @dev Reverts with UnknownActor when revoking an actor that is not authorized.
+    ///
+    /// @param account The account whose configuration is changed.
+    /// @param chainId Replay domain: 0 = multichain (valid on every chain), otherwise the current chain.
+    /// @param actorChanges Ordered authorize/revoke operations to apply.
+    /// @param auth Authenticator(20) || authenticator-specific data authenticating a CONFIG-capable actor.
     function applySignedActorChanges(
         address account,
         uint256 chainId,
@@ -398,8 +471,12 @@ contract AccountConfiguration {
     // ACCOUNT LOCKS
     // ----------------------------------------------------------------------------------------------------------------
 
-    /// @notice Lock the account to freeze actor configuration.
-    /// @param unlockDelay The delay in seconds before the account can be unlocked (capped at ~18 hours).
+    /// @notice Locks the caller's account to freeze actor configuration until an unlock is initiated and elapses.
+    ///
+    /// @dev Reverts with AccountIsLocked when the account is already locked.
+    /// @dev Reverts with ZeroUnlockDelay when `unlockDelay` is zero.
+    ///
+    /// @param unlockDelay Delay in seconds, after initiateUnlock, before the account unlocks (max uint16, ~18 hours).
     function lock(uint16 unlockDelay) external onlyUnlocked(msg.sender) {
         // Require non-zero unlock delay
         if (unlockDelay == 0) revert ZeroUnlockDelay();
@@ -411,7 +488,9 @@ contract AccountConfiguration {
         emit AccountLocked(msg.sender, unlockDelay);
     }
 
-    /// @notice Initiate unlock of the account after delay has passed.
+    /// @notice Initiates unlocking the caller's account; it becomes unlocked once the configured delay elapses.
+    ///
+    /// @dev Reverts with NotLocked when the account is not in the locked state.
     function initiateUnlock() external {
         AccountState storage config = _accountState[msg.sender];
 
@@ -427,10 +506,16 @@ contract AccountConfiguration {
     // VIEW FUNCTIONS
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice Authenticate an account bytes signature in authenticator(20) || data format.
+    /// @notice Validates an account signature in `authenticator(20) || data` format; never reverts.
+    ///
     /// @dev ERC-1271-style boolean check: returns false on any failure (invalid signature, unknown/revoked actor,
-    ///      actorId not bound to the auth authenticator, or an actor lacking SIGNATURE scope) rather than reverting.
-    ///      authenticateActor reverts on authentication failure, so it is called externally and the revert is caught.
+    ///      actorId not bound to the presented authenticator, or an actor lacking SIGNER scope). authenticateActor
+    ///      reverts on failure, so it is called externally and the revert is caught.
+    ///
+    /// @param account The account the signature is validated against.
+    /// @param hash The digest that was signed.
+    /// @param signature Authenticator(20) || authenticator-specific data.
+    ///
     /// @return verified True if the signature is valid and the resolved actor may sign messages.
     function verifySignature(address account, bytes32 hash, bytes calldata signature)
         external
@@ -444,18 +529,23 @@ contract AccountConfiguration {
         }
     }
 
-    /// @notice Authenticate an account approved a hash using auth in authenticator(20) || data format, returning
-    ///         the verified actor's authorization surface so a consumer (e.g. an ERC-4337 account) can make a
-    ///         full authorization decision from a single call without re-deriving the actorId.
-    /// @dev Authorization is scope + policy, not scope alone. `scope` is the actor's capability set; `policyType`
-    ///      and `policyTarget` describe its policy gate. `policyType` is the per-actor policy sub-type byte —
-    ///      currently `0x00` (none) or non-zero (gated); its specific non-zero value is reserved for future,
-    ///      manager-defined semantics and is returned here so the return shape need not change when that lands.
-    ///      `policyTarget` is the resolved policy *manager* (never the signed commitment, which stays an
-    ///      execution-time read via getPolicy), or address(0) when ungated.
+    /// @notice Authenticates that an account approved `hash` using auth in `authenticator(20) || data` format,
+    ///         returning the verified actor's authorization surface (scope plus policy) so a consumer can decide
+    ///         authorization from a single call without re-deriving the actorId.
+    ///
+    /// @dev `policyTarget` is the resolved policy manager, never the signed commitment (an execution-time read via
+    ///      getPolicy), or address(0) when ungated.
+    /// @dev Reverts with InvalidAuthLength when `auth` is shorter than 20 bytes.
+    /// @dev Reverts with AuthenticationFailed, AuthenticatorMismatch, ActorExpired, DefaultEoaRevoked, or
+    ///      InvalidSignature when the actor cannot be authenticated.
+    ///
+    /// @param account The account the signature is validated against.
+    /// @param hash The digest that was signed.
+    /// @param auth Authenticator(20) || authenticator-specific data.
+    ///
     /// @return scope The scope of the verified actor (0x00 = unrestricted).
     /// @return policyType The actor's policy sub-type byte (0x00 = none).
-    /// @return policyTarget The actor's policy gate target, or address(0) if ungated.
+    /// @return policyTarget The actor's policy gate target (manager), or address(0) if ungated.
     function authenticateActor(address account, bytes32 hash, bytes calldata auth)
         public
         view
@@ -465,7 +555,15 @@ contract AccountConfiguration {
         return _authenticate(account, hash, address(bytes20(auth[:20])), auth[20:]);
     }
 
-    /// @notice Compute the counterfactual address for an account.
+    /// @notice Computes the counterfactual CREATE2 address for an account without deploying it.
+    ///
+    /// @dev Reverts with BytecodeTooLarge when `bytecode` exceeds the maximum encodable length.
+    ///
+    /// @param userSalt Caller-chosen salt mixed into the CREATE2 address derivation.
+    /// @param bytecode Account deployment bytecode.
+    /// @param initialActors Bootstrap owners committed into the effective salt.
+    ///
+    /// @return The counterfactual account address.
     function computeAddress(bytes32 userSalt, bytes calldata bytecode, InitialActor[] calldata initialActors)
         public
         view
@@ -481,6 +579,12 @@ contract AccountConfiguration {
     // STORAGE VIEWS
     // ----------------------------------------------------------------------------------------------------------------
 
+    /// @notice Returns whether `actorId` is currently a live actor on `account`.
+    ///
+    /// @param account The account to check.
+    /// @param actorId The actor identifier to check.
+    ///
+    /// @return True if the actor is authorized and live.
     function isActor(address account, bytes32 actorId) public view returns (bool) {
         // A populated _actorConfig entry is always live: any non-self actor, or a non-k1 self authenticator.
         if (_actorConfig[actorId][account].authenticator >= K1_AUTHENTICATOR) return true;
@@ -489,11 +593,18 @@ contract AccountConfiguration {
         return false;
     }
 
+    /// @notice Resolves the effective ActorConfig for `actorId` on `account`.
+    ///
     /// @dev With a populated _actorConfig entry, returns it verbatim (any non-self actor, or a non-k1 self). For the
     ///      self-actorId without such an entry, the k1 self lives inline in AccountState: a live one (flag unset)
     ///      reports as a native ecrecover owner carrying its inline scope/expiry/policy (all-zero = full owner); a
-    ///      disabled one — or any unknown actor — reports as the all-zero (empty) config. This keeps live-vs-disabled
+    ///      disabled one, or any unknown actor, reports as the all-zero (empty) config, keeping live-vs-disabled
     ///      unambiguous without a sentinel.
+    ///
+    /// @param account The account to read.
+    /// @param actorId The actor identifier to resolve.
+    ///
+    /// @return The resolved actor configuration, or the all-zero config if the actor is not live.
     function getActorConfig(address account, bytes32 actorId) external view returns (ActorConfig memory) {
         ActorConfig memory config = _actorConfig[actorId][account];
         if (config.authenticator != address(0)) return config;
@@ -509,14 +620,15 @@ contract AccountConfiguration {
         return config;
     }
 
-    /// @notice Resolves an actor's policy sub-type, gate target, and signed commitment.
-    /// @dev Convenience aggregator for off-chain consumers. Enforcement is at execution: this resolves the actor's
-    ///      policy sub-type, where a policy-bearing actor may call, and the commitment a target validates presented
-    ///      parameters against. 0x00 -> (0, 0, 0); non-zero -> (policyType, manager, commitment). The policy
-    ///      manager/commitment are keyed by actorId, so the inline k1 self and a non-k1 self share that keyspace;
-    ///      mutual exclusion guarantees at most one is live, so the active gate is read by actorId.
-    ///      On-chain consumers (notably the policy manager validating a dispatched 8130 tx) should prefer the
-    ///      single-SLOAD `getPolicyCommitment` / `getPolicyManager` accessors.
+    /// @notice Resolves an actor's policy sub-type, gate target (manager), and signed commitment.
+    ///
+    /// @dev Convenience aggregator for off-chain consumers; on-chain consumers should prefer the single-SLOAD
+    ///      getPolicyCommitment / getPolicyManager accessors. Ungated resolves to (0, 0, 0); gated resolves to
+    ///      (policyType, manager, commitment).
+    ///
+    /// @param account The account to read.
+    /// @param actorId The actor identifier to resolve.
+    ///
     /// @return policyType The actor's policy sub-type byte (0x00 = none).
     /// @return target The actor's policy gate target (manager), or address(0) if ungated.
     /// @return commitment The actor's signed policy commitment, or bytes32(0) if ungated.
@@ -538,32 +650,58 @@ contract AccountConfiguration {
         return (policyType, _policyManager[actorId][account], _policyCommitment[actorId][account]);
     }
 
-    /// @notice Resolves an actor's signed policy commitment, or bytes32(0) if ungated / no actor.
-    /// @dev Single SLOAD. Intended for a policy manager's per-tx validation read on the protocol-dispatched
-    ///      8130 tx path: the manager already knows its own address and policy sub-type, so the commitment is
-    ///      the only state it needs from this contract to validate. The invariant maintained by
-    ///      _authorizeActor / _revokeActor is that this slot is non-zero iff the actor has a non-zero
-    ///      policyType, across both the inline-k1 self and the _actorConfig homes (manager/commitment share a
-    ///      single keyspace keyed by actorId), so a zero return unambiguously means "no policy / no actor".
+    /// @notice Resolves an actor's signed policy commitment, or bytes32(0) if ungated or no actor.
+    ///
+    /// @dev Single SLOAD. The invariant maintained by _authorizeActor / _revokeActor is that this slot is non-zero
+    ///      iff the actor has a non-zero policyType, so a zero return unambiguously means "no policy / no actor".
+    ///
+    /// @param account The account to read.
+    /// @param actorId The actor identifier to resolve.
+    ///
+    /// @return The signed policy commitment, or bytes32(0) if ungated or no actor.
     function getPolicyCommitment(address account, bytes32 actorId) external view returns (bytes32) {
         return _policyCommitment[actorId][account];
     }
 
-    /// @notice Resolves an actor's policy gate target (manager), or address(0) if ungated / no actor.
-    /// @dev Single SLOAD. Same invariant as `getPolicyCommitment`.
+    /// @notice Resolves an actor's policy gate target (manager), or address(0) if ungated or no actor.
+    ///
+    /// @dev Single SLOAD. Same invariant as getPolicyCommitment.
+    ///
+    /// @param account The account to read.
+    /// @param actorId The actor identifier to resolve.
+    ///
+    /// @return The policy gate target (manager), or address(0) if ungated or no actor.
     function getPolicyManager(address account, bytes32 actorId) external view returns (address) {
         return _policyManager[actorId][account];
     }
 
+    /// @notice Returns the account's multichain and local change sequences (replay counters).
+    ///
+    /// @param account The account to read.
+    ///
+    /// @return The account's ChangeSequences (multichain and local counters).
     function getChangeSequences(address account) external view returns (ChangeSequences memory) {
         AccountState storage state = _accountState[account];
         return ChangeSequences({multichain: state.multichainSequence, local: state.localSequence});
     }
 
+    /// @notice Returns whether the account is currently locked (configuration frozen).
+    ///
+    /// @param account The account to check.
+    ///
+    /// @return True if the account is locked at the current block timestamp.
     function isLocked(address account) external view returns (bool) {
         return block.timestamp < _accountState[account].unlocksAt;
     }
 
+    /// @notice Returns the account's full lock status.
+    ///
+    /// @param account The account to read.
+    ///
+    /// @return locked True if the account is locked at the current block timestamp.
+    /// @return hasInitiatedUnlock True if an unlock has been initiated but not yet elapsed.
+    /// @return unlocksAt The timestamp at which the account unlocks (type(uint40).max while hard-locked).
+    /// @return unlockDelay The configured unlock delay in seconds.
     function getLockStatus(address account)
         external
         view

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -7,6 +7,8 @@ import {IAuthenticator} from "./interfaces/IAuthenticator.sol";
 ///         Manages actor authorization, account creation, change sequencing, and account lock. This contract is
 ///         also the canonical reference for the EIP-8130 Account Configuration ABI: its public structs, events,
 ///         and function signatures are the spec surface, and there is no separate interface file to keep in sync.
+///
+/// @author Coinbase
 contract AccountConfiguration {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // STRUCTS
@@ -146,12 +148,13 @@ contract AccountConfiguration {
     ///         (see _authorizeActor), since a policy could otherwise be escaped by minting a fresh unrestricted actor.
     uint8 public constant SCOPE_CONFIG = 0x08;
 
-    /// @dev Authenticator namespace: 1 = the canonical secp256k1 ("K1") verifier (native ecrecover); 2..max = custom
-    ///      IAuthenticator contracts. address(0) is reserved as the "no actor configured" storage sentinel and is
-    ///      never a valid authenticator selector.
     /// @notice The single secp256k1 authenticator. The default EOA and every k1 actor share this one identity; the
     ///         actor config alone distinguishes a full-owner EOA from a scoped key. Signed with a K1_AUTHENTICATOR
     ///         (20) || r‖s‖v auth blob.
+    ///
+    /// @dev Authenticator namespace: 1 = the canonical secp256k1 ("K1") verifier (native ecrecover); 2..max = custom
+    ///      IAuthenticator contracts. address(0) is reserved as the "no actor configured" storage sentinel and is
+    ///      never a valid authenticator selector.
     address public constant K1_AUTHENTICATOR = address(1);
 
     // ----------------------------------------------------------------------------------------------------------------
@@ -228,48 +231,70 @@ contract AccountConfiguration {
 
     /// @notice An account address argument was the zero address.
     error ZeroAccount();
+
     /// @notice The account already has EIP-8130 state, so it cannot be created or imported again.
     error AlreadyInitialized();
+
     /// @notice The operation is not permitted while the account is locked.
     error AccountIsLocked();
+
     /// @notice The signed chainId is neither 0 (multichain) nor the current chain.
     error InvalidChainId();
+
     /// @notice The authenticated actor lacks the scope required to change actors.
     error UnauthorizedActorChange();
+
     /// @notice An ActorChange carried an unrecognized changeType.
     error UnknownChangeType();
+
     /// @notice The importAccount ERC-1271 signature check did not return the magic value.
     error InvalidImportSignature();
+
     /// @notice lock() was called with a zero unlock delay.
     error ZeroUnlockDelay();
+
     /// @notice initiateUnlock() was called when the account was not in the locked (unlocksAt == max) state.
     error NotLocked();
+
     /// @notice The auth blob is shorter than the 20-byte authenticator selector prefix.
     error InvalidAuthLength();
+
     /// @notice createAccount/importAccount was called with an empty initialActors set.
     error NoInitialActors();
+
     /// @notice initialActors are not strictly ascending by actorId (unsorted or duplicated).
     error ActorsNotSortedOrDuplicate();
+
     /// @notice An actor config named an authenticator below the K1 sentinel (i.e. address(0)).
     error InvalidAuthenticator();
+
     /// @notice A policy-bearing actor must be scope-restricted and must not hold change-actors scope.
     error InvalidPolicyScope();
+
     /// @notice The policyData length or embedded manager/commitment did not match the policyType.
     error InvalidPolicyData();
+
     /// @notice The referenced actor is not currently authorized on the account.
     error UnknownActor();
+
     /// @notice An authenticator resolved a zero actorId (authentication failed).
     error AuthenticationFailed();
+
     /// @notice The resolved actor is not bound to the presented authenticator.
     error AuthenticatorMismatch();
+
     /// @notice The actor's expiry has passed.
     error ActorExpired();
+
     /// @notice The signature was malformed: bad length, non-canonical v, high-s, or a zero recovery.
     error InvalidSignature();
+
     /// @notice The account's default (implicit/scoped) EOA key has been revoked.
     error DefaultEoaRevoked();
+
     /// @notice The provided account bytecode exceeds the maximum encodable length.
     error BytecodeTooLarge();
+
     /// @notice CREATE2 did not deploy code at the expected account address (e.g. bytecode too large per EIP-170,
     ///      leading 0xEF byte per EIP-3541, or out of gas). Reverting unwinds all state writes so no orphaned
     ///      EIP-8130 configuration is left behind.
@@ -297,11 +322,15 @@ contract AccountConfiguration {
     // MODIFIERS
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
+    /// @notice Modifier to check if an account is unlocked.
+    /// @dev Reverts with AccountIsLocked when the account is locked.
     modifier onlyUnlocked(address account) {
         if (_checkAndClearLock(account)) revert AccountIsLocked();
         _;
     }
 
+    /// @notice Modifier to check if an account is not the zero address.
+    /// @dev Reverts with ZeroAccount when the account is the zero address.
     modifier nonZeroAccount(address account) {
         if (account == address(0)) revert ZeroAccount();
         _;

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -74,6 +74,8 @@ contract AccountConfiguration {
     // CONSTANTS
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
+    /// @dev ERC-1271 isValidSignature(bytes32,bytes) selector, which also equals the ERC-1271 magic return value
+    ///      (0x1626ba7e); used both to build the import staticcall and to validate its result.
     bytes4 constant ERC1271_SELECTOR = bytes4(keccak256("isValidSignature(bytes32,bytes)"));
 
     /// @notice Typehash binding an importAccount signature to its salt, chainId, and initial actor set.
@@ -764,6 +766,10 @@ contract AccountConfiguration {
     // ACTOR CHANGES
     // ----------------------------------------------------------------------------------------------------------------
 
+    /// @dev Registers the bootstrap actor set shared by createAccount and importAccount: requires a non-empty,
+    ///      strictly ascending-by-actorId list (rejecting unsorted or duplicate entries) and authorizes each entry
+    ///      as an unrestricted owner (scope 0, no expiry, no policy). Reverts with NoInitialActors or
+    ///      ActorsNotSortedOrDuplicate.
     function _initializeAccount(address account, InitialActor[] calldata initialActors)
         internal
         nonZeroAccount(account)
@@ -787,6 +793,11 @@ contract AccountConfiguration {
         }
     }
 
+    /// @dev Authorizes (upserts) `actorId` with `config` and optional `policyData`, emitting ActorAuthorized. Rejects
+    ///      a sub-K1 authenticator and requires any policy-bearing actor to be scope-restricted without CONFIG scope.
+    ///      The self-actorId is routed by authenticator type (a k1 self inline in AccountState, a non-k1 self in
+    ///      _actorConfig) and the two are kept mutually exclusive; every other actor lives in _actorConfig. Reverts
+    ///      with InvalidAuthenticator, InvalidPolicyScope, or InvalidPolicyData.
     function _authorizeActor(address account, bytes32 actorId, ActorConfig memory config, bytes memory policyData)
         internal
         nonZeroAccount(account)
@@ -887,6 +898,9 @@ contract AccountConfiguration {
         }
     }
 
+    /// @dev Revokes `actorId` from `account`, clearing its config and policy slots and emitting ActorRevoked. For the
+    ///      self-actorId it also disables the inline k1 self (sets FLAG_REVOKE_DEFAULT_EOA and zeroes the inline
+    ///      fields). Reverts with UnknownActor when the actor is not currently live.
     function _revokeActor(address account, bytes32 actorId) internal nonZeroAccount(account) {
         if (!isActor(account, actorId)) revert UnknownActor();
         delete _actorConfig[actorId][account];
@@ -955,6 +969,9 @@ contract AccountConfiguration {
         );
     }
 
+    /// @dev Computes the digest signed over an applySignedActorChanges batch: each ActorChange is hashed structurally
+    ///      (its variable-length `data` pre-hashed to a fixed-width layout) and the batch is bound to `account`,
+    ///      `chainId`, and `sequence` via SIGNED_ACTOR_CHANGES_TYPEHASH.
     function _computeSignedActorChangesDigest(
         address account,
         uint256 chainId,
@@ -991,6 +1008,10 @@ contract AccountConfiguration {
     // AUTHENTICATION
     // ----------------------------------------------------------------------------------------------------------------
 
+    /// @dev Resolves and authenticates the actor behind `authenticator`/`data`, returning its (scope, policyType,
+    ///      policyTarget). Routes the K1 sentinel to _authenticateK1; otherwise calls the IAuthenticator and requires
+    ///      the resolved actorId to carry a matching, unexpired _actorConfig entry. Reverts with AuthenticationFailed,
+    ///      AuthenticatorMismatch, or ActorExpired.
     function _authenticate(address account, bytes32 hash, address authenticator, bytes calldata data)
         internal
         view
@@ -1055,6 +1076,9 @@ contract AccountConfiguration {
         return _policyManager[actorId][account];
     }
 
+    /// @dev Recovers the ECDSA signer from a 65-byte r‖s‖v signature over `hash`, enforcing EIP-2 (low-s only,
+    ///      canonical v of 27 or 28). Reverts with InvalidSignature on a bad length or non-canonical encoding; may
+    ///      return address(0) if ecrecover fails, which callers treat as a failed authentication.
     function _recoverSigner(bytes32 hash, bytes calldata data) internal pure returns (address recovered) {
         if (data.length != 65) revert InvalidSignature();
         bytes32 r = bytes32(data[:32]);

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -21,18 +21,21 @@ struct Call {
 ///      all chains, so if the protocol ever calls authenticate() on it the call naturally fails.
 address constant TRUSTED_EXECUTOR = address(uint160(uint256(keccak256("trustedExecutor"))));
 
-/// @notice Bare default account implementation for EIP-8130.
-///
-///         This is the minimal spec: it handles batched execution and ERC-1271 signature validation, and defers
-///         all authorization to the AccountConfiguration system contract.
-///
-///         Deploy this via {UpgradeableAccount} (behind an UpgradeableProxy), which layers UUPS upgradeability
-///         on top with no other change in behavior.
+/// @notice Canonical model of the EIP-8130 default account: the behavior every EOA exhibits by default on an
+///         EIP-8130 chain, expressed in Solidity. It handles batched execution and ERC-1271 signature validation,
+///         and defers all authorization to the AccountConfiguration system contract.
 ///
 ///         Caller authorization:
 ///           - address(this) is always authorized (hardcoded), covering 8130 self-call batches
 ///           - Trusted executors (PolicyManagers, relayers, EntryPoints) are registered as actors with
 ///             TRUSTED_EXECUTOR as the authenticator in AccountConfiguration
+///
+/// @dev Not a deployment target. This describes the default EOA behavior applied natively on an EIP-8130 chain; it
+///      is intentionally minimal and is NOT ERC-4337 compatible. An account that wants smart-account features (for
+///      example ERC-4337 on a chain without native EIP-8130 support) should delegate or deploy to a purpose-built
+///      account, not to this one. If this bytecode is deployed anyway, it MUST sit behind an upgradeable (UUPS)
+///      proxy: adopting those features later means swapping in different bytecode, which is only possible if the
+///      deployment is upgradeable. See {UpgradeableAccount} for that upgradeable variant.
 ///
 /// @author Coinbase
 contract DefaultAccount is Receiver {

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -5,16 +5,20 @@ import {Receiver} from "solady/accounts/Receiver.sol";
 
 import {AccountConfiguration} from "../AccountConfiguration.sol";
 
+/// @notice A single call in an execution batch.
 struct Call {
+    /// @dev Address the account calls.
     address target;
+    /// @dev Wei forwarded with the call.
     uint256 value;
+    /// @dev Calldata passed to `target`.
     bytes data;
 }
 
 /// @dev Sentinel `authenticator` value marking an actor as a trusted executor: an address (e.g. a PolicyManager,
-///      EntryPoint, or relayer) authorized to drive execution on the account directly by matching `msg.sender`,
-///      rather than by verifying a signature. No contract exists here — if the protocol ever calls authenticate()
-///      on it, the call naturally fails. Deterministic across all chains (hash-derived, no deployment needed).
+///      EntryPoint, or relayer) authorized to drive execution on the account by matching `msg.sender` rather than
+///      by verifying a signature. No contract exists at this address; it is hash-derived and deterministic across
+///      all chains, so if the protocol ever calls authenticate() on it the call naturally fails.
 address constant TRUSTED_EXECUTOR = address(uint160(uint256(keccak256("trustedExecutor"))));
 
 /// @notice Bare default account implementation for EIP-8130.
@@ -26,12 +30,17 @@ address constant TRUSTED_EXECUTOR = address(uint160(uint256(keccak256("trustedEx
 ///         on top with no other change in behavior.
 ///
 ///         Caller authorization:
-///           - address(this) is always authorized (hardcoded) — covers 8130 self-call batches
+///           - address(this) is always authorized (hardcoded), covering 8130 self-call batches
 ///           - Trusted executors (PolicyManagers, relayers, EntryPoints) are registered as actors with
 ///             TRUSTED_EXECUTOR as the authenticator in AccountConfiguration
+///
+/// @author Coinbase
 contract DefaultAccount is Receiver {
+    /// @notice The AccountConfiguration system contract that owns this account's authorization state.
     AccountConfiguration public immutable ACCOUNT_CONFIGURATION;
 
+    /// @notice Deploys the account implementation bound to an AccountConfiguration instance.
+    /// @param accountConfiguration Address of the AccountConfiguration system contract.
     constructor(address accountConfiguration) {
         ACCOUNT_CONFIGURATION = AccountConfiguration(accountConfiguration);
     }
@@ -40,6 +49,12 @@ contract DefaultAccount is Receiver {
     //  EXECUTION
     // ══════════════════════════════════════════════
 
+    /// @notice Executes a batch of calls from the account; reverts the entire batch if any call fails.
+    ///
+    /// @dev Reverts when the caller is neither the account itself nor a registered TRUSTED_EXECUTOR actor.
+    /// @dev Reverts when any inner call reverts.
+    ///
+    /// @param calls Ordered calls to execute, each as (target, value, data).
     function executeBatch(Call[] calldata calls) external virtual {
         require(_isAuthorizedCaller(msg.sender));
         for (uint256 i; i < calls.length; i++) {
@@ -52,11 +67,13 @@ contract DefaultAccount is Receiver {
     //  ERC-1271
     // ══════════════════════════════════════════════
 
-    /// @notice Signature validation via AccountConfiguration. Requires the verified actor to hold SIGNER
-    ///         scope (or be an unrestricted owner); `verifySignature` enforces this and never reverts.
-    /// @param hash The digest to authenticate
-    /// @param signature Auth data in authenticator || data format
-    /// @return magicValue 0x1626ba7e if valid, 0xffffffff otherwise
+    /// @notice Validates an ERC-1271 signature via AccountConfiguration; requires the verified actor to hold
+    ///         SIGNER scope or be an unrestricted owner. Never reverts.
+    ///
+    /// @param hash The digest to authenticate.
+    /// @param signature Auth data in `authenticator || data` format.
+    ///
+    /// @return The ERC-1271 magic value 0x1626ba7e if valid, otherwise 0xffffffff.
     function isValidSignature(bytes32 hash, bytes calldata signature) external view virtual returns (bytes4) {
         return
             ACCOUNT_CONFIGURATION.verifySignature(address(this), hash, signature)
@@ -68,6 +85,11 @@ contract DefaultAccount is Receiver {
     //  VIEW
     // ══════════════════════════════════════════════
 
+    /// @notice Returns whether `caller` may drive execution on this account.
+    ///
+    /// @param caller Address to check.
+    ///
+    /// @return True if `caller` is the account itself or a registered TRUSTED_EXECUTOR actor.
     function isAuthorizedCaller(address caller) external view returns (bool) {
         return _isAuthorizedCaller(caller);
     }
@@ -76,6 +98,7 @@ contract DefaultAccount is Receiver {
     //  INTERNALS
     // ══════════════════════════════════════════════
 
+    /// @dev Authorized if `caller` is the account itself or holds the TRUSTED_EXECUTOR authenticator.
     function _isAuthorizedCaller(address caller) internal view virtual returns (bool) {
         if (caller == address(this)) return true;
         AccountConfiguration.ActorConfig memory config =

--- a/src/authenticators/DelegateAuthenticator.sol
+++ b/src/authenticators/DelegateAuthenticator.sol
@@ -5,10 +5,10 @@ import {AccountConfiguration} from "../AccountConfiguration.sol";
 import {IAuthenticator} from "../interfaces/IAuthenticator.sol";
 
 /// @notice Delegates authentication to another account's actor configuration; a single hop only.
-///         actorId = bytes32(bytes20(delegate_address)).
+///         actorId = bytes32(bytes20(delegate_address))
 ///
-///         This contract exists for non-8130 chains where verifySignature() runs in normal EVM. On 8130
-///         chains, the protocol handles DELEGATE directly at the protocol level.
+///         This contract exists for non-8130 chains where verifySignature() runs in normal EVM.
+///         On 8130 chains, the protocol handles DELEGATE directly at the protocol level.
 ///
 ///         Data layout: delegate_address (20) || nested_authenticator (20) || nested_data
 ///
@@ -23,7 +23,7 @@ contract DelegateAuthenticator is IAuthenticator {
         ACCOUNT_CONFIGURATION = AccountConfiguration(accountConfiguration);
     }
 
-    /// @notice Authenticates by delegating to another account's actor configuration; a single hop only.
+    /// @notice Authenticates by delegating to another account's actor configuration; only one hop is permitted.
     ///
     /// @dev Reverts when `data` is shorter than 40 bytes.
     /// @dev Reverts when the nested authenticator is this contract (recursive delegation is not permitted).

--- a/src/authenticators/DelegateAuthenticator.sol
+++ b/src/authenticators/DelegateAuthenticator.sol
@@ -4,21 +4,35 @@ pragma solidity ^0.8.30;
 import {AccountConfiguration} from "../AccountConfiguration.sol";
 import {IAuthenticator} from "../interfaces/IAuthenticator.sol";
 
-/// @notice Delegates authentication to another account's actor configuration.
-///         actorId = bytes32(bytes20(delegate_address)). Only 1 hop permitted.
+/// @notice Delegates authentication to another account's actor configuration; a single hop only.
+///         actorId = bytes32(bytes20(delegate_address)).
 ///
-///         This contract exists for non-8130 chains where verifySignature() runs
-///         in normal EVM. On 8130 chains, the protocol handles DELEGATE directly
-///         at the protocol level.
+///         This contract exists for non-8130 chains where verifySignature() runs in normal EVM. On 8130
+///         chains, the protocol handles DELEGATE directly at the protocol level.
 ///
 ///         Data layout: delegate_address (20) || nested_authenticator (20) || nested_data
+///
+/// @author Coinbase
 contract DelegateAuthenticator is IAuthenticator {
+    /// @notice The AccountConfiguration system contract used to validate the nested (delegate) signature.
     AccountConfiguration public immutable ACCOUNT_CONFIGURATION;
 
+    /// @notice Deploys the authenticator bound to an AccountConfiguration instance.
+    /// @param accountConfiguration Address of the AccountConfiguration system contract.
     constructor(address accountConfiguration) {
         ACCOUNT_CONFIGURATION = AccountConfiguration(accountConfiguration);
     }
 
+    /// @notice Authenticates by delegating to another account's actor configuration; a single hop only.
+    ///
+    /// @dev Reverts when `data` is shorter than 40 bytes.
+    /// @dev Reverts when the nested authenticator is this contract (recursive delegation is not permitted).
+    /// @dev Reverts when the delegate account does not validate the nested signature.
+    ///
+    /// @param hash The digest being authenticated.
+    /// @param data delegate address (20) then the nested auth blob (nested authenticator address then its data).
+    ///
+    /// @return actorId The delegate's actorId, bytes32(bytes20(delegate)), when the nested signature is valid.
     function authenticate(bytes32 hash, bytes calldata data) external view returns (bytes32 actorId) {
         require(data.length >= 40);
         address delegate = address(bytes20(data[:20]));

--- a/src/authenticators/P256Authenticator.sol
+++ b/src/authenticators/P256Authenticator.sol
@@ -5,10 +5,21 @@ import {P256} from "openzeppelin/utils/cryptography/P256.sol";
 
 import {IAuthenticator} from "../interfaces/IAuthenticator.sol";
 
-/// @notice P-256 raw ECDSA authenticator. actorId = keccak256(pub_key_x || pub_key_y).
-/// @dev Data layout: r (32) || s (32) || pub_key_x (32) || pub_key_y (32) || pre_hash (1)
-///      pre_hash byte is included for protocol-level native authenticator consistency.
+/// @notice P-256 raw ECDSA authenticator; actorId = keccak256(pub_key_x || pub_key_y).
+///
+/// @dev Data layout: r (32) || s (32) || pub_key_x (32) || pub_key_y (32) || pre_hash (1). The trailing
+///      pre_hash byte is accepted for native-authenticator layout consistency and is not otherwise interpreted.
+///
+/// @author Coinbase
 contract P256Authenticator is IAuthenticator {
+    /// @notice Verifies a raw secp256r1 (P-256) signature and returns the signer's actorId.
+    ///
+    /// @dev Reverts when `data` is not exactly 129 bytes.
+    ///
+    /// @param hash The digest that was signed.
+    /// @param data r (32) || s (32) || pub_key_x (32) || pub_key_y (32) || pre_hash (1).
+    ///
+    /// @return actorId keccak256(pub_key_x || pub_key_y) if the signature is valid, otherwise bytes32(0).
     function authenticate(bytes32 hash, bytes calldata data) external view returns (bytes32 actorId) {
         require(data.length == 129);
         bytes32 r = bytes32(data[:32]);

--- a/src/authenticators/WebAuthnAuthenticator.sol
+++ b/src/authenticators/WebAuthnAuthenticator.sol
@@ -5,8 +5,17 @@ import {WebAuthn} from "openzeppelin/utils/cryptography/WebAuthn.sol";
 
 import {IAuthenticator} from "../interfaces/IAuthenticator.sol";
 
-/// @notice P-256 WebAuthn/Passkey authenticator. actorId = keccak256(pub_key_x || pub_key_y).
+/// @notice P-256 WebAuthn/Passkey authenticator; actorId = keccak256(pub_key_x || pub_key_y).
+/// @author Coinbase
 contract WebAuthnAuthenticator is IAuthenticator {
+    /// @notice Verifies a WebAuthn (P-256 passkey) assertion and returns the signer's actorId.
+    ///
+    /// @dev Reverts when `data` cannot be abi-decoded into (WebAuthn.WebAuthnAuth, bytes32, bytes32).
+    ///
+    /// @param hash The challenge digest; checked against the assertion's clientDataJSON.
+    /// @param data abi.encode(WebAuthn.WebAuthnAuth assertion, bytes32 pub_key_x, bytes32 pub_key_y).
+    ///
+    /// @return actorId keccak256(pub_key_x || pub_key_y) if the assertion is valid, otherwise bytes32(0).
     function authenticate(bytes32 hash, bytes calldata data) external view returns (bytes32 actorId) {
         (WebAuthn.WebAuthnAuth memory auth, bytes32 x, bytes32 y) =
             abi.decode(data, (WebAuthn.WebAuthnAuth, bytes32, bytes32));

--- a/src/interfaces/IAuthenticator.sol
+++ b/src/interfaces/IAuthenticator.sol
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-/// @notice Authenticator interface for EIP-8130 signature authentication.
-///         Authenticators derive the actorId from the provided signature data and return it.
-///         Returns bytes32(0) for invalid signatures.
+/// @notice Authenticator interface for EIP-8130 signature authentication. Implementations derive the actorId
+///         from the provided signature data and return it, or bytes32(0) for an invalid signature.
+/// @author Coinbase
 interface IAuthenticator {
-    /// @param hash The hash to authenticate the signature for
-    /// @param data Authenticator-specific signature data (includes public key material)
-    /// @return actorId The authenticated actor identifier, or bytes32(0) if invalid
+    /// @notice Authenticates a signature and returns the signer's actorId, or bytes32(0) if invalid.
+    ///
+    /// @param hash The hash to authenticate the signature for.
+    /// @param data Authenticator-specific signature data (includes public key material).
+    ///
+    /// @return actorId The authenticated actor identifier, or bytes32(0) if invalid.
     function authenticate(bytes32 hash, bytes calldata data) external view returns (bytes32 actorId);
 }


### PR DESCRIPTION
## Summary
- Add complete NatSpec to `AccountConfiguration`, `DefaultAccount`, the `P256`, `WebAuthn`, and `Delegate` authenticators, and the `IAuthenticator` interface they implement.
- `AccountConfiguration`: documents all external/public functions (with `@param`/`@return` and enumerated revert conditions), events, structs, errors, and public constants/typehashes.
- Comments only: no changes to code, logic, function signatures, or storage layout.

## Notes
- Each `@dev Reverts with ...` enumeration was verified against the actual code paths.
- `forge build` passes and `forge fmt --check src/` is clean.