### PR TITLE
refactor: replace bare require() with custom errors

### DIFF
--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -42,6 +42,12 @@ contract DefaultAccount is Receiver {
     /// @notice The AccountConfiguration system contract that owns this account's authorization state.
     AccountConfiguration public immutable ACCOUNT_CONFIGURATION;
 
+    /// @notice The caller is neither the account itself nor a registered TRUSTED_EXECUTOR actor.
+    error UnauthorizedCaller();
+
+    /// @notice An inner call in the executed batch reverted.
+    error CallFailed();
+
     /// @notice Deploys the account implementation bound to an AccountConfiguration instance.
     /// @param accountConfiguration Address of the AccountConfiguration system contract.
     constructor(address accountConfiguration) {
@@ -54,15 +60,15 @@ contract DefaultAccount is Receiver {
 
     /// @notice Executes a batch of calls from the account; reverts the entire batch if any call fails.
     ///
-    /// @dev Reverts when the caller is neither the account itself nor a registered TRUSTED_EXECUTOR actor.
-    /// @dev Reverts when any inner call reverts.
+    /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a TRUSTED_EXECUTOR actor.
+    /// @dev Reverts with CallFailed when any inner call reverts.
     ///
     /// @param calls Ordered calls to execute, each as (target, value, data).
     function executeBatch(Call[] calldata calls) external virtual {
-        require(_isAuthorizedCaller(msg.sender));
+        if (!_isAuthorizedCaller(msg.sender)) revert UnauthorizedCaller();
         for (uint256 i; i < calls.length; i++) {
             (bool success,) = calls[i].target.call{value: calls[i].value}(calls[i].data);
-            require(success);
+            if (!success) revert CallFailed();
         }
     }
 

--- a/src/accounts/DefaultHighRateAccount.sol
+++ b/src/accounts/DefaultHighRateAccount.sol
@@ -12,17 +12,27 @@ import {Call, DefaultAccount} from "./DefaultAccount.sol";
 ///         Deployed behind a plain 45-byte ERC-1167 proxy, so its behaviour is fully fixed by its (hardcoded)
 ///         implementation address.
 contract DefaultHighRateAccount is DefaultAccount {
+    /// @notice A value-bearing call was attempted while the account is locked.
+    error AccountLocked();
+
     constructor(address accountConfiguration) DefaultAccount(accountConfiguration) {}
 
+    /// @notice Executes a batch of calls from the account, blocking outbound value transfers while locked.
+    ///
+    /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a TRUSTED_EXECUTOR actor.
+    /// @dev Reverts with AccountLocked when a call carries non-zero value and the account is locked.
+    /// @dev Reverts with CallFailed when any inner call reverts.
+    ///
+    /// @param calls Ordered calls to execute, each as (target, value, data).
     function executeBatch(Call[] calldata calls) external override {
-        require(_isAuthorizedCaller(msg.sender));
+        if (!_isAuthorizedCaller(msg.sender)) revert UnauthorizedCaller();
         for (uint256 i; i < calls.length; i++) {
             if (calls[i].value > 0) {
                 (bool locked,,,) = ACCOUNT_CONFIGURATION.getLockStatus(address(this));
-                require(!locked);
+                if (locked) revert AccountLocked();
             }
             (bool success,) = calls[i].target.call{value: calls[i].value}(calls[i].data);
-            require(success);
+            if (!success) revert CallFailed();
         }
     }
 }

--- a/src/accounts/UpgradeableAccount.sol
+++ b/src/accounts/UpgradeableAccount.sol
@@ -40,12 +40,17 @@ contract UpgradeableAccount is DefaultAccount, UUPSUpgradeable {
     /// @dev The authenticated actor may not authorize upgrades (not an unrestricted owner and lacks CONFIG scope).
     error UpgradeUnauthorized();
 
+    /// @dev upgradeToAndCall was called directly instead of through {upgradeBySignature}, so no CONFIG-signed
+    ///      authorization set the one-shot flag.
+    error UpgradeNotInitiated();
+
     constructor(address accountConfiguration) DefaultAccount(accountConfiguration) {}
 
     /// @dev {upgradeBySignature} is the only place that sets {_upgradeAuthorized}, so satisfying this confirms a
     ///      CONFIG-scoped signature has already authorized the implementation change being applied.
+    /// @dev Reverts with UpgradeNotInitiated when the flag is unset (a direct upgradeToAndCall call).
     function _authorizeUpgrade(address) internal override {
-        require(_upgradeAuthorized);
+        if (!_upgradeAuthorized) revert UpgradeNotInitiated();
         _upgradeAuthorized = false;
     }
 

--- a/src/accounts/example/BackwardsCompatible4337Account.sol
+++ b/src/accounts/example/BackwardsCompatible4337Account.sol
@@ -66,11 +66,14 @@ contract BackwardsCompatible4337Account is DefaultAccount {
     ///         Signature format follows 8130 authenticator conventions (authenticator_type || data),
     ///         and optionally carries signed actor/owner changes applied during validation
     ///         (see {SIGNED_ACTOR_CHANGES_MAGIC}).
+    ///
+    /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a TRUSTED_EXECUTOR actor
+    ///      (typically the EntryPoint).
     function validateUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash, uint256 missingAccountFunds)
         external
         returns (uint256 validationData)
     {
-        require(_isAuthorizedCaller(msg.sender));
+        if (!_isAuthorizedCaller(msg.sender)) revert UnauthorizedCaller();
 
         validationData = _validateSignature(userOp, userOpHash, missingAccountFunds) ? 0 : 1;
 

--- a/src/authenticators/DelegateAuthenticator.sol
+++ b/src/authenticators/DelegateAuthenticator.sol
@@ -17,6 +17,15 @@ contract DelegateAuthenticator is IAuthenticator {
     /// @notice The AccountConfiguration system contract used to validate the nested (delegate) signature.
     AccountConfiguration public immutable ACCOUNT_CONFIGURATION;
 
+    /// @notice The auth data is shorter than the 40-byte delegate + nested-authenticator prefix.
+    error InvalidDataLength();
+
+    /// @notice The nested authenticator points back to this contract; only one delegation hop is permitted.
+    error RecursiveDelegation();
+
+    /// @notice The nested signer is not authorized to sign for the delegate account.
+    error InvalidNestedSignature();
+
     /// @notice Deploys the authenticator bound to an AccountConfiguration instance.
     /// @param accountConfiguration Address of the AccountConfiguration system contract.
     constructor(address accountConfiguration) {
@@ -25,16 +34,17 @@ contract DelegateAuthenticator is IAuthenticator {
 
     /// @notice Authenticates by delegating to another account's actor configuration; only one hop is permitted.
     ///
-    /// @dev Reverts when `data` is shorter than 40 bytes.
-    /// @dev Reverts when the nested authenticator is this contract (recursive delegation is not permitted).
-    /// @dev Reverts when the delegate account does not validate the nested signature.
+    /// @dev Reverts with InvalidDataLength when `data` is shorter than 40 bytes.
+    /// @dev Reverts with RecursiveDelegation when the nested authenticator is this contract (recursive delegation
+    ///      is not permitted).
+    /// @dev Reverts with InvalidNestedSignature when the delegate account does not validate the nested signature.
     ///
     /// @param hash The digest being authenticated.
     /// @param data delegate address (20) then the nested auth blob (nested authenticator address then its data).
     ///
     /// @return actorId The delegate's actorId, bytes32(bytes20(delegate)), when the nested signature is valid.
     function authenticate(bytes32 hash, bytes calldata data) external view returns (bytes32 actorId) {
-        require(data.length >= 40);
+        if (data.length < 40) revert InvalidDataLength();
         address delegate = address(bytes20(data[:20]));
         bytes calldata nestedAuth = data[20:];
 
@@ -42,9 +52,9 @@ contract DelegateAuthenticator is IAuthenticator {
 
         // Prevent recursive delegation (only 1 hop permitted)
         address nestedAuthenticator = address(bytes20(nestedAuth[:20]));
-        require(nestedAuthenticator != address(this));
+        if (nestedAuthenticator == address(this)) revert RecursiveDelegation();
 
         // Nested signer must have SIGNATURE scope on the delegate account.
-        require(ACCOUNT_CONFIGURATION.verifySignature(delegate, hash, nestedAuth));
+        if (!ACCOUNT_CONFIGURATION.verifySignature(delegate, hash, nestedAuth)) revert InvalidNestedSignature();
     }
 }

--- a/src/authenticators/P256Authenticator.sol
+++ b/src/authenticators/P256Authenticator.sol
@@ -12,16 +12,19 @@ import {IAuthenticator} from "../interfaces/IAuthenticator.sol";
 ///
 /// @author Coinbase
 contract P256Authenticator is IAuthenticator {
+    /// @notice The auth data length is not exactly 129 bytes.
+    error InvalidDataLength();
+
     /// @notice Verifies a raw secp256r1 (P-256) signature and returns the signer's actorId.
     ///
-    /// @dev Reverts when `data` is not exactly 129 bytes.
+    /// @dev Reverts with InvalidDataLength when `data` is not exactly 129 bytes.
     ///
     /// @param hash The digest that was signed.
     /// @param data r (32) || s (32) || pub_key_x (32) || pub_key_y (32) || pre_hash (1).
     ///
     /// @return actorId keccak256(pub_key_x || pub_key_y) if the signature is valid, otherwise bytes32(0).
     function authenticate(bytes32 hash, bytes calldata data) external view returns (bytes32 actorId) {
-        require(data.length == 129);
+        if (data.length != 129) revert InvalidDataLength();
         bytes32 r = bytes32(data[:32]);
         bytes32 s = bytes32(data[32:64]);
         bytes32 x = bytes32(data[64:96]);

--- a/test/unit/accounts/BackwardsCompatible4337Account.t.sol
+++ b/test/unit/accounts/BackwardsCompatible4337Account.t.sol
@@ -243,7 +243,7 @@ contract BackwardsCompatible4337AccountTest is AccountConfigurationTest {
         PackedUserOperation memory userOp = _buildUserOp(account, _buildK1Auth(ACTOR_PK, userOpHash));
 
         vm.prank(address(0xdead));
-        vm.expectRevert();
+        vm.expectRevert(DefaultAccount.UnauthorizedCaller.selector);
         BackwardsCompatible4337Account(payable(account)).validateUserOp(userOp, userOpHash, 0);
     }
 

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -90,7 +90,7 @@ contract DefaultAccountTest is AccountConfigurationTest {
         value = bound(value, 0, type(uint128).max);
 
         vm.prank(caller);
-        vm.expectRevert();
+        vm.expectRevert(DefaultAccount.UnauthorizedCaller.selector);
         DefaultAccount(payable(account)).executeBatch(_singleCall(address(target), value, data));
     }
 
@@ -103,7 +103,7 @@ contract DefaultAccountTest is AccountConfigurationTest {
         vm.assume(owner != account);
 
         vm.prank(owner);
-        vm.expectRevert();
+        vm.expectRevert(DefaultAccount.UnauthorizedCaller.selector);
         DefaultAccount(payable(account))
             .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (1))));
     }
@@ -121,7 +121,7 @@ contract DefaultAccountTest is AccountConfigurationTest {
         _authorizeActor(account, ACTOR_PK, bytes32(bytes20(actor)), k1Authenticator);
 
         vm.prank(actor);
-        vm.expectRevert();
+        vm.expectRevert(DefaultAccount.UnauthorizedCaller.selector);
         DefaultAccount(payable(account))
             .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (1))));
     }
@@ -134,7 +134,7 @@ contract DefaultAccountTest is AccountConfigurationTest {
         vm.deal(account, value);
 
         vm.prank(account);
-        vm.expectRevert();
+        vm.expectRevert(DefaultAccount.CallFailed.selector);
         DefaultAccount(payable(account))
             .executeBatch(_singleCall(address(target), value, abi.encodeCall(MockTarget.reverting, ())));
     }
@@ -150,7 +150,7 @@ contract DefaultAccountTest is AccountConfigurationTest {
         calls[1] = Call(address(target), 0, abi.encodeCall(MockTarget.reverting, ()));
 
         vm.prank(account);
-        vm.expectRevert();
+        vm.expectRevert(DefaultAccount.CallFailed.selector);
         DefaultAccount(payable(account)).executeBatch(calls);
 
         assertEq(target.value(), 0);

--- a/test/unit/accounts/DefaultHighRateAccount.t.sol
+++ b/test/unit/accounts/DefaultHighRateAccount.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {DefaultHighRateAccount} from "../../../src/accounts/DefaultHighRateAccount.sol";
-import {Call} from "../../../src/accounts/DefaultAccount.sol";
+import {Call, DefaultAccount} from "../../../src/accounts/DefaultAccount.sol";
 import {AccountConfiguration} from "../../../src/AccountConfiguration.sol";
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 
@@ -92,7 +92,7 @@ contract DefaultHighRateAccountTest is AccountConfigurationTest {
         (address account,) = _createHighRateK1Account(ACTOR_PK);
 
         vm.prank(address(0xdead));
-        vm.expectRevert();
+        vm.expectRevert(DefaultAccount.UnauthorizedCaller.selector);
         DefaultHighRateAccount(payable(account))
             .executeBatch(_singleCall(address(target), 0, abi.encodeCall(HighRateMockTarget.setValue, (1))));
     }
@@ -101,7 +101,7 @@ contract DefaultHighRateAccountTest is AccountConfigurationTest {
         (address account,) = _createHighRateK1Account(ACTOR_PK);
 
         vm.prank(account);
-        vm.expectRevert();
+        vm.expectRevert(DefaultAccount.CallFailed.selector);
         DefaultHighRateAccount(payable(account))
             .executeBatch(_singleCall(address(target), 0, abi.encodeCall(HighRateMockTarget.reverting, ())));
     }
@@ -113,7 +113,7 @@ contract DefaultHighRateAccountTest is AccountConfigurationTest {
         _lockAccount(account, 1 hours);
 
         vm.prank(account);
-        vm.expectRevert();
+        vm.expectRevert(DefaultHighRateAccount.AccountLocked.selector);
         DefaultHighRateAccount(payable(account))
             .executeBatch(_singleCall(address(target), 0.1 ether, abi.encodeCall(HighRateMockTarget.setValue, (1))));
     }

--- a/test/unit/accounts/UpgradeableAccount.t.sol
+++ b/test/unit/accounts/UpgradeableAccount.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.30;
 import {UpgradeableAccount} from "../../../src/accounts/UpgradeableAccount.sol";
 import {UpgradeableProxy} from "../../../src/accounts/UpgradeableProxy.sol";
 import {UUPSUpgradeable} from "solady/utils/UUPSUpgradeable.sol";
-import {Call} from "../../../src/accounts/DefaultAccount.sol";
+import {Call, DefaultAccount} from "../../../src/accounts/DefaultAccount.sol";
 import {AccountConfiguration} from "../../../src/AccountConfiguration.sol";
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 
@@ -130,7 +130,7 @@ contract UpgradeableAccountTest is AccountConfigurationTest {
         (address account,) = _createUpgradeableAccount(ACTOR_PK);
 
         vm.prank(address(0xdead));
-        vm.expectRevert();
+        vm.expectRevert(DefaultAccount.UnauthorizedCaller.selector);
         UpgradeableAccount(payable(account))
             .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (1))));
     }
@@ -139,7 +139,7 @@ contract UpgradeableAccountTest is AccountConfigurationTest {
         (address account,) = _createUpgradeableAccount(ACTOR_PK);
 
         vm.prank(account);
-        vm.expectRevert();
+        vm.expectRevert(DefaultAccount.CallFailed.selector);
         UpgradeableAccount(payable(account))
             .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.reverting, ())));
     }
@@ -154,7 +154,7 @@ contract UpgradeableAccountTest is AccountConfigurationTest {
         UpgradeableAccountV2 v2Impl = new UpgradeableAccountV2(address(accountConfiguration));
 
         vm.prank(account);
-        vm.expectRevert();
+        vm.expectRevert(UpgradeableAccount.UpgradeNotInitiated.selector);
         UpgradeableAccount(payable(account)).upgradeToAndCall(address(v2Impl), "");
     }
 
@@ -163,7 +163,7 @@ contract UpgradeableAccountTest is AccountConfigurationTest {
         UpgradeableAccountV2 v2Impl = new UpgradeableAccountV2(address(accountConfiguration));
 
         vm.prank(address(0xdead));
-        vm.expectRevert();
+        vm.expectRevert(UpgradeableAccount.UpgradeNotInitiated.selector);
         UpgradeableAccount(payable(account)).upgradeToAndCall(address(v2Impl), "");
     }
 
@@ -193,7 +193,7 @@ contract UpgradeableAccountTest is AccountConfigurationTest {
         calls[0] = Call(account, 0, abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (address(v2Impl), "")));
 
         vm.prank(account);
-        vm.expectRevert();
+        vm.expectRevert(DefaultAccount.CallFailed.selector);
         UpgradeableAccount(payable(account)).executeBatch(calls);
     }
 

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -2,15 +2,16 @@
 pragma solidity ^0.8.30;
 
 import {AccountConfiguration} from "../../../src/AccountConfiguration.sol";
+import {DelegateAuthenticator} from "../../../src/authenticators/DelegateAuthenticator.sol";
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 
 /// @notice Fuzzed, branch-complete test suite for DelegateAuthenticator.authenticate.
 ///
 ///         Source data layout: delegate_address(20) ‖ nested_authenticator(20) ‖ nested_data.
-///         Guards, in source-execution order (all bare `require`, so assert with vm.expectRevert()):
-///           1. require(data.length >= 40)
-///           2. require(nestedAuthenticator != address(this))   // blocks 1-hop recursion
-///           3. require(ACCOUNT_CONFIGURATION.verifySignature(delegate, hash, nestedAuth))
+///         Guards, in source-execution order, each reverting with a custom error:
+///           1. InvalidDataLength       — data.length < 40
+///           2. RecursiveDelegation     — nestedAuthenticator == address(this) (blocks 1-hop recursion)
+///           3. InvalidNestedSignature  — verifySignature(delegate, hash, nestedAuth) is false
 ///         On success returns actorId = bytes32(bytes20(delegate)).
 ///
 ///         verifySignature(delegate, hash, nestedAuth) is true iff the nested auth resolves to a live
@@ -33,7 +34,7 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
             data[i] = bytes1(uint8(uint256(keccak256(abi.encode(fillSeed, i)))));
         }
 
-        vm.expectRevert();
+        vm.expectRevert(DelegateAuthenticator.InvalidDataLength.selector);
         delegateAuthenticator.authenticate(hash, data);
     }
 
@@ -48,7 +49,7 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
         bytes memory data = abi.encodePacked(delegate, self, tail);
         assertGe(data.length, 40);
 
-        vm.expectRevert();
+        vm.expectRevert(DelegateAuthenticator.RecursiveDelegation.selector);
         delegateAuthenticator.authenticate(hash, data);
     }
 
@@ -69,7 +70,7 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
         bytes memory nestedAuth = abi.encodePacked(k1Authenticator, _signDigest(wrongPk, hash));
         bytes memory data = abi.encodePacked(delegateAccount, nestedAuth);
 
-        vm.expectRevert();
+        vm.expectRevert(DelegateAuthenticator.InvalidNestedSignature.selector);
         delegateAuthenticator.authenticate(hash, data);
     }
 
@@ -89,7 +90,7 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
         bytes memory nestedAuth = abi.encodePacked(k1Authenticator, _signDigest(ownerAPk, hash));
         bytes memory data = abi.encodePacked(accountB, nestedAuth);
 
-        vm.expectRevert();
+        vm.expectRevert(DelegateAuthenticator.InvalidNestedSignature.selector);
         delegateAuthenticator.authenticate(hash, data);
     }
 
@@ -115,7 +116,7 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
         bytes memory nestedAuth = abi.encodePacked(k1Authenticator, _signDigest(signerPk, hash));
         bytes memory data = abi.encodePacked(delegateAccount, nestedAuth);
 
-        vm.expectRevert();
+        vm.expectRevert(DelegateAuthenticator.InvalidNestedSignature.selector);
         delegateAuthenticator.authenticate(hash, data);
     }
 

--- a/test/unit/authenticators/P256Authenticator.t.sol
+++ b/test/unit/authenticators/P256Authenticator.t.sol
@@ -4,19 +4,20 @@ pragma solidity ^0.8.30;
 import {Math} from "openzeppelin/utils/math/Math.sol";
 import {P256} from "openzeppelin/utils/cryptography/P256.sol";
 
+import {P256Authenticator} from "../../../src/authenticators/P256Authenticator.sol";
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 
 /// @notice P256Authenticator tests. Data layout: r(32) ‖ s(32) ‖ x(32) ‖ y(32) ‖ preHash(1) = 129 bytes.
 ///         The authenticator reverts on wrong length, returns actorId = keccak256(x‖y) on a valid signature, and
 ///         returns bytes32(0) on any verification failure (it never reverts on a bad-but-well-formed signature).
 contract P256AuthenticatorTest is AccountConfigurationTest {
-    // ── revert: length guard (require(data.length == 129)) ──
+    // ── revert: length guard (InvalidDataLength) ──
 
     /// @notice Reverts for any calldata whose length is not exactly 129 bytes.
-    /// @dev Fuzz confirms no length other than 129 is accepted; bare require reverts with empty data.
+    /// @dev Fuzz confirms no length other than 129 is accepted; reverts with InvalidDataLength.
     function test_authenticate_revert_wrongDataLength(bytes memory data) public {
         vm.assume(data.length != 129);
-        vm.expectRevert();
+        vm.expectRevert(P256Authenticator.InvalidDataLength.selector);
         p256Authenticator.authenticate(keccak256("h"), data);
     }
 
@@ -29,7 +30,7 @@ contract P256AuthenticatorTest is AccountConfigurationTest {
         for (uint256 i; i < 128; ++i) {
             short[i] = data[i];
         }
-        vm.expectRevert();
+        vm.expectRevert(P256Authenticator.InvalidDataLength.selector);
         p256Authenticator.authenticate(hash, short);
     }
 
@@ -39,7 +40,7 @@ contract P256AuthenticatorTest is AccountConfigurationTest {
         pk = _boundP256Pk(pk);
         bytes memory data = abi.encodePacked(_p256SignData(pk, hash), uint8(0));
         assertEq(data.length, 130);
-        vm.expectRevert();
+        vm.expectRevert(P256Authenticator.InvalidDataLength.selector);
         p256Authenticator.authenticate(hash, data);
     }
 


### PR DESCRIPTION
## Summary
- Replace every bare `require()` in `src/` with named custom errors across the account and authenticator contracts, so failures revert with a specific, decodable selector instead of empty data.
- Update the affected tests to assert the specific error selectors, and refresh NatSpec / test comments to reference the new errors.

## Custom errors added
- `DefaultAccount`: `UnauthorizedCaller`, `CallFailed` (inherited by `DefaultHighRateAccount`, `UpgradeableAccount`, `BackwardsCompatible4337Account`)
- `DefaultHighRateAccount`: `AccountLocked`
- `DelegateAuthenticator`: `InvalidDataLength`, `RecursiveDelegation`, `InvalidNestedSignature`
- `P256Authenticator`: `InvalidDataLength`
- `UpgradeableAccount`: `UpgradeNotInitiated`

## Notes
- Mechanical control-flow conversion: `require(cond)` -> `if (!cond) revert Error();`. No logic or storage changes; parameterless errors preserve the bare requires' zero-payload semantics.
- Tests updated to `vm.expectRevert(<selector>)`. Two cases correctly resolve to the outer error: an `upgradeToAndCall` batched via `executeBatch` surfaces `CallFailed` (the batch swallows the inner revert).
- `forge test`: 322 passing. `forge fmt --check` clean.