### PR TITLE
fix: shadowed-local warnings + zero-commitment policy actor note + style + optimizations

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc = "0.8.30"
+solc = "0.8.36"
 optimizer = true
 via_ir = true
 evm_version = "osaka"

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -829,8 +829,8 @@ contract AccountConfiguration {
             return (true, false, type(uint40).max, uint16(config.lockUnion));
         }
         // Unlock initiated: lockUnion holds the effective unlock timestamp; the delay has been consumed.
-        uint40 unlocksAt = config.lockUnion;
-        return (block.timestamp < unlocksAt, true, unlocksAt, 0);
+        uint40 unlockTime = config.lockUnion;
+        return (block.timestamp < unlockTime, true, unlockTime, 0);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -1144,8 +1144,8 @@ contract AccountConfiguration {
         // Expiry is read from the same slot; an expired actor fails authentication. 0 = no expiry.
         if (config.expiry != 0 && block.timestamp > config.expiry) revert ActorExpired();
         // Read the policy-manager slot only for a policy-gated actor; non-policy actors (incl. admin) skip the SLOAD.
-        address policyTarget = (config.scope & SCOPE_POLICY != 0) ? _policyManager[actorId][account] : address(0);
-        return (config.scope, policyTarget);
+        address target = (config.scope & SCOPE_POLICY != 0) ? _policyManager[actorId][account] : address(0);
+        return (config.scope, target);
     }
 
     /// @dev The single secp256k1 ("K1") path. Recovers the signer (EIP-2 enforced), then resolves the actor:
@@ -1173,8 +1173,8 @@ contract AccountConfiguration {
             bytes32 selfActorId = bytes32(bytes20(account));
             uint8 selfScope = st.defaultEOAScope;
             // Skip the policy-manager SLOAD unless this self key is policy-gated (the common admin self never is).
-            address policyTarget = (selfScope & SCOPE_POLICY != 0) ? _policyManager[selfActorId][account] : address(0);
-            return (selfScope, policyTarget);
+            address target = (selfScope & SCOPE_POLICY != 0) ? _policyManager[selfActorId][account] : address(0);
+            return (selfScope, target);
         }
 
         bytes32 actorId = bytes32(bytes20(recovered));

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+pragma solidity 0.8.36;
 
 import {IAuthenticator} from "./interfaces/IAuthenticator.sol";
 
@@ -20,7 +20,7 @@ contract AccountConfiguration {
         uint64 local; // chain_id == block.chainid; starts at 1 once initialized (created/imported), 0 = uninitialized
     }
 
-    /// @notice An actor's authorization: authenticator, scope, expiry, and policy sub-type.
+    /// @notice An actor's authorization: authenticator, scope, and expiry.
     struct ActorConfig {
         address authenticator;
         uint8 scope;
@@ -146,7 +146,7 @@ contract AccountConfiguration {
     uint8 public constant UNLOCK_OP = 0x02;
 
     // ----------------------------------------------------------------------------------------------------------------
-    // ACTOR ELEVATED SCOPES
+    // ACTOR SCOPE BITS
     // ----------------------------------------------------------------------------------------------------------------
 
     /// @notice Actor can initiate transactions with account as sender
@@ -159,9 +159,10 @@ contract AccountConfiguration {
     ///         enforced here.
     uint8 public constant SCOPE_POLICY = 0x02;
 
-    /// @notice Actor is bound to a protocol-side nonce lane. This contract stores the scope bit verbatim and does
-    ///         not interpret it — nonce lane semantics (including which lane, and how lanes are allocated) are
-    ///         entirely protocol-side.
+    /// @notice Permits a restricted (non-admin) actor to use sequenced `nonce_key`s for sender-context transactions;
+    ///         without it a restricted actor may use only the nonce-free key (NONCE_KEY_MAX), while admin actors are
+    ///         unconstrained. This contract stores the scope bit verbatim and does not interpret it — nonce semantics
+    ///         are enforced entirely protocol-side.
     uint8 public constant SCOPE_NONCE = 0x04;
 
     /// @notice Actor can self-pay gas for the account's own operations (payer == sender).
@@ -170,8 +171,8 @@ contract AccountConfiguration {
     /// @notice Actor can sponsor gas on behalf of a different sender (payer != sender).
     uint8 public constant SCOPE_SPONSOR_PAYER = 0x10;
 
-    // Note: ERC-1271 signing is authorized for any operational actor (admin scope == 0x00, or a SENDER actor
-    // without POLICY), not a separate grant — there is no SIGNER scope bit. See verifySignature.
+    // ERC-1271 signing rides on operational authority (admin scope == 0x00, or a SENDER actor without POLICY);
+    // it is not its own scope bit. See verifySignature.
 
     // 0x20, 0x40, 0x80 are spare (unused).
 
@@ -745,7 +746,7 @@ contract AccountConfiguration {
     ///      Enforcement is at execution: this resolves where a policy-gated actor may call and the commitment a
     ///      target validates presented parameters against. The policy manager/commitment are keyed by actorId, so
     ///      the inline k1 self and a non-k1 self share that keyspace; mutual exclusion guarantees at most one is
-    ///      live, so the active gate is read by actorId. Both slots are written iff the actor's scope carries
+    ///      live, so the active gate is read by actorId. Both slots are non-zero only when the actor's scope carries
     ///      SCOPE_POLICY (see _authorizeActor / _revokeActor); either MAY still be zero for an actor deliberately
     ///      gated to a zero manager or a zero (no-params) commitment. On-chain consumers should prefer the
     ///      single-SLOAD `getPolicyCommitment` / `getPolicyManager` accessors directly.
@@ -762,7 +763,7 @@ contract AccountConfiguration {
     /// @notice Resolves an actor's signed policy commitment, or bytes32(0) if ungated / no actor / zero commitment.
     ///
     /// @dev Single SLOAD. Intended for a policy manager's per-tx validation read on the protocol-dispatched
-    ///      8130 tx path. This slot is written iff the actor's scope carries SCOPE_POLICY (see _authorizeActor /
+    ///      8130 tx path. This slot is non-zero only when the actor's scope carries SCOPE_POLICY (see _authorizeActor /
     ///      _revokeActor), but MAY be zero for a policy-gated actor with a zero (no-params) commitment; gating is
     ///      therefore determined by the SCOPE_POLICY bit, not by this slot being non-zero.
     ///
@@ -924,36 +925,37 @@ contract AccountConfiguration {
                 // Upsert: overwrite any existing non-k1 self in place.
                 _actorConfig[actorId][account] = config;
                 // Mutual exclusion: disable and clear the inline k1 self.
-                st.flags |= FLAG_REVOKE_DEFAULT_EOA;
-                st.defaultEOAScope = 0;
-                st.defaultEOAExpiry = 0;
+                _disableInlineSelf(st);
             }
-            // Policy manager/commitment are keyed by actorId (shared keyspace across both self homes): reset, then
-            // write both slots verbatim iff the incoming scope carries SCOPE_POLICY (a zero manager/commitment is
-            // valid and simply leaves the slot zero).
-            delete _policyCommitment[actorId][account];
-            delete _policyManager[actorId][account];
-            if (config.scope & SCOPE_POLICY != 0) {
-                _policyCommitment[actorId][account] = commitment;
-                _policyManager[actorId][account] = manager;
-            }
+            // Policy slots are keyed by actorId (shared keyspace across both self homes).
+            _writePolicySlots(actorId, account, manager, commitment);
 
             _emitActorAuthorized(account, actorId, config, manager, commitment);
             return;
         }
 
-        // Non-self actor: single _actorConfig home. Upsert: overwrite in place. Reset the policy slots first so an
-        // actor moving policy-gated -> ungated (or to a different manager) can't leak stale policy state, preserving
-        // the "policy slots written iff scope & SCOPE_POLICY != 0" invariant.
+        // Non-self actor: single _actorConfig home. Upsert: overwrite in place.
         _actorConfig[actorId][account] = config;
-        delete _policyCommitment[actorId][account];
-        delete _policyManager[actorId][account];
-        if (config.scope & SCOPE_POLICY != 0) {
-            _policyCommitment[actorId][account] = commitment;
-            _policyManager[actorId][account] = manager;
-        }
+        _writePolicySlots(actorId, account, manager, commitment);
 
         _emitActorAuthorized(account, actorId, config, manager, commitment);
+    }
+
+    /// @dev Writes an actor's policy slots verbatim. `_slicePolicy` yields a zero manager/commitment for a non-policy
+    ///      scope, so an ungated actor simply zeroes the slots — a single unconditional write both installs a new gate
+    ///      and clears any stale one when an actor moves policy-gated -> ungated or re-keys to a different manager,
+    ///      preserving the "policy slots are non-zero iff scope & SCOPE_POLICY != 0" invariant.
+    function _writePolicySlots(bytes32 actorId, address account, address manager, bytes32 commitment) private {
+        _policyCommitment[actorId][account] = commitment;
+        _policyManager[actorId][account] = manager;
+    }
+
+    /// @dev Disables the inline k1 ("self") key: sets FLAG_REVOKE_DEFAULT_EOA so the inline full-owner path stays off
+    ///      and zeroes the inline scope/expiry. Used when authorizing a non-k1 self (mutual exclusion) and on revoke.
+    function _disableInlineSelf(AccountState storage st) private {
+        st.flags |= FLAG_REVOKE_DEFAULT_EOA;
+        st.defaultEOAScope = 0;
+        st.defaultEOAExpiry = 0;
     }
 
     /// @dev Emit ActorAuthorized with a tightly packed payload. The base packs to 32 bytes
@@ -984,12 +986,12 @@ contract AccountConfiguration {
     {
         if (scope & SCOPE_POLICY == 0) {
             if (policyData.length != 0) revert InvalidPolicyData();
-        } else {
-            if (policyData.length != 52) revert InvalidPolicyData();
-            assembly ("memory-safe") {
-                manager := shr(96, mload(add(policyData, 0x20)))
-                commitment := mload(add(policyData, 0x34))
-            }
+            return (address(0), bytes32(0));
+        }
+        if (policyData.length != 52) revert InvalidPolicyData();
+        assembly ("memory-safe") {
+            manager := shr(96, mload(add(policyData, 0x20)))
+            commitment := mload(add(policyData, 0x34))
         }
     }
 
@@ -1005,10 +1007,7 @@ contract AccountConfiguration {
         // For the self-actorId, disable the k1 self: set the flag (so the inline full-owner path stays off) and
         // clear the inline config. Covers both homes — a non-k1 self was deleted above. Never auto-resurrected.
         if (actorId == bytes32(bytes20(account))) {
-            AccountState storage st = _accountState[account];
-            st.flags |= FLAG_REVOKE_DEFAULT_EOA;
-            st.defaultEOAScope = 0;
-            st.defaultEOAExpiry = 0;
+            _disableInlineSelf(_accountState[account]);
         }
         emit ActorRevoked(account, actorId);
     }
@@ -1132,20 +1131,36 @@ contract AccountConfiguration {
     function _authenticate(address account, bytes32 hash, address authenticator, bytes calldata data)
         internal
         view
-        returns (uint8 scope, address policyTarget)
+        returns (uint8, address)
     {
         if (authenticator == K1_AUTHENTICATOR) return _authenticateK1(account, hash, data);
 
         bytes32 actorId = IAuthenticator(authenticator).authenticate(hash, data);
         if (actorId == bytes32(0)) revert AuthenticationFailed();
 
+        return _resolveExplicitActor(account, actorId, authenticator);
+    }
+
+    /// @dev Resolves an explicit _actorConfig-homed actor: requires a matching authenticator and an unexpired entry,
+    ///      returning its scope and policy gate target. Shared by the non-k1 (_authenticate) and k1 other-actor
+    ///      (_authenticateK1) paths. Reverts with AuthenticatorMismatch or ActorExpired.
+    function _resolveExplicitActor(address account, bytes32 actorId, address expectedAuthenticator)
+        private
+        view
+        returns (uint8 scope, address policyTarget)
+    {
         ActorConfig memory config = _actorConfig[actorId][account];
-        if (config.authenticator != authenticator) revert AuthenticatorMismatch();
+        if (config.authenticator != expectedAuthenticator) revert AuthenticatorMismatch();
         // Expiry is read from the same slot; an expired actor fails authentication. 0 = no expiry.
         if (config.expiry != 0 && block.timestamp > config.expiry) revert ActorExpired();
-        // Read the policy-manager slot only for a policy-gated actor; non-policy actors (incl. admin) skip the SLOAD.
-        address target = (config.scope & SCOPE_POLICY != 0) ? _policyManager[actorId][account] : address(0);
-        return (config.scope, target);
+        scope = config.scope;
+        policyTarget = _policyTargetFor(scope, actorId, account);
+    }
+
+    /// @dev Resolves the policy gate target for an actor: the policy manager for a policy-gated actor
+    ///      (scope & SCOPE_POLICY != 0), or address(0) otherwise. Non-policy actors (incl. admin) skip the SLOAD.
+    function _policyTargetFor(uint8 scope, bytes32 actorId, address account) private view returns (address) {
+        return (scope & SCOPE_POLICY != 0) ? _policyManager[actorId][account] : address(0);
     }
 
     /// @dev The single secp256k1 ("K1") path. Recovers the signer (EIP-2 enforced), then resolves the actor:
@@ -1170,21 +1185,11 @@ contract AccountConfiguration {
             AccountState storage st = _accountState[account];
             if (st.flags & FLAG_REVOKE_DEFAULT_EOA != 0) revert DefaultEoaRevoked();
             if (st.defaultEOAExpiry != 0 && block.timestamp > st.defaultEOAExpiry) revert ActorExpired();
-            bytes32 selfActorId = bytes32(bytes20(account));
             uint8 selfScope = st.defaultEOAScope;
-            // Skip the policy-manager SLOAD unless this self key is policy-gated (the common admin self never is).
-            address target = (selfScope & SCOPE_POLICY != 0) ? _policyManager[selfActorId][account] : address(0);
-            return (selfScope, target);
+            return (selfScope, _policyTargetFor(selfScope, bytes32(bytes20(account)), account));
         }
 
-        bytes32 actorId = bytes32(bytes20(recovered));
-        ActorConfig memory config = _actorConfig[actorId][account];
-        if (config.authenticator != K1_AUTHENTICATOR) revert AuthenticatorMismatch();
-        // Expiry is read from the same slot; an expired actor fails authentication. 0 = no expiry.
-        if (config.expiry != 0 && block.timestamp > config.expiry) revert ActorExpired();
-        // Read the policy-manager slot only for a policy-gated actor; non-policy actors skip the SLOAD.
-        address policyTarget = (config.scope & SCOPE_POLICY != 0) ? _policyManager[actorId][account] : address(0);
-        return (config.scope, policyTarget);
+        return _resolveExplicitActor(account, bytes32(bytes20(recovered)), K1_AUTHENTICATOR);
     }
 
     /// @dev True if the account's default (implicit) EOA has been revoked via the AccountState flag.

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+pragma solidity 0.8.36;
 
 import {Receiver} from "solady/accounts/Receiver.sol";
 

--- a/src/accounts/DefaultHighRateAccount.sol
+++ b/src/accounts/DefaultHighRateAccount.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+pragma solidity 0.8.36;
 
 import {Call, DefaultAccount} from "./DefaultAccount.sol";
 

--- a/src/accounts/UpgradeableAccount.sol
+++ b/src/accounts/UpgradeableAccount.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+pragma solidity 0.8.36;
 
 import {UUPSUpgradeable} from "solady/utils/UUPSUpgradeable.sol";
 

--- a/src/accounts/UpgradeableProxy.sol
+++ b/src/accounts/UpgradeableProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+pragma solidity 0.8.36;
 
 /// @notice Generates runtime bytecode for an ERC-1967 proxy with a hardcoded default
 ///         implementation. Works immediately on deployment — no initialization required.

--- a/src/authenticators/DelegateAuthenticator.sol
+++ b/src/authenticators/DelegateAuthenticator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+pragma solidity 0.8.36;
 
 import {AccountConfiguration} from "../AccountConfiguration.sol";
 import {IAuthenticator} from "../interfaces/IAuthenticator.sol";

--- a/src/authenticators/P256Authenticator.sol
+++ b/src/authenticators/P256Authenticator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+pragma solidity 0.8.36;
 
 import {P256} from "openzeppelin/utils/cryptography/P256.sol";
 

--- a/src/authenticators/WebAuthnAuthenticator.sol
+++ b/src/authenticators/WebAuthnAuthenticator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+pragma solidity 0.8.36;
 
 import {WebAuthn} from "openzeppelin/utils/cryptography/WebAuthn.sol";
 

--- a/src/examples/policies/PolicyManager.sol
+++ b/src/examples/policies/PolicyManager.sol
@@ -92,23 +92,29 @@ contract PolicyManager is ReentrancyGuard {
     ///      enforcement reverted (e.g. revoked/expired binding, over budget, or a failing account call).
     event ExecutionSkipped(address indexed account, address indexed policy, bytes32 indexed actorId);
 
+    /// @notice No installed binding exists for the given `(policy, commitment)`.
     error PolicyNotInstalled(bytes32 commitment);
+    /// @notice A binding for this `(policy, commitment)` is already installed; installs are one-shot per commitment.
     error PolicyAlreadyInstalled(bytes32 commitment);
+    /// @notice The current time is outside the binding's `[validAfter, validUntil)` execution window.
     error OutsideValidityWindow(uint40 validAfter, uint40 validUntil, uint256 timestamp);
+    /// @notice The account has not signed this exact commitment for this manager on the given actor (the resolved
+    ///         policy manager or commitment does not match the binding).
     error CommitmentNotAuthorized(bytes32 actorId, address target, bytes32 commitment);
-    /// @dev The executing account is not the account the commitment was installed for. Commitments are opaque in
-    ///      AccountConfiguration, so this binds execution (and the commitment-keyed policy state) to its owner.
+    /// @notice The executing account is not the account the commitment was installed for. Commitments are opaque in
+    ///         AccountConfiguration, so this binds execution (and the commitment-keyed policy state) to its owner.
     error CommitmentAccountMismatch(address expected, address actual);
-    /// @dev The acting actor has no live policy commitment for the account — i.e. it is not a gated actor of this
-    ///      account, was revoked, or (on the external path) the account did not gate this manager for it.
+    /// @notice The acting actor has no live policy commitment for the account — i.e. it is not a gated actor of this
+    ///         account, was revoked, or (on the external path) the account did not gate this manager for it.
     error NoActivePolicy(bytes32 actorId);
-    /// @dev The acting actor's `ActorConfig.expiry` has passed. Commitment is not cleared on expiry (only on revoke),
-    ///      so the manager must enforce this itself — especially on {executeFor}, which has no protocol auth path.
+    /// @notice The acting actor's `ActorConfig.expiry` has passed. Commitment is not cleared on expiry (only on
+    ///         revoke), so the manager must enforce this itself — especially on {executeFor}, which has no protocol
+    ///         auth path.
     error ActorExpired(bytes32 actorId);
-    /// @dev {executeForMany} array length mismatch between `accounts` and `executionData`.
+    /// @notice {executeForMany} array length mismatch between `accounts` and `executionData`.
     error LengthMismatch();
-    /// @dev The per-account self-call boundary used by {executeForMany} was invoked by someone other than this
-    ///      contract.
+    /// @notice The per-account self-call boundary used by {executeForMany} was invoked by someone other than this
+    ///         contract.
     error OnlySelf();
 
     /// @notice Computes the commitment (binding identifier) for a binding.

--- a/src/examples/policies/PolicyManager.sol
+++ b/src/examples/policies/PolicyManager.sol
@@ -193,6 +193,8 @@ contract PolicyManager is ReentrancyGuard {
 
         // Single-SLOAD read of the live signed commitment for the acting actor. Zero means the actor is not a gated
         // key of this account (or was revoked): there is no binding to enforce, so reject.
+        // Note: a zero-commitment SCOPE_POLICY actor is valid per the spec (gating is set by the scope bit, not the
+        // commitment value) but is treated as ungated here — a real binding commits to keccak256 params, never zero.
         bytes32 commitment = ACCOUNT_CONFIGURATION.getPolicyCommitment(account, actorId);
         if (commitment == bytes32(0)) revert NoActivePolicy(actorId);
         _requireNotExpired(account, actorId);
@@ -280,6 +282,7 @@ contract PolicyManager is ReentrancyGuard {
         if (ACCOUNT_CONFIGURATION.getPolicyManager(account, actorId) != address(this)) {
             revert NoActivePolicy(actorId);
         }
+        // Note: a zero-commitment SCOPE_POLICY actor is valid per the spec but treated as ungated here (see execute).
         bytes32 commitment = ACCOUNT_CONFIGURATION.getPolicyCommitment(account, actorId);
         if (commitment == bytes32(0)) revert NoActivePolicy(actorId);
         _requireNotExpired(account, actorId);

--- a/src/examples/policies/README.md
+++ b/src/examples/policies/README.md
@@ -145,7 +145,8 @@ as a *policy-only* actor — it has no authority of its own, it only carries a b
 AccountConfiguration.ActorConfig({
     authenticator: EXTERNAL_POLICY_AUTHENTICATOR, // recognized actor; NO direct executeBatch; not 8130-usable
     scope:         0x02,                          // SCOPE_POLICY — gated initiation only (MAY also OR SCOPE_SELF_PAYER
-                                                  //   for self-pay; SHOULD NOT combine with SENDER — POLICY gates regardless)
+                                                  //   for self-pay; SHOULD NOT combine with SENDER — POLICY gates
+                                                  //   regardless, so SENDER adds no authority the protocol will honor)
     expiry:        0
 });
 ```

--- a/src/examples/policies/SessionPolicy.sol
+++ b/src/examples/policies/SessionPolicy.sol
@@ -119,27 +119,27 @@ contract SessionPolicy is Policy {
     ///      window spans [0, max], so the cumulative spend simply never refreshes within representable time.
     uint40 internal constant ONE_TIME_PERIOD = type(uint40).max;
 
-    /// @dev The action's `target` is not in the committed call-target allowlist.
+    /// @notice The action's `target` is not in the committed call-target allowlist.
     error TargetNotAllowed(address target);
-    /// @dev `selector` is not permitted on `target` (the target pins an explicit selector allowlist that omits it).
+    /// @notice `selector` is not permitted on `target` (the target pins an explicit selector allowlist that omits it).
     error SelectorNotAllowed(address target, bytes4 selector);
-    /// @dev `recipient` (decoded from the ERC-20 call) is not in the selector's committed recipient allowlist.
+    /// @notice `recipient` (decoded from the ERC-20 call) is not in the selector's committed recipient allowlist.
     error RecipientNotAllowed(address target, bytes4 selector, address recipient);
-    /// @dev The action carried 1–3 bytes of calldata: too short to hold a 4-byte selector, so it is rejected rather
-    ///      than guessed.
+    /// @notice The action carried 1–3 bytes of calldata: too short to hold a 4-byte selector, so it is rejected rather
+    ///         than guessed.
     error MissingSelector();
-    /// @dev A configured spend `limit` exceeds uint160 and cannot be stored in the normalized allowance field.
+    /// @notice A configured spend `limit` exceeds uint160 and cannot be stored in the normalized allowance field.
     error LimitTooLarge(address token, uint256 limit);
-    /// @dev A configured spend limit was zero, which would be a no-op cap; reject at install to fail closed.
+    /// @notice A configured spend limit was zero, which would be a no-op cap; reject at install to fail closed.
     error ZeroLimit(address token);
-    /// @dev A recipient allowlist was attached to a selector whose recipient argument this policy cannot decode
-    ///      (only the standard ERC-20 selectors are supported).
+    /// @notice A recipient allowlist was attached to a selector whose recipient argument this policy cannot decode
+    ///         (only the standard ERC-20 selectors are supported).
     error RecipientRuleUnsupportedSelector(bytes4 selector);
-    /// @dev A supported ERC-20 call's calldata was too short to decode its (recipient, amount) arguments.
+    /// @notice A supported ERC-20 call's calldata was too short to decode its (recipient, amount) arguments.
     error MalformedTokenCall(bytes4 selector);
-    /// @dev A limited token must pin its allowed selectors: `anySelector` would let non-ERC20 methods move value
-    ///      without debiting the spend cap. Native-ETH limits (`token == address(0)`) are unaffected — they gate
-    ///      call `value`, not a call target.
+    /// @notice A limited token must pin its allowed selectors: `anySelector` would let non-ERC20 methods move value
+    ///         without debiting the spend cap. Native-ETH limits (`token == address(0)`) are unaffected — they gate
+    ///         call `value`, not a call target.
     error AnySelectorOnLimitedToken(address token);
 
     constructor(address policyManager) Policy(policyManager) {}


### PR DESCRIPTION

- **Shadowed locals (solc warnings).** Renamed locals that shadowed a declaration in scope: `unlocksAt` → `unlockTime` in `getLockStatus`, and `policyTarget` → `target` in `_authenticate` (shadowed the named return) and `_authenticateK1` (shadowed the sibling function-body local). Pure renames — no behavior change.
- **Zero-commitment policy actor.** Added an inline note to `PolicyManager.execute()` / `_enforceExternal()` explaining that a `SCOPE_POLICY` actor with a zero commitment is valid per the spec (gating is the scope bit, not the commitment value) but is treated as ungated by this reference manager, because a real binding commits to nonzero `keccak256` params. Matches the note already in the policies README.
- **README wording.** Sharpened the `SCOPE_POLICY` example: combining `SENDER` adds no authority the protocol will honor (the README already said "SHOULD NOT", not "MUST NOT").

## Test plan
- `forge build` — clean, no "declaration shadows" warnings.
- `forge test` — 355 passed, 0 failed.