### PR TITLE
fix: return actorId from authenticateActor

### DIFF
--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -516,7 +516,7 @@ contract AccountConfiguration {
 
         // Compute digest and authenticate
         bytes32 digest = _computeSignedActorChangesDigest(account, chainId, sequence, actorChanges);
-        (uint8 scope,) = authenticateActor(account, digest, auth);
+        (, uint8 scope,) = authenticateActor(account, digest, auth);
 
         // Only an unrestricted actor (scope 0) may change actors; there is no elevated "admin" scope bit.
         if (scope != 0) revert UnauthorizedActorChange();
@@ -574,7 +574,7 @@ contract AccountConfiguration {
         uint64 sequence = _accountState[account].localSequence++;
 
         bytes32 digest = _computeSignedLockChangesDigest(account, block.chainid, op, unlockDelay, sequence);
-        (uint8 scope,) = authenticateActor(account, digest, auth);
+        (, uint8 scope,) = authenticateActor(account, digest, auth);
 
         // Only an unrestricted actor (scope 0) may change the lock; there is no elevated "admin" scope bit.
         if (scope != 0) revert UnauthorizedLockChange();
@@ -629,7 +629,7 @@ contract AccountConfiguration {
         view
         returns (bool verified)
     {
-        try this.authenticateActor(account, hash, signature) returns (uint8 scope, address) {
+        try this.authenticateActor(account, hash, signature) returns (bytes32, uint8 scope, address) {
             // ERC-1271 signing is authorized for any operational actor: the admin (scope == 0x00), or a SENDER actor
             // that is not gated by a policy (SCOPE_SENDER set AND SCOPE_POLICY unset). Signing is an encoding of
             // authority a SENDER actor already holds via calls, not a separate grant, so it needs no dedicated scope
@@ -642,9 +642,13 @@ contract AccountConfiguration {
     }
 
     /// @notice Authenticates that an account approved `hash` using auth in `authenticator(20) || data` format,
-    ///         returning the verified actor's authorization surface so a consumer (e.g. an ERC-4337 account) can
-    ///         decide authorization from a single call without re-deriving the actorId.
+    ///         returning the verified actor's identity and authorization surface so a consumer (e.g. an ERC-4337
+    ///         account on a non-8130 chain) can decide authorization AND drive the policy flow from a single call,
+    ///         without re-deriving (or re-invoking the authenticator to recover) the actorId.
     ///
+    /// @dev `actorId` is the resolved actor identifier — the same value an 8130 chain surfaces via the tx-context
+    ///      precompile. It lets an off-8130 consumer read `getPolicyCommitment(account, actorId)` (an execution-time
+    ///      read) for a policy-gated actor, reaching parity with the native hot path.
     /// @dev `scope` is the actor's capability set, stored verbatim and never interpreted by this contract —
     ///      protocol-side semantics for bits like SCOPE_NONCE live outside this contract. Consumers decide policy
     ///      gating via `scope & SCOPE_POLICY`, NOT via `policyTarget != 0`.
@@ -658,12 +662,13 @@ contract AccountConfiguration {
     /// @param hash The digest that was signed.
     /// @param auth Authenticator(20) || authenticator-specific data.
     ///
+    /// @return actorId The identifier of the verified actor.
     /// @return scope The scope of the verified actor (0x00 = unrestricted).
     /// @return policyTarget The actor's policy gate target (manager), or address(0).
     function authenticateActor(address account, bytes32 hash, bytes calldata auth)
         public
         view
-        returns (uint8 scope, address policyTarget)
+        returns (bytes32 actorId, uint8 scope, address policyTarget)
     {
         if (auth.length < 20) revert InvalidAuthLength();
         return _authenticate(account, hash, address(bytes20(auth[:20])), auth[20:]);
@@ -1142,21 +1147,22 @@ contract AccountConfiguration {
     // AUTHENTICATION
     // ----------------------------------------------------------------------------------------------------------------
 
-    /// @dev Resolves and authenticates the actor behind `authenticator`/`data`, returning its (scope, policyTarget).
-    ///      Routes the K1 sentinel to _authenticateK1; otherwise calls the IAuthenticator and requires the resolved
-    ///      actorId to carry a matching, unexpired _actorConfig entry. Reverts with AuthenticationFailed,
-    ///      AuthenticatorMismatch, or ActorExpired.
+    /// @dev Resolves and authenticates the actor behind `authenticator`/`data`, returning its
+    ///      (actorId, scope, policyTarget). Routes the K1 sentinel to _authenticateK1; otherwise calls the
+    ///      IAuthenticator and requires the resolved actorId to carry a matching, unexpired _actorConfig entry.
+    ///      Reverts with AuthenticationFailed, AuthenticatorMismatch, or ActorExpired.
     function _authenticate(address account, bytes32 hash, address authenticator, bytes calldata data)
         internal
         view
-        returns (uint8, address)
+        returns (bytes32, uint8, address)
     {
         if (authenticator == K1_AUTHENTICATOR) return _authenticateK1(account, hash, data);
 
         bytes32 actorId = IAuthenticator(authenticator).authenticate(hash, data);
         if (actorId == bytes32(0)) revert AuthenticationFailed();
 
-        return _resolveExplicitActor(account, actorId, authenticator);
+        (uint8 scope, address policyTarget) = _resolveExplicitActor(account, actorId, authenticator);
+        return (actorId, scope, policyTarget);
     }
 
     /// @dev Resolves an explicit _actorConfig-homed actor: requires a matching authenticator and an unexpired entry,
@@ -1192,7 +1198,7 @@ contract AccountConfiguration {
     function _authenticateK1(address account, bytes32 hash, bytes calldata data)
         internal
         view
-        returns (uint8, address)
+        returns (bytes32, uint8, address)
     {
         address recovered = _recoverSigner(hash, data);
         if (recovered == address(0)) revert InvalidSignature();
@@ -1203,11 +1209,14 @@ contract AccountConfiguration {
             AccountState storage st = _accountState[account];
             if (st.flags & FLAG_REVOKE_DEFAULT_EOA != 0) revert DefaultEoaRevoked();
             if (st.defaultEOAExpiry != 0 && block.timestamp > st.defaultEOAExpiry) revert ActorExpired();
+            bytes32 selfActorId = bytes32(bytes20(account));
             uint8 selfScope = st.defaultEOAScope;
-            return (selfScope, _policyTargetFor(selfScope, bytes32(bytes20(account)), account));
+            return (selfActorId, selfScope, _policyTargetFor(selfScope, selfActorId, account));
         }
 
-        return _resolveExplicitActor(account, bytes32(bytes20(recovered)), K1_AUTHENTICATOR);
+        bytes32 actorId = bytes32(bytes20(recovered));
+        (uint8 scope, address policyTarget) = _resolveExplicitActor(account, actorId, K1_AUTHENTICATOR);
+        return (actorId, scope, policyTarget);
     }
 
     /// @dev True if the account's default (implicit) EOA has been revoked via the AccountState flag.

--- a/src/authenticators/DelegateAuthenticator.sol
+++ b/src/authenticators/DelegateAuthenticator.sol
@@ -59,7 +59,9 @@ contract DelegateAuthenticator is IAuthenticator {
         // vouch requires admin to preserve non-escalation): an operational SENDER key can sign for its own account,
         // yet it must NOT be able to vouch as a delegate here. authenticateActor reverts on any auth failure and
         // otherwise returns the resolved scope, so we require scope == 0x00 explicitly.
-        try ACCOUNT_CONFIGURATION.authenticateActor(delegate, hash, nestedAuth) returns (uint8 nestedScope, address) {
+        try ACCOUNT_CONFIGURATION.authenticateActor(delegate, hash, nestedAuth) returns (
+            bytes32, uint8 nestedScope, address
+        ) {
             if (nestedScope != 0) revert InvalidNestedSignature();
         } catch {
             revert InvalidNestedSignature();

--- a/test/unit/AccountConfiguration/applyKeyChange.t.sol
+++ b/test/unit/AccountConfiguration/applyKeyChange.t.sol
@@ -286,7 +286,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         assertEq(cfg.authenticator, address(k1Authenticator));
         assertEq(cfg.scope, scope);
 
-        (uint8 outScope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint8 outScope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(outScope, scope);
     }
 
@@ -378,7 +378,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         _authorizeActor(eoa, newPk, selfActorId, accountConfiguration.K1_AUTHENTICATOR());
         assertTrue(accountConfiguration.isActor(eoa, selfActorId));
 
-        (uint8 scope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint8 scope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(scope, 0);
     }
 
@@ -395,7 +395,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
 
         // Phase 0: the default EOA is live and authenticates with its own k1 signature.
         assertTrue(accountConfiguration.isActor(eoa, selfActorId));
-        (uint8 scope0,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint8 scope0,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(scope0, 0);
 
         // Phase 1: in one batch signed by the EOA, add the device key as a full owner and revoke the default EOA.
@@ -408,7 +408,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         assertTrue(accountConfiguration.isActor(eoa, deviceActorId));
         vm.expectRevert();
         accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
-        (uint8 scope1,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(devicePk, hash));
+        (, uint8 scope1,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(devicePk, hash));
         assertEq(scope1, 0);
 
         // Phase 2: the device key re-enables the K1 key by authorizing the self-actorId as a native k1 owner.
@@ -417,7 +417,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         _signApply(eoa, devicePk, reEnable);
 
         assertTrue(accountConfiguration.isActor(eoa, selfActorId));
-        (uint8 scope2,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint8 scope2,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(scope2, 0);
     }
 
@@ -723,7 +723,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         assertEq(
             accountConfiguration.getActorConfig(eoa, selfId).authenticator, accountConfiguration.K1_AUTHENTICATOR()
         );
-        (uint8 scope,) = accountConfiguration.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
+        (, uint8 scope,) = accountConfiguration.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
         assertEq(scope, 0);
     }
 

--- a/test/unit/AccountConfiguration/authenticate.t.sol
+++ b/test/unit/AccountConfiguration/authenticate.t.sol
@@ -642,6 +642,64 @@ contract AuthenticateTest is AccountConfigurationTest {
         assertEq(actorId, expectedActorId);
     }
 
+    /// @notice A non-k1 WebAuthn actor returns the actorId resolved by its authenticator (second non-k1 path).
+    function test_authenticateActor_success_returnsActorId_webAuthn(uint256 ownerSeed, uint256 pkSeed, bytes32 hash)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 pk = _boundP256Pk(pkSeed);
+
+        (address account,) = _createK1Account(ownerPk);
+        bytes32 expectedActorId = _p256ActorId(pk);
+        _authorizeActorWithScope(account, ownerPk, expectedActorId, address(webAuthnAuthenticator), 0x00);
+
+        bytes memory auth = abi.encodePacked(address(webAuthnAuthenticator), _webauthnSignData(pk, hash));
+        (bytes32 actorId,,) = accountConfiguration.authenticateActor(account, hash, auth);
+        assertEq(actorId, expectedActorId);
+    }
+
+    /// @notice actorId is returned unchanged alongside a non-zero (fuzzed) scope — identity is independent of scope.
+    function test_authenticateActor_success_returnsActorId_scopedActor(
+        uint256 ownerSeed,
+        uint256 actorSeed,
+        uint8 scopeSeed,
+        bytes32 hash
+    ) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 actorPk = _boundK1Pk(actorSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(actorPk));
+        uint8 scope = uint8(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_POLICY;
+
+        (address account,) = _createK1Account(ownerPk);
+        vm.assume(vm.addr(actorPk) != account);
+        bytes32 expectedActorId = bytes32(bytes20(vm.addr(actorPk)));
+        _authorizeActorWithScope(account, ownerPk, expectedActorId, address(k1Authenticator), scope);
+
+        (bytes32 actorId, uint8 outScope,) =
+            accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        assertEq(actorId, expectedActorId);
+        assertEq(outScope, scope);
+    }
+
+    /// @notice A scoped (downgraded) inline self still returns actorId == bytes32(bytes20(account)).
+    function test_authenticateActor_success_returnsActorId_scopedInlineSelf(
+        uint256 eoaSeed,
+        uint8 scopeSeed,
+        bytes32 hash
+    ) public {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
+        address eoa = vm.addr(eoaPk);
+        bytes32 selfActorId = bytes32(bytes20(eoa));
+        uint8 scope = uint8(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_POLICY;
+
+        _authorizeActorWithScope(eoa, eoaPk, selfActorId, address(k1Authenticator), scope);
+
+        (bytes32 actorId, uint8 outScope,) =
+            accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        assertEq(actorId, selfActorId);
+        assertEq(outScope, scope);
+    }
+
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // verifySignature (operational authority)
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

--- a/test/unit/AccountConfiguration/authenticate.t.sol
+++ b/test/unit/AccountConfiguration/authenticate.t.sol
@@ -354,7 +354,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
 
-        (uint8 scope, address policyTarget) =
+        (, uint8 scope, address policyTarget) =
             accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
 
         assertEq(scope, uint8(0x00));
@@ -374,7 +374,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         vm.assume(vm.addr(actorPk) != account);
         _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), 0x00);
 
-        (uint8 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        (, uint8 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
@@ -392,7 +392,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         _authorizeActorWithScope(account, ownerPk, _p256ActorId(pk), address(p256Authenticator), scope);
 
         bytes memory auth = abi.encodePacked(address(p256Authenticator), _p256SignData(pk, hash));
-        (uint8 outScope,) = accountConfiguration.authenticateActor(account, hash, auth);
+        (, uint8 outScope,) = accountConfiguration.authenticateActor(account, hash, auth);
         assertEq(outScope, scope);
     }
 
@@ -412,7 +412,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         _authorizeActorWithScope(account, ownerPk, _p256ActorId(pk), address(webAuthnAuthenticator), scope);
 
         bytes memory auth = abi.encodePacked(address(webAuthnAuthenticator), _webauthnSignData(pk, hash));
-        (uint8 outScope,) = accountConfiguration.authenticateActor(account, hash, auth);
+        (, uint8 outScope,) = accountConfiguration.authenticateActor(account, hash, auth);
         assertEq(outScope, scope);
     }
 
@@ -434,7 +434,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         vm.assume(vm.addr(actorPk) != account);
         _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), scope);
 
-        (uint8 outScope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        (, uint8 outScope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(outScope, scope);
     }
 
@@ -451,7 +451,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         vm.assume(vm.addr(actorPk) != account);
         _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), 0x00);
 
-        (uint8 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        (, uint8 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
@@ -472,7 +472,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         _authorizeActorWithExpiry(account, ownerPk, bytes32(bytes20(vm.addr(sessionPk))), address(k1Authenticator), 0);
 
         vm.warp(block.timestamp + bound(warpSeed, 1, 3650 days));
-        (uint8 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
+        (, uint8 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
@@ -496,7 +496,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         );
 
         vm.warp(expiry);
-        (uint8 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
+        (, uint8 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
@@ -523,7 +523,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
         _authorizeGatedActor(account, ownerPk, sessionActorId, scope, manager, commitment);
 
-        (uint8 outScope, address outTarget) =
+        (, uint8 outScope, address outTarget) =
             accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
 
         assertEq(outScope, scope);
@@ -536,7 +536,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
 
-        (uint8 scope, address policyTarget) =
+        (, uint8 scope, address policyTarget) =
             accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
 
         assertEq(scope, uint8(0x00));
@@ -554,7 +554,7 @@ contract AuthenticateTest is AccountConfigurationTest {
 
         _authorizeActorWithScope(eoa, eoaPk, selfActorId, address(k1Authenticator), scope);
 
-        (uint8 outScope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint8 outScope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(outScope, scope);
     }
 
@@ -570,7 +570,7 @@ contract AuthenticateTest is AccountConfigurationTest {
 
         _implicitAuthorizeActor(eoa, eoaPk, bytes32(bytes20(vm.addr(bobPk))), address(k1Authenticator));
 
-        (uint8 scope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(bobPk, hash));
+        (, uint8 scope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(bobPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
@@ -587,10 +587,59 @@ contract AuthenticateTest is AccountConfigurationTest {
         vm.assume(accountA != accountB);
 
         bytes memory auth = _buildK1Auth(ownerPk, hash);
-        (uint8 scopeA,) = accountConfiguration.authenticateActor(accountA, hash, auth);
-        (uint8 scopeB,) = accountConfiguration.authenticateActor(accountB, hash, auth);
+        (, uint8 scopeA,) = accountConfiguration.authenticateActor(accountA, hash, auth);
+        (, uint8 scopeB,) = accountConfiguration.authenticateActor(accountB, hash, auth);
         assertEq(scopeA, uint8(0x00));
         assertEq(scopeB, uint8(0x00));
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // actorId — surfaced as the first return of authenticateActor
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    //
+    // Off-8130 consumers (e.g. an ERC-4337 account) need the resolved actorId to drive getPolicyCommitment without
+    // re-invoking the authenticator — parity with the tx-context precompile on an 8130 chain.
+
+    /// @notice The inline-self k1 path returns actorId == bytes32(bytes20(account)).
+    function test_authenticateActor_success_returnsActorId_inlineSelf(uint256 eoaSeed, bytes32 hash) public view {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
+        address eoa = vm.addr(eoaPk);
+
+        (bytes32 actorId,,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        assertEq(actorId, bytes32(bytes20(eoa)));
+    }
+
+    /// @notice A non-self k1 actor returns actorId == bytes32(bytes20(signer)).
+    function test_authenticateActor_success_returnsActorId_nonSelfK1(uint256 ownerSeed, uint256 actorSeed, bytes32 hash)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 actorPk = _boundK1Pk(actorSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(actorPk));
+
+        (address account,) = _createK1Account(ownerPk);
+        vm.assume(vm.addr(actorPk) != account);
+        bytes32 expectedActorId = bytes32(bytes20(vm.addr(actorPk)));
+        _authorizeActorWithScope(account, ownerPk, expectedActorId, address(k1Authenticator), 0x00);
+
+        (bytes32 actorId,,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        assertEq(actorId, expectedActorId);
+    }
+
+    /// @notice A non-k1 (P-256) actor returns the actorId resolved by its authenticator.
+    function test_authenticateActor_success_returnsActorId_nonK1(uint256 ownerSeed, uint256 pkSeed, bytes32 hash)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 pk = _boundP256Pk(pkSeed);
+
+        (address account,) = _createK1Account(ownerPk);
+        bytes32 expectedActorId = _p256ActorId(pk);
+        _authorizeActorWithScope(account, ownerPk, expectedActorId, address(p256Authenticator), 0x00);
+
+        bytes memory auth = abi.encodePacked(address(p256Authenticator), _p256SignData(pk, hash));
+        (bytes32 actorId,,) = accountConfiguration.authenticateActor(account, hash, auth);
+        assertEq(actorId, expectedActorId);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

--- a/test/unit/AccountConfiguration/importAccount.t.sol
+++ b/test/unit/AccountConfiguration/importAccount.t.sol
@@ -565,7 +565,7 @@ contract ImportAccountTest is AccountConfigurationTest {
         // The same key still authenticates as a full owner — now via its explicit self config, not the (disabled)
         // implicit fallback.
         bytes32 h = keccak256("post import");
-        (uint8 scope,) = accountConfiguration.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
+        (, uint8 scope,) = accountConfiguration.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
         assertEq(scope, 0);
     }
 }

--- a/test/unit/AccountConfiguration/policyAccessors.t.sol
+++ b/test/unit/AccountConfiguration/policyAccessors.t.sol
@@ -8,7 +8,7 @@ import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 ///           - `getPolicy(account, actorId)`           — off-chain aggregate: (manager, commitment)
 ///           - `getPolicyCommitment(account, actorId)` — single-SLOAD hot-path read
 ///           - `getPolicyManager(account, actorId)`    — single-SLOAD hot-path read
-///           - policyTarget                            — surfaced as the second return of `authenticateActor`
+///           - policyTarget                            — surfaced as the third return of `authenticateActor`
 ///
 ///         All are `view`; there are no events to assert. Every test fuzzes its inputs (managers, commitments,
 ///         actorIds, keys, scopes). Gating is determined by the SCOPE_POLICY bit, never by "slot non-zero": a
@@ -487,10 +487,10 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // policyTarget — surfaced as the second return of authenticateActor
+    // policyTarget — surfaced as the third return of authenticateActor
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     //
-    // authenticateActor returns the stored policy manager as its second value (address(0) when unwritten).
+    // authenticateActor returns the stored policy manager as its third value (address(0) when unwritten).
 
     /// @notice A gated non-self actor authenticates; policyTarget resolves to the stored manager, equal to the
     ///         granular getPolicyManager read.
@@ -515,7 +515,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
             account, rootPk, sessionActorId, _boundGatedScope(scopeSeed), manager, _boundNonZeroWord(commitmentSeed)
         );
 
-        (uint8 outScope, address policyTarget) =
+        (, uint8 outScope, address policyTarget) =
             accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
         assertTrue(outScope & accountConfiguration.SCOPE_POLICY() != 0);
         assertEq(policyTarget, manager);
@@ -536,7 +536,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
 
         _authorizeUngatedActor(account, rootPk, sessionActorId, address(k1Authenticator));
 
-        (, address policyTarget) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
+        (,, address policyTarget) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
         assertEq(policyTarget, address(0));
     }
 
@@ -557,7 +557,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
             eoa, eoaPk, _boundGatedScope(scopeSeed), manager, _boundNonZeroWord(commitmentSeed)
         );
 
-        (, address policyTarget) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (,, address policyTarget) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(policyTarget, manager);
         assertEq(policyTarget, accountConfiguration.getPolicyManager(eoa, selfActorId));
     }
@@ -568,7 +568,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
 
-        (uint8 outScope, address policyTarget) =
+        (, uint8 outScope, address policyTarget) =
             accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(outScope, uint8(0x00));
         assertEq(policyTarget, address(0));


### PR DESCRIPTION
## Summary

- `authenticateActor` now returns the resolved `actorId` as its first value: `(bytes32 actorId, uint8 scope, address policyTarget)`.
- This gives off-8130 (ERC-4337) consumers the identity they need to drive the policy flow — reading `getPolicyCommitment(account, actorId)` at execution time — without re-deriving it or re-invoking the authenticator. It reaches parity with the tx-context precompile that surfaces the actorId on native 8130 chains.
- `actorId` is threaded out of `_authenticate` / `_authenticateK1` (both already computed it on every branch — k1 self, k1 other-actor, and the `IAuthenticator` path); `_resolveExplicitActor` keeps its `(scope, policyTarget)` shape and each caller composes the actorId it already holds.
- Internal call sites updated: `applySignedActorChanges` / `applySignedLockChanges` (`(, uint8 scope,)`), `verifySignature`'s try/catch, and the `DelegateAuthenticator` try/catch.
- Added tests asserting the returned actorId for the inline-self k1, non-self k1, and non-k1 (P-256) paths.

## Context / motivation

On an 8130-native chain the hot path is: tx-context precompile → actorId → `getPolicyCommitment()`. Off-8130 (4337), the account authenticates via `authenticateActor()`, which returned only `(scope, policyTarget)` — leaving no way to obtain the actorId for the commitment lookup without re-running the authenticator. Returning the actorId closes that gap.

> Note: I don't know when this got removed — surfacing the actorId here restores that capability regardless.

## Test plan

- [x] `forge build` — clean (pre-existing library/test warnings only)
- [x] `forge test` — 312 passed, 0 failed
- [x] New tests: `test_authenticateActor_success_returnsActorId_{inlineSelf,nonSelfK1,nonK1}`