### PR TITLE
feat(policies): add executeAttested for precompile-less (4337) chains

### DIFF
--- a/src/policies/PolicyManager.sol
+++ b/src/policies/PolicyManager.sol
@@ -31,9 +31,12 @@ address constant EXTERNAL_POLICY_AUTHENTICATOR = address(uint160(uint256(keccak2
 ///        here is the account itself. That is the authorization boundary: only a gated session-key transaction
 ///        (routed through the account) can invoke {execute}.
 ///
-///      Two acting models, two entrypoints:
+///      Acting models and entrypoints:
 ///      - {execute}: the *account itself* acts (a gated session key, dispatched by the protocol as the account). The
 ///        acting identity comes from the transaction-context precompile and `account == msg.sender`.
+///      - {executeAttested}: the *account itself* acts on a chain with no transaction-context precompile (e.g.
+///        ERC-4337 only). There is no protocol identity, so the account is `msg.sender` and *attests* the acting
+///        `actorId` explicitly. Guarded against self-origination and against use where a live precompile exists.
 ///      - {executeFor} / {executeForMany}: an *external caller* acts on behalf of one or more accounts that authorized
 ///        it (e.g. a subscription provider pulling from many accounts in one transaction). Identity is the caller
 ///        itself (`actorId == bytes20(msg.sender)`) and `account` comes from the supplied binding.
@@ -53,7 +56,8 @@ address constant EXTERNAL_POLICY_AUTHENTICATOR = address(uint160(uint256(keccak2
 ///      {execute} with that target's binding and would otherwise resolve identity. Do not "optimize" the
 ///      entrypoints onto separate reentrancy guards.
 ///
-///      Scope: account-acting {execute}, and external-caller {executeFor} / {executeForMany}.
+///      Scope: account-acting {execute} (precompile) and {executeAttested} (account-attested, no precompile), and
+///      external-caller {executeFor} / {executeForMany}.
 contract PolicyManager is ReentrancyGuard {
     using Address for address;
 
@@ -95,8 +99,17 @@ contract PolicyManager is ReentrancyGuard {
     ///         account, was revoked, or (on the external path) the account did not gate this manager for it.
     error NoActivePolicy(bytes32 actorId);
     /// @notice The acting actor's `ActorConfig.expiry` has passed. Commitment is not cleared on expiry (only on
-    ///         revoke), so the manager must enforce this itself on {executeFor}, which has no protocol auth path.
+    ///         revoke), so the manager must enforce this itself on {executeFor} and {executeAttested}, which have no
+    ///         protocol auth path.
     error ActorExpired(bytes32 actorId);
+    /// @notice {executeAttested} was invoked by a self-originating sender (`tx.origin == msg.sender`). That is the
+    ///         signature of an EOA/7702 direct send or an 8130 self-dispatch — neither is an account-attested,
+    ///         externally-driven execution, so the attested path is refused. Use {execute} (8130) or a normal tx.
+    error SelfOrigination();
+    /// @notice {executeAttested} was called while the transaction-context precompile is asserting a protocol
+    ///         identity (`getTransactionSenderActorId() != 0`). On an 8130 chain the account-acting path is
+    ///         {execute}; the attested path is refused so a gated actor cannot claim a different actor's identity.
+    error ProtocolIdentityActive(bytes32 actorId);
     /// @notice {executeForMany} array length mismatch between `bindings` and `executionData`.
     error LengthMismatch();
     /// @notice The per-account self-call boundary used by {executeForMany} was invoked by someone other than this
@@ -141,6 +154,60 @@ contract PolicyManager is ReentrancyGuard {
         if (signed != commitment) revert BindingCommitmentMismatch(signed, commitment);
 
         // No manager-match / expiry checks here — see @dev above. The external entrypoints below re-add both.
+        _enforce(binding, commitment, executionData, account);
+    }
+
+    /// @notice Account-attested variant of {execute} for chains without the EIP-8130 transaction-context precompile
+    ///         (e.g. an ERC-4337-only chain). The account itself drives the manager and *attests* which of its own
+    ///         actors is acting by passing `actorId` explicitly, standing in for the protocol identity that
+    ///         {execute} reads from the precompile.
+    ///
+    /// @dev Trust model — read carefully. {execute} gets two guarantees from the protocol: the `actorId` is
+    ///      authentic (from the precompile) and a `SCOPE_POLICY` actor could *only* have reached this manager (the
+    ///      8130 gate). Neither exists here, so BOTH move to the account, which is `msg.sender`:
+    ///      - **Authenticity** — the account must have authenticated the acting key (e.g. in `validateUserOp`)
+    ///        before calling, and pass that key's `actorId`.
+    ///      - **Confinement** — the account MUST fill in `actorId` itself and MUST NOT let a restricted actor choose
+    ///        it via user-supplied calldata. Otherwise a restricted key crafts a call to
+    ///        `executeAttested(privilegedActorId, ...)` and self-escalates. Reproducing the 8130 gate in account code
+    ///        (forcing a policy-scoped actor onto its own `actorId`) is the account's responsibility; the manager
+    ///        cannot verify it and trusts `msg.sender`.
+    ///
+    ///      Two guards keep this path from being abused as a bypass of the protocol path on chains that *do* have
+    ///      8130 semantics:
+    ///      - `tx.origin != msg.sender` — forbids self-origination. An EOA/7702 direct send and an 8130 self-dispatch
+    ///        both have `tx.origin == account == msg.sender`; only an externally-driven account (ERC-4337 EntryPoint
+    ///        or other trusted executor) has a distinct origin. This is an anti-authentication (restriction) use of
+    ///        `tx.origin`, not an identity check.
+    ///      - `getTransactionSenderActorId() == 0` — if the precompile is asserting a protocol identity, the chain
+    ///        supports 8130 and the correct account-acting path is {execute}. Refusing here stops a gated actor X
+    ///        (dispatched as the account) from calling `executeAttested(Y, ...)` to drive another actor's binding.
+    ///
+    ///      Like {executeFor}, this path has no protocol auth, so it re-checks actor expiry locally.
+    ///
+    /// @param actorId       The account-attested acting actor (an actor configured on `msg.sender`).
+    /// @param binding       Full account-authorized binding (config + window + salt); `binding.account` must be `msg.sender`.
+    /// @param executionData Per-use action parameters interpreted by the policy.
+    function executeAttested(bytes32 actorId, PolicyBinding calldata binding, bytes calldata executionData)
+        external
+        nonReentrant
+    {
+        // Forbid self-origination: only an externally-driven account (4337 EntryPoint / trusted executor) qualifies.
+        if (tx.origin == msg.sender) revert SelfOrigination();
+
+        // On a chain with a live precompile, the protocol asserts identity — use {execute}, not this path.
+        bytes32 protocolActor = _actingActorId();
+        if (protocolActor != bytes32(0)) revert ProtocolIdentityActive(protocolActor);
+
+        address account = msg.sender;
+        if (binding.account != account) revert InvalidBindingAccount(account, binding.account);
+
+        bytes32 commitment = _commitment(binding);
+        bytes32 signed = ACCOUNT_CONFIGURATION.getPolicyCommitment(account, actorId);
+        if (signed == bytes32(0)) revert NoActivePolicy(actorId);
+        if (signed != commitment) revert BindingCommitmentMismatch(signed, commitment);
+
+        _requireNotExpired(account, actorId);
         _enforce(binding, commitment, executionData, account);
     }
 

--- a/test/unit/examples/ExecuteAttested.t.sol
+++ b/test/unit/examples/ExecuteAttested.t.sol
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {ReentrancyGuard} from "openzeppelin/utils/ReentrancyGuard.sol";
+
+import {AccountConfiguration} from "../../../src/AccountConfiguration.sol";
+import {ITransactionContext, TX_CONTEXT_ADDRESS} from "../../../src/interfaces/ITransactionContext.sol";
+import {Call, DefaultAccount, TRUSTED_EXECUTOR} from "../../../src/accounts/DefaultAccount.sol";
+
+import {PolicyManager} from "../../../src/policies/PolicyManager.sol";
+import {Policy} from "../../../src/policies/Policy.sol";
+import {SessionPolicy} from "../../../src/policies/SessionPolicy.sol";
+import {RecurringAllowance} from "../../../src/policies/RecurringAllowance.sol";
+
+import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
+
+contract AttMockERC20 {
+    mapping(address => uint256) public balanceOf;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+}
+
+/// @notice Policy that re-enters {PolicyManager.executeAttested} from within its own {onExecute} hook. The manager's
+///         shared {ReentrancyGuard} must revert the nested call while the outer execution is still in flight.
+contract ReentrantAttestedPolicy is Policy {
+    constructor(address policyManager) Policy(policyManager) {}
+
+    function _onExecute(bytes32, address account, bytes calldata, bytes calldata, address)
+        internal
+        override
+        returns (bytes memory, bytes memory)
+    {
+        PolicyManager.PolicyBinding memory dummy;
+        dummy.account = account;
+        // Guard is locked by the outer call → this reverts ReentrancyGuardReentrantCall before any body check.
+        PolicyManager(address(POLICY_MANAGER)).executeAttested(bytes32(0), dummy, "");
+        return ("", "");
+    }
+}
+
+/// @notice Coverage for {PolicyManager.executeAttested}: the account-acting path for chains with no EIP-8130
+///         transaction-context precompile (e.g. ERC-4337 only). The account is `msg.sender` and attests the acting
+///         `actorId`. In these tests the precompile is left un-mocked so `getTransactionSenderActorId()` returns 0
+///         (a precompile-less chain), and calls are driven with a distinct `tx.origin` (a bundler / trusted executor)
+///         so the self-origination guard passes — the realistic ERC-4337 shape.
+contract ExecuteAttestedTest is AccountConfigurationTest {
+    PolicyManager internal manager;
+    SessionPolicy internal policy;
+    AttMockERC20 internal token;
+
+    address internal account;
+    address internal recipient = address(0x5EE);
+    address internal bundler = address(0xB0274E5); // distinct tx.origin (ERC-4337 bundler / trusted executor)
+
+    uint256 internal constant ROOT_PK = 0xA11CE;
+
+    uint8 internal constant SCOPE_POLICY = 0x02;
+    uint8 internal constant AUTHORIZE_ACTOR = 0x01;
+    uint8 internal constant REVOKE_ACTOR = 0x02;
+
+    uint40 internal constant MONTH = 30 days;
+
+    function setUp() public override {
+        super.setUp();
+        vm.warp(1_700_000_000);
+
+        manager = new PolicyManager(address(accountConfiguration));
+        policy = new SessionPolicy(address(manager));
+        token = new AttMockERC20();
+        account = _createAccount(bytes32(0));
+    }
+
+    // ── Happy path ──
+
+    function test_executeAttested_happyPath_movesTokens() public {
+        (bytes32 actorId, PolicyManager.PolicyBinding memory binding, bytes32 commitment) = _installSession(1, 100e6);
+
+        vm.expectEmit(true, true, true, true);
+        emit PolicyManager.PolicyExecuted(account, address(policy), commitment, account);
+
+        vm.prank(account, bundler);
+        manager.executeAttested(actorId, binding, _transfer(30e6));
+
+        assertEq(token.balanceOf(recipient), 30e6);
+        assertEq(token.balanceOf(account), 1_000e6 - 30e6);
+    }
+
+    function test_executeAttested_enforcesSpendLimit() public {
+        (bytes32 actorId, PolicyManager.PolicyBinding memory binding,) = _installSession(1, 50e6);
+
+        vm.prank(account, bundler);
+        manager.executeAttested(actorId, binding, _transfer(50e6));
+
+        // A second transfer this month exceeds the $50 cap.
+        vm.expectRevert(abi.encodeWithSelector(RecurringAllowance.ExceededAllowance.selector, 51e6, 50e6));
+        vm.prank(account, bundler);
+        manager.executeAttested(actorId, binding, _transfer(1e6));
+    }
+
+    // ── Guards specific to the attested path ──
+
+    function test_executeAttested_revertsOnSelfOrigination() public {
+        // tx.origin == msg.sender is an EOA/7702 direct send or an 8130 self-dispatch — refused.
+        (bytes32 actorId, PolicyManager.PolicyBinding memory binding,) = _installSession(1, 100e6);
+
+        vm.expectRevert(PolicyManager.SelfOrigination.selector);
+        vm.prank(account, account);
+        manager.executeAttested(actorId, binding, _transfer(1));
+    }
+
+    function test_executeAttested_revertsWhenPrecompileActive() public {
+        // A live precompile asserting a protocol identity means the chain is 8130 → use execute(), not this path.
+        (bytes32 actorId, PolicyManager.PolicyBinding memory binding,) = _installSession(1, 100e6);
+        bytes32 protocolActor = keccak256("some-protocol-actor");
+        _mockActingActor(protocolActor);
+
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.ProtocolIdentityActive.selector, protocolActor));
+        vm.prank(account, bundler);
+        manager.executeAttested(actorId, binding, _transfer(1));
+    }
+
+    // ── Shared authorization boundary ──
+
+    function test_executeAttested_revertsInvalidBindingAccount() public {
+        (bytes32 actorId,,) = _installSession(1, 100e6);
+        // Binding names a different account than msg.sender.
+        PolicyManager.PolicyBinding memory foreign = _bindingFor(address(0xF00), 1, 100e6);
+
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.InvalidBindingAccount.selector, account, address(0xF00)));
+        vm.prank(account, bundler);
+        manager.executeAttested(actorId, foreign, _transfer(1));
+    }
+
+    function test_executeAttested_revertsForUnknownActor() public {
+        // Actor was never gated for a policy on this account → zero signed commitment.
+        (, PolicyManager.PolicyBinding memory binding,) = _installSession(1, 100e6);
+        bytes32 unknown = keccak256("never-authorized");
+
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.NoActivePolicy.selector, unknown));
+        vm.prank(account, bundler);
+        manager.executeAttested(unknown, binding, _transfer(1));
+    }
+
+    function test_executeAttested_revertsBindingCommitmentMismatch() public {
+        (bytes32 actorId,, bytes32 commitment) = _installSession(1, 100e6);
+        // Supply a binding that recomputes to a different commitment (different salt).
+        PolicyManager.PolicyBinding memory wrong = _bindingFor(account, 999, 100e6);
+        bytes32 actual = manager.commitmentOf(wrong);
+
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.BindingCommitmentMismatch.selector, commitment, actual));
+        vm.prank(account, bundler);
+        manager.executeAttested(actorId, wrong, _transfer(1));
+    }
+
+    function test_executeAttested_revertsAfterRevoke() public {
+        (bytes32 actorId, PolicyManager.PolicyBinding memory binding,) = _installSession(1, 100e6);
+        _revokePolicyActor(actorId);
+
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.NoActivePolicy.selector, actorId));
+        vm.prank(account, bundler);
+        manager.executeAttested(actorId, binding, _transfer(1));
+    }
+
+    function test_executeAttested_revertsWhenActorExpired() public {
+        // No protocol auth on this path, so the manager must enforce expiry locally.
+        uint48 expiry = uint48(block.timestamp + 1 days);
+        (bytes32 actorId, PolicyManager.PolicyBinding memory binding,) = _installSessionWithExpiry(1, 100e6, expiry);
+
+        vm.warp(uint256(expiry) + 1);
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.ActorExpired.selector, actorId));
+        vm.prank(account, bundler);
+        manager.executeAttested(actorId, binding, _transfer(1));
+    }
+
+    function test_executeAttested_revertsBeforeValidAfter() public {
+        uint40 validAfter = uint40(block.timestamp + 1 days);
+        (bytes32 actorId, PolicyManager.PolicyBinding memory binding) = _installSessionWithWindow(1, validAfter, 0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(PolicyManager.OutsideValidityWindow.selector, validAfter, uint40(0), block.timestamp)
+        );
+        vm.prank(account, bundler);
+        manager.executeAttested(actorId, binding, _transfer(1));
+    }
+
+    function test_executeAttested_revertsAfterValidUntil() public {
+        uint40 validUntil = uint40(block.timestamp + 1 days);
+        (bytes32 actorId, PolicyManager.PolicyBinding memory binding) = _installSessionWithWindow(1, 0, validUntil);
+
+        vm.warp(uint256(validUntil));
+        vm.expectRevert(
+            abi.encodeWithSelector(PolicyManager.OutsideValidityWindow.selector, uint40(0), validUntil, block.timestamp)
+        );
+        vm.prank(account, bundler);
+        manager.executeAttested(actorId, binding, _transfer(1));
+    }
+
+    // ── Reentrancy ──
+
+    function test_executeAttested_reentrancy_directReenterReverts() public {
+        // A malicious policy tries to re-enter executeAttested from its own hook; the shared guard blocks it.
+        ReentrantAttestedPolicy evil = new ReentrantAttestedPolicy(address(manager));
+        PolicyManager.PolicyBinding memory binding = PolicyManager.PolicyBinding({
+            account: account, policy: address(evil), policyConfig: "", validAfter: 0, validUntil: 0, salt: 7
+        });
+        bytes32 actorId = _sessionActorId(7);
+        _authorizePolicyActor(actorId, manager.commitmentOf(binding), 0);
+
+        vm.expectRevert(ReentrancyGuard.ReentrancyGuardReentrantCall.selector);
+        vm.prank(account, bundler);
+        manager.executeAttested(actorId, binding, "");
+    }
+
+    function test_executeAttested_reentrancy_viaSessionPolicyTargetingManagerReverts() public {
+        // SessionPolicy does not blocklist the manager as a target (only the account itself). The reentrancy guard is
+        // what stops it: the account's executeBatch re-enters the manager, which reverts, surfacing as CallFailed.
+        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
+        scopes[0] =
+            SessionPolicy.CallScope({target: address(manager), selectorRules: new SessionPolicy.SelectorRule[](0)});
+        bytes memory cfg =
+            abi.encode(SessionPolicy.Config({tokenLimits: new SessionPolicy.TokenLimit[](0), callScopes: scopes}));
+
+        PolicyManager.PolicyBinding memory binding = PolicyManager.PolicyBinding({
+            account: account, policy: address(policy), policyConfig: cfg, validAfter: 0, validUntil: 0, salt: 8
+        });
+        bytes32 actorId = _sessionActorId(8);
+        _authorizePolicyActor(actorId, manager.commitmentOf(binding), 0);
+
+        PolicyManager.PolicyBinding memory inner;
+        inner.account = account;
+        bytes memory reenter = abi.encode(
+            SessionPolicy.Action({
+                target: address(manager),
+                value: 0,
+                data: abi.encodeCall(PolicyManager.executeAttested, (actorId, inner, ""))
+            })
+        );
+
+        vm.expectRevert(DefaultAccount.CallFailed.selector);
+        vm.prank(account, bundler);
+        manager.executeAttested(actorId, binding, reenter);
+    }
+
+    // ── Helpers ──
+
+    function _mockActingActor(bytes32 actorId) internal {
+        vm.mockCall(
+            TX_CONTEXT_ADDRESS,
+            abi.encodeWithSelector(ITransactionContext.getTransactionSenderActorId.selector),
+            abi.encode(actorId)
+        );
+    }
+
+    function _transfer(uint256 amount) internal view returns (bytes memory) {
+        return abi.encode(
+            SessionPolicy.Action({
+                target: address(token), value: 0, data: abi.encodeCall(AttMockERC20.transfer, (recipient, amount))
+            })
+        );
+    }
+
+    /// @dev SessionPolicy config: `transfer` only on `token`, with a recurring monthly spend limit.
+    function _config(uint256 limit) internal view returns (bytes memory) {
+        SessionPolicy.TokenLimit[] memory limits = new SessionPolicy.TokenLimit[](1);
+        limits[0] = SessionPolicy.TokenLimit({token: address(token), limit: limit, period: MONTH});
+        SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
+        rules[0] = SessionPolicy.SelectorRule({selector: AttMockERC20.transfer.selector, recipients: new address[](0)});
+        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
+        scopes[0] = SessionPolicy.CallScope({target: address(token), selectorRules: rules});
+        return abi.encode(SessionPolicy.Config({tokenLimits: limits, callScopes: scopes}));
+    }
+
+    function _bindingFor(address acct, uint256 salt, uint256 limit)
+        internal
+        view
+        returns (PolicyManager.PolicyBinding memory)
+    {
+        return PolicyManager.PolicyBinding({
+            account: acct,
+            policy: address(policy),
+            policyConfig: _config(limit),
+            validAfter: 0,
+            validUntil: 0,
+            salt: salt
+        });
+    }
+
+    function _sessionActorId(uint256 salt) internal pure returns (bytes32) {
+        return keccak256(abi.encode("attested-session", salt));
+    }
+
+    function _installSession(uint256 salt, uint256 limit)
+        internal
+        returns (bytes32 actorId, PolicyManager.PolicyBinding memory binding, bytes32 commitment)
+    {
+        return _installSessionWithExpiry(salt, limit, 0);
+    }
+
+    function _installSessionWithExpiry(uint256 salt, uint256 limit, uint48 expiry)
+        internal
+        returns (bytes32 actorId, PolicyManager.PolicyBinding memory binding, bytes32 commitment)
+    {
+        binding = _bindingFor(account, salt, limit);
+        actorId = _sessionActorId(salt);
+        commitment = manager.commitmentOf(binding);
+        _authorizePolicyActor(actorId, commitment, expiry);
+    }
+
+    function _installSessionWithWindow(uint256 salt, uint40 validAfter, uint40 validUntil)
+        internal
+        returns (bytes32 actorId, PolicyManager.PolicyBinding memory binding)
+    {
+        binding = PolicyManager.PolicyBinding({
+            account: account,
+            policy: address(policy),
+            policyConfig: _config(100e6),
+            validAfter: validAfter,
+            validUntil: validUntil,
+            salt: salt
+        });
+        actorId = _sessionActorId(salt);
+        _authorizePolicyActor(actorId, manager.commitmentOf(binding), 0);
+    }
+
+    function _createAccount(bytes32 salt) internal returns (address acct) {
+        AccountConfiguration.InitialActor memory root = AccountConfiguration.InitialActor({
+            actorId: bytes32(bytes20(vm.addr(ROOT_PK))),
+            authenticator: address(k1Authenticator),
+            scope: 0,
+            policyData: ""
+        });
+        AccountConfiguration.InitialActor memory mgr = AccountConfiguration.InitialActor({
+            actorId: bytes32(bytes20(address(manager))), authenticator: TRUSTED_EXECUTOR, scope: 0, policyData: ""
+        });
+        AccountConfiguration.InitialActor[] memory actors = new AccountConfiguration.InitialActor[](2);
+        (actors[0], actors[1]) = root.actorId < mgr.actorId ? (root, mgr) : (mgr, root);
+
+        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
+        acct = accountConfiguration.createAccount(salt, bytecode, actors);
+        token.mint(acct, 1_000e6);
+    }
+
+    function _authorizePolicyActor(bytes32 actorId, bytes32 commitment, uint48 expiry) internal {
+        AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
+            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: expiry
+        });
+        bytes memory policyData = abi.encodePacked(address(manager), commitment);
+
+        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
+        changes[0] = AccountConfiguration.ActorChange({
+            actorId: actorId, changeType: AUTHORIZE_ACTOR, data: abi.encode(cfg, policyData)
+        });
+        _applyAsRoot(changes);
+    }
+
+    function _revokePolicyActor(bytes32 actorId) internal {
+        AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
+        changes[0] = AccountConfiguration.ActorChange({actorId: actorId, changeType: REVOKE_ACTOR, data: ""});
+        _applyAsRoot(changes);
+    }
+
+    function _applyAsRoot(AccountConfiguration.ActorChange[] memory changes) internal {
+        uint64 chainId = uint64(block.chainid);
+        uint64 sequence = accountConfiguration.getChangeSequences(account).local;
+        bytes32 digest = _computeActorChangeBatchDigest(account, chainId, sequence, changes);
+        accountConfiguration.applySignedActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `executeAttested` to `PolicyManager`: an **account-acting** entrypoint for chains that have **no EIP-8130 transaction-context precompile** (e.g. an ERC-4337-only chain). On such chains `execute()` can't work because `getTransactionSenderActorId()` always returns `0`, so the account instead drives the manager and **attests** which of its own actors is acting by passing `actorId` explicitly.

This stands in for the protocol identity that `execute()` reads from the precompile, giving the session-key / policy flow a path on 4337-only chains.

## Trust model

`execute()` gets two guarantees from the protocol — the `actorId` is authentic (precompile) and a `SCOPE_POLICY` actor could *only* have reached the manager (8130 gate). Neither exists here, so **both move to the account** (`msg.sender`):

- **Authenticity** — the account must have authenticated the acting key (e.g. in `validateUserOp`) and pass that key's `actorId`.
- **Confinement** — the account MUST fill in `actorId` itself and MUST NOT let a restricted actor choose it via user-supplied calldata, or a restricted key could self-escalate. This is the account's responsibility (mirrors the 8130 gate in account code); the manager cannot verify it and trusts `msg.sender`.

## Guards

- **`tx.origin != msg.sender`** (`SelfOrigination`) — forbids self-origination. EOA/7702 direct sends and 8130 self-dispatch both have `tx.origin == account == msg.sender`; only an externally-driven account (4337 EntryPoint / trusted executor) has a distinct origin. Anti-authentication (restriction) use of `tx.origin`, not identity.
- **`getTransactionSenderActorId() == 0`** (`ProtocolIdentityActive`) — if a live precompile is asserting a protocol identity, the chain supports 8130 and the correct path is `execute()`. Refusing here stops a gated actor X (dispatched as the account) from calling `executeAttested(Y, ...)` to drive another actor's binding.

Also: enforces `binding.account == msg.sender`, recomputes the commitment against the live signed commitment, re-checks actor expiry locally (no protocol auth on this path, matching `executeFor`), and shares the `nonReentrant` guard with the other entrypoints.

## Design decision: no manager-match check

Unlike `executeFor`, `executeAttested` intentionally does **not** verify `getPolicyManager(account, actorId) == address(this)`. In `executeFor` the `account` is an attacker-supplied parameter, so that check establishes the account chose this manager. Here `account == msg.sender`, and under this path's model the account is trusted to gate *who* may invoke the manager and *as which actor*. Routing to the correct manager is additionally enforced **transitively**: the commitment pins `binding.policy`, and each policy has an immutable `POLICY_MANAGER` with an `onlyPolicyManager` guard — so a manager can only successfully enforce a commitment whose policy is bound to it. The `_policyManager` slot exists mainly for the protocol gate, which is absent on this path.

## Tests

`test/unit/examples/ExecuteAttested.t.sol` (13 tests; full suite 331 passing):

- **Happy path** — token movement + `PolicyExecuted` event; spend-limit enforcement.
- **Attested-path guards** — `SelfOrigination`, `ProtocolIdentityActive`.
- **Shared auth boundary** — `InvalidBindingAccount`, `NoActivePolicy` (unknown actor / after revoke), `BindingCommitmentMismatch`, `ActorExpired`, validity-window bounds.
- **Reentrancy** — direct policy re-enter (`ReentrancyGuardReentrantCall`) and the realistic `SessionPolicy`-targets-the-manager vector (`CallFailed`), confirming the shared `nonReentrant` guard is load-bearing. Note: `SessionPolicy` only blocklists the account itself as a target (`SelfTargetNotAllowed`), so the guard — not the policy — is what stops re-entry.

## Reviewer notes

- [x] **Verify the 8130 `tx.origin == account` assumption** against the spec — the `SelfOrigination` guard relies on it (the precompile guard covers the same escalation independently).
- [x] **Account-side gate** — the 4337 example account (`BackwardsCompatible4337Account`, separate examples repo) must force a policy-scoped actor's userOp onto its own `actorId`. Documented in NatSpec; not enforceable by the manager.