### PR TITLE
Account-scoped ERC-1271 replay protection in AccountConfiguration.verifySignature

### DIFF
--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -629,7 +629,13 @@ contract AccountConfiguration {
         view
         returns (bool verified)
     {
-        try this.authenticateActor(account, hash, signature) returns (bytes32, uint8 scope, address) {
+        // EIP-7739 rehash: bind `hash` to THIS account's EIP-712 domain before authenticating, so a signature
+        // produced for one account cannot be replayed as a valid 1271 signature for another account that shares the
+        // same owner key. See {replaySafeHash}. This is the PersonalSign workflow; see the note there on the
+        // TypedDataSign (readable app typed-data) follow-on.
+        try this.authenticateActor(account, replaySafeHash(account, hash), signature) returns (
+            bytes32, uint8 scope, address
+        ) {
             // ERC-1271 signing is authorized for any operational actor: the admin (scope == 0x00), or a SENDER actor
             // that is not gated by a policy (SCOPE_SENDER set AND SCOPE_POLICY unset). Signing is an encoding of
             // authority a SENDER actor already holds via calls, not a separate grant, so it needs no dedicated scope
@@ -639,6 +645,64 @@ contract AccountConfiguration {
         } catch {
             return false;
         }
+    }
+
+    // ── EIP-7739 account-scoped ERC-1271 rehashing ──────────────────────────────────────────────────────────
+    //
+    // ERC-1271 signatures are validated against a digest bound to the specific `account` (EIP-712
+    // verifyingContract = account). Without this, a key that owns multiple accounts (e.g. a wallet and its
+    // sub-account, which share an owner) would have any 1271 signature valid on all of them: cross-account replay.
+    // Doing it HERE (rather than in each account's bytecode) means every account — including the codeless-EOA
+    // DefaultAccount and precompile/registry-direct verifiers that cannot EXTCALL account bytecode (e.g. b20
+    // permits) — gets the binding for free and against one canonical convention.
+    //
+    // 8130's own signed messages (actor changes, import, lock) bind context in-struct and use no domain separator;
+    // this EIP-712 domain is introduced solely for the ERC-1271 / 7739 surface.
+    //
+    // SCOPE OF THIS DRAFT: only the EIP-7739 *PersonalSign* workflow (arbitrary message digests) is implemented.
+    // The *TypedDataSign* workflow — which lets wallet UIs display an app's readable EIP-712 payload while still
+    // binding the account — is a port of Solady ERC1271's nested-EIP-712 reconstruction, parameterized by `account`
+    // instead of `address(this)`. It is intentionally omitted here: it adds substantial assembly surface to the
+    // audited singleton, and the account-binding security property is already demonstrated by PersonalSign.
+
+    /// @dev EIP-712 domain typehash for the per-account ERC-1271 domain.
+    bytes32 private constant _EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+
+    /// @dev keccak256("PersonalSign(bytes prefixed)") — the EIP-7739 PersonalSign struct typehash.
+    bytes32 private constant _PERSONAL_SIGN_TYPEHASH =
+        0x983e65e5148e570cd828ead231ee759a8d7958721a768f93bc4483ba005c32de;
+
+    /// @dev Canonical name/version for every account's ERC-1271 domain. The registry imposes one convention for all
+    ///      8130 accounts, so a signature binds to the account regardless of the account's own bytecode.
+    bytes32 private constant _ACCOUNT_DOMAIN_NAME_HASH = keccak256("EIP8130Account");
+    bytes32 private constant _ACCOUNT_DOMAIN_VERSION_HASH = keccak256("1");
+
+    /// @notice The account-scoped digest a signer must sign for a plain message to be accepted by
+    ///         {verifySignature}. This is the EIP-7739 `PersonalSign` digest: `hash` wrapped in an EIP-712 domain
+    ///         whose `verifyingContract` is `account` (plus the current chainId), so the signature is bound to this
+    ///         specific account and cannot be replayed onto another account that shares the same owner key.
+    ///
+    /// @param account The account the message is being signed for.
+    /// @param hash The raw message digest.
+    ///
+    /// @return The account-scoped EIP-712 digest to sign.
+    function replaySafeHash(address account, bytes32 hash) public view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(_PERSONAL_SIGN_TYPEHASH, hash));
+        return keccak256(abi.encodePacked(hex"1901", _accountDomainSeparator(account), structHash));
+    }
+
+    /// @dev EIP-712 domain separator for `account`'s ERC-1271 domain (verifyingContract = account, current chainId).
+    function _accountDomainSeparator(address account) internal view returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                _EIP712_DOMAIN_TYPEHASH,
+                _ACCOUNT_DOMAIN_NAME_HASH,
+                _ACCOUNT_DOMAIN_VERSION_HASH,
+                block.chainid,
+                account
+            )
+        );
     }
 
     /// @notice Authenticates that an account approved `hash` using auth in `authenticator(20) || data` format,

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -619,7 +619,7 @@ contract AccountConfiguration {
     ///      reverts on failure, so it is called externally and the revert is caught.
     ///
     /// @param account The account the signature is validated against.
-    /// @param hash The digest that was signed.
+    /// @param hash The raw digest; authenticated as replaySafeHash(account, hash).
     /// @param signature Authenticator(20) || authenticator-specific data.
     ///
     /// @return verified True if the signature is valid and the resolved actor is operational (admin, or a SENDER
@@ -629,10 +629,7 @@ contract AccountConfiguration {
         view
         returns (bool verified)
     {
-        // EIP-7739 rehash: bind `hash` to THIS account's EIP-712 domain before authenticating, so a signature
-        // produced for one account cannot be replayed as a valid 1271 signature for another account that shares the
-        // same owner key. See {replaySafeHash}. This is the PersonalSign workflow; see the note there on the
-        // TypedDataSign (readable app typed-data) follow-on.
+        // Authenticate against the account-scoped digest (see {replaySafeHash}), not the raw hash.
         try this.authenticateActor(account, replaySafeHash(account, hash), signature) returns (
             bytes32, uint8 scope, address
         ) {
@@ -647,47 +644,28 @@ contract AccountConfiguration {
         }
     }
 
-    // ── EIP-7739 account-scoped ERC-1271 rehashing ──────────────────────────────────────────────────────────
-    //
-    // ERC-1271 signatures are validated against a digest bound to the specific `account` (EIP-712
-    // verifyingContract = account). Without this, a key that owns multiple accounts (e.g. a wallet and its
-    // sub-account, which share an owner) would have any 1271 signature valid on all of them: cross-account replay.
-    // Doing it HERE (rather than in each account's bytecode) means every account — including the codeless-EOA
-    // DefaultAccount and precompile/registry-direct verifiers that cannot EXTCALL account bytecode (e.g. b20
-    // permits) — gets the binding for free and against one canonical convention.
-    //
-    // 8130's own signed messages (actor changes, import, lock) bind context in-struct and use no domain separator;
-    // this EIP-712 domain is introduced solely for the ERC-1271 / 7739 surface.
-    //
-    // SCOPE: this implements the EIP-7739 *PersonalSign* workflow, which delivers the full account-binding
-    // security property for every ERC-1271 message (arbitrary digests): signers sign {replaySafeHash}. The
-    // *TypedDataSign* workflow — which additionally lets wallet UIs display an app's readable EIP-712 payload while
-    // binding the account — is an additive UX layer (a port of Solady ERC1271's nested-EIP-712 reconstruction,
-    // parameterized by `account` instead of `address(this)`) tracked as a follow-up. It changes none of the
-    // security guarantees delivered here; until it lands, wallet UIs display the opaque PersonalSign digest.
+    // Account-scoped ERC-1271: signatures are authenticated against replaySafeHash(account, hash), an EIP-712
+    // digest with verifyingContract = account, binding a 1271 signature to a single account. This is the EIP-7739
+    // PersonalSign digest; TypedDataSign is not implemented. The registry's own signed messages (actor changes,
+    // import, lock) bind context in-struct and do not use this domain.
 
-    /// @dev EIP-712 domain typehash for the per-account ERC-1271 domain.
+    /// @dev EIP-712 domain typehash.
     bytes32 private constant _EIP712_DOMAIN_TYPEHASH =
         keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
 
-    /// @dev keccak256("PersonalSign(bytes prefixed)") — the EIP-7739 PersonalSign struct typehash.
+    /// @dev keccak256("PersonalSign(bytes prefixed)").
     bytes32 private constant _PERSONAL_SIGN_TYPEHASH =
         0x983e65e5148e570cd828ead231ee759a8d7958721a768f93bc4483ba005c32de;
 
-    /// @dev Canonical name/version for every account's ERC-1271 domain. The registry imposes one convention for all
-    ///      8130 accounts, so a signature binds to the account regardless of the account's own bytecode.
+    /// @dev Account ERC-1271 domain name/version, fixed for all accounts.
     bytes32 private constant _ACCOUNT_DOMAIN_NAME_HASH = keccak256("EIP8130Account");
     bytes32 private constant _ACCOUNT_DOMAIN_VERSION_HASH = keccak256("1");
 
-    /// @notice The account-scoped digest a signer must sign for a plain message to be accepted by
-    ///         {verifySignature}. This is the EIP-7739 `PersonalSign` digest: `hash` wrapped in an EIP-712 domain
-    ///         whose `verifyingContract` is `account` (plus the current chainId), so the signature is bound to this
-    ///         specific account and cannot be replayed onto another account that shares the same owner key.
-    ///
-    /// @param account The account the message is being signed for.
-    /// @param hash The raw message digest.
-    ///
-    /// @return The account-scoped EIP-712 digest to sign.
+    /// @notice Account-scoped digest to sign for `hash` to be accepted by {verifySignature}: `hash` wrapped in an
+    ///         EIP-712 domain with verifyingContract = `account` and the current chainId.
+    /// @param account Account the signature is bound to.
+    /// @param hash Raw message digest.
+    /// @return The digest to sign.
     function replaySafeHash(address account, bytes32 hash) public view returns (bytes32) {
         bytes32 structHash = keccak256(abi.encode(_PERSONAL_SIGN_TYPEHASH, hash));
         return keccak256(abi.encodePacked(hex"1901", _accountDomainSeparator(account), structHash));

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -675,11 +675,7 @@ contract AccountConfiguration {
     function _accountDomainSeparator(address account) internal view returns (bytes32) {
         return keccak256(
             abi.encode(
-                _EIP712_DOMAIN_TYPEHASH,
-                _ACCOUNT_DOMAIN_NAME_HASH,
-                _ACCOUNT_DOMAIN_VERSION_HASH,
-                block.chainid,
-                account
+                _EIP712_DOMAIN_TYPEHASH, _ACCOUNT_DOMAIN_NAME_HASH, _ACCOUNT_DOMAIN_VERSION_HASH, block.chainid, account
             )
         );
     }

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -659,11 +659,12 @@ contract AccountConfiguration {
     // 8130's own signed messages (actor changes, import, lock) bind context in-struct and use no domain separator;
     // this EIP-712 domain is introduced solely for the ERC-1271 / 7739 surface.
     //
-    // SCOPE OF THIS DRAFT: only the EIP-7739 *PersonalSign* workflow (arbitrary message digests) is implemented.
-    // The *TypedDataSign* workflow — which lets wallet UIs display an app's readable EIP-712 payload while still
-    // binding the account — is a port of Solady ERC1271's nested-EIP-712 reconstruction, parameterized by `account`
-    // instead of `address(this)`. It is intentionally omitted here: it adds substantial assembly surface to the
-    // audited singleton, and the account-binding security property is already demonstrated by PersonalSign.
+    // SCOPE: this implements the EIP-7739 *PersonalSign* workflow, which delivers the full account-binding
+    // security property for every ERC-1271 message (arbitrary digests): signers sign {replaySafeHash}. The
+    // *TypedDataSign* workflow — which additionally lets wallet UIs display an app's readable EIP-712 payload while
+    // binding the account — is an additive UX layer (a port of Solady ERC1271's nested-EIP-712 reconstruction,
+    // parameterized by `account` instead of `address(this)`) tracked as a follow-up. It changes none of the
+    // security guarantees delivered here; until it lands, wallet UIs display the opaque PersonalSign digest.
 
     /// @dev EIP-712 domain typehash for the per-account ERC-1271 domain.
     bytes32 private constant _EIP712_DOMAIN_TYPEHASH =

--- a/test/unit/AccountConfiguration/authenticate.t.sol
+++ b/test/unit/AccountConfiguration/authenticate.t.sol
@@ -725,7 +725,9 @@ contract AuthenticateTest is AccountConfigurationTest {
         _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), scope);
 
         bool expected = scope == 0 || (scope & SCOPE_SENDER != 0);
-        assertEq(accountConfiguration.verifySignature(account, hash, _buildK1Auth(actorPk, hash)), expected);
+        // verifySignature applies the account-scoped EIP-7739 wrap.
+        bytes memory auth = _buildK1Auth(actorPk, accountConfiguration.replaySafeHash(account, hash));
+        assertEq(accountConfiguration.verifySignature(account, hash, auth), expected);
     }
 
     /// @notice A SENDER actor without POLICY is operational and verifies true via verifySignature.
@@ -742,15 +744,17 @@ contract AuthenticateTest is AccountConfigurationTest {
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(actorPk) != account);
         bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        // verifySignature applies the account-scoped EIP-7739 wrap; replaySafeHash(account, hash) is scope-independent.
+        bytes memory auth = _buildK1Auth(actorPk, accountConfiguration.replaySafeHash(account, hash));
 
         _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_SENDER);
-        assertTrue(accountConfiguration.verifySignature(account, hash, _buildK1Auth(actorPk, hash)));
+        assertTrue(accountConfiguration.verifySignature(account, hash, auth));
 
         _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_SENDER | SCOPE_SELF_PAYER);
-        assertTrue(accountConfiguration.verifySignature(account, hash, _buildK1Auth(actorPk, hash)));
+        assertTrue(accountConfiguration.verifySignature(account, hash, auth));
 
         _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_SENDER | SCOPE_NONCE);
-        assertTrue(accountConfiguration.verifySignature(account, hash, _buildK1Auth(actorPk, hash)));
+        assertTrue(accountConfiguration.verifySignature(account, hash, auth));
     }
 
     /// @notice A non-SENDER capability-only actor (SELF_PAYER-only, SPONSOR_PAYER-only, NONCE-only) is NOT

--- a/test/unit/AccountConfiguration/erc7739.t.sol
+++ b/test/unit/AccountConfiguration/erc7739.t.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
+
+/// @notice Draft: registry-native EIP-7739 (PersonalSign) rehashing in AccountConfiguration.verifySignature.
+///
+/// @dev Demonstrates that ERC-1271 signatures are now bound to a specific account at the singleton level, so
+///      cross-account replay is closed for EVERY consumer of verifySignature — including registry-direct verifiers
+///      (e.g. precompile-based permits) that cannot call account bytecode.
+contract AccountConfigurationERC7739Test is AccountConfigurationTest {
+    uint256 constant OWNER_PK = 0xA11CE;
+
+    /// @dev verifySignature now rehashes: a signature over the RAW app hash is rejected; the signer must sign the
+    ///      account-scoped replaySafeHash.
+    function test_verifySignature_requiresAccountScopedDigest() public {
+        (address account,) = _createK1AccountWithSalt(OWNER_PK, bytes32(uint256(1)));
+        bytes32 appHash = keccak256("hello world");
+
+        assertFalse(
+            accountConfiguration.verifySignature(account, appHash, _buildK1Auth(OWNER_PK, appHash)),
+            "raw-hash signature must be rejected now that verifySignature rehashes"
+        );
+
+        bytes32 signable = accountConfiguration.replaySafeHash(account, appHash);
+        assertTrue(
+            accountConfiguration.verifySignature(account, appHash, _buildK1Auth(OWNER_PK, signable)),
+            "account-scoped (replaySafeHash) signature must validate"
+        );
+    }
+
+    /// @dev The core fix: a signature made for one account does NOT validate on another account that shares the
+    ///      same owner key (a wallet and its sub-account share an owner). Enforced at the registry, so a
+    ///      registry-direct verifier gets this without ever calling the account.
+    function test_verifySignature_blocksCrossAccountReplay() public {
+        (address accountA,) = _createK1AccountWithSalt(OWNER_PK, bytes32(uint256(0xA)));
+        (address accountB,) = _createK1AccountWithSalt(OWNER_PK, bytes32(uint256(0xB)));
+        assertTrue(accountA != accountB, "accounts must differ");
+
+        bytes32 appHash = keccak256("sign in to dapp");
+        bytes memory sigForA = _buildK1Auth(OWNER_PK, accountConfiguration.replaySafeHash(accountA, appHash));
+
+        assertTrue(accountConfiguration.verifySignature(accountA, appHash, sigForA), "valid on the intended account");
+        assertFalse(
+            accountConfiguration.verifySignature(accountB, appHash, sigForA),
+            "must NOT replay onto another account with the same owner key"
+        );
+    }
+
+    /// @dev replaySafeHash is account-scoped: the same message yields different digests per account (and per chain,
+    ///      via the EIP-712 domain).
+    function test_replaySafeHash_isAccountScoped() public {
+        (address accountA,) = _createK1AccountWithSalt(OWNER_PK, bytes32(uint256(0xA)));
+        (address accountB,) = _createK1AccountWithSalt(OWNER_PK, bytes32(uint256(0xB)));
+        bytes32 appHash = keccak256("msg");
+
+        assertTrue(
+            accountConfiguration.replaySafeHash(accountA, appHash)
+                != accountConfiguration.replaySafeHash(accountB, appHash),
+            "digests must differ by account"
+        );
+    }
+
+    /// @dev A non-owner key is rejected even when it signs the correct account-scoped digest.
+    function test_verifySignature_rejectsNonOwner() public {
+        (address account,) = _createK1AccountWithSalt(OWNER_PK, bytes32(uint256(1)));
+        bytes32 appHash = keccak256("hello world");
+        bytes32 signable = accountConfiguration.replaySafeHash(account, appHash);
+
+        assertFalse(
+            accountConfiguration.verifySignature(account, appHash, _buildK1Auth(0xBEEF, signable)),
+            "a non-owner signature must be rejected"
+        );
+    }
+}

--- a/test/unit/AccountConfiguration/importAccount.t.sol
+++ b/test/unit/AccountConfiguration/importAccount.t.sol
@@ -526,9 +526,7 @@ contract ImportAccountTest is AccountConfigurationTest {
 
         AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(device);
         bytes32 digest = _computeImportDigest(eoa, actors);
-        // Canonical k1 auth blob: K1_AUTHENTICATOR || signature, signed by the EOA's own key (the implicit owner).
-        // importAccount validates via the account's ERC-1271, which now applies the account-scoped EIP-7739 wrap, so
-        // the self-signature is over replaySafeHash(eoa, digest).
+        // importAccount validates via the account's ERC-1271, which wraps: sign replaySafeHash(eoa, digest).
         accountConfiguration.importAccount(
             eoa, uint64(block.chainid), actors, _buildK1Auth(eoaPk, accountConfiguration.replaySafeHash(eoa, digest))
         );
@@ -560,7 +558,7 @@ contract ImportAccountTest is AccountConfigurationTest {
         });
 
         bytes32 digest = _computeImportDigest(eoa, actors);
-        // importAccount validates via the account's ERC-1271, which now applies the account-scoped EIP-7739 wrap.
+        // importAccount validates via the account's ERC-1271, which wraps: sign replaySafeHash(eoa, digest).
         accountConfiguration.importAccount(
             eoa, uint64(block.chainid), actors, _buildK1Auth(eoaPk, accountConfiguration.replaySafeHash(eoa, digest))
         );

--- a/test/unit/AccountConfiguration/importAccount.t.sol
+++ b/test/unit/AccountConfiguration/importAccount.t.sol
@@ -527,7 +527,11 @@ contract ImportAccountTest is AccountConfigurationTest {
         AccountConfiguration.InitialActor[] memory actors = _singleUnrestrictedActor(device);
         bytes32 digest = _computeImportDigest(eoa, actors);
         // Canonical k1 auth blob: K1_AUTHENTICATOR || signature, signed by the EOA's own key (the implicit owner).
-        accountConfiguration.importAccount(eoa, uint64(block.chainid), actors, _buildK1Auth(eoaPk, digest));
+        // importAccount validates via the account's ERC-1271, which now applies the account-scoped EIP-7739 wrap, so
+        // the self-signature is over replaySafeHash(eoa, digest).
+        accountConfiguration.importAccount(
+            eoa, uint64(block.chainid), actors, _buildK1Auth(eoaPk, accountConfiguration.replaySafeHash(eoa, digest))
+        );
 
         assertEq(accountConfiguration.getChangeSequences(eoa).local, 1);
         assertTrue(accountConfiguration.isActor(eoa, bytes32(bytes20(device))));
@@ -556,7 +560,10 @@ contract ImportAccountTest is AccountConfigurationTest {
         });
 
         bytes32 digest = _computeImportDigest(eoa, actors);
-        accountConfiguration.importAccount(eoa, uint64(block.chainid), actors, _buildK1Auth(eoaPk, digest));
+        // importAccount validates via the account's ERC-1271, which now applies the account-scoped EIP-7739 wrap.
+        accountConfiguration.importAccount(
+            eoa, uint64(block.chainid), actors, _buildK1Auth(eoaPk, accountConfiguration.replaySafeHash(eoa, digest))
+        );
 
         assertEq(accountConfiguration.getChangeSequences(eoa).local, 1);
         // The self-actorId is a live explicit owner.

--- a/test/unit/accounts/CanonicalHighRatePayerAccount.t.sol
+++ b/test/unit/accounts/CanonicalHighRatePayerAccount.t.sol
@@ -156,7 +156,8 @@ contract CanonicalHighRatePayerAccountTest is AccountConfigurationTest {
         (address account,) = _createHighRatePayerK1Account(ACTOR_PK);
 
         bytes32 hash = keccak256("validate me");
-        bytes memory authData = _buildK1Auth(ACTOR_PK, hash);
+        // verifySignature applies the account-scoped EIP-7739 wrap, so sign the replaySafeHash digest.
+        bytes memory authData = _buildK1Auth(ACTOR_PK, accountConfiguration.replaySafeHash(account, hash));
 
         bytes4 result = CanonicalHighRatePayerAccount(payable(account)).isValidSignature(hash, authData);
         assertEq(result, bytes4(0x1626ba7e));

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -312,7 +312,8 @@ contract DefaultAccountTest is AccountConfigurationTest {
         // Authorize the actor with SENDER scope only (no POLICY) — it is operational and can validate signatures.
         _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(actor)), k1Authenticator, SCOPE_SENDER);
 
-        bytes memory authData = _buildK1Auth(actorPk, hash);
+        // verifySignature applies the account-scoped EIP-7739 wrap, so sign the replaySafeHash digest.
+        bytes memory authData = _buildK1Auth(actorPk, accountConfiguration.replaySafeHash(account, hash));
 
         bytes4 result = DefaultAccount(payable(account)).isValidSignature(hash, authData);
         assertEq(result, ERC1271_MAGIC);
@@ -345,7 +346,8 @@ contract DefaultAccountTest is AccountConfigurationTest {
         uint256 pk = _boundK1Pk(pkSeed);
         (address account,) = _createK1Account(pk);
 
-        bytes memory authData = _buildK1Auth(pk, hash);
+        // verifySignature applies the account-scoped EIP-7739 wrap, so sign the replaySafeHash digest.
+        bytes memory authData = _buildK1Auth(pk, accountConfiguration.replaySafeHash(account, hash));
 
         bytes4 result = DefaultAccount(payable(account)).isValidSignature(hash, authData);
         assertEq(result, ERC1271_MAGIC);

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -140,8 +140,13 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
 
         bytes memory nestedAuth = abi.encodePacked(k1Authenticator, _signDigest(signerPk, hash));
 
-        // The SENDER-without-POLICY actor is operational: verifySignature returns true.
-        assertTrue(accountConfiguration.verifySignature(delegateAccount, hash, nestedAuth));
+        // The SENDER-without-POLICY actor is operational: verifySignature returns true. verifySignature applies the
+        // account-scoped EIP-7739 wrap, so this assertion signs the replaySafeHash digest; the raw-hash `nestedAuth`
+        // is what the delegate vouch below consumes (the vouch authenticates over the raw hash, not the 1271 wrap).
+        bytes memory wrappedAuth = abi.encodePacked(
+            k1Authenticator, _signDigest(signerPk, accountConfiguration.replaySafeHash(delegateAccount, hash))
+        );
+        assertTrue(accountConfiguration.verifySignature(delegateAccount, hash, wrappedAuth));
 
         // But it cannot vouch as a delegate — the nested check stays admin-only.
         bytes memory data = abi.encodePacked(delegateAccount, nestedAuth);

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -140,9 +140,7 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
 
         bytes memory nestedAuth = abi.encodePacked(k1Authenticator, _signDigest(signerPk, hash));
 
-        // The SENDER-without-POLICY actor is operational: verifySignature returns true. verifySignature applies the
-        // account-scoped EIP-7739 wrap, so this assertion signs the replaySafeHash digest; the raw-hash `nestedAuth`
-        // is what the delegate vouch below consumes (the vouch authenticates over the raw hash, not the 1271 wrap).
+        // verifySignature wraps: sign replaySafeHash. (nestedAuth, over the raw hash, is for the vouch below.)
         bytes memory wrappedAuth = abi.encodePacked(
             k1Authenticator, _signDigest(signerPk, accountConfiguration.replaySafeHash(delegateAccount, hash))
         );


### PR DESCRIPTION
## What

`verifySignature(account, hash, sig)` now authenticates against `replaySafeHash(account, hash)` — an EIP-712 digest with `verifyingContract = account` — instead of the raw `hash`. This binds a 1271 signature to a single account, closing cross-account replay (a key that owns multiple accounts, e.g. a wallet and a sub-account, previously had any 1271 signature valid on all of them).

This is the same `replaySafeHash` wrap `CoinbaseSmartWallet` v1 has shipped for years, relocated into the registry so it also covers the codeless-EOA `DefaultAccount` and any registry-direct verifier that cannot call account bytecode.

## Changes

- `replaySafeHash(address account, bytes32 hash)` — public helper returning the account-scoped digest a signer must sign. Byte-compatible with the EIP-7739 PersonalSign digest.
- A per-account EIP-712 domain (name/version fixed for all accounts, `verifyingContract = account`, current chainId). The registry's own signed messages (actor changes, import, lock) bind context in-struct and do not use this domain.
- `verifySignature` wraps via `replaySafeHash` before `authenticateActor`. `authenticateActor` (the raw primitive) is unchanged.

## Not included

The EIP-7739 **TypedDataSign** workflow (verifier reconstructs an app's EIP-712 payload from the signature so wallets can display readable typed data) is not implemented. It is addable later in upgradeable account code on top of `authenticateActor`, without changing this contract.

## Behavior change

Callers of `verifySignature` must now sign `replaySafeHash(account, hash)`, not the raw hash:
- `DefaultAccount.isValidSignature` inherits the wrap (no bytecode change).
- `importAccount` validates the importing owner via the account's ERC-1271, so 7702 self-imports (EOA delegated to `DefaultAccount`) now sign `replaySafeHash(eoa, importDigest)`. Open question for reviewers: keep this, or have `importAccount` authenticate via `authenticateActor` over its in-struct digest instead of the 1271 path?
- The delegate vouch is unaffected (it authenticates over the raw hash via `authenticateActor`).

## Decisions for review

- **Location:** registry-native (this PR) vs account-side (each account owns 1271; registry stays minimal). Registry-native covers registry-direct verifiers but is write-once; account-side is upgradeable. Context: #proj-aa-v2.
- **Domain name/version:** `"EIP8130Account"` / `"1"` — a fixed convention for all accounts.
- **chainId** is included (1271 signatures are chain-specific).

## Testing

`test/unit/AccountConfiguration/erc7739.t.sol`: raw-hash rejected, account-scoped accepted, cross-account replay blocked, non-owner rejected. Existing `verifySignature` / ERC-1271 tests re-signed against `replaySafeHash`. Full suite: 335 passing.
