### PR TITLE
refactor: Scopes library, uint16 scope, drop isActor/verifySignature

### DIFF
--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.36;
 
 import {IAuthenticator} from "./interfaces/IAuthenticator.sol";
+import {Scopes} from "./libraries/Scopes.sol";
 
 /// @notice Account Configuration system contract for EIP-8130.
 ///         Manages actor authorization, account creation, change sequencing, and account lock. This contract is
@@ -20,28 +21,29 @@ contract AccountConfiguration {
         uint64 local; // chain_id == block.chainid; starts at 1 once initialized (created/imported), 0 = uninitialized
     }
 
-    /// @notice An actor's authorization: authenticator, scope, and expiry.
+    /// @notice An actor's authorization: authenticator, expiry, and scope. Field order matches the normative
+    ///         `actor_config` slot layout: authenticator(20) ‖ expiry(6) ‖ scope(2) ‖ reserved(4).
     struct ActorConfig {
         address authenticator;
-        uint8 scope;
         uint48 expiry; // Unix seconds; 0 = no expiry. Actor invalid once block.timestamp > expiry
+        uint16 scope;
     }
 
-    /// @notice Initial actor for account creation and import. Carries its scope and, when scope & SCOPE_POLICY is
+    /// @notice Initial actor for account creation and import. Carries its scope and, when scope & Scopes.POLICY is
     ///         set, its policy data; expiry is always 0 for initial actors (scoped-with-expiry keys are added later
     ///         via applySignedActorChanges).
     struct InitialActor {
         bytes32 actorId;
         address authenticator;
-        uint8 scope; // 0x00 = unrestricted admin
-        bytes policyData; // empty unless scope & SCOPE_POLICY; then manager(20) || commitment(32)
+        uint16 scope; // 0x00 = unrestricted admin
+        bytes policyData; // empty unless scope & Scopes.POLICY; then manager(20) || commitment(32)
     }
 
     /// @notice A full actor record: identifier, config, and policy data.
     struct Actor {
         bytes32 actorId;
         ActorConfig config;
-        // Sliced by scope: empty when scope & SCOPE_POLICY == 0; manager[20] || commitment[32] when set.
+        // Sliced by scope: empty when scope & Scopes.POLICY == 0; manager[20] || commitment[32] when set.
         bytes policyData;
     }
 
@@ -56,8 +58,8 @@ contract AccountConfiguration {
     ///
     /// @dev Packed into a single storage slot; the field layout is normative (nodes read the raw slot for mempool
     ///      rate-limit tiering, see the EIP's Account Lock section). Field order and widths match the spec's
-    ///      account-state table: multichainSequence, localSequence, flags, lockUnion, defaultEOAScope,
-    ///      defaultEOAExpiry, then 3 reserved bytes that MUST stay zero.
+    ///      account-state table: multichainSequence, localSequence, flags, lockUnion, defaultEOAExpiry,
+    ///      defaultEOAScope, then 2 reserved bytes that MUST stay zero.
     ///      localSequence > 0 doubles as the account initialized flag.
     ///      `flags` is a bitfield: bit 0 (FLAG_REVOKE_DEFAULT_EOA) disables the k1 self key; bit 1 (FLAG_LOCKED)
     ///      freezes actor configuration; bit 2 (FLAG_UNLOCK_INITIATED) selects how `lockUnion` is interpreted.
@@ -66,7 +68,7 @@ contract AccountConfiguration {
     ///      The defaultEOA* fields are the inline home for the account's own secp256k1 ("self") key — the actor whose
     ///      actorId is bytes32(bytes20(account)). When FLAG_REVOKE_DEFAULT_EOA is unset, a k1 signature recovering to
     ///      the account authenticates with this inline config (all-zero = full owner; non-zero scope/expiry = a
-    ///      scoped self key), resolved in a single SLOAD. Policy gating (when scope & SCOPE_POLICY != 0) is still keyed
+    ///      scoped self key), resolved in a single SLOAD. Policy gating (when scope & Scopes.POLICY != 0) is still keyed
     ///      by actorId in the shared _policyManager/_policyCommitment keyspace. The separate _actorConfig[self][account]
     ///      slot is reserved for a *non-k1* self authenticator (e.g. a post-quantum verifier returning the
     ///      self-actorId); the two homes are mutually exclusive (see _authorizeActor).
@@ -75,9 +77,9 @@ contract AccountConfiguration {
         uint64 localSequence; // 8 bytes – also serves as initialized flag
         uint8 flags; // 1 byte – bitfield: bit 0 REVOKE_DEFAULT_EOA, bit 1 LOCKED, bit 2 UNLOCK_INITIATED
         uint40 lockUnion; // 5 bytes – union: unlockDelay while UNLOCK_INITIATED clear, else unlocksAt (timestamp)
-        uint8 defaultEOAScope; // 1 byte – inline self k1 scope (0 = full owner)
         uint48 defaultEOAExpiry; // 6 bytes – inline self k1 expiry (Unix seconds; 0 = no expiry)
-        // 3 bytes reserved (remaining slot bytes); MUST stay zero.
+        uint16 defaultEOAScope; // 2 bytes – inline self k1 scope (0 = full owner)
+        // 2 bytes reserved (remaining slot bytes); MUST stay zero.
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -94,17 +96,17 @@ contract AccountConfiguration {
     ///      import signature cannot be replayed on another chain. Initial actors are hashed structurally via
     ///      ACTOR_TYPEHASH / ACTORCONFIG_TYPEHASH below.
     bytes32 public constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
-        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry)"
+        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
     );
 
     /// @notice Typehash used to structurally hash each Actor within an ActorInitialization import digest.
     bytes32 public constant ACTOR_TYPEHASH = keccak256(
-        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry)"
+        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
     );
 
     /// @notice Typehash used to structurally hash an Actor's ActorConfig within an import digest.
     bytes32 public constant ACTORCONFIG_TYPEHASH =
-        keccak256("ActorConfig(address authenticator,uint8 scope,uint48 expiry)");
+        keccak256("ActorConfig(address authenticator,uint48 expiry,uint16 scope)");
 
     /// @notice Typehash binding a signed actor-change batch to its account, chainId, and sequence.
     ///
@@ -146,35 +148,15 @@ contract AccountConfiguration {
     uint8 public constant UNLOCK_OP = 0x02;
 
     // ----------------------------------------------------------------------------------------------------------------
-    // ACTOR SCOPE BITS
+    // ACTOR SCOPE
     // ----------------------------------------------------------------------------------------------------------------
 
-    /// @notice Actor can initiate transactions with account as sender
-    uint8 public constant SCOPE_SENDER = 0x01;
-
-    /// @notice Actor is gated to a policy: every call it makes must land on the resolved manager (this contract
-    ///         stores manager + commitment; the protocol enforces that the actor's calls only ever reach that
-    ///         target). This contract does not reject scope combinations (e.g. SCOPE_POLICY | SCOPE_SELF_PAYER) — any
-    ///         use-time exclusivity between SCOPE_POLICY and the account's other capabilities is protocol-side, not
-    ///         enforced here.
-    uint8 public constant SCOPE_POLICY = 0x02;
-
-    /// @notice Permits a restricted (non-admin) actor to use sequenced `nonce_key`s for sender-context transactions;
-    ///         without it a restricted actor may use only the nonce-free key (NONCE_KEY_MAX), while admin actors are
-    ///         unconstrained. This contract stores the scope bit verbatim and does not interpret it — nonce semantics
-    ///         are enforced entirely protocol-side.
-    uint8 public constant SCOPE_NONCE = 0x04;
-
-    /// @notice Actor can self-pay gas for the account's own operations (payer == sender).
-    uint8 public constant SCOPE_SELF_PAYER = 0x08;
-
-    /// @notice Actor can sponsor gas on behalf of a different sender (payer != sender).
-    uint8 public constant SCOPE_SPONSOR_PAYER = 0x10;
-
-    // ERC-1271 signing rides on operational authority (admin scope == 0x00, or a SENDER actor without POLICY);
-    // it is not its own scope bit. See verifySignature.
-
-    // 0x20, 0x40, 0x80 are spare (unused).
+    // This contract is deliberately scope-agnostic. `scope == 0` is the admin predicate (the only scope value it
+    // acts on for config/lock changes), and it interprets exactly one grant bit — Scopes.POLICY — to slice and
+    // store an actor's policy data. Every other named grant (SENDER, NONCE, SELF_PAYER, SPONSOR_PAYER, DELEGATE,
+    // and future bits) is stored verbatim and never read here; its meaning is enforced by whoever consumes it
+    // (protocol nodes, account contracts, policy managers). The full uint16 grant vocabulary lives in
+    // {Scopes}. This contract does not reject scope combinations — any use-time exclusivity is protocol-side.
 
     /// @notice The single secp256k1 authenticator. The default EOA and every k1 actor share this one identity; the
     ///         actor config alone distinguishes a full-owner EOA from a scoped key. Signed with a K1_AUTHENTICATOR
@@ -223,8 +205,8 @@ contract AccountConfiguration {
     /// @param account The account whose actor was authorized.
     /// @param actorId The authorized actor's identifier.
     /// @param actorData Tightly packed authorization surface, mirroring the wire packing:
-    ///        authenticator(20) || scope(1) || expiry(6) || reserved(5 zero bytes) = 32 bytes, and, only when
-    ///        scope & SCOPE_POLICY != 0, followed by the resolved policy gate manager(20) || commitment(32). So the
+    ///        authenticator(20) || expiry(6) || scope(2) || reserved(4 zero bytes) = 32 bytes, and, only when
+    ///        scope & Scopes.POLICY != 0, followed by the resolved policy gate manager(20) || commitment(32). So the
     ///        payload is 32 bytes for an ungated actor and 84 bytes for a policy-gated one.
     event ActorAuthorized(address indexed account, bytes32 indexed actorId, bytes actorData);
 
@@ -316,7 +298,7 @@ contract AccountConfiguration {
 
     /// @notice An actor config named an authenticator below the K1 sentinel (i.e. address(0)).
     error InvalidAuthenticator();
-    /// @notice The policyData length did not match `scope & SCOPE_POLICY` (52 bytes when set, empty when unset).
+    /// @notice The policyData length did not match `scope & Scopes.POLICY` (52 bytes when set, empty when unset).
     error InvalidPolicyData();
 
     /// @notice The referenced actor is not currently authorized on the account.
@@ -353,11 +335,11 @@ contract AccountConfiguration {
     /// @dev Account must be inner-most mapping key to pass ERC-7562 storage access rules for ERC-4337 compatibility.
     mapping(bytes32 actorId => mapping(address account => ActorConfig)) internal _actorConfig;
 
-    /// @notice Per-actor signed policy commitment. Set when the actor's scope carries SCOPE_POLICY.
+    /// @notice Per-actor signed policy commitment. Set when the actor's scope carries Scopes.POLICY.
     /// @dev Read only during execution (via getPolicy), never during signature validity checks.
     mapping(bytes32 actorId => mapping(address account => bytes32)) internal _policyCommitment;
 
-    /// @notice Per-actor policy manager address. Set when the actor's scope carries SCOPE_POLICY.
+    /// @notice Per-actor policy manager address. Set when the actor's scope carries Scopes.POLICY.
     mapping(bytes32 actorId => mapping(address account => address)) internal _policyManager;
 
     /// @notice Per-account state: sequences, lock status (single slot per account)
@@ -386,7 +368,7 @@ contract AccountConfiguration {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     /// @notice Deploys a new account with its initial actors. Each initial actor is registered with its declared
-    ///         `scope` and, when `scope & SCOPE_POLICY` is set, its `policyData` (an external `manager` is expressible
+    ///         `scope` and, when `scope & Scopes.POLICY` is set, its `policyData` (an external `manager` is expressible
     ///         at create; `manager = account` is not, as the address is unknown at commitment time). `expiry` is
     ///         always 0 at create — scoped-with-expiry keys are added afterwards via applySignedActorChanges. The
     ///         implicit default-EOA key is disabled on creation.
@@ -516,7 +498,7 @@ contract AccountConfiguration {
 
         // Compute digest and authenticate
         bytes32 digest = _computeSignedActorChangesDigest(account, chainId, sequence, actorChanges);
-        (, uint8 scope,) = authenticateActor(account, digest, auth);
+        (, uint16 scope,) = authenticateActor(account, digest, auth);
 
         // Only an unrestricted actor (scope 0) may change actors; there is no elevated "admin" scope bit.
         if (scope != 0) revert UnauthorizedActorChange();
@@ -574,7 +556,7 @@ contract AccountConfiguration {
         uint64 sequence = _accountState[account].localSequence++;
 
         bytes32 digest = _computeSignedLockChangesDigest(account, block.chainid, op, unlockDelay, sequence);
-        (, uint8 scope,) = authenticateActor(account, digest, auth);
+        (, uint16 scope,) = authenticateActor(account, digest, auth);
 
         // Only an unrestricted actor (scope 0) may change the lock; there is no elevated "admin" scope bit.
         if (scope != 0) revert UnauthorizedLockChange();
@@ -612,42 +594,12 @@ contract AccountConfiguration {
     // VIEW FUNCTIONS
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice Validates an account signature in `authenticator(20) || data` format; never reverts.
-    ///
-    /// @dev ERC-1271-style boolean check: returns false on any failure (invalid signature, unknown/revoked actor,
-    ///      actorId not bound to the presented authenticator, or a non-operational actor). authenticateActor
-    ///      reverts on failure, so it is called externally and the revert is caught.
-    ///
-    /// @param account The account the signature is validated against.
-    /// @param hash The raw digest; authenticated as replaySafeHash(account, hash).
-    /// @param signature Authenticator(20) || authenticator-specific data.
-    ///
-    /// @return verified True if the signature is valid and the resolved actor is operational (admin, or a SENDER
-    ///         actor that does not carry POLICY).
-    function verifySignature(address account, bytes32 hash, bytes calldata signature)
-        external
-        view
-        returns (bool verified)
-    {
-        // Authenticate against the account-scoped digest (see {replaySafeHash}), not the raw hash.
-        try this.authenticateActor(account, replaySafeHash(account, hash), signature) returns (
-            bytes32, uint8 scope, address
-        ) {
-            // ERC-1271 signing is authorized for any operational actor: the admin (scope == 0x00), or a SENDER actor
-            // that is not gated by a policy (SCOPE_SENDER set AND SCOPE_POLICY unset). Signing is an encoding of
-            // authority a SENDER actor already holds via calls, not a separate grant, so it needs no dedicated scope
-            // bit. A POLICY-bearing actor is not operational and cannot sign: a signature acts outside its policy
-            // gate, so honoring one would let it act off its gate.
-            return scope == 0 || ((scope & SCOPE_SENDER != 0) && (scope & SCOPE_POLICY == 0));
-        } catch {
-            return false;
-        }
-    }
-
-    // Account-scoped ERC-1271: signatures are authenticated against replaySafeHash(account, hash), an EIP-712
-    // digest with verifyingContract = account, binding a 1271 signature to a single account. This is the EIP-7739
-    // PersonalSign digest; TypedDataSign is not implemented. The registry's own signed messages (actor changes,
-    // import, lock) bind context in-struct and do not use this domain.
+    // Account-scoped ERC-1271: this contract owns only the account-scoped digest ({replaySafeHash}) — an EIP-712
+    // PersonalSign digest with verifyingContract = account, binding a 1271 signature to a single account (EIP-7739;
+    // TypedDataSign is not implemented). The actual ERC-1271 verification (authenticate + operational-actor check)
+    // lives on the account contract (see DefaultAccount.isValidSignature), keeping this contract scope-agnostic;
+    // it is not a grant, so it needs no scope bit. The registry's own signed messages (actor changes, import,
+    // lock) bind context in-struct and do not use this domain.
 
     /// @dev EIP-712 domain typehash.
     bytes32 private constant _EIP712_DOMAIN_TYPEHASH =
@@ -661,8 +613,9 @@ contract AccountConfiguration {
     bytes32 private constant _ACCOUNT_DOMAIN_NAME_HASH = keccak256("EIP8130Account");
     bytes32 private constant _ACCOUNT_DOMAIN_VERSION_HASH = keccak256("1");
 
-    /// @notice Account-scoped digest to sign for `hash` to be accepted by {verifySignature}: `hash` wrapped in an
-    ///         EIP-712 domain with verifyingContract = `account` and the current chainId.
+    /// @notice Account-scoped digest to sign for `hash` to be accepted by an account's ERC-1271 check (e.g.
+    ///         {DefaultAccount.isValidSignature}): `hash` wrapped in an EIP-712 domain with verifyingContract =
+    ///         `account` and the current chainId.
     /// @param account Account the signature is bound to.
     /// @param hash Raw message digest.
     /// @return The digest to sign.
@@ -689,8 +642,8 @@ contract AccountConfiguration {
     ///      precompile. It lets an off-8130 consumer read `getPolicyCommitment(account, actorId)` (an execution-time
     ///      read) for a policy-gated actor, reaching parity with the native hot path.
     /// @dev `scope` is the actor's capability set, stored verbatim and never interpreted by this contract —
-    ///      protocol-side semantics for bits like SCOPE_NONCE live outside this contract. Consumers decide policy
-    ///      gating via `scope & SCOPE_POLICY`, NOT via `policyTarget != 0`.
+    ///      protocol-side semantics for bits like Scopes.NONCE live outside this contract. Consumers decide policy
+    ///      gating via `scope & Scopes.POLICY`, NOT via `policyTarget != 0`.
     /// @dev `policyTarget` is the resolved policy manager, never the signed commitment (an execution-time read via
     ///      getPolicy). It MAY be address(0) for a policy-gated actor deliberately gated to address(0).
     /// @dev Reverts with InvalidAuthLength when `auth` is shorter than 20 bytes.
@@ -707,7 +660,7 @@ contract AccountConfiguration {
     function authenticateActor(address account, bytes32 hash, bytes calldata auth)
         public
         view
-        returns (bytes32 actorId, uint8 scope, address policyTarget)
+        returns (bytes32 actorId, uint16 scope, address policyTarget)
     {
         if (auth.length < 20) revert InvalidAuthLength();
         return _authenticate(account, hash, address(bytes20(auth[:20])), auth[20:]);
@@ -735,24 +688,6 @@ contract AccountConfiguration {
     // STORAGE VIEWS
     // ----------------------------------------------------------------------------------------------------------------
 
-    /// @notice Returns whether `actorId` is currently authorized on `account` (a stored actor entry exists, or the
-    ///         inline k1 self is enabled).
-    ///
-    /// @dev Does NOT check expiry: an expired-but-not-revoked actor still returns true. This is intentional —
-    ///      _revokeActor relies on it to revoke expired actors — so callers needing liveness must check expiry too.
-    ///
-    /// @param account The account to check.
-    /// @param actorId The actor identifier to check.
-    ///
-    /// @return True if the actor is authorized (possibly expired).
-    function isActor(address account, bytes32 actorId) public view returns (bool) {
-        // A populated _actorConfig entry is always live: any non-self actor, or a non-k1 self authenticator.
-        if (_actorConfig[actorId][account].authenticator >= K1_AUTHENTICATOR) return true;
-        // No _actorConfig entry: the self-actorId's k1 key lives inline in AccountState, live unless the flag is set.
-        if (actorId == bytes32(bytes20(account))) return !_isDefaultEoaRevoked(account);
-        return false;
-    }
-
     /// @notice Resolves the effective ActorConfig for `actorId` on `account`.
     ///
     /// @dev With a populated _actorConfig entry, returns it verbatim (any non-self actor, or a non-k1 self). For the
@@ -767,7 +702,7 @@ contract AccountConfiguration {
     /// @return The resolved actor configuration, or the all-zero config if the actor is not live.
     function getActorConfig(address account, bytes32 actorId) external view returns (ActorConfig memory) {
         ActorConfig memory config = _actorConfig[actorId][account];
-        // Non-zero authenticator = a stored entry. Uses the same `>= K1_AUTHENTICATOR` namespace idiom as isActor:
+        // Non-zero authenticator = a stored entry. Uses the same `>= K1_AUTHENTICATOR` namespace idiom as _isActor:
         // every stored authenticator is K1_AUTHENTICATOR (0x1) or a contract, so this is equivalent to != address(0).
         if (config.authenticator >= K1_AUTHENTICATOR) return config;
         if (actorId == bytes32(bytes20(account)) && !_isDefaultEoaRevoked(account)) {
@@ -785,7 +720,7 @@ contract AccountConfiguration {
     ///      target validates presented parameters against. The policy manager/commitment are keyed by actorId, so
     ///      the inline k1 self and a non-k1 self share that keyspace; mutual exclusion guarantees at most one is
     ///      live, so the active gate is read by actorId. Both slots are non-zero only when the actor's scope carries
-    ///      SCOPE_POLICY (see _authorizeActor / _revokeActor); either MAY still be zero for an actor deliberately
+    ///      Scopes.POLICY (see _authorizeActor / _revokeActor); either MAY still be zero for an actor deliberately
     ///      gated to a zero manager or a zero (no-params) commitment. On-chain consumers should prefer the
     ///      single-SLOAD `getPolicyCommitment` / `getPolicyManager` accessors directly.
     ///
@@ -801,9 +736,9 @@ contract AccountConfiguration {
     /// @notice Resolves an actor's signed policy commitment, or bytes32(0) if ungated / no actor / zero commitment.
     ///
     /// @dev Single SLOAD. Intended for a policy manager's per-tx validation read on the protocol-dispatched
-    ///      8130 tx path. This slot is non-zero only when the actor's scope carries SCOPE_POLICY (see _authorizeActor /
+    ///      8130 tx path. This slot is non-zero only when the actor's scope carries Scopes.POLICY (see _authorizeActor /
     ///      _revokeActor), but MAY be zero for a policy-gated actor with a zero (no-params) commitment; gating is
-    ///      therefore determined by the SCOPE_POLICY bit, not by this slot being non-zero.
+    ///      therefore determined by the Scopes.POLICY bit, not by this slot being non-zero.
     ///
     /// @param account The account to read.
     /// @param actorId The actor identifier to resolve.
@@ -912,7 +847,7 @@ contract AccountConfiguration {
 
     /// @dev Registers the bootstrap actor set shared by createAccount and importAccount: requires a non-empty,
     ///      strictly ascending-by-actorId list (rejecting unsorted or duplicate entries) and authorizes each entry
-    ///      with its declared scope and (when scope & SCOPE_POLICY is set) policyData. Expiry is always 0 for
+    ///      with its declared scope and (when scope & Scopes.POLICY is set) policyData. Expiry is always 0 for
     ///      initial actors; scoped-with-expiry keys are added later via applySignedActorChanges. Reverts with
     ///      NoInitialActors or ActorsNotSortedOrDuplicate.
     function _initializeAccount(address account, InitialActor[] calldata initialActors)
@@ -929,7 +864,7 @@ contract AccountConfiguration {
             previousActorId = initialActors[i].actorId;
 
             // Initial actors carry scope verbatim (0x00 = unrestricted admin) and never an expiry. When
-            // scope & SCOPE_POLICY is set, policyData is validated by the same frozen rule as authorizeActor
+            // scope & Scopes.POLICY is set, policyData is validated by the same frozen rule as authorizeActor
             // (52 bytes). Authorizing the self-actorId as k1 writes its scope into the inline default-EOA fields.
             ActorConfig memory config =
                 ActorConfig({authenticator: initialActors[i].authenticator, scope: initialActors[i].scope, expiry: 0});
@@ -951,9 +886,9 @@ contract AccountConfiguration {
         // authentication time, mirroring the reference PolicyManager's treatment of a zero-commitment policy actor.
         if (config.authenticator < K1_AUTHENTICATOR) revert InvalidAuthenticator();
 
-        // Slice the signed policy by scope & SCOPE_POLICY. The commitment is opaque to the protocol. This contract
-        // does not reject scope combinations (e.g. SCOPE_POLICY | SCOPE_SELF_PAYER) — any use-time exclusivity between
-        // SCOPE_POLICY and the account's other capabilities is protocol-side, not enforced here.
+        // Slice the signed policy by scope & Scopes.POLICY. The commitment is opaque to the protocol. This contract
+        // does not reject scope combinations (e.g. Scopes.POLICY | Scopes.SELF_PAYER) — any use-time exclusivity between
+        // Scopes.POLICY and the account's other capabilities is protocol-side, not enforced here.
         (address manager, bytes32 commitment) = _slicePolicy(config.scope, policyData);
 
         if (actorId == bytes32(bytes20(account))) {
@@ -991,7 +926,7 @@ contract AccountConfiguration {
     /// @dev Writes an actor's policy slots verbatim. `_slicePolicy` yields a zero manager/commitment for a non-policy
     ///      scope, so an ungated actor simply zeroes the slots — a single unconditional write both installs a new gate
     ///      and clears any stale one when an actor moves policy-gated -> ungated or re-keys to a different manager,
-    ///      preserving the "policy slots are non-zero iff scope & SCOPE_POLICY != 0" invariant.
+    ///      preserving the "policy slots are non-zero iff scope & Scopes.POLICY != 0" invariant.
     function _writePolicySlots(bytes32 actorId, address account, address manager, bytes32 commitment) private {
         _policyCommitment[actorId][account] = commitment;
         _policyManager[actorId][account] = manager;
@@ -1006,8 +941,8 @@ contract AccountConfiguration {
     }
 
     /// @dev Emit ActorAuthorized with a tightly packed payload. The base packs to 32 bytes
-    ///      (authenticator(20) || scope(1) || expiry(6) || reserved(5 zero bytes)); the policy gate
-    ///      (manager(20) || commitment(32), 52 bytes) is appended only when scope & SCOPE_POLICY != 0.
+    ///      (authenticator(20) || expiry(6) || scope(2) || reserved(4 zero bytes)); the policy gate
+    ///      (manager(20) || commitment(32), 52 bytes) is appended only when scope & Scopes.POLICY != 0.
     function _emitActorAuthorized(
         address account,
         bytes32 actorId,
@@ -1015,23 +950,23 @@ contract AccountConfiguration {
         address manager,
         bytes32 commitment
     ) private {
-        bytes memory actorData = (config.scope & SCOPE_POLICY != 0)
-            ? abi.encodePacked(config.authenticator, config.scope, config.expiry, bytes5(0), manager, commitment)
-            : abi.encodePacked(config.authenticator, config.scope, config.expiry, bytes5(0));
+        bytes memory actorData = (config.scope & Scopes.POLICY != 0)
+            ? abi.encodePacked(config.authenticator, config.expiry, config.scope, bytes4(0), manager, commitment)
+            : abi.encodePacked(config.authenticator, config.expiry, config.scope, bytes4(0));
         emit ActorAuthorized(account, actorId, actorData);
     }
 
-    /// @dev Validates `policyData` against `scope & SCOPE_POLICY` and returns (manager, commitment).
+    /// @dev Validates `policyData` against `scope & Scopes.POLICY` and returns (manager, commitment).
     ///      Unset: empty data -> (0, 0). Set: exactly 52 bytes manager[20] || commitment[32] -> (manager,
     ///      commitment), written verbatim. Neither field need be non-zero: a zero commitment is a valid "no
     ///      params" and a zero manager gates the actor to address(0). Only a length mismatch reverts. The protocol
     ///      does not interpret the commitment value; self-enforcement is expressed as manager == account.
-    function _slicePolicy(uint8 scope, bytes memory policyData)
+    function _slicePolicy(uint16 scope, bytes memory policyData)
         internal
         pure
         returns (address manager, bytes32 commitment)
     {
-        if (scope & SCOPE_POLICY == 0) {
+        if (scope & Scopes.POLICY == 0) {
             if (policyData.length != 0) revert InvalidPolicyData();
             return (address(0), bytes32(0));
         }
@@ -1042,11 +977,23 @@ contract AccountConfiguration {
         }
     }
 
+    /// @dev Returns whether `actorId` is currently authorized on `account` (a stored actor entry exists, or the
+    ///      inline k1 self is enabled). Does NOT check expiry: an expired-but-not-revoked actor still returns true —
+    ///      intentional, since _revokeActor relies on it to revoke expired actors. Off-chain liveness checks should
+    ///      read {getActorConfig} (authenticator != 0) and enforce expiry themselves.
+    function _isActor(address account, bytes32 actorId) private view returns (bool) {
+        // A populated _actorConfig entry is always live: any non-self actor, or a non-k1 self authenticator.
+        if (_actorConfig[actorId][account].authenticator >= K1_AUTHENTICATOR) return true;
+        // No _actorConfig entry: the self-actorId's k1 key lives inline in AccountState, live unless the flag is set.
+        if (actorId == bytes32(bytes20(account))) return !_isDefaultEoaRevoked(account);
+        return false;
+    }
+
     /// @dev Revokes `actorId` from `account`, clearing its config and policy slots and emitting ActorRevoked. For the
     ///      self-actorId it also disables the inline k1 self (sets FLAG_REVOKE_DEFAULT_EOA and zeroes the inline
     ///      fields). Reverts with UnknownActor when the actor is not currently live.
     function _revokeActor(address account, bytes32 actorId) internal nonZeroAccount(account) {
-        if (!isActor(account, actorId)) revert UnknownActor();
+        if (!_isActor(account, actorId)) revert UnknownActor();
         delete _actorConfig[actorId][account];
         // Policy state is keyed by (account, actorId) and cleared exactly on revoke.
         delete _policyCommitment[actorId][account];
@@ -1086,7 +1033,7 @@ contract AccountConfiguration {
     }
 
     /// @dev Packed commitment over the initial actor set. Per-actor contribution is
-    ///      actorId (32) || authenticator (20) || scope (1) || policyData, where policyData is empty (POLICY unset)
+    ///      actorId (32) || authenticator (20) || scope (2) || policyData, where policyData is empty (POLICY unset)
     ///      or exactly 52 bytes (POLICY set), so the length is unambiguous. Expiry does not participate (always 0
     ///      for initial actors).
     function _computeActorsCommitment(InitialActor[] calldata initialActors) internal pure returns (bytes32) {
@@ -1117,7 +1064,7 @@ contract AccountConfiguration {
             // accepted here. policyData is hashed via keccak256 into the Actor struct hash. The typehash structure
             // matches the importAccount signature payload in EIP-8130.
             bytes32 configHash = keccak256(
-                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, initialActors[i].scope, uint48(0))
+                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), initialActors[i].scope)
             );
             actorHashes[i] = keccak256(
                 abi.encode(ACTOR_TYPEHASH, initialActors[i].actorId, configHash, keccak256(initialActors[i].policyData))
@@ -1193,14 +1140,14 @@ contract AccountConfiguration {
     function _authenticate(address account, bytes32 hash, address authenticator, bytes calldata data)
         internal
         view
-        returns (bytes32, uint8, address)
+        returns (bytes32, uint16, address)
     {
         if (authenticator == K1_AUTHENTICATOR) return _authenticateK1(account, hash, data);
 
         bytes32 actorId = IAuthenticator(authenticator).authenticate(hash, data);
         if (actorId == bytes32(0)) revert AuthenticationFailed();
 
-        (uint8 scope, address policyTarget) = _resolveExplicitActor(account, actorId, authenticator);
+        (uint16 scope, address policyTarget) = _resolveExplicitActor(account, actorId, authenticator);
         return (actorId, scope, policyTarget);
     }
 
@@ -1210,7 +1157,7 @@ contract AccountConfiguration {
     function _resolveExplicitActor(address account, bytes32 actorId, address expectedAuthenticator)
         private
         view
-        returns (uint8 scope, address policyTarget)
+        returns (uint16 scope, address policyTarget)
     {
         ActorConfig memory config = _actorConfig[actorId][account];
         if (config.authenticator != expectedAuthenticator) revert AuthenticatorMismatch();
@@ -1221,9 +1168,9 @@ contract AccountConfiguration {
     }
 
     /// @dev Resolves the policy gate target for an actor: the policy manager for a policy-gated actor
-    ///      (scope & SCOPE_POLICY != 0), or address(0) otherwise. Non-policy actors (incl. admin) skip the SLOAD.
-    function _policyTargetFor(uint8 scope, bytes32 actorId, address account) private view returns (address) {
-        return (scope & SCOPE_POLICY != 0) ? _policyManager[actorId][account] : address(0);
+    ///      (scope & Scopes.POLICY != 0), or address(0) otherwise. Non-policy actors (incl. admin) skip the SLOAD.
+    function _policyTargetFor(uint16 scope, bytes32 actorId, address account) private view returns (address) {
+        return (scope & Scopes.POLICY != 0) ? _policyManager[actorId][account] : address(0);
     }
 
     /// @dev The single secp256k1 ("K1") path. Recovers the signer (EIP-2 enforced), then resolves the actor:
@@ -1233,11 +1180,11 @@ contract AccountConfiguration {
     ///          its own authenticator), and mutual exclusion keeps the flag set whenever one is live.
     ///        - otherwise the signer's actorId must carry an explicit K1 config in _actorConfig (any other k1 actor).
     ///      Both the common self and other-actor paths cost a single SLOAD; the policy-manager slot is read only for a
-    ///      policy-gated actor (`scope & SCOPE_POLICY != 0`), so non-policy authentications avoid the extra SLOAD.
+    ///      policy-gated actor (`scope & Scopes.POLICY != 0`), so non-policy authentications avoid the extra SLOAD.
     function _authenticateK1(address account, bytes32 hash, bytes calldata data)
         internal
         view
-        returns (bytes32, uint8, address)
+        returns (bytes32, uint16, address)
     {
         address recovered = _recoverSigner(hash, data);
         if (recovered == address(0)) revert InvalidSignature();
@@ -1249,12 +1196,12 @@ contract AccountConfiguration {
             if (st.flags & FLAG_REVOKE_DEFAULT_EOA != 0) revert DefaultEoaRevoked();
             if (st.defaultEOAExpiry != 0 && block.timestamp > st.defaultEOAExpiry) revert ActorExpired();
             bytes32 selfActorId = bytes32(bytes20(account));
-            uint8 selfScope = st.defaultEOAScope;
+            uint16 selfScope = st.defaultEOAScope;
             return (selfActorId, selfScope, _policyTargetFor(selfScope, selfActorId, account));
         }
 
         bytes32 actorId = bytes32(bytes20(recovered));
-        (uint8 scope, address policyTarget) = _resolveExplicitActor(account, actorId, K1_AUTHENTICATOR);
+        (uint16 scope, address policyTarget) = _resolveExplicitActor(account, actorId, K1_AUTHENTICATOR);
         return (actorId, scope, policyTarget);
     }
 

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -153,8 +153,8 @@ contract AccountConfiguration {
 
     // This contract is deliberately scope-agnostic. `scope == 0` is the admin predicate (the only scope value it
     // acts on for config/lock changes), and it interprets exactly one grant bit — Scopes.POLICY — to slice and
-    // store an actor's policy data. Every other named grant (SENDER, NONCE, SELF_PAYER, SPONSOR_PAYER, DELEGATE,
-    // and future bits) is stored verbatim and never read here; its meaning is enforced by whoever consumes it
+    // store an actor's policy data. Every other named grant (SENDER, NONCE, SELF_PAYER, SPONSOR_PAYER, and future
+    // bits) is stored verbatim and never read here; its meaning is enforced by whoever consumes it
     // (protocol nodes, account contracts, policy managers). The full uint16 grant vocabulary lives in
     // {Scopes}. This contract does not reject scope combinations — any use-time exclusivity is protocol-side.
 

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.36;
 import {Receiver} from "solady/accounts/Receiver.sol";
 
 import {AccountConfiguration} from "../AccountConfiguration.sol";
+import {Scopes} from "../libraries/Scopes.sol";
 
 /// @notice A single call in an execution batch.
 struct Call {
@@ -43,11 +44,9 @@ contract DefaultAccount is Receiver {
     /// @notice The AccountConfiguration system contract that owns this account's authorization state.
     AccountConfiguration public immutable ACCOUNT_CONFIGURATION;
 
-    /// @dev Local mirrors of {AccountConfiguration.SCOPE_SENDER} / {AccountConfiguration.SCOPE_POLICY}: a contract's
-    ///      public constants are not accessible via its type, and reading the getters would add external calls to the
-    ///      execution hot path. Kept in sync with AccountConfiguration.
-    uint8 private constant SCOPE_SENDER = 0x01;
-    uint8 private constant SCOPE_POLICY = 0x02;
+    /// @dev ERC-1271 magic return value for a valid signature (`isValidSignature(bytes32,bytes)` selector).
+    bytes4 private constant ERC1271_MAGIC = 0x1626ba7e;
+    bytes4 private constant ERC1271_FAIL = 0xFFFFFFFF;
 
     /// @notice The caller is neither the account itself nor a registered TRUSTED_EXECUTOR actor.
     error UnauthorizedCaller();
@@ -86,15 +85,28 @@ contract DefaultAccount is Receiver {
     /// @notice Validates an ERC-1271 signature via AccountConfiguration; requires the verified actor to be
     ///         operational (the unrestricted admin, scope == 0x00, or a SENDER actor without POLICY). Never reverts.
     ///
+    /// @dev Authenticates against the account-scoped digest {AccountConfiguration.replaySafeHash}, not the raw
+    ///      `hash`, so a signature is bound to this account (EIP-7739 PersonalSign) and cannot replay onto another
+    ///      account sharing the same key. `authenticateActor` reverts on any failure, so it is called externally and
+    ///      the revert is caught. Signing is not a scope grant: it is authorized for any operational actor — the
+    ///      admin, or a SENDER actor not gated by a policy — because it only encodes authority such an actor already
+    ///      holds via calls. A POLICY-bearing actor is never operational and cannot sign (a signature would act off
+    ///      its policy gate). This mirrors the operational-actor rule in {_isAuthorizedCaller}.
+    ///
     /// @param hash The digest to authenticate.
     /// @param signature Auth data in `authenticator || data` format.
     ///
     /// @return The ERC-1271 magic value 0x1626ba7e if valid, otherwise 0xffffffff.
     function isValidSignature(bytes32 hash, bytes calldata signature) external view virtual returns (bytes4) {
-        return
-            ACCOUNT_CONFIGURATION.verifySignature(address(this), hash, signature)
-                ? bytes4(0x1626ba7e)
-                : bytes4(0xFFFFFFFF);
+        bytes32 digest = ACCOUNT_CONFIGURATION.replaySafeHash(address(this), hash);
+        try ACCOUNT_CONFIGURATION.authenticateActor(address(this), digest, signature) returns (
+            bytes32, uint16 scope, address
+        ) {
+            bool operational = scope == 0 || ((scope & Scopes.SENDER != 0) && (scope & Scopes.POLICY == 0));
+            return operational ? ERC1271_MAGIC : ERC1271_FAIL;
+        } catch {
+            return ERC1271_FAIL;
+        }
     }
 
     // ══════════════════════════════════════════════
@@ -117,17 +129,17 @@ contract DefaultAccount is Receiver {
     /// @dev Authorized if `caller` is the account itself, or holds the TRUSTED_EXECUTOR authenticator with an
     ///      unexpired config AND operational (sender) authority. Expiry: 0 means none; a non-zero expiry is enforced
     ///      so a user-set expiry is honored on the execution path. Scope: driving execution requires sender
-    ///      authority — the unrestricted admin (scope == 0x00) or an actor with SCOPE_SENDER that is not gated by a
-    ///      policy (SCOPE_POLICY unset). A POLICY-gated actor must route every call through its manager, so granting
+    ///      authority — the unrestricted admin (scope == 0x00) or an actor with Scopes.SENDER that is not gated by a
+    ///      policy (Scopes.POLICY unset). A POLICY-gated actor must route every call through its manager, so granting
     ///      it direct executeBatch would bypass that gate; fail closed. This mirrors the operational-actor definition
-    ///      in AccountConfiguration.verifySignature, keeping the execution and signing authorization surfaces aligned.
+    ///      in {isValidSignature}, keeping the execution and signing authorization surfaces aligned.
     function _isAuthorizedCaller(address caller) internal view virtual returns (bool) {
         if (caller == address(this)) return true;
         AccountConfiguration.ActorConfig memory config =
             ACCOUNT_CONFIGURATION.getActorConfig(address(this), bytes32(bytes20(caller)));
         if (config.authenticator != TRUSTED_EXECUTOR) return false;
         if (config.expiry != 0 && block.timestamp > config.expiry) return false;
-        uint8 scope = config.scope;
-        return scope == 0 || ((scope & SCOPE_SENDER != 0) && (scope & SCOPE_POLICY == 0));
+        uint16 scope = config.scope;
+        return scope == 0 || ((scope & Scopes.SENDER != 0) && (scope & Scopes.POLICY == 0));
     }
 }

--- a/src/authenticators/DelegateAuthenticator.sol
+++ b/src/authenticators/DelegateAuthenticator.sol
@@ -7,7 +7,7 @@ import {IAuthenticator} from "../interfaces/IAuthenticator.sol";
 /// @notice Delegates authentication to another account's actor configuration; a single hop only.
 ///         actorId = bytes32(bytes20(delegate_address))
 ///
-///         This contract exists for non-8130 chains where verifySignature() runs in normal EVM.
+///         This contract exists for non-8130 chains where authentication runs in normal EVM.
 ///         On 8130 chains, the protocol handles DELEGATE directly at the protocol level.
 ///
 ///         Data layout: delegate_address (20) || nested_authenticator (20) || nested_data
@@ -54,13 +54,12 @@ contract DelegateAuthenticator is IAuthenticator {
         address nestedAuthenticator = address(bytes20(nestedAuth[:20]));
         if (nestedAuthenticator == address(this)) revert RecursiveDelegation();
 
-        // The nested actor MUST be the admin (scope == 0x00) of the delegate account. This is enforced
-        // independently of verifySignature, which is now operational (signing is not admin-only, but a delegate
-        // vouch requires admin to preserve non-escalation): an operational SENDER key can sign for its own account,
-        // yet it must NOT be able to vouch as a delegate here. authenticateActor reverts on any auth failure and
-        // otherwise returns the resolved scope, so we require scope == 0x00 explicitly.
+        // The nested actor MUST be the admin (scope == 0x00) of the delegate account, to preserve non-escalation:
+        // an operational (e.g. SENDER) key can sign for its own account, yet it must NOT be able to vouch as a
+        // delegate here. authenticateActor reverts on any auth failure and otherwise returns the resolved scope,
+        // so we require scope == 0x00 explicitly.
         try ACCOUNT_CONFIGURATION.authenticateActor(delegate, hash, nestedAuth) returns (
-            bytes32, uint8 nestedScope, address
+            bytes32, uint16 nestedScope, address
         ) {
             if (nestedScope != 0) revert InvalidNestedSignature();
         } catch {

--- a/src/libraries/Scopes.sol
+++ b/src/libraries/Scopes.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.36;
+
+/// @notice Canonical EIP-8130 actor scope grants: the named bits of the `uint16` scope bitmask carried in an
+///         actor's config.
+///
+/// @dev Reference vocabulary, not enforcement. AccountConfiguration is deliberately scope-agnostic: it treats
+///      `scope == 0` as the admin predicate and interprets only {POLICY} (to slice/store policy data). Every other
+///      bit's *meaning* is enforced by whoever reads it — protocol nodes for the transaction paths, account
+///      contracts for ERC-1271, policy managers for gating. This library only gives those consumers a shared set of
+///      names so the same value is not re-declared as a magic number at each site.
+///
+///      The assignment is append-only: a value once given a name keeps it, and new grants take the next free bit.
+///      That is safe against the immutable AccountConfiguration deployment because unknown bits grant nothing and
+///      are stored verbatim (see the EIP's Actor Scope section), so adding a bit here can never change how an
+///      already-deployed config behaves. Admin is intentionally absent — it is the *absence* of grants
+///      (`scope == 0`), a predicate rather than a pure grant.
+///
+/// @author Coinbase
+library Scopes {
+    /// @notice Ungated initiation (`sender_auth`): may originate transactions to any `call.to`.
+    uint16 internal constant SENDER = 0x0001;
+
+    /// @notice Gated initiation (`sender_auth`): may originate transactions only to the actor's `policy_manager`.
+    ///         The one bit AccountConfiguration itself interprets, to slice and store the actor's policy data.
+    uint16 internal constant POLICY = 0x0002;
+
+    /// @notice Permits a restricted actor to use sequenced `nonce_key`s for sender-context transactions.
+    uint16 internal constant NONCE = 0x0004;
+
+    /// @notice Self-pay gas: authorizes paying the account's own gas when `payer == sender`.
+    uint16 internal constant SELF_PAYER = 0x0008;
+
+    /// @notice Sponsor gas: authorizes acting as `payer_auth` for a different sender (`payer != sender`).
+    uint16 internal constant SPONSOR_PAYER = 0x0010;
+
+    /// @notice Manage delegate actors: authorizes authorizing/revoking actors whose
+    ///         `authenticator == DELEGATE_AUTHENTICATOR`, without conferring full admin config authority.
+    uint16 internal constant DELEGATE = 0x0020;
+
+    // 0x0040..0x8000 (bits 6–15) are spare, reserved for future pure grants.
+}

--- a/src/libraries/Scopes.sol
+++ b/src/libraries/Scopes.sol
@@ -10,6 +10,10 @@ pragma solidity 0.8.36;
 ///      contracts for ERC-1271, policy managers for gating. This library only gives those consumers a shared set of
 ///      names so the same value is not re-declared as a magic number at each site.
 ///
+///      Delegation for agent fleets is expressed via the external-policy pattern (an account authorizes a hub as a
+///      single POLICY-gated external actor that drives it through a policy manager), so no dedicated delegate grant
+///      is defined here.
+///
 ///      The assignment is append-only: a value once given a name keeps it, and new grants take the next free bit.
 ///      That is safe against the immutable AccountConfiguration deployment because unknown bits grant nothing and
 ///      are stored verbatim (see the EIP's Actor Scope section), so adding a bit here can never change how an
@@ -34,9 +38,5 @@ library Scopes {
     /// @notice Sponsor gas: authorizes acting as `payer_auth` for a different sender (`payer != sender`).
     uint16 internal constant SPONSOR_PAYER = 0x0010;
 
-    /// @notice Manage delegate actors: authorizes authorizing/revoking actors whose
-    ///         `authenticator == DELEGATE_AUTHENTICATOR`, without conferring full admin config authority.
-    uint16 internal constant DELEGATE = 0x0020;
-
-    // 0x0040..0x8000 (bits 6–15) are spare, reserved for future pure grants.
+    // 0x0020..0x8000 (bits 5–15) are spare, reserved for future pure grants.
 }

--- a/test/lib/AccountConfigurationTest.sol
+++ b/test/lib/AccountConfigurationTest.sol
@@ -9,6 +9,7 @@ import {P256} from "openzeppelin/utils/cryptography/P256.sol";
 import {WebAuthn} from "openzeppelin/utils/cryptography/WebAuthn.sol";
 
 import {AccountConfiguration} from "../../src/AccountConfiguration.sol";
+import {Scopes} from "../../src/libraries/Scopes.sol";
 import {DefaultAccount} from "../../src/accounts/DefaultAccount.sol";
 import {DelegateAuthenticator} from "../../src/authenticators/DelegateAuthenticator.sol";
 import {IAuthenticator} from "../../src/interfaces/IAuthenticator.sol";
@@ -50,6 +51,20 @@ contract AccountConfigurationTest is Test {
         webAuthnAuthenticator = IAuthenticator(new WebAuthnAuthenticator());
         delegateAuthenticator = IAuthenticator(new DelegateAuthenticator(address(accountConfiguration)));
         defaultAccountImplementation = address(new DefaultAccount(address(accountConfiguration)));
+    }
+
+    /// @dev Existence check mirroring the (now-internal) actor liveness predicate: an actor is authorized when a
+    ///      stored config entry exists (authenticator != 0), which {getActorConfig} also reports for a live inline
+    ///      k1 self. Does not check expiry. Replaces the removed public `isActor` for tests.
+    function _isActor(address account, bytes32 actorId) internal view returns (bool) {
+        return accountConfiguration.getActorConfig(account, actorId).authenticator != address(0);
+    }
+
+    /// @dev Account-level ERC-1271 check. verifySignature moved off AccountConfiguration onto the account contract;
+    ///      `account` must be a deployed DefaultAccount (as created by the helpers here). Returns true on the magic
+    ///      value. Replaces the removed registry-level `verifySignature` for tests.
+    function _isValidSig(address account, bytes32 hash, bytes memory auth) internal view returns (bool) {
+        return DefaultAccount(payable(account)).isValidSignature(hash, auth) == bytes4(0x1626ba7e);
     }
 
     // ── Bytecode helpers ──

--- a/test/unit/AccountConfiguration/applyAccountChange.t.sol
+++ b/test/unit/AccountConfiguration/applyAccountChange.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {AccountConfiguration} from "../../../src/AccountConfiguration.sol";
+import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 
 /// @notice Branch-complete, fuzz-by-default suite for the account lock surface: applySignedLockChanges (op = lock /
@@ -41,7 +42,7 @@ contract AccountLockTest is AccountConfigurationTest {
 
     /// @dev Authorize a k1 actor (actorId = bytes32(bytes20(newSigner))) with `scope` on `account`, signed by the
     ///      account's admin owner `ownerPk`.
-    function _authorizeK1ActorWithScope(address account, uint256 ownerPk, address newSigner, uint8 scope) internal {
+    function _authorizeK1ActorWithScope(address account, uint256 ownerPk, address newSigner, uint16 scope) internal {
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({
             changeType: 0x01,
@@ -76,7 +77,7 @@ contract AccountLockTest is AccountConfigurationTest {
         address scopedSigner = vm.addr(scopedPk);
         vm.assume(scopedSigner != account);
 
-        _authorizeK1ActorWithScope(account, ownerPk, scopedSigner, accountConfiguration.SCOPE_SENDER());
+        _authorizeK1ActorWithScope(account, ownerPk, scopedSigner, Scopes.SENDER);
 
         bytes memory auth = _lockAuth(scopedPk, account, delay);
         vm.expectRevert(AccountConfiguration.UnauthorizedLockChange.selector);
@@ -488,7 +489,7 @@ contract AccountLockTest is AccountConfigurationTest {
 
         accountConfiguration.applySignedActorChanges(account, chainId, changes, auth);
 
-        assertTrue(accountConfiguration.isActor(account, newActorId));
+        assertTrue(_isActor(account, newActorId));
         // The onlyUnlocked prelude cleared the stale unlock timestamp back to 0.
         (,, uint40 unlocksAt,) = accountConfiguration.getLockStatus(account);
         assertEq(unlocksAt, 0);

--- a/test/unit/AccountConfiguration/applyKeyChange.t.sol
+++ b/test/unit/AccountConfiguration/applyKeyChange.t.sol
@@ -48,13 +48,13 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         (address account, bytes32 ownerId) = _createK1Account(pk);
         vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
         _authorizeActor(account, pk, actorId, address(k1Authenticator));
-        assertTrue(accountConfiguration.isActor(account, actorId));
+        assertTrue(_isActor(account, actorId));
 
         AccountConfiguration.ActorChange[] memory ch = new AccountConfiguration.ActorChange[](1);
         ch[0] = AccountConfiguration.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
         _signApply(account, pk, ch);
 
-        assertFalse(accountConfiguration.isActor(account, actorId));
+        assertFalse(_isActor(account, actorId));
     }
 
     /// @notice A batch of multiple authorize operations applies every element.
@@ -70,8 +70,8 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         ch[1] = _authorizeChange(idB, address(k1Authenticator), 0, "")[0];
         _signApply(account, pk, ch);
 
-        assertTrue(accountConfiguration.isActor(account, idA));
-        assertTrue(accountConfiguration.isActor(account, idB));
+        assertTrue(_isActor(account, idA));
+        assertTrue(_isActor(account, idB));
     }
 
     /// @notice Each applied batch increments the account's local change sequence by one.
@@ -124,7 +124,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
 
         AccountConfiguration.ActorChange[] memory ch = _authorizeChange(targetId, address(k1Authenticator), 0, "");
         _signApply(account, actorPk, ch);
-        assertTrue(accountConfiguration.isActor(account, targetId));
+        assertTrue(_isActor(account, targetId));
     }
 
     /// @notice Any scoped (non-zero) actor cannot authorize actors; admin is exactly scope == 0.
@@ -188,7 +188,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(eoa, selfActorId);
         assertEq(cfg.scope, newScope);
         assertEq(cfg.authenticator, accountConfiguration.K1_AUTHENTICATOR());
-        assertTrue(accountConfiguration.isActor(eoa, selfActorId));
+        assertTrue(_isActor(eoa, selfActorId));
     }
 
     /// @notice Revoking an actor that was never authorized reverts.
@@ -232,7 +232,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         vm.assume(actorId != bytes32(bytes20(eoa)));
 
         _signApply(eoa, eoaPk, _authorizeChange(actorId, address(k1Authenticator), 0, ""));
-        assertTrue(accountConfiguration.isActor(eoa, actorId));
+        assertTrue(_isActor(eoa, actorId));
     }
 
     /// @notice The implicit EOA self key can be revoked via the default-EOA flag using another key.
@@ -245,13 +245,13 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         bytes32 selfActorId = bytes32(bytes20(eoa));
         bytes32 newActorId = bytes32(bytes20(vm.addr(newPk)));
         vm.assume(newActorId != selfActorId);
-        assertTrue(accountConfiguration.isActor(eoa, selfActorId));
+        assertTrue(_isActor(eoa, selfActorId));
 
         _implicitAuthorizeActor(eoa, eoaPk, newActorId, address(k1Authenticator));
         _revokeActor(eoa, newPk, selfActorId);
 
-        assertFalse(accountConfiguration.isActor(eoa, selfActorId));
-        assertTrue(accountConfiguration.isActor(eoa, newActorId));
+        assertFalse(_isActor(eoa, selfActorId));
+        assertTrue(_isActor(eoa, newActorId));
 
         AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(eoa, selfActorId);
         assertEq(cfg.authenticator, address(0));
@@ -277,16 +277,16 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         bytes32 selfActorId = bytes32(bytes20(eoa));
         scope = uint8(bound(uint256(scope), 1, 255)) & ~SCOPE_POLICY;
         vm.assume(scope != 0);
-        assertTrue(accountConfiguration.isActor(eoa, selfActorId));
+        assertTrue(_isActor(eoa, selfActorId));
 
         _implicitAuthorizeActorWithScope(eoa, eoaPk, selfActorId, address(k1Authenticator), scope);
 
-        assertTrue(accountConfiguration.isActor(eoa, selfActorId));
+        assertTrue(_isActor(eoa, selfActorId));
         AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(eoa, selfActorId);
         assertEq(cfg.authenticator, address(k1Authenticator));
         assertEq(cfg.scope, scope);
 
-        (, uint8 outScope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint16 outScope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(outScope, scope);
     }
 
@@ -318,7 +318,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         uint64 seq = accountConfiguration.getChangeSequences(eoa).multichain;
         bytes32 digest = _computeActorChangeBatchDigest(eoa, 0, seq, ch);
         accountConfiguration.applySignedActorChanges(eoa, 0, ch, _buildK1Auth(eoaPk, digest));
-        assertTrue(accountConfiguration.isActor(eoa, actorId));
+        assertTrue(_isActor(eoa, actorId));
     }
 
     // ── Default EOA self-actorId semantics ──
@@ -335,7 +335,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         (address account,) = _createK1Account(pk);
         bytes32 selfActorId = bytes32(bytes20(account));
 
-        assertFalse(accountConfiguration.isActor(account, selfActorId));
+        assertFalse(_isActor(account, selfActorId));
         AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, selfActorId);
         assertEq(cfg.authenticator, address(0));
         assertEq(cfg.scope, 0);
@@ -346,11 +346,11 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         bytes32 selfActorId = bytes32(bytes20(account));
-        assertFalse(accountConfiguration.isActor(account, selfActorId));
+        assertFalse(_isActor(account, selfActorId));
 
         _authorizeActor(account, pk, selfActorId, accountConfiguration.K1_AUTHENTICATOR());
 
-        assertTrue(accountConfiguration.isActor(account, selfActorId));
+        assertTrue(_isActor(account, selfActorId));
         AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, selfActorId);
         assertEq(cfg.authenticator, accountConfiguration.K1_AUTHENTICATOR());
         assertEq(cfg.scope, 0);
@@ -366,19 +366,19 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         bytes32 selfActorId = bytes32(bytes20(eoa));
         bytes32 newActorId = bytes32(bytes20(vm.addr(newPk)));
         vm.assume(newActorId != selfActorId);
-        assertTrue(accountConfiguration.isActor(eoa, selfActorId));
+        assertTrue(_isActor(eoa, selfActorId));
 
         _implicitAuthorizeActor(eoa, eoaPk, newActorId, address(k1Authenticator));
         _revokeActor(eoa, newPk, selfActorId);
-        assertFalse(accountConfiguration.isActor(eoa, selfActorId));
+        assertFalse(_isActor(eoa, selfActorId));
 
         vm.expectRevert();
         accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
 
         _authorizeActor(eoa, newPk, selfActorId, accountConfiguration.K1_AUTHENTICATOR());
-        assertTrue(accountConfiguration.isActor(eoa, selfActorId));
+        assertTrue(_isActor(eoa, selfActorId));
 
-        (, uint8 scope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint16 scope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(scope, 0);
     }
 
@@ -394,8 +394,8 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         vm.assume(deviceActorId != selfActorId);
 
         // Phase 0: the default EOA is live and authenticates with its own k1 signature.
-        assertTrue(accountConfiguration.isActor(eoa, selfActorId));
-        (, uint8 scope0,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        assertTrue(_isActor(eoa, selfActorId));
+        (, uint16 scope0,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(scope0, 0);
 
         // Phase 1: in one batch signed by the EOA, add the device key as a full owner and revoke the default EOA.
@@ -404,11 +404,11 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         switchChanges[1] = AccountConfiguration.ActorChange({actorId: selfActorId, changeType: 0x02, data: ""});
         _signApply(eoa, eoaPk, switchChanges);
 
-        assertFalse(accountConfiguration.isActor(eoa, selfActorId));
-        assertTrue(accountConfiguration.isActor(eoa, deviceActorId));
+        assertFalse(_isActor(eoa, selfActorId));
+        assertTrue(_isActor(eoa, deviceActorId));
         vm.expectRevert();
         accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
-        (, uint8 scope1,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(devicePk, hash));
+        (, uint16 scope1,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(devicePk, hash));
         assertEq(scope1, 0);
 
         // Phase 2: the device key re-enables the K1 key by authorizing the self-actorId as a native k1 owner.
@@ -416,8 +416,8 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             _authorizeChange(selfActorId, accountConfiguration.K1_AUTHENTICATOR(), 0, "");
         _signApply(eoa, devicePk, reEnable);
 
-        assertTrue(accountConfiguration.isActor(eoa, selfActorId));
-        (, uint8 scope2,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        assertTrue(_isActor(eoa, selfActorId));
+        (, uint16 scope2,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(scope2, 0);
     }
 
@@ -436,8 +436,8 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         ch[1] = AccountConfiguration.ActorChange({actorId: selfActorId, changeType: 0x02, data: ""});
         _signApply(eoa, eoaPk, ch);
 
-        assertFalse(accountConfiguration.isActor(eoa, selfActorId));
-        assertTrue(accountConfiguration.isActor(eoa, newActorId));
+        assertFalse(_isActor(eoa, selfActorId));
+        assertTrue(_isActor(eoa, newActorId));
 
         AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(eoa, selfActorId);
         assertEq(cfg.authenticator, address(0));
@@ -467,7 +467,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), ch, _buildK1Auth(eoaPk, digest));
 
         accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), ch, _buildK1Auth(newPk, digest));
-        assertTrue(accountConfiguration.isActor(eoa, targetId));
+        assertTrue(_isActor(eoa, targetId));
     }
 
     /// @notice A revoked signer key can no longer authorize actor changes.
@@ -577,7 +577,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         AccountConfiguration.ActorChange[] memory ch = _authorizeChange(targetId, address(k1Authenticator), 0, "");
         if (signerScope == 0) {
             _signApply(account, signerPk, ch);
-            assertTrue(accountConfiguration.isActor(account, targetId));
+            assertTrue(_isActor(account, targetId));
         } else {
             bytes memory auth = _authOver(account, signerPk, ch);
             vm.expectRevert(AccountConfiguration.UnauthorizedActorChange.selector);
@@ -661,7 +661,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         ch[0] = _authorizeChange(actorId, address(k1Authenticator), 0, "")[0];
         ch[1] = AccountConfiguration.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
         _signApply(account, pk, ch);
-        assertFalse(accountConfiguration.isActor(account, actorId));
+        assertFalse(_isActor(account, actorId));
 
         // Pre-authorize, then [revoke A, authorize A] → A ends live.
         _authorizeActor(account, pk, actorId, address(k1Authenticator));
@@ -669,7 +669,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         ch2[0] = AccountConfiguration.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
         ch2[1] = _authorizeChange(actorId, address(k1Authenticator), 0, "")[0];
         _signApply(account, pk, ch2);
-        assertTrue(accountConfiguration.isActor(account, actorId));
+        assertTrue(_isActor(account, actorId));
     }
 
     /// @notice An unrestricted (scope 0) signer may revoke itself mid-batch; the scope gate is evaluated once,
@@ -694,8 +694,8 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         ch[1] = _authorizeChange(bId, address(k1Authenticator), 0, "")[0];
         _signApply(account, signerPk, ch);
 
-        assertFalse(accountConfiguration.isActor(account, signerId));
-        assertTrue(accountConfiguration.isActor(account, bId));
+        assertFalse(_isActor(account, signerId));
+        assertTrue(_isActor(account, bId));
     }
 
     /// @notice Self-actorId flip: k1 self → non-k1 (p256) self → k1 self; the non-k1 config replaces then is replaced.
@@ -723,7 +723,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         assertEq(
             accountConfiguration.getActorConfig(eoa, selfId).authenticator, accountConfiguration.K1_AUTHENTICATOR()
         );
-        (, uint8 scope,) = accountConfiguration.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
+        (, uint16 scope,) = accountConfiguration.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
         assertEq(scope, 0);
     }
 

--- a/test/unit/AccountConfiguration/authenticate.t.sol
+++ b/test/unit/AccountConfiguration/authenticate.t.sol
@@ -6,7 +6,7 @@ import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 
 /// @notice Fuzzed, branch-complete suite for the authentication paths of AccountConfiguration:
 ///         authenticateActor -> _authenticate -> {_authenticateK1, IAuthenticator} -> _recoverSigner, plus the
-///         verifySignature / getActorConfig / getPolicy / isActor views that read the same actor resolution.
+///         isValidSignature / getActorConfig / getPolicy views that read the same actor resolution.
 ///
 ///         Source-order revert coverage (as declared / hit through authenticateActor):
 ///           1. InvalidAuthLength      authenticateActor: auth.length < 20
@@ -354,7 +354,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
 
-        (, uint8 scope, address policyTarget) =
+        (, uint16 scope, address policyTarget) =
             accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
 
         assertEq(scope, uint8(0x00));
@@ -374,7 +374,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         vm.assume(vm.addr(actorPk) != account);
         _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), 0x00);
 
-        (, uint8 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        (, uint16 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
@@ -392,7 +392,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         _authorizeActorWithScope(account, ownerPk, _p256ActorId(pk), address(p256Authenticator), scope);
 
         bytes memory auth = abi.encodePacked(address(p256Authenticator), _p256SignData(pk, hash));
-        (, uint8 outScope,) = accountConfiguration.authenticateActor(account, hash, auth);
+        (, uint16 outScope,) = accountConfiguration.authenticateActor(account, hash, auth);
         assertEq(outScope, scope);
     }
 
@@ -412,7 +412,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         _authorizeActorWithScope(account, ownerPk, _p256ActorId(pk), address(webAuthnAuthenticator), scope);
 
         bytes memory auth = abi.encodePacked(address(webAuthnAuthenticator), _webauthnSignData(pk, hash));
-        (, uint8 outScope,) = accountConfiguration.authenticateActor(account, hash, auth);
+        (, uint16 outScope,) = accountConfiguration.authenticateActor(account, hash, auth);
         assertEq(outScope, scope);
     }
 
@@ -434,7 +434,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         vm.assume(vm.addr(actorPk) != account);
         _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), scope);
 
-        (, uint8 outScope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        (, uint16 outScope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(outScope, scope);
     }
 
@@ -451,7 +451,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         vm.assume(vm.addr(actorPk) != account);
         _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), 0x00);
 
-        (, uint8 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        (, uint16 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
@@ -472,7 +472,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         _authorizeActorWithExpiry(account, ownerPk, bytes32(bytes20(vm.addr(sessionPk))), address(k1Authenticator), 0);
 
         vm.warp(block.timestamp + bound(warpSeed, 1, 3650 days));
-        (, uint8 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
+        (, uint16 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
@@ -496,7 +496,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         );
 
         vm.warp(expiry);
-        (, uint8 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
+        (, uint16 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
@@ -523,7 +523,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
         _authorizeGatedActor(account, ownerPk, sessionActorId, scope, manager, commitment);
 
-        (, uint8 outScope, address outTarget) =
+        (, uint16 outScope, address outTarget) =
             accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
 
         assertEq(outScope, scope);
@@ -536,7 +536,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
 
-        (, uint8 scope, address policyTarget) =
+        (, uint16 scope, address policyTarget) =
             accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
 
         assertEq(scope, uint8(0x00));
@@ -554,7 +554,7 @@ contract AuthenticateTest is AccountConfigurationTest {
 
         _authorizeActorWithScope(eoa, eoaPk, selfActorId, address(k1Authenticator), scope);
 
-        (, uint8 outScope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint16 outScope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(outScope, scope);
     }
 
@@ -570,7 +570,7 @@ contract AuthenticateTest is AccountConfigurationTest {
 
         _implicitAuthorizeActor(eoa, eoaPk, bytes32(bytes20(vm.addr(bobPk))), address(k1Authenticator));
 
-        (, uint8 scope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(bobPk, hash));
+        (, uint16 scope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(bobPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
@@ -587,8 +587,8 @@ contract AuthenticateTest is AccountConfigurationTest {
         vm.assume(accountA != accountB);
 
         bytes memory auth = _buildK1Auth(ownerPk, hash);
-        (, uint8 scopeA,) = accountConfiguration.authenticateActor(accountA, hash, auth);
-        (, uint8 scopeB,) = accountConfiguration.authenticateActor(accountB, hash, auth);
+        (, uint16 scopeA,) = accountConfiguration.authenticateActor(accountA, hash, auth);
+        (, uint16 scopeB,) = accountConfiguration.authenticateActor(accountB, hash, auth);
         assertEq(scopeA, uint8(0x00));
         assertEq(scopeB, uint8(0x00));
     }
@@ -675,7 +675,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         bytes32 expectedActorId = bytes32(bytes20(vm.addr(actorPk)));
         _authorizeActorWithScope(account, ownerPk, expectedActorId, address(k1Authenticator), scope);
 
-        (bytes32 actorId, uint8 outScope,) =
+        (bytes32 actorId, uint16 outScope,) =
             accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(actorId, expectedActorId);
         assertEq(outScope, scope);
@@ -694,22 +694,22 @@ contract AuthenticateTest is AccountConfigurationTest {
 
         _authorizeActorWithScope(eoa, eoaPk, selfActorId, address(k1Authenticator), scope);
 
-        (bytes32 actorId, uint8 outScope,) =
+        (bytes32 actorId, uint16 outScope,) =
             accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(actorId, selfActorId);
         assertEq(outScope, scope);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // verifySignature (operational authority)
+    // isValidSignature (operational authority)
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice verifySignature returns true for any operational actor: the admin (scope == 0x00) or a SENDER actor
+    /// @notice isValidSignature returns true for any operational actor: the admin (scope == 0x00) or a SENDER actor
     ///         without POLICY. Payer-only / nonce-only (non-SENDER) scopes are not operational and verify false.
     /// @dev Fuzzes the (POLICY-cleared) scope space and asserts the boolean equals the operational predicate
     ///      `scope == 0 || (scope & SCOPE_SENDER != 0)`, proving ERC-1271 signing is operational — not admin-only,
     ///      and with no dedicated SIGNER grant.
-    function test_verifySignature_success_operationalAcrossScopes(
+    function test_isValidSignature_success_operationalAcrossScopes(
         uint256 ownerSeed,
         uint256 actorSeed,
         uint8 scopeSeed,
@@ -725,18 +725,20 @@ contract AuthenticateTest is AccountConfigurationTest {
         _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), scope);
 
         bool expected = scope == 0 || (scope & SCOPE_SENDER != 0);
-        // verifySignature applies the account-scoped EIP-7739 wrap.
+        // isValidSignature applies the account-scoped EIP-7739 wrap.
         bytes memory auth = _buildK1Auth(actorPk, accountConfiguration.replaySafeHash(account, hash));
-        assertEq(accountConfiguration.verifySignature(account, hash, auth), expected);
+        assertEq(_isValidSig(account, hash, auth), expected);
     }
 
-    /// @notice A SENDER actor without POLICY is operational and verifies true via verifySignature.
+    /// @notice A SENDER actor without POLICY is operational and verifies true via isValidSignature.
     /// @dev Positive guard for the operational-authority path: signing is authority a SENDER key already holds via
     ///      calls, so it does not require the admin scope. Covers SENDER alone and SENDER combined with the
     ///      SELF_PAYER / NONCE capability bits (still no POLICY).
-    function test_verifySignature_success_trueForSenderWithoutPolicy(uint256 ownerSeed, uint256 actorSeed, bytes32 hash)
-        public
-    {
+    function test_isValidSignature_success_trueForSenderWithoutPolicy(
+        uint256 ownerSeed,
+        uint256 actorSeed,
+        bytes32 hash
+    ) public {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
         uint256 actorPk = _boundK1Pk(actorSeed);
         vm.assume(vm.addr(ownerPk) != vm.addr(actorPk));
@@ -744,23 +746,23 @@ contract AuthenticateTest is AccountConfigurationTest {
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(actorPk) != account);
         bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
-        // verifySignature applies the account-scoped EIP-7739 wrap; replaySafeHash(account, hash) is scope-independent.
+        // isValidSignature applies the account-scoped EIP-7739 wrap; replaySafeHash(account, hash) is scope-independent.
         bytes memory auth = _buildK1Auth(actorPk, accountConfiguration.replaySafeHash(account, hash));
 
         _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_SENDER);
-        assertTrue(accountConfiguration.verifySignature(account, hash, auth));
+        assertTrue(_isValidSig(account, hash, auth));
 
         _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_SENDER | SCOPE_SELF_PAYER);
-        assertTrue(accountConfiguration.verifySignature(account, hash, auth));
+        assertTrue(_isValidSig(account, hash, auth));
 
         _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_SENDER | SCOPE_NONCE);
-        assertTrue(accountConfiguration.verifySignature(account, hash, auth));
+        assertTrue(_isValidSig(account, hash, auth));
     }
 
     /// @notice A non-SENDER capability-only actor (SELF_PAYER-only, SPONSOR_PAYER-only, NONCE-only) is NOT
     ///         operational and verifies false.
     /// @dev Negative guard: only admin or SENDER-without-POLICY are operational.
-    function test_verifySignature_success_falseForNonSenderScopes(uint256 ownerSeed, uint256 actorSeed, bytes32 hash)
+    function test_isValidSignature_success_falseForNonSenderScopes(uint256 ownerSeed, uint256 actorSeed, bytes32 hash)
         public
     {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
@@ -772,18 +774,18 @@ contract AuthenticateTest is AccountConfigurationTest {
         bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
 
         _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_SELF_PAYER);
-        assertFalse(accountConfiguration.verifySignature(account, hash, _buildK1Auth(actorPk, hash)));
+        assertFalse(_isValidSig(account, hash, _buildK1Auth(actorPk, hash)));
 
         _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_SPONSOR_PAYER);
-        assertFalse(accountConfiguration.verifySignature(account, hash, _buildK1Auth(actorPk, hash)));
+        assertFalse(_isValidSig(account, hash, _buildK1Auth(actorPk, hash)));
 
         _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_NONCE);
-        assertFalse(accountConfiguration.verifySignature(account, hash, _buildK1Auth(actorPk, hash)));
+        assertFalse(_isValidSig(account, hash, _buildK1Auth(actorPk, hash)));
     }
 
     /// @notice A policy-bearing actor is NEVER a valid ERC-1271 signer (a POLICY actor is not operational).
-    /// @dev verifySignature must return false for a scoped SCOPE_POLICY actor.
-    function test_verifySignature_success_falseForPolicyActor(
+    /// @dev isValidSignature must return false for a scoped SCOPE_POLICY actor.
+    function test_isValidSignature_success_falseForPolicyActor(
         uint256 ownerSeed,
         uint256 sessionSeed,
         address manager,
@@ -800,16 +802,16 @@ contract AuthenticateTest is AccountConfigurationTest {
         vm.assume(vm.addr(sessionPk) != account);
         bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
         _authorizeGatedActor(account, ownerPk, sessionActorId, SCOPE_POLICY, manager, commitment);
-        assertFalse(accountConfiguration.verifySignature(account, hash, _buildK1Auth(sessionPk, hash)));
+        assertFalse(_isValidSig(account, hash, _buildK1Auth(sessionPk, hash)));
 
         // SENDER | POLICY is still not operational: the POLICY bit disqualifies it even though SENDER is set.
         _authorizeGatedActor(account, ownerPk, sessionActorId, SCOPE_SENDER | SCOPE_POLICY, manager, commitment);
-        assertFalse(accountConfiguration.verifySignature(account, hash, _buildK1Auth(sessionPk, hash)));
+        assertFalse(_isValidSig(account, hash, _buildK1Auth(sessionPk, hash)));
     }
 
-    /// @notice verifySignature returns false when authentication fails outright (unregistered signer).
+    /// @notice isValidSignature returns false when authentication fails outright (unregistered signer).
     /// @dev authenticateActor reverts (AuthenticatorMismatch) and the try/catch collapses it to false.
-    function test_verifySignature_success_falseOnUnauthenticated(uint256 ownerSeed, uint256 strangerSeed, bytes32 hash)
+    function test_isValidSignature_success_falseOnUnauthenticated(uint256 ownerSeed, uint256 strangerSeed, bytes32 hash)
         public
     {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
@@ -819,11 +821,11 @@ contract AuthenticateTest is AccountConfigurationTest {
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(strangerPk) != account);
 
-        assertFalse(accountConfiguration.verifySignature(account, hash, _buildK1Auth(strangerPk, hash)));
+        assertFalse(_isValidSig(account, hash, _buildK1Auth(strangerPk, hash)));
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // getPolicy / getActorConfig / isActor (actor-resolution views)
+    // getPolicy / getActorConfig (actor-resolution views) (actor-resolution views)
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     /// @notice getPolicy resolves a gated actor's manager and signed commitment.
@@ -896,7 +898,7 @@ contract AuthenticateTest is AccountConfigurationTest {
     /// @dev No _actorConfig entry, actorId == self, flag unset -> true.
     function test_isActor_success_implicitEoaTrue(uint256 eoaSeed) public view {
         address eoa = vm.addr(_boundK1Pk(eoaSeed));
-        assertTrue(accountConfiguration.isActor(eoa, bytes32(bytes20(eoa))));
+        assertTrue(_isActor(eoa, bytes32(bytes20(eoa))));
     }
 
     /// @notice isActor reports a non-self actorId on a never-created EOA as not live.
@@ -904,7 +906,7 @@ contract AuthenticateTest is AccountConfigurationTest {
     function test_isActor_success_nonSelfActorIdNotImplicit(uint256 eoaSeed, bytes32 randomActorId) public view {
         address eoa = vm.addr(_boundK1Pk(eoaSeed));
         vm.assume(randomActorId != bytes32(bytes20(eoa)));
-        assertFalse(accountConfiguration.isActor(eoa, randomActorId));
+        assertFalse(_isActor(eoa, randomActorId));
     }
 
     /// @notice isActor reports the self-actorId as not live after the self key has been revoked.
@@ -916,7 +918,7 @@ contract AuthenticateTest is AccountConfigurationTest {
 
         _revokeActor(eoa, eoaPk, selfActorId);
 
-        assertFalse(accountConfiguration.isActor(eoa, selfActorId));
+        assertFalse(_isActor(eoa, selfActorId));
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

--- a/test/unit/AccountConfiguration/createAccount.t.sol
+++ b/test/unit/AccountConfiguration/createAccount.t.sol
@@ -178,7 +178,7 @@ contract CreateAccountTest is AccountConfigurationTest {
         assertEq(predicted.code.length, 0);
         assertEq(accountConfiguration.getChangeSequences(predicted).local, 0);
         assertEq(accountConfiguration.getChangeSequences(predicted).multichain, 0);
-        assertFalse(accountConfiguration.isActor(predicted, actorId));
+        assertFalse(_isActor(predicted, actorId));
 
         // The writes were unwound, so the re-init guard is not tripped: the retry re-attempts the deploy and fails
         // again on the same invalid bytecode rather than reverting AlreadyInitialized.
@@ -203,7 +203,7 @@ contract CreateAccountTest is AccountConfigurationTest {
 
         assertTrue(account != address(0));
         assertGt(account.code.length, 0);
-        assertTrue(accountConfiguration.isActor(account, actorId));
+        assertTrue(_isActor(account, actorId));
     }
 
     /// @notice Verifies an account with many sorted initial actors deploys and registers every actor as live
@@ -220,7 +220,7 @@ contract CreateAccountTest is AccountConfigurationTest {
 
         assertGt(account.code.length, 0);
         for (uint256 i; i < count; i++) {
-            assertTrue(accountConfiguration.isActor(account, actors[i].actorId));
+            assertTrue(_isActor(account, actors[i].actorId));
         }
     }
 
@@ -245,7 +245,7 @@ contract CreateAccountTest is AccountConfigurationTest {
         assertEq(cfg.authenticator, authenticator);
         assertEq(cfg.scope, 0x00);
         assertEq(cfg.expiry, 0);
-        assertTrue(accountConfiguration.isActor(account, actorId));
+        assertTrue(_isActor(account, actorId));
     }
 
     /// @notice Verifies initial actors are unrestricted owners and the account is initialized with safe lock defaults
@@ -290,7 +290,7 @@ contract CreateAccountTest is AccountConfigurationTest {
 
         // The account's own self-actorId is not the seeded actor, so the inline k1 self stays disabled.
         vm.assume(bytes32(bytes20(account)) != actorId);
-        assertFalse(accountConfiguration.isActor(account, bytes32(bytes20(account))));
+        assertFalse(_isActor(account, bytes32(bytes20(account))));
     }
 
     /// @notice Verifies arbitrary valid runtime bytecode of a fuzzed length/content deploys successfully

--- a/test/unit/AccountConfiguration/erc7739.t.sol
+++ b/test/unit/AccountConfiguration/erc7739.t.sol
@@ -3,36 +3,37 @@ pragma solidity ^0.8.30;
 
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 
-/// @notice Draft: registry-native EIP-7739 (PersonalSign) rehashing in AccountConfiguration.verifySignature.
+/// @notice EIP-7739 (PersonalSign) rehashing for account-level ERC-1271 (DefaultAccount.isValidSignature), built on
+///         the account-scoped digest AccountConfiguration.replaySafeHash.
 ///
-/// @dev Demonstrates that ERC-1271 signatures are now bound to a specific account at the singleton level, so
-///      cross-account replay is closed for EVERY consumer of verifySignature — including registry-direct verifiers
-///      (e.g. precompile-based permits) that cannot call account bytecode.
+/// @dev ERC-1271 verification lives on the account contract (AccountConfiguration is scope-agnostic and no longer
+///      exposes verifySignature). Because the account authenticates against replaySafeHash(account, hash) — an
+///      EIP-712 digest with verifyingContract = account — a signature is bound to a single account, so a signature
+///      made for one account cannot be replayed onto another account that shares the same owner key.
 contract AccountConfigurationERC7739Test is AccountConfigurationTest {
     uint256 constant OWNER_PK = 0xA11CE;
 
-    /// @dev verifySignature now rehashes: a signature over the RAW app hash is rejected; the signer must sign the
+    /// @dev isValidSignature rehashes: a signature over the RAW app hash is rejected; the signer must sign the
     ///      account-scoped replaySafeHash.
-    function test_verifySignature_requiresAccountScopedDigest() public {
+    function test_isValidSignature_requiresAccountScopedDigest() public {
         (address account,) = _createK1AccountWithSalt(OWNER_PK, bytes32(uint256(1)));
         bytes32 appHash = keccak256("hello world");
 
         assertFalse(
-            accountConfiguration.verifySignature(account, appHash, _buildK1Auth(OWNER_PK, appHash)),
-            "raw-hash signature must be rejected now that verifySignature rehashes"
+            _isValidSig(account, appHash, _buildK1Auth(OWNER_PK, appHash)),
+            "raw-hash signature must be rejected now that isValidSignature rehashes"
         );
 
         bytes32 signable = accountConfiguration.replaySafeHash(account, appHash);
         assertTrue(
-            accountConfiguration.verifySignature(account, appHash, _buildK1Auth(OWNER_PK, signable)),
+            _isValidSig(account, appHash, _buildK1Auth(OWNER_PK, signable)),
             "account-scoped (replaySafeHash) signature must validate"
         );
     }
 
     /// @dev The core fix: a signature made for one account does NOT validate on another account that shares the
-    ///      same owner key (a wallet and its sub-account share an owner). Enforced at the registry, so a
-    ///      registry-direct verifier gets this without ever calling the account.
-    function test_verifySignature_blocksCrossAccountReplay() public {
+    ///      same owner key (a wallet and its sub-account share an owner).
+    function test_isValidSignature_blocksCrossAccountReplay() public {
         (address accountA,) = _createK1AccountWithSalt(OWNER_PK, bytes32(uint256(0xA)));
         (address accountB,) = _createK1AccountWithSalt(OWNER_PK, bytes32(uint256(0xB)));
         assertTrue(accountA != accountB, "accounts must differ");
@@ -40,10 +41,9 @@ contract AccountConfigurationERC7739Test is AccountConfigurationTest {
         bytes32 appHash = keccak256("sign in to dapp");
         bytes memory sigForA = _buildK1Auth(OWNER_PK, accountConfiguration.replaySafeHash(accountA, appHash));
 
-        assertTrue(accountConfiguration.verifySignature(accountA, appHash, sigForA), "valid on the intended account");
+        assertTrue(_isValidSig(accountA, appHash, sigForA), "valid on the intended account");
         assertFalse(
-            accountConfiguration.verifySignature(accountB, appHash, sigForA),
-            "must NOT replay onto another account with the same owner key"
+            _isValidSig(accountB, appHash, sigForA), "must NOT replay onto another account with the same owner key"
         );
     }
 
@@ -62,14 +62,13 @@ contract AccountConfigurationERC7739Test is AccountConfigurationTest {
     }
 
     /// @dev A non-owner key is rejected even when it signs the correct account-scoped digest.
-    function test_verifySignature_rejectsNonOwner() public {
+    function test_isValidSignature_rejectsNonOwner() public {
         (address account,) = _createK1AccountWithSalt(OWNER_PK, bytes32(uint256(1)));
         bytes32 appHash = keccak256("hello world");
         bytes32 signable = accountConfiguration.replaySafeHash(account, appHash);
 
         assertFalse(
-            accountConfiguration.verifySignature(account, appHash, _buildK1Auth(0xBEEF, signable)),
-            "a non-owner signature must be rejected"
+            _isValidSig(account, appHash, _buildK1Auth(0xBEEF, signable)), "a non-owner signature must be rejected"
         );
     }
 }

--- a/test/unit/AccountConfiguration/importAccount.t.sol
+++ b/test/unit/AccountConfiguration/importAccount.t.sol
@@ -52,12 +52,12 @@ contract ImportAccountTest is AccountConfigurationTest {
     // retains the full Actor/ActorConfig typehash structure; for imported (always unrestricted) actors the config
     // fields are zero and policyData is empty.
     bytes32 constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
-        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry)"
+        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
     );
     bytes32 constant ACTOR_TYPEHASH = keccak256(
-        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry)"
+        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
     );
-    bytes32 constant ACTORCONFIG_TYPEHASH = keccak256("ActorConfig(address authenticator,uint8 scope,uint48 expiry)");
+    bytes32 constant ACTORCONFIG_TYPEHASH = keccak256("ActorConfig(address authenticator,uint48 expiry,uint16 scope)");
 
     // ── digest helpers ──
 
@@ -79,7 +79,7 @@ contract ImportAccountTest is AccountConfigurationTest {
         for (uint256 i; i < initialActors.length; i++) {
             // Hash the actor's real scope; expiry is always 0 at import. policyData is hashed into the Actor hash.
             bytes32 configHash = keccak256(
-                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, initialActors[i].scope, uint48(0))
+                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), initialActors[i].scope)
             );
             actorHashes[i] = keccak256(
                 abi.encode(ACTOR_TYPEHASH, initialActors[i].actorId, configHash, keccak256(initialActors[i].policyData))
@@ -411,7 +411,7 @@ contract ImportAccountTest is AccountConfigurationTest {
         accountConfiguration.importAccount(address(wallet), block.chainid, actors, sig);
 
         assertEq(accountConfiguration.getChangeSequences(address(wallet)).local, 1);
-        assertTrue(accountConfiguration.isActor(address(wallet), bytes32(bytes20(vm.addr(ownerPk)))));
+        assertTrue(_isActor(address(wallet), bytes32(bytes20(vm.addr(ownerPk)))));
     }
 
     /// @notice Verifies a chainId == 0 (multichain) import signature authorizes import and still sets localSequence.
@@ -426,7 +426,7 @@ contract ImportAccountTest is AccountConfigurationTest {
 
         assertEq(accountConfiguration.getChangeSequences(address(wallet)).local, 1);
         assertEq(accountConfiguration.getChangeSequences(address(wallet)).multichain, 0);
-        assertTrue(accountConfiguration.isActor(address(wallet), bytes32(bytes20(vm.addr(ownerPk)))));
+        assertTrue(_isActor(address(wallet), bytes32(bytes20(vm.addr(ownerPk)))));
     }
 
     /// @notice Verifies importAccount emits AccountImported(account) exactly once on the happy path.
@@ -453,7 +453,7 @@ contract ImportAccountTest is AccountConfigurationTest {
         accountConfiguration.importAccount(address(wallet), chainId, actors, sig);
 
         // The implicit default EOA (self-actorId) is disabled by default on import.
-        assertFalse(accountConfiguration.isActor(address(wallet), bytes32(bytes20(address(wallet)))));
+        assertFalse(_isActor(address(wallet), bytes32(bytes20(address(wallet)))));
         AccountConfiguration.ActorConfig memory selfConfig =
             accountConfiguration.getActorConfig(address(wallet), bytes32(bytes20(address(wallet))));
         assertEq(selfConfig.authenticator, address(0));
@@ -478,7 +478,7 @@ contract ImportAccountTest is AccountConfigurationTest {
         assertEq(accountConfiguration.getChangeSequences(address(wallet)).local, 1);
         for (uint256 i; i < count; i++) {
             bytes32 actorId = actors[i].actorId;
-            assertTrue(accountConfiguration.isActor(address(wallet), actorId));
+            assertTrue(_isActor(address(wallet), actorId));
             AccountConfiguration.ActorConfig memory config =
                 accountConfiguration.getActorConfig(address(wallet), actorId);
             assertEq(config.authenticator, address(k1Authenticator));
@@ -508,8 +508,8 @@ contract ImportAccountTest is AccountConfigurationTest {
         accountConfiguration.importAccount(eoa, uint64(block.chainid), actors, sig);
 
         assertEq(accountConfiguration.getChangeSequences(eoa).local, 1);
-        assertTrue(accountConfiguration.isActor(eoa, bytes32(bytes20(device))));
-        assertFalse(accountConfiguration.isActor(eoa, bytes32(bytes20(eoa))));
+        assertTrue(_isActor(eoa, bytes32(bytes20(device))));
+        assertFalse(_isActor(eoa, bytes32(bytes20(eoa))));
     }
 
     /// @notice Verifies a real EIP-7702 EOA delegated to DefaultAccount can self-import with its own k1 signature.
@@ -532,8 +532,8 @@ contract ImportAccountTest is AccountConfigurationTest {
         );
 
         assertEq(accountConfiguration.getChangeSequences(eoa).local, 1);
-        assertTrue(accountConfiguration.isActor(eoa, bytes32(bytes20(device))));
-        assertFalse(accountConfiguration.isActor(eoa, bytes32(bytes20(eoa))));
+        assertTrue(_isActor(eoa, bytes32(bytes20(device))));
+        assertFalse(_isActor(eoa, bytes32(bytes20(eoa))));
 
         // The implicit default EOA is disabled after import: its own k1 sig now finds no config.
         bytes32 h = keccak256("post import");
@@ -565,12 +565,12 @@ contract ImportAccountTest is AccountConfigurationTest {
 
         assertEq(accountConfiguration.getChangeSequences(eoa).local, 1);
         // The self-actorId is a live explicit owner.
-        assertTrue(accountConfiguration.isActor(eoa, bytes32(bytes20(eoa))));
+        assertTrue(_isActor(eoa, bytes32(bytes20(eoa))));
 
         // The same key still authenticates as a full owner — now via its explicit self config, not the (disabled)
         // implicit fallback.
         bytes32 h = keccak256("post import");
-        (, uint8 scope,) = accountConfiguration.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
+        (, uint16 scope,) = accountConfiguration.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
         assertEq(scope, 0);
     }
 }

--- a/test/unit/AccountConfiguration/policyAccessors.t.sol
+++ b/test/unit/AccountConfiguration/policyAccessors.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {AccountConfiguration} from "../../../src/AccountConfiguration.sol";
+import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 
 /// @notice Fully-fuzzed unit tests for the policy accessors on `AccountConfiguration`:
@@ -36,7 +37,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         (address account,) = _createK1Account(rootPk);
         actorId = _boundExplicitActorId(account, rootPk, actorId);
 
-        uint8 scope = _boundGatedScope(scopeSeed);
+        uint16 scope = _boundGatedScope(scopeSeed);
         address manager = _boundNonZeroAddress(managerSeed);
         bytes32 commitment = _boundNonZeroWord(commitmentSeed);
 
@@ -83,7 +84,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
 
-        uint8 scope = _boundGatedScope(scopeSeed);
+        uint16 scope = _boundGatedScope(scopeSeed);
         address manager = _boundNonZeroAddress(managerSeed);
         bytes32 commitment = _boundNonZeroWord(commitmentSeed);
 
@@ -348,7 +349,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         (address account,) = _createK1Account(rootPk);
         actorId = _boundExplicitActorId(account, rootPk, actorId);
 
-        uint8 scope = _boundGatedScope(scopeSeed);
+        uint16 scope = _boundGatedScope(scopeSeed);
         address manager = _boundNonZeroAddress(managerSeed);
         bytes32 commitment = _boundNonZeroWord(commitmentSeed);
         address newManager = _boundNonZeroAddress(newManagerSeed);
@@ -373,13 +374,13 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         (address account,) = _createK1Account(rootPk);
         actorId = _boundExplicitActorId(account, rootPk, actorId);
 
-        _authorizePolicyActor(account, rootPk, actorId, accountConfiguration.SCOPE_POLICY(), address(0), bytes32(0));
+        _authorizePolicyActor(account, rootPk, actorId, Scopes.POLICY, address(0), bytes32(0));
 
         // Slots are zero, yet the actor is gated by the SCOPE_POLICY bit.
         assertEq(accountConfiguration.getPolicyManager(account, actorId), address(0));
         assertEq(accountConfiguration.getPolicyCommitment(account, actorId), bytes32(0));
         AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, actorId);
-        assertTrue(cfg.scope & accountConfiguration.SCOPE_POLICY() != 0);
+        assertTrue(cfg.scope & Scopes.POLICY != 0);
     }
 
     /// @notice This contract does not reject scope combinations: an actor may carry SCOPE_POLICY alongside any
@@ -394,17 +395,12 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         address manager = _boundNonZeroAddress(managerSeed);
         bytes32 commitment = _boundNonZeroWord(commitmentSeed);
 
-        uint8[4] memory otherScopes = [
-            uint8(0),
-            accountConfiguration.SCOPE_SELF_PAYER(),
-            accountConfiguration.SCOPE_SPONSOR_PAYER(),
-            accountConfiguration.SCOPE_NONCE()
-        ];
+        uint16[4] memory otherScopes = [uint16(0), Scopes.SELF_PAYER, Scopes.SPONSOR_PAYER, Scopes.NONCE];
         for (uint256 i; i < otherScopes.length; i++) {
             // Policy actors are keyed by actorId only; no signing key is needed, so a distinct address-shaped id
             // avoids the vm.addr curve-order bound on an unbounded rootPk + i.
             bytes32 actorId = bytes32(bytes20(address(uint160(1000 + i))));
-            uint8 scope = otherScopes[i] | accountConfiguration.SCOPE_POLICY();
+            uint16 scope = otherScopes[i] | Scopes.POLICY;
             _authorizePolicyActor(account, rootPk, actorId, scope, manager, commitment);
 
             assertEq(accountConfiguration.getPolicyManager(account, actorId), manager);
@@ -433,7 +429,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         actorB = _boundExplicitActorId(account, rootPk, actorB);
         vm.assume(actorA != actorB);
 
-        uint8 scope = _boundGatedScope(scopeSeed);
+        uint16 scope = _boundGatedScope(scopeSeed);
         address managerA = _boundNonZeroAddress(managerSeedA);
         bytes32 commitmentA = _boundNonZeroWord(commitmentSeedA);
         address managerB = _boundNonZeroAddress(managerSeedB);
@@ -471,7 +467,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         vm.assume(sharedActorId != bytes32(bytes20(accountA)));
         vm.assume(sharedActorId != bytes32(bytes20(accountB)));
 
-        uint8 scope = _boundGatedScope(scopeSeed);
+        uint16 scope = _boundGatedScope(scopeSeed);
         address managerA = _boundNonZeroAddress(managerSeedA);
         bytes32 commitmentA = _boundNonZeroWord(commitmentSeedA);
         address managerB = _boundNonZeroAddress(managerSeedB);
@@ -515,9 +511,9 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
             account, rootPk, sessionActorId, _boundGatedScope(scopeSeed), manager, _boundNonZeroWord(commitmentSeed)
         );
 
-        (, uint8 outScope, address policyTarget) =
+        (, uint16 outScope, address policyTarget) =
             accountConfiguration.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
-        assertTrue(outScope & accountConfiguration.SCOPE_POLICY() != 0);
+        assertTrue(outScope & Scopes.POLICY != 0);
         assertEq(policyTarget, manager);
         assertEq(policyTarget, accountConfiguration.getPolicyManager(account, sessionActorId));
     }
@@ -568,7 +564,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
 
-        (, uint8 outScope, address policyTarget) =
+        (, uint16 outScope, address policyTarget) =
             accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(outScope, uint8(0x00));
         assertEq(policyTarget, address(0));
@@ -579,8 +575,8 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     /// @dev A policy-bearing actor's scope: always carries SCOPE_POLICY, with arbitrary other bits mixed in.
-    function _boundGatedScope(uint8 seed) internal view returns (uint8) {
-        return uint8(seed) | accountConfiguration.SCOPE_POLICY();
+    function _boundGatedScope(uint8 seed) internal view returns (uint16) {
+        return uint8(seed) | Scopes.POLICY;
     }
 
     /// @dev A non-zero policy manager address (so a written slot is distinguishable from an unwritten one).
@@ -642,7 +638,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         address account,
         uint256 rootPk,
         bytes32 actorId,
-        uint8 scope,
+        uint16 scope,
         address policyManager,
         bytes32 commitment
     ) internal {
@@ -669,7 +665,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
     function _authorizeInlineSelfWithPolicy(
         address eoa,
         uint256 eoaPk,
-        uint8 scope,
+        uint16 scope,
         address policyManager,
         bytes32 commitment
     ) internal {

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -144,7 +144,7 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
         bytes memory wrappedAuth = abi.encodePacked(
             k1Authenticator, _signDigest(signerPk, accountConfiguration.replaySafeHash(delegateAccount, hash))
         );
-        assertTrue(accountConfiguration.verifySignature(delegateAccount, hash, wrappedAuth));
+        assertTrue(_isValidSig(delegateAccount, hash, wrappedAuth));
 
         // But it cannot vouch as a delegate — the nested check stays admin-only.
         bytes memory data = abi.encodePacked(delegateAccount, nestedAuth);

--- a/test/unit/examples/ExternalPolicyCaller.t.sol
+++ b/test/unit/examples/ExternalPolicyCaller.t.sol
@@ -159,23 +159,12 @@ contract ExternalPolicyCallerTest is AccountConfigurationTest {
         _revokeProvider(a2);
         address a3 = _optIn(bytes32(uint256(3)), 100e6, MONTH);
 
-        (PolicyManager.PolicyBinding memory b1,) = _binding(a1, 1, 100e6, MONTH);
-        (PolicyManager.PolicyBinding memory b2,) = _binding(a2, 2, 100e6, MONTH);
-        (PolicyManager.PolicyBinding memory b3,) = _binding(a3, 3, 100e6, MONTH);
-        PolicyManager.PolicyBinding[] memory bindings = new PolicyManager.PolicyBinding[](3);
-        bindings[0] = b1;
-        bindings[1] = b2;
-        bindings[2] = b3;
-        bytes[] memory data = new bytes[](3);
-        data[0] = _pull(10e6);
-        data[1] = _pull(10e6);
-        data[2] = _pull(20e6);
+        (PolicyManager.PolicyBinding[] memory bindings, bytes[] memory data) = _threePulls(a1, a2, a3);
 
         vm.expectEmit(true, true, true, false);
         emit PolicyManager.ExecutionSkipped(a2, address(policy), bytes32(bytes20(provider)));
 
-        vm.prank(provider);
-        bool[] memory results = manager.executeForMany(bindings, data);
+        bool[] memory results = _runBatch(bindings, data);
 
         assertTrue(results[0]);
         assertFalse(results[1]);
@@ -231,6 +220,34 @@ contract ExternalPolicyCallerTest is AccountConfigurationTest {
 
     // ── Helpers ──
 
+    /// @dev Builds the (bindings, data) pair for the three-subscriber best-effort batch. Extracted so the batch
+    ///      test does not hold every intermediate binding live across the executeForMany ABI-encode (via-IR stack).
+    function _threePulls(address a1, address a2, address a3)
+        internal
+        view
+        returns (PolicyManager.PolicyBinding[] memory bindings, bytes[] memory data)
+    {
+        bindings = new PolicyManager.PolicyBinding[](3);
+        (bindings[0],) = _binding(a1, 1, 100e6, MONTH);
+        (bindings[1],) = _binding(a2, 2, 100e6, MONTH);
+        (bindings[2],) = _binding(a3, 3, 100e6, MONTH);
+        data = new bytes[](3);
+        data[0] = _pull(10e6);
+        data[1] = _pull(10e6);
+        data[2] = _pull(20e6);
+    }
+
+    /// @dev Drives executeForMany from a minimal-local-count frame. The ABI-encode of `bindings` (an array of
+    ///      structs carrying dynamic `policyConfig`) is deep under via-IR, so isolating it here keeps it within the
+    ///      stack limit regardless of the caller's live locals.
+    function _runBatch(PolicyManager.PolicyBinding[] memory bindings, bytes[] memory data)
+        internal
+        returns (bool[] memory)
+    {
+        vm.prank(provider);
+        return manager.executeForMany(bindings, data);
+    }
+
     function _pull(uint256 amount) internal view returns (bytes memory) {
         return abi.encode(
             SessionPolicy.Action({
@@ -239,15 +256,21 @@ contract ExternalPolicyCallerTest is AccountConfigurationTest {
         );
     }
 
-    /// @dev SessionPolicy config: `transfer` only on `token`, with a USDC-style recurring spend limit.
+    /// @dev SessionPolicy config: `transfer` only on `token`, with a USDC-style recurring spend limit. The struct
+    ///      build is split from the abi.encode so the deeply-nested encoder (Config → CallScope[] → SelectorRule[]
+    ///      → address[]) runs in its own minimal-local frame, staying within the via-IR stack limit.
     function _config(uint256 limit, uint40 period) internal view returns (bytes memory) {
+        return abi.encode(_sessionConfig(limit, period));
+    }
+
+    function _sessionConfig(uint256 limit, uint40 period) internal view returns (SessionPolicy.Config memory) {
         SessionPolicy.TokenLimit[] memory limits = new SessionPolicy.TokenLimit[](1);
         limits[0] = SessionPolicy.TokenLimit({token: address(token), limit: limit, period: period});
         SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
         rules[0] = SessionPolicy.SelectorRule({selector: ExtMockERC20.transfer.selector, recipients: new address[](0)});
         SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
         scopes[0] = SessionPolicy.CallScope({target: address(token), selectorRules: rules});
-        return abi.encode(SessionPolicy.Config({tokenLimits: limits, callScopes: scopes}));
+        return SessionPolicy.Config({tokenLimits: limits, callScopes: scopes});
     }
 
     function _binding(address account, uint256 salt, uint256 limit, uint40 period)


### PR DESCRIPTION
## Summary

Makes `AccountConfiguration` deliberately scope-agnostic and moves the scope vocabulary into a shared library, per the [EIP spec updates](https://github.com/chunter-cb/eips/pull/13). Draft for review; the `DelegateAuthenticator` is intentionally left external (not folded into the config).

- **New `src/libraries/Scopes.sol`** — canonical `uint16` actor-scope grants (`SENDER`, `POLICY`, `NONCE`, `SELF_PAYER`, `SPONSOR_PAYER`, `DELEGATE`), documented as append-only. `AccountConfiguration` now references only `Scopes.POLICY` (the one bit it interprets, to slice/store policy data) plus the `scope == 0` admin predicate; all `SCOPE_*` public constant getters are removed.
- **Widen scope `uint8` → `uint16` + reorder** — `ActorConfig` / `AccountState` fields reordered to the normative slot layout `authenticator ‖ expiry ‖ scope ‖ reserved`. Updated typehash strings, the import digest / actors-commitment encodings, and the `ActorAuthorized` packing accordingly.
- **Remove `isActor`** — the public function is gone; liveness is now a private `_isActor` (used by revoke). Off-chain/tests read `getActorConfig(...).authenticator != 0`.
- **Remove `verifySignature`** — registry-level ERC-1271 is gone. Verification is relocated to `DefaultAccount.isValidSignature`, which authenticates against `AccountConfiguration.replaySafeHash` (still on the config) and applies the operational-actor rule (admin, or SENDER without POLICY). `replaySafeHash` remains public so accounts can build the account-scoped digest.
- **`DelegateAuthenticator`** — nested scope typed as `uint16`; no `DELEGATE` gating added to the config (per discussion).

## Design note (open question)

A future multisig authenticator would resemble `DelegateAuthenticator` but with a threshold — an argument against enshrining delegate logic in the config. The `DELEGATE` grant is fairly specific; a less use-case-specific grant (or making it work without a dedicated bit) is worth a follow-up discussion. Nothing here blocks that.

## Test plan

- [x] `forge build` (via-IR) green — split a deeply-nested `SessionPolicy.Config` encode in `ExternalPolicyCaller.t.sol` to stay within the stack limit.
- [x] `forge test` — 335 passed, 0 failed.
- [ ] Reviewer: confirm dropping the public `SCOPE_*` getters is acceptable (ABI change), and the ERC-1271 relocation to the account contract.