### PR TITLE
feat: local-channel epoch expiration for actors

### DIFF
--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -25,16 +25,14 @@ contract AccountConfiguration {
         uint64 local; // chain_id == block.chainid; packed epoch|nonce (epoch = bits[63:40], nonce = bits[39:0])
     }
 
-    /// @notice An actor's authorization: authenticator, expiry, install epoch, and scope. Field order matches the
-    ///         normative `actor_config` slot layout:
-    ///         authenticator(20) ‖ expiry(6) ‖ installEpoch(3) ‖ scope(2) ‖ reserved(1).
+    /// @notice An actor's authorization: authenticator, expiry, and scope. Field order matches the normative
+    ///         `actor_config` slot layout: authenticator(20) ‖ expiry(6) ‖ scope(2) ‖ reserved(4).
     /// @dev `scope` occupies the last populated bytes so a future scope widening consumes reserved space and shifts
-    ///      nothing. `installEpoch` is never a caller input on the authorize path: it is stamped from the epoch bound
-    ///      in the change's sequence/digest (see {applySignedActorChanges} and the EIP's Actor Epoch section).
+    ///      nothing. There is no per-actor epoch stamp: the local-channel epoch guards install/change *signatures* at
+    ///      the apply path (see {applySignedActorChanges}/{BUMP_EPOCH}), not live actors at authentication.
     struct ActorConfig {
         address authenticator;
         uint48 expiry; // Unix seconds; 0 = no expiry. Actor invalid once block.timestamp > expiry
-        uint24 installEpoch; // local-channel epoch at authorization; non-admin actors are rejected once it != current
         uint16 scope;
     }
 
@@ -56,11 +54,11 @@ contract AccountConfiguration {
         bytes policyData;
     }
 
-    /// @notice A single authorize/revoke operation within a signed batch.
+    /// @notice A single authorize/revoke/bump operation within a signed batch.
     struct ActorChange {
-        uint8 changeType; // 0x01 = authorizeActor, 0x02 = revokeActor
-        bytes32 actorId;
-        bytes data; // operation-specific: ActorConfig || policyData for authorize, empty for revoke
+        uint8 changeType; // 0x01 = authorizeActor, 0x02 = revokeActor, 0x03 = bumpEpoch
+        bytes32 actorId; // ignored for bumpEpoch
+        bytes data; // operation-specific: ActorConfig || policyData for authorize, empty for revoke/bumpEpoch
     }
 
     /// @notice Per-account packed state: sequences, lock status, and the inline home for the account's k1 self key.
@@ -68,7 +66,7 @@ contract AccountConfiguration {
     /// @dev Packed into a single storage slot; the field layout is normative (nodes read the raw slot for mempool
     ///      rate-limit tiering, see the EIP's Account Lock section). Field order and widths match the spec's
     ///      account-state table: multichainSequence, localSequence, flags, lockUnion, defaultEOAExpiry,
-    ///      defaultEOAScope, then 2 reserved bytes that MUST stay zero.
+    ///      defaultEOAScope, then 1 reserved byte that MUST stay zero.
     ///      localSequence > 0 doubles as the account initialized flag.
     ///      `flags` is a bitfield: bit 0 (FLAG_REVOKE_DEFAULT_EOA) disables the k1 self key; bit 1 (FLAG_LOCKED)
     ///      freezes actor configuration; bit 2 (FLAG_UNLOCK_INITIATED) selects how `lockUnion` is interpreted.
@@ -85,10 +83,10 @@ contract AccountConfiguration {
         uint64 multichainSequence; // 8 bytes – plain monotonic counter (chain_id 0)
         uint64 localSequence; // 8 bytes – packed epoch|nonce (epoch = bits[63:40], nonce = bits[39:0]); != 0 = initialized
         uint8 flags; // 1 byte – bitfield: bit 0 REVOKE_DEFAULT_EOA, bit 1 LOCKED, bit 2 UNLOCK_INITIATED
-        uint40 lockUnion; // 5 bytes – union: unlockDelay while UNLOCK_INITIATED clear, else unlocksAt (timestamp)
+        uint48 lockUnion; // 6 bytes – union: unlockDelay while UNLOCK_INITIATED clear, else unlocksAt (Unix seconds)
         uint48 defaultEOAExpiry; // 6 bytes – inline self k1 expiry (Unix seconds; 0 = no expiry)
         uint16 defaultEOAScope; // 2 bytes – inline self k1 scope (0 = full owner)
-        // 2 bytes reserved (remaining slot bytes); MUST stay zero.
+        // 1 byte reserved (remaining slot byte); MUST stay zero.
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -105,17 +103,17 @@ contract AccountConfiguration {
     ///      import signature cannot be replayed on another chain. Initial actors are hashed structurally via
     ///      ACTOR_TYPEHASH / ACTORCONFIG_TYPEHASH below.
     bytes32 public constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
-        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint24 installEpoch,uint16 scope)"
+        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
     );
 
     /// @notice Typehash used to structurally hash each Actor within an ActorInitialization import digest.
     bytes32 public constant ACTOR_TYPEHASH = keccak256(
-        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint24 installEpoch,uint16 scope)"
+        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
     );
 
     /// @notice Typehash used to structurally hash an Actor's ActorConfig within an import digest.
     bytes32 public constant ACTORCONFIG_TYPEHASH =
-        keccak256("ActorConfig(address authenticator,uint48 expiry,uint24 installEpoch,uint16 scope)");
+        keccak256("ActorConfig(address authenticator,uint48 expiry,uint16 scope)");
 
     /// @notice Typehash binding a signed actor-change batch to its account, chainId, and sequence.
     ///
@@ -136,14 +134,6 @@ contract AccountConfiguration {
     bytes32 public constant LOCK_CHANGE_TYPEHASH =
         keccak256("SignedLockChange(address account,uint256 chainId,uint8 op,uint16 unlockDelay,uint64 sequence)");
 
-    /// @notice Typehash binding an epoch-bump signature to its account, chainId, and the epoch being advanced.
-    ///
-    /// @dev NOT compliant with EIP-712, to mitigate phishing attacks. Binds the current chainId (local-channel only)
-    ///      and the epoch the signer intends to advance; a replay fails once the epoch has moved on (see
-    ///      {applySignedEpochBump}).
-    bytes32 public constant EPOCH_BUMP_TYPEHASH =
-        keccak256("SignedEpochBump(address account,uint256 chainId,uint24 epoch)");
-
     // ----------------------------------------------------------------------------------------------------------------
     // ACTOR CHANGE TYPES
     // ----------------------------------------------------------------------------------------------------------------
@@ -153,6 +143,12 @@ contract AccountConfiguration {
 
     /// @notice Revoke an actor from the account
     uint8 public constant REVOKE_ACTOR = 0x02;
+
+    /// @notice Advance the account's local-channel epoch within a sequenced batch. `actorId`/`data` MUST be empty.
+    ///         Local channel only; not permitted on the unordered MAX-sentinel path. Enables an atomic
+    ///         [REVOKE_ACTOR(x), BUMP_EPOCH] batch that revokes x AND permanently kills x's install signature (and
+    ///         every other pending change/install bound to the old epoch) in one signature. See {applySignedActorChanges}.
+    uint8 public constant BUMP_EPOCH = 0x03;
 
     // ----------------------------------------------------------------------------------------------------------------
     // LOCK CHANGE OPS
@@ -287,10 +283,11 @@ contract AccountConfiguration {
     ///
     /// @param account The account whose unlock was initiated.
     /// @param unlocksAt The timestamp at which the account will unlock.
-    event AccountUnlockInitiated(address indexed account, uint40 unlocksAt);
+    event AccountUnlockInitiated(address indexed account, uint48 unlocksAt);
 
-    /// @notice Emitted when an account's local-channel epoch is advanced, mass-revoking every non-admin actor
-    ///         authorized at the old epoch.
+    /// @notice Emitted when an account's local-channel epoch is advanced (via a BUMP_EPOCH change), invalidating every
+    ///         pending local signed change/install bound to the old epoch. Live actors are unaffected — this cancels
+    ///         signatures, not agents. Wallets should treat it as a signal to re-prompt for any change they still want.
     ///
     /// @param account The account whose epoch was bumped.
     /// @param newEpoch The new (post-bump) epoch.
@@ -363,15 +360,15 @@ contract AccountConfiguration {
     /// @notice The actor's expiry has passed.
     error ActorExpired();
 
-    /// @notice A non-admin actor's installEpoch no longer matches the account's current local-channel epoch (its
-    ///         generation was mass-revoked by an epoch bump).
-    error ActorEpochRevoked();
-
     /// @notice A local-channel signed change bound an epoch that is not the account's current epoch (stale/replayed).
     error EpochMismatch();
 
     /// @notice The local-channel epoch is already at type(uint24).max and cannot be advanced further.
     error EpochExhausted();
+
+    /// @notice A BUMP_EPOCH change was invalid: it carried non-empty data, or was on the multichain channel
+    ///         (chainId 0), where the epoch does not live.
+    error InvalidBumpChange();
 
     /// @notice The ordered local nonce is exhausted (would collide with the MAX sentinel); use a fresh epoch.
     error SequenceExhausted();
@@ -541,24 +538,31 @@ contract AccountConfiguration {
     ///      (scope 0) — there is no elevated scope for changing actors; admin is exactly scope == 0. Replay is
     ///      bound by `chainId` and `sequence`, dispatched by channel and nonce:
     ///        - chainId 0 (multichain): `sequence` is a plain monotonic counter; it MUST equal the current value and
-    ///          is consumed. Authorized actors are stamped with the account's current local epoch.
+    ///          is consumed. The epoch does not participate (it is local-channel only).
     ///        - local (chainId == block.chainid), sequenced nonce (`_nonceOf(sequence) < SEQUENCE_MASK`): the packed
     ///          epoch|nonce MUST equal the current word; the nonce is consumed (carry-guarded so the ordered space
     ///          never collides with the MAX sentinel).
     ///        - local, MAX sentinel nonce (`_nonceOf(sequence) == SEQUENCE_MASK`): the epoch MUST equal the current
     ///          epoch; nothing is consumed. Restricted to AUTHORIZE_ACTOR, non-admin (scope != 0), expiring
     ///          (expiry != 0), insert-only actors — an unordered channel for installing agent-key fleets.
-    ///      `installEpoch` is never a caller input: it is stamped from the epoch bound in the digest (the sequence),
-    ///      never the live epoch at apply time, so a `[bump, replay]` cannot resurrect a change at a fresh generation.
+    ///      The epoch is purely a replay guard for install/change *signatures*, checked here at the apply path (the
+    ///      `_accountState` slot is already loaded by onlyUnlocked): a batch binds the epoch in its digest, so a
+    ///      BUMP_EPOCH change permanently invalidates every other pending local change/install bound to the old
+    ///      epoch. It never touches live actors (no per-actor stamp, no authentication-time check), so a bump cancels
+    ///      pending signatures, not agents.
+    /// @dev A BUMP_EPOCH change (local channel, empty data, never on the MAX path) advances the epoch and resets the
+    ///      nonce to 0. Batching [REVOKE_ACTOR(x), BUMP_EPOCH] atomically revokes x and kills its install signature.
     /// @dev Reverts with AccountIsLocked when the account is locked.
     /// @dev Reverts with InvalidChainId when `chainId` is neither 0 (multichain) nor the current chain.
     /// @dev Reverts with InvalidSequence, EpochMismatch, or SequenceExhausted when `sequence` does not match the
     ///      channel's current value / epoch or the ordered nonce is exhausted.
     /// @dev Reverts with InvalidAuthLength, InvalidSignature, AuthenticationFailed, AuthenticatorMismatch,
-    ///      ActorExpired, ActorEpochRevoked, or DefaultEoaRevoked when `auth` fails to authenticate a live actor.
+    ///      ActorExpired, or DefaultEoaRevoked when `auth` fails to authenticate a live actor.
     /// @dev Reverts with UnauthorizedActorChange when the authenticated actor is not unrestricted (scope != 0).
     /// @dev Reverts with InvalidMaxSentinelChange when a MAX-sentinel batch carries a non-authorize change, or an
     ///      admin/non-expiring/overwriting actor.
+    /// @dev Reverts with InvalidBumpChange when a BUMP_EPOCH change carries data or is on the multichain channel, or
+    ///      EpochExhausted when the epoch is already at its maximum.
     /// @dev Reverts with UnknownChangeType when a change carries an unrecognized changeType.
     /// @dev Reverts with InvalidAuthenticator or InvalidPolicyData on a malformed authorize.
     /// @dev Reverts with UnknownActor when revoking an actor that is not authorized.
@@ -578,8 +582,8 @@ contract AccountConfiguration {
     ) external onlyUnlocked(account) {
         if (chainId != 0 && chainId != block.chainid) revert InvalidChainId();
 
-        // Validate/consume the channel and resolve the epoch to stamp into every authorized actor.
-        (uint24 installEpoch, bool isMaxSentinel) = _consumeChangeSequence(account, chainId, sequence);
+        // Validate/consume the channel; the MAX sentinel path is unordered and non-consuming.
+        bool isMaxSentinel = _consumeChangeSequence(account, chainId, sequence);
 
         // Compute digest and authenticate
         bytes32 digest = _computeSignedActorChangesDigest(account, chainId, sequence, actorChanges);
@@ -590,53 +594,70 @@ contract AccountConfiguration {
 
         // Apply actorChanges
         for (uint256 i; i < actorChanges.length; i++) {
-            if (actorChanges[i].changeType == AUTHORIZE_ACTOR) {
+            uint8 changeType = actorChanges[i].changeType;
+            if (changeType == AUTHORIZE_ACTOR) {
                 (ActorConfig memory newActorConfig, bytes memory policyData) =
                     abi.decode(actorChanges[i].data, (ActorConfig, bytes));
-                // Stamp installEpoch from the epoch bound in the digest; the caller-provided value is ignored.
-                newActorConfig.installEpoch = installEpoch;
                 if (isMaxSentinel) _requireMaxSentinelAuthorize(account, actorChanges[i].actorId, newActorConfig);
                 _authorizeActor(account, actorChanges[i].actorId, newActorConfig, policyData);
-            } else if (actorChanges[i].changeType == REVOKE_ACTOR) {
+            } else if (changeType == REVOKE_ACTOR) {
                 // The MAX sentinel is an install-only channel; revokes must use the ordered/multichain path.
                 if (isMaxSentinel) revert InvalidMaxSentinelChange();
                 _revokeActor(account, actorChanges[i].actorId);
+            } else if (changeType == BUMP_EPOCH) {
+                // The MAX sentinel is authorize-only; a bump must ride the ordered channel so it is itself
+                // single-use (its batch binds the pre-bump epoch and can never replay).
+                if (isMaxSentinel) revert InvalidMaxSentinelChange();
+                // The epoch lives only in the local channel; reject a multichain bump or any bound data.
+                if (chainId == 0 || actorChanges[i].data.length != 0) revert InvalidBumpChange();
+                _bumpEpoch(account);
             } else {
                 revert UnknownChangeType();
             }
         }
     }
 
-    /// @dev Validates and (for consuming paths) advances the change channel for a signed actor-change batch, returning
-    ///      the epoch to stamp into every authorized actor and whether this is the MAX sentinel (non-consuming) path.
-    ///      See {applySignedActorChanges} for the per-channel/nonce dispatch rules.
+    /// @dev Validates and (for consuming paths) advances the change channel for a signed actor-change batch,
+    ///      returning whether this is the MAX sentinel (unordered, non-consuming) path. See {applySignedActorChanges}
+    ///      for the per-channel/nonce dispatch rules.
     function _consumeChangeSequence(address account, uint256 chainId, uint64 sequence)
         private
-        returns (uint24 installEpoch, bool isMaxSentinel)
+        returns (bool isMaxSentinel)
     {
         AccountState storage st = _accountState[account];
 
-        // Multichain channel: a plain monotonic counter. Stamp the account's current local epoch.
+        // Multichain channel: a plain monotonic counter (no epoch).
         if (chainId == 0) {
             if (sequence != st.multichainSequence) revert InvalidSequence();
             st.multichainSequence = sequence + 1;
-            return (_epochOf(st.localSequence), false);
+            return false;
         }
 
         // Local channel: the packed epoch|nonce word.
         uint64 local = st.localSequence;
-        uint24 currentEpoch = _epochOf(local);
-        if (_epochOf(sequence) != currentEpoch) revert EpochMismatch();
+        if (_epochOf(sequence) != _epochOf(local)) revert EpochMismatch();
 
         uint64 nonce = _nonceOf(sequence);
-        if (nonce == SEQUENCE_MASK) return (currentEpoch, true); // MAX sentinel: unordered, non-consuming
+        if (nonce == SEQUENCE_MASK) return true; // MAX sentinel: unordered, non-consuming
 
         // Sequenced: bind the exact current nonce and consume it, carry-guarding the ordered space away from the
         // MAX sentinel (the nonce never reaches SEQUENCE_MASK - 1).
         if (nonce != _nonceOf(local)) revert InvalidSequence();
         if (nonce >= SEQUENCE_MASK - 2) revert SequenceExhausted();
         st.localSequence = local + 1;
-        return (currentEpoch, false);
+        return false;
+    }
+
+    /// @dev Advances the account's local-channel epoch and resets the nonce to 0, invalidating every pending local
+    ///      signed change/install bound to the old epoch. Overwrites the nonce consumed for the enclosing sequenced
+    ///      batch (harmless: that batch bound the old epoch, so a replay now fails the epoch check). Reverts
+    ///      EpochExhausted at the max epoch. Live actors are untouched — the epoch is never read at authentication.
+    function _bumpEpoch(address account) private {
+        AccountState storage st = _accountState[account];
+        uint24 epoch = _epochOf(st.localSequence);
+        if (epoch >= type(uint24).max) revert EpochExhausted();
+        st.localSequence = uint64((uint256(epoch) + 1) << EPOCH_SHIFT);
+        emit EpochBumped(account, epoch + 1);
     }
 
     /// @dev Enforces the MAX-sentinel authorize restrictions: the actor MUST be non-admin (scope != 0), carry a
@@ -714,60 +735,13 @@ contract AccountConfiguration {
             if (flags & FLAG_LOCKED == 0 || flags & FLAG_UNLOCK_INITIATED != 0) revert NotLocked();
 
             // Reinterpret the union: it held the stored delay, now it holds the effective unlock timestamp.
-            uint40 unlocksAt = uint40(block.timestamp + uint16(config.lockUnion));
+            uint48 unlocksAt = uint48(block.timestamp + uint16(config.lockUnion));
             config.flags = flags | FLAG_UNLOCK_INITIATED;
             config.lockUnion = unlocksAt;
             emit AccountUnlockInitiated(account, unlocksAt);
         } else {
             revert UnknownLockOp();
         }
-    }
-
-    // ----------------------------------------------------------------------------------------------------------------
-    // EPOCH BUMP
-    // ----------------------------------------------------------------------------------------------------------------
-
-    /// @notice Advances the account's local-channel epoch, mass-revoking every non-admin actor authorized at the old
-    ///         epoch (their installEpoch no longer matches — see {authenticateActor}). Admin actors and the inline
-    ///         secp256k1 self are exempt, so the key needed to bump/recover always survives.
-    ///
-    /// @dev Signed, relayable, admin-authorized (scope 0). The digest binds `block.chainid` and `epoch`; the contract
-    ///      requires `epoch == _epochOf(localSequence)` (the current epoch) and `epoch < type(uint24).max`. On success
-    ///      it sets `localSequence = (epoch + 1) << EPOCH_SHIFT` — advancing the epoch and resetting the nonce to 0 —
-    ///      and emits EpochBumped. The bump is epoch-bound (never nonce-bound), so it never races a pending admin
-    ///      change for a nonce slot, and self-invalidating: a replay binding `epoch` fails once the epoch is `epoch+1`.
-    ///      It consumes no nonce and, unlike the other config paths, is NOT gated by lock: a bump can only remove
-    ///      authority, and refusing it while locked would create a brick path. In one operation it kills every pending
-    ///      local signed change (sequenced and MAX sentinel — their bound epoch is now stale) and revokes every
-    ///      non-admin actor at the old epoch, instantly at authentication, node-filterable, with no enumeration.
-    /// @dev Reverts with EpochMismatch when `epoch` is not the account's current epoch.
-    /// @dev Reverts with EpochExhausted when the epoch is already at type(uint24).max.
-    /// @dev Reverts with InvalidAuthLength, InvalidSignature, AuthenticationFailed, AuthenticatorMismatch,
-    ///      ActorExpired, or DefaultEoaRevoked when `auth` fails to authenticate a live actor.
-    /// @dev Reverts with UnauthorizedActorChange when the authenticated actor is not unrestricted (scope != 0).
-    ///
-    /// @param account The account whose epoch is advanced.
-    /// @param epoch The current epoch the signer intends to advance (bound in the digest).
-    /// @param auth Authenticator(20) || authenticator-specific data authenticating an unrestricted (admin) actor.
-    function applySignedEpochBump(address account, uint24 epoch, bytes calldata auth) external {
-        AccountState storage st = _accountState[account];
-
-        // Bind the bump to the current epoch: a stale/replayed epoch fails, and once bumped the same signature is
-        // self-invalidating (its epoch is no longer current).
-        if (epoch != _epochOf(st.localSequence)) revert EpochMismatch();
-        if (epoch >= type(uint24).max) revert EpochExhausted();
-
-        bytes32 digest = _computeEpochBumpDigest(account, block.chainid, epoch);
-        (, uint16 scope,) = authenticateActor(account, digest, auth);
-
-        // Only an unrestricted actor (scope 0, admin) may bump; admins are exempt from the epoch check, so the signer
-        // needed here always survives a prior bump.
-        if (scope != 0) revert UnauthorizedActorChange();
-
-        // Advance the epoch and reset the nonce to 0. This invalidates every pending local change (their bound
-        // epoch|nonce no longer matches) and revokes every non-admin actor stamped at the old epoch.
-        st.localSequence = uint64((uint256(epoch) + 1) << EPOCH_SHIFT);
-        emit EpochBumped(account, epoch + 1);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -887,10 +861,8 @@ contract AccountConfiguration {
         if (config.authenticator >= K1_AUTHENTICATOR) return config;
         if (actorId == bytes32(bytes20(account)) && !_isDefaultEoaRevoked(account)) {
             AccountState storage st = _accountState[account];
-            // The inline k1 self carries no install stamp (it is exempt from the epoch check); report installEpoch 0.
-            return ActorConfig({
-                authenticator: K1_AUTHENTICATOR, expiry: st.defaultEOAExpiry, installEpoch: 0, scope: st.defaultEOAScope
-            });
+            return
+                ActorConfig({authenticator: K1_AUTHENTICATOR, expiry: st.defaultEOAExpiry, scope: st.defaultEOAScope});
         }
         return config;
     }
@@ -967,12 +939,12 @@ contract AccountConfiguration {
     ///
     /// @return locked True if the account is locked at the current block timestamp.
     /// @return hasInitiatedUnlock True if an unlock has been initiated but not yet elapsed.
-    /// @return unlocksAt The timestamp at which the account unlocks (type(uint40).max while hard-locked).
+    /// @return unlocksAt The timestamp at which the account unlocks (type(uint48).max while hard-locked).
     /// @return unlockDelay The configured unlock delay in seconds.
     function getLockStatus(address account)
         external
         view
-        returns (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 unlockDelay)
+        returns (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 unlockDelay)
     {
         AccountState storage config = _accountState[account];
         uint8 flags = config.flags;
@@ -982,10 +954,10 @@ contract AccountConfiguration {
         }
         if (flags & FLAG_UNLOCK_INITIATED == 0) {
             // Hard-locked: lockUnion holds the configured delay; synthesize the max sentinel for unlocksAt.
-            return (true, false, type(uint40).max, uint16(config.lockUnion));
+            return (true, false, type(uint48).max, uint16(config.lockUnion));
         }
         // Unlock initiated: lockUnion holds the effective unlock timestamp; the delay has been consumed.
-        uint40 unlockTime = config.lockUnion;
+        uint48 unlockTime = config.lockUnion;
         return (block.timestamp < unlockTime, true, unlockTime, 0);
     }
 
@@ -1048,11 +1020,8 @@ contract AccountConfiguration {
             // Initial actors carry scope verbatim (0x00 = unrestricted admin) and never an expiry. When
             // scope & Scopes.POLICY is set, policyData is validated by the same frozen rule as authorizeActor
             // (52 bytes). Authorizing the self-actorId as k1 writes its scope into the inline default-EOA fields.
-            // Creation/import is the bootstrap at epoch 0: initial actors are stamped installEpoch 0 (matching the
-            // localSequence epoch set to 0 on init) and never carry an expiry.
-            ActorConfig memory config = ActorConfig({
-                authenticator: initialActors[i].authenticator, expiry: 0, installEpoch: 0, scope: initialActors[i].scope
-            });
+            ActorConfig memory config =
+                ActorConfig({authenticator: initialActors[i].authenticator, expiry: 0, scope: initialActors[i].scope});
             _authorizeActor(account, initialActors[i].actorId, config, initialActors[i].policyData);
         }
     }
@@ -1126,7 +1095,7 @@ contract AccountConfiguration {
     }
 
     /// @dev Emit ActorAuthorized with a tightly packed payload. The base packs to 32 bytes
-    ///      (authenticator(20) || expiry(6) || installEpoch(3) || scope(2) || reserved(1 zero byte)); the policy gate
+    ///      (authenticator(20) || expiry(6) || scope(2) || reserved(4 zero bytes)); the policy gate
     ///      (manager(20) || commitment(32), 52 bytes) is appended only when scope & Scopes.POLICY != 0.
     function _emitActorAuthorized(
         address account,
@@ -1136,10 +1105,8 @@ contract AccountConfiguration {
         bytes32 commitment
     ) private {
         bytes memory actorData = (config.scope & Scopes.POLICY != 0)
-            ? abi.encodePacked(
-                config.authenticator, config.expiry, config.installEpoch, config.scope, bytes1(0), manager, commitment
-            )
-            : abi.encodePacked(config.authenticator, config.expiry, config.installEpoch, config.scope, bytes1(0));
+            ? abi.encodePacked(config.authenticator, config.expiry, config.scope, bytes4(0), manager, commitment)
+            : abi.encodePacked(config.authenticator, config.expiry, config.scope, bytes4(0));
         emit ActorAuthorized(account, actorId, actorData);
     }
 
@@ -1247,13 +1214,11 @@ contract AccountConfiguration {
     {
         bytes32[] memory actorHashes = new bytes32[](initialActors.length);
         for (uint256 i; i < initialActors.length; i++) {
-            // Hash the actor's real scope. Expiry and installEpoch are always 0 at import — import is the bootstrap
-            // at epoch 0, and an actor-provided expiry/install epoch is never accepted here. policyData is hashed via
-            // keccak256 into the Actor struct hash. The typehash structure matches the importAccount payload.
+            // Hash the actor's real scope. Expiry is always 0 at import — an actor-provided expiry is never accepted
+            // here. policyData is hashed via keccak256 into the Actor struct hash. The typehash structure matches the
+            // importAccount payload.
             bytes32 configHash = keccak256(
-                abi.encode(
-                    ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), uint24(0), initialActors[i].scope
-                )
+                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), initialActors[i].scope)
             );
             actorHashes[i] = keccak256(
                 abi.encode(ACTOR_TYPEHASH, initialActors[i].actorId, configHash, keccak256(initialActors[i].policyData))
@@ -1318,12 +1283,6 @@ contract AccountConfiguration {
         return keccak256(abi.encode(LOCK_CHANGE_TYPEHASH, account, chainId, op, unlockDelay, sequence));
     }
 
-    /// @dev Computes the digest signed over an applySignedEpochBump call, binding it to `account`, `chainId`, and the
-    ///      epoch being advanced via EPOCH_BUMP_TYPEHASH.
-    function _computeEpochBumpDigest(address account, uint256 chainId, uint24 epoch) internal pure returns (bytes32) {
-        return keccak256(abi.encode(EPOCH_BUMP_TYPEHASH, account, chainId, epoch));
-    }
-
     // ----------------------------------------------------------------------------------------------------------------
     // AUTHENTICATION
     // ----------------------------------------------------------------------------------------------------------------
@@ -1348,10 +1307,8 @@ contract AccountConfiguration {
 
     /// @dev Resolves an explicit _actorConfig-homed actor: requires a matching authenticator and an unexpired entry,
     ///      returning its scope and policy gate target. Shared by the non-k1 (_authenticate) and k1 other-actor
-    ///      (_authenticateK1) paths. Non-admin actors (scope != 0) additionally fail if their installEpoch no longer
-    ///      matches the account's current local epoch (mass-revoked by an epoch bump) — one cold SLOAD paid only by
-    ///      restricted actors; admins (scope 0) skip it. Reverts with AuthenticatorMismatch, ActorExpired, or
-    ///      ActorEpochRevoked.
+    ///      (_authenticateK1) paths. The one-SLOAD validation invariant holds: the epoch is never read here (it guards
+    ///      install signatures at the apply path, not live actors). Reverts with AuthenticatorMismatch or ActorExpired.
     function _resolveExplicitActor(address account, bytes32 actorId, address expectedAuthenticator)
         private
         view
@@ -1362,11 +1319,6 @@ contract AccountConfiguration {
         // Expiry is read from the same slot; an expired actor fails authentication. 0 = no expiry.
         if (config.expiry != 0 && block.timestamp > config.expiry) revert ActorExpired();
         scope = config.scope;
-        // Epoch check: a non-admin actor is live only while its install generation is current. Admins are exempt so
-        // the scope==0 signer needed to bump/recover always survives.
-        if (scope != 0 && config.installEpoch != _epochOf(_accountState[account].localSequence)) {
-            revert ActorEpochRevoked();
-        }
         policyTarget = _policyTargetFor(scope, actorId, account);
     }
 

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -16,16 +16,25 @@ contract AccountConfiguration {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     /// @notice Per-account replay counters for signed changes.
+    ///
+    /// @dev `multichain` is a plain monotonic uint64 counter (chain_id 0). `local` is the local-chain channel packed
+    ///      as epoch|nonce: bits [63:40] are the epoch (uint24), bits [39:0] are the nonce (uint40). It starts at
+    ///      epoch 0, nonce 1 once initialized (created/imported); 0 = uninitialized. See {EPOCH_SHIFT}/{SEQUENCE_MASK}.
     struct ChangeSequences {
-        uint64 multichain; // chain_id 0
-        uint64 local; // chain_id == block.chainid; starts at 1 once initialized (created/imported), 0 = uninitialized
+        uint64 multichain; // chain_id 0; plain monotonic counter
+        uint64 local; // chain_id == block.chainid; packed epoch|nonce (epoch = bits[63:40], nonce = bits[39:0])
     }
 
-    /// @notice An actor's authorization: authenticator, expiry, and scope. Field order matches the normative
-    ///         `actor_config` slot layout: authenticator(20) ‖ expiry(6) ‖ scope(2) ‖ reserved(4).
+    /// @notice An actor's authorization: authenticator, expiry, install epoch, and scope. Field order matches the
+    ///         normative `actor_config` slot layout:
+    ///         authenticator(20) ‖ expiry(6) ‖ installEpoch(3) ‖ scope(2) ‖ reserved(1).
+    /// @dev `scope` occupies the last populated bytes so a future scope widening consumes reserved space and shifts
+    ///      nothing. `installEpoch` is never a caller input on the authorize path: it is stamped from the epoch bound
+    ///      in the change's sequence/digest (see {applySignedActorChanges} and the EIP's Actor Epoch section).
     struct ActorConfig {
         address authenticator;
         uint48 expiry; // Unix seconds; 0 = no expiry. Actor invalid once block.timestamp > expiry
+        uint24 installEpoch; // local-channel epoch at authorization; non-admin actors are rejected once it != current
         uint16 scope;
     }
 
@@ -73,8 +82,8 @@ contract AccountConfiguration {
     ///      slot is reserved for a *non-k1* self authenticator (e.g. a post-quantum verifier returning the
     ///      self-actorId); the two homes are mutually exclusive (see _authorizeActor).
     struct AccountState {
-        uint64 multichainSequence; // 8 bytes
-        uint64 localSequence; // 8 bytes – also serves as initialized flag
+        uint64 multichainSequence; // 8 bytes – plain monotonic counter (chain_id 0)
+        uint64 localSequence; // 8 bytes – packed epoch|nonce (epoch = bits[63:40], nonce = bits[39:0]); != 0 = initialized
         uint8 flags; // 1 byte – bitfield: bit 0 REVOKE_DEFAULT_EOA, bit 1 LOCKED, bit 2 UNLOCK_INITIATED
         uint40 lockUnion; // 5 bytes – union: unlockDelay while UNLOCK_INITIATED clear, else unlocksAt (timestamp)
         uint48 defaultEOAExpiry; // 6 bytes – inline self k1 expiry (Unix seconds; 0 = no expiry)
@@ -96,17 +105,17 @@ contract AccountConfiguration {
     ///      import signature cannot be replayed on another chain. Initial actors are hashed structurally via
     ///      ACTOR_TYPEHASH / ACTORCONFIG_TYPEHASH below.
     bytes32 public constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
-        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
+        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint24 installEpoch,uint16 scope)"
     );
 
     /// @notice Typehash used to structurally hash each Actor within an ActorInitialization import digest.
     bytes32 public constant ACTOR_TYPEHASH = keccak256(
-        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
+        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint24 installEpoch,uint16 scope)"
     );
 
     /// @notice Typehash used to structurally hash an Actor's ActorConfig within an import digest.
     bytes32 public constant ACTORCONFIG_TYPEHASH =
-        keccak256("ActorConfig(address authenticator,uint48 expiry,uint16 scope)");
+        keccak256("ActorConfig(address authenticator,uint48 expiry,uint24 installEpoch,uint16 scope)");
 
     /// @notice Typehash binding a signed actor-change batch to its account, chainId, and sequence.
     ///
@@ -127,6 +136,14 @@ contract AccountConfiguration {
     bytes32 public constant LOCK_CHANGE_TYPEHASH =
         keccak256("SignedLockChange(address account,uint256 chainId,uint8 op,uint16 unlockDelay,uint64 sequence)");
 
+    /// @notice Typehash binding an epoch-bump signature to its account, chainId, and the epoch being advanced.
+    ///
+    /// @dev NOT compliant with EIP-712, to mitigate phishing attacks. Binds the current chainId (local-channel only)
+    ///      and the epoch the signer intends to advance; a replay fails once the epoch has moved on (see
+    ///      {applySignedEpochBump}).
+    bytes32 public constant EPOCH_BUMP_TYPEHASH =
+        keccak256("SignedEpochBump(address account,uint256 chainId,uint24 epoch)");
+
     // ----------------------------------------------------------------------------------------------------------------
     // ACTOR CHANGE TYPES
     // ----------------------------------------------------------------------------------------------------------------
@@ -146,6 +163,32 @@ contract AccountConfiguration {
 
     /// @notice applySignedLockChanges op that initiates the unlock of a hard-locked account.
     uint8 public constant UNLOCK_OP = 0x02;
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // LOCAL CHANNEL: EPOCH | NONCE PACKING
+    // ----------------------------------------------------------------------------------------------------------------
+
+    // The local change channel (AccountState.localSequence) is one uint64 reinterpreted as a packed epoch|nonce: the
+    // high bits are a mass-revocation generation counter (epoch), the low bits order sequenced changes within an
+    // epoch (nonce). The field offset/width are unchanged, so node raw-slot lock tiering is unaffected. The multichain
+    // channel is NOT split; it stays a plain monotonic uint64.
+
+    /// @notice Bit offset of the `epoch` within the packed local channel; the `nonce` occupies bits [39:0].
+    uint256 public constant EPOCH_SHIFT = 40;
+
+    /// @notice Low-40-bit nonce mask. Also the local-channel MAX sentinel nonce: an unordered, non-consuming config
+    ///         change slot used to authorize independent actors without sharing the ordered sequence.
+    uint64 public constant SEQUENCE_MASK = (uint64(1) << 40) - 1;
+
+    /// @dev Extracts the epoch (high 24 bits) from a packed local-channel word.
+    function _epochOf(uint64 word) internal pure returns (uint24) {
+        return uint24(word >> EPOCH_SHIFT);
+    }
+
+    /// @dev Extracts the nonce (low 40 bits) from a packed local-channel word.
+    function _nonceOf(uint64 word) internal pure returns (uint64) {
+        return word & SEQUENCE_MASK;
+    }
 
     // ----------------------------------------------------------------------------------------------------------------
     // ACTOR SCOPE
@@ -246,6 +289,13 @@ contract AccountConfiguration {
     /// @param unlocksAt The timestamp at which the account will unlock.
     event AccountUnlockInitiated(address indexed account, uint40 unlocksAt);
 
+    /// @notice Emitted when an account's local-channel epoch is advanced, mass-revoking every non-admin actor
+    ///         authorized at the old epoch.
+    ///
+    /// @param account The account whose epoch was bumped.
+    /// @param newEpoch The new (post-bump) epoch.
+    event EpochBumped(address indexed account, uint24 newEpoch);
+
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // ERRORS
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -312,6 +362,26 @@ contract AccountConfiguration {
 
     /// @notice The actor's expiry has passed.
     error ActorExpired();
+
+    /// @notice A non-admin actor's installEpoch no longer matches the account's current local-channel epoch (its
+    ///         generation was mass-revoked by an epoch bump).
+    error ActorEpochRevoked();
+
+    /// @notice A local-channel signed change bound an epoch that is not the account's current epoch (stale/replayed).
+    error EpochMismatch();
+
+    /// @notice The local-channel epoch is already at type(uint24).max and cannot be advanced further.
+    error EpochExhausted();
+
+    /// @notice The ordered local nonce is exhausted (would collide with the MAX sentinel); use a fresh epoch.
+    error SequenceExhausted();
+
+    /// @notice A signed change bound a sequence that does not match the account's current channel value.
+    error InvalidSequence();
+
+    /// @notice A MAX-sentinel (unordered) actor-change batch violated its restrictions: it carried a non-authorize
+    ///         change, or an admin (scope == 0), non-expiring (expiry == 0), or overwriting (already-live) actor.
+    error InvalidMaxSentinelChange();
 
     /// @notice The signature was malformed: bad length, non-canonical v, high-s, or a zero recovery.
     error InvalidSignature();
@@ -469,32 +539,47 @@ contract AccountConfiguration {
     ///
     /// @dev Authenticates `auth` against the account's actors and requires the resolved actor to be unrestricted
     ///      (scope 0) — there is no elevated scope for changing actors; admin is exactly scope == 0. Replay is
-    ///      bound by `chainId` (0 = multichain, else the current chain) and a monotonic per-account sequence
-    ///      consumed on each call.
+    ///      bound by `chainId` and `sequence`, dispatched by channel and nonce:
+    ///        - chainId 0 (multichain): `sequence` is a plain monotonic counter; it MUST equal the current value and
+    ///          is consumed. Authorized actors are stamped with the account's current local epoch.
+    ///        - local (chainId == block.chainid), sequenced nonce (`_nonceOf(sequence) < SEQUENCE_MASK`): the packed
+    ///          epoch|nonce MUST equal the current word; the nonce is consumed (carry-guarded so the ordered space
+    ///          never collides with the MAX sentinel).
+    ///        - local, MAX sentinel nonce (`_nonceOf(sequence) == SEQUENCE_MASK`): the epoch MUST equal the current
+    ///          epoch; nothing is consumed. Restricted to AUTHORIZE_ACTOR, non-admin (scope != 0), expiring
+    ///          (expiry != 0), insert-only actors — an unordered channel for installing agent-key fleets.
+    ///      `installEpoch` is never a caller input: it is stamped from the epoch bound in the digest (the sequence),
+    ///      never the live epoch at apply time, so a `[bump, replay]` cannot resurrect a change at a fresh generation.
     /// @dev Reverts with AccountIsLocked when the account is locked.
     /// @dev Reverts with InvalidChainId when `chainId` is neither 0 (multichain) nor the current chain.
+    /// @dev Reverts with InvalidSequence, EpochMismatch, or SequenceExhausted when `sequence` does not match the
+    ///      channel's current value / epoch or the ordered nonce is exhausted.
     /// @dev Reverts with InvalidAuthLength, InvalidSignature, AuthenticationFailed, AuthenticatorMismatch,
-    ///      ActorExpired, or DefaultEoaRevoked when `auth` fails to authenticate a live actor.
+    ///      ActorExpired, ActorEpochRevoked, or DefaultEoaRevoked when `auth` fails to authenticate a live actor.
     /// @dev Reverts with UnauthorizedActorChange when the authenticated actor is not unrestricted (scope != 0).
+    /// @dev Reverts with InvalidMaxSentinelChange when a MAX-sentinel batch carries a non-authorize change, or an
+    ///      admin/non-expiring/overwriting actor.
     /// @dev Reverts with UnknownChangeType when a change carries an unrecognized changeType.
     /// @dev Reverts with InvalidAuthenticator or InvalidPolicyData on a malformed authorize.
     /// @dev Reverts with UnknownActor when revoking an actor that is not authorized.
     ///
     /// @param account The account whose configuration is changed.
     /// @param chainId Replay domain: 0 = multichain (valid on every chain), otherwise the current chain.
+    /// @param sequence For chainId 0, the multichain counter; for the local channel, the packed epoch|nonce. A nonce
+    ///        of SEQUENCE_MASK selects the unordered, non-consuming MAX sentinel path.
     /// @param actorChanges Ordered authorize/revoke operations to apply.
     /// @param auth Authenticator(20) || authenticator-specific data authenticating an unrestricted actor.
     function applySignedActorChanges(
         address account,
         uint256 chainId,
+        uint64 sequence,
         ActorChange[] calldata actorChanges,
         bytes calldata auth
     ) external onlyUnlocked(account) {
         if (chainId != 0 && chainId != block.chainid) revert InvalidChainId();
 
-        // Increment the corresponding sequence
-        uint64 sequence =
-            chainId == 0 ? _accountState[account].multichainSequence++ : _accountState[account].localSequence++;
+        // Validate/consume the channel and resolve the epoch to stamp into every authorized actor.
+        (uint24 installEpoch, bool isMaxSentinel) = _consumeChangeSequence(account, chainId, sequence);
 
         // Compute digest and authenticate
         bytes32 digest = _computeSignedActorChangesDigest(account, chainId, sequence, actorChanges);
@@ -508,13 +593,57 @@ contract AccountConfiguration {
             if (actorChanges[i].changeType == AUTHORIZE_ACTOR) {
                 (ActorConfig memory newActorConfig, bytes memory policyData) =
                     abi.decode(actorChanges[i].data, (ActorConfig, bytes));
+                // Stamp installEpoch from the epoch bound in the digest; the caller-provided value is ignored.
+                newActorConfig.installEpoch = installEpoch;
+                if (isMaxSentinel) _requireMaxSentinelAuthorize(account, actorChanges[i].actorId, newActorConfig);
                 _authorizeActor(account, actorChanges[i].actorId, newActorConfig, policyData);
             } else if (actorChanges[i].changeType == REVOKE_ACTOR) {
+                // The MAX sentinel is an install-only channel; revokes must use the ordered/multichain path.
+                if (isMaxSentinel) revert InvalidMaxSentinelChange();
                 _revokeActor(account, actorChanges[i].actorId);
             } else {
                 revert UnknownChangeType();
             }
         }
+    }
+
+    /// @dev Validates and (for consuming paths) advances the change channel for a signed actor-change batch, returning
+    ///      the epoch to stamp into every authorized actor and whether this is the MAX sentinel (non-consuming) path.
+    ///      See {applySignedActorChanges} for the per-channel/nonce dispatch rules.
+    function _consumeChangeSequence(address account, uint256 chainId, uint64 sequence)
+        private
+        returns (uint24 installEpoch, bool isMaxSentinel)
+    {
+        AccountState storage st = _accountState[account];
+
+        // Multichain channel: a plain monotonic counter. Stamp the account's current local epoch.
+        if (chainId == 0) {
+            if (sequence != st.multichainSequence) revert InvalidSequence();
+            st.multichainSequence = sequence + 1;
+            return (_epochOf(st.localSequence), false);
+        }
+
+        // Local channel: the packed epoch|nonce word.
+        uint64 local = st.localSequence;
+        uint24 currentEpoch = _epochOf(local);
+        if (_epochOf(sequence) != currentEpoch) revert EpochMismatch();
+
+        uint64 nonce = _nonceOf(sequence);
+        if (nonce == SEQUENCE_MASK) return (currentEpoch, true); // MAX sentinel: unordered, non-consuming
+
+        // Sequenced: bind the exact current nonce and consume it, carry-guarding the ordered space away from the
+        // MAX sentinel (the nonce never reaches SEQUENCE_MASK - 1).
+        if (nonce != _nonceOf(local)) revert InvalidSequence();
+        if (nonce >= SEQUENCE_MASK - 2) revert SequenceExhausted();
+        st.localSequence = local + 1;
+        return (currentEpoch, false);
+    }
+
+    /// @dev Enforces the MAX-sentinel authorize restrictions: the actor MUST be non-admin (scope != 0), carry a
+    ///      non-zero expiry (so routine per-agent revocation stays independent of the epoch brake), and be an insert
+    ///      (MUST NOT overwrite a live actor). Reverts InvalidMaxSentinelChange otherwise.
+    function _requireMaxSentinelAuthorize(address account, bytes32 actorId, ActorConfig memory config) private view {
+        if (config.scope == 0 || config.expiry == 0 || _isActor(account, actorId)) revert InvalidMaxSentinelChange();
     }
 
     // ----------------------------------------------------------------------------------------------------------------
@@ -551,9 +680,13 @@ contract AccountConfiguration {
     ///        max uint16, ~18 hours); MUST be 0 for the unlock op.
     /// @param auth Authenticator(20) || authenticator-specific data authenticating an unrestricted actor.
     function applySignedLockChanges(address account, uint8 op, uint16 unlockDelay, bytes calldata auth) external {
-        // Local channel only: bind the digest to the current chain and consume the local sequence (post-increment,
-        // hashing the pre-increment value — identical to applySignedActorChanges so both paths share one counter).
-        uint64 sequence = _accountState[account].localSequence++;
+        // Local channel only: bind the digest to the current chain and consume the local sequence. Lock is an
+        // ordered, consuming op: it hashes the current packed epoch|nonce word and increments the nonce (leaving the
+        // epoch bits untouched). The carry guard keeps the ordered nonce clear of the MAX sentinel (and prevents any
+        // overflow into the epoch bits), mirroring the sequenced path in applySignedActorChanges.
+        uint64 sequence = _accountState[account].localSequence;
+        if (_nonceOf(sequence) >= SEQUENCE_MASK - 2) revert SequenceExhausted();
+        _accountState[account].localSequence = sequence + 1;
 
         bytes32 digest = _computeSignedLockChangesDigest(account, block.chainid, op, unlockDelay, sequence);
         (, uint16 scope,) = authenticateActor(account, digest, auth);
@@ -588,6 +721,53 @@ contract AccountConfiguration {
         } else {
             revert UnknownLockOp();
         }
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // EPOCH BUMP
+    // ----------------------------------------------------------------------------------------------------------------
+
+    /// @notice Advances the account's local-channel epoch, mass-revoking every non-admin actor authorized at the old
+    ///         epoch (their installEpoch no longer matches — see {authenticateActor}). Admin actors and the inline
+    ///         secp256k1 self are exempt, so the key needed to bump/recover always survives.
+    ///
+    /// @dev Signed, relayable, admin-authorized (scope 0). The digest binds `block.chainid` and `epoch`; the contract
+    ///      requires `epoch == _epochOf(localSequence)` (the current epoch) and `epoch < type(uint24).max`. On success
+    ///      it sets `localSequence = (epoch + 1) << EPOCH_SHIFT` — advancing the epoch and resetting the nonce to 0 —
+    ///      and emits EpochBumped. The bump is epoch-bound (never nonce-bound), so it never races a pending admin
+    ///      change for a nonce slot, and self-invalidating: a replay binding `epoch` fails once the epoch is `epoch+1`.
+    ///      It consumes no nonce and, unlike the other config paths, is NOT gated by lock: a bump can only remove
+    ///      authority, and refusing it while locked would create a brick path. In one operation it kills every pending
+    ///      local signed change (sequenced and MAX sentinel — their bound epoch is now stale) and revokes every
+    ///      non-admin actor at the old epoch, instantly at authentication, node-filterable, with no enumeration.
+    /// @dev Reverts with EpochMismatch when `epoch` is not the account's current epoch.
+    /// @dev Reverts with EpochExhausted when the epoch is already at type(uint24).max.
+    /// @dev Reverts with InvalidAuthLength, InvalidSignature, AuthenticationFailed, AuthenticatorMismatch,
+    ///      ActorExpired, or DefaultEoaRevoked when `auth` fails to authenticate a live actor.
+    /// @dev Reverts with UnauthorizedActorChange when the authenticated actor is not unrestricted (scope != 0).
+    ///
+    /// @param account The account whose epoch is advanced.
+    /// @param epoch The current epoch the signer intends to advance (bound in the digest).
+    /// @param auth Authenticator(20) || authenticator-specific data authenticating an unrestricted (admin) actor.
+    function applySignedEpochBump(address account, uint24 epoch, bytes calldata auth) external {
+        AccountState storage st = _accountState[account];
+
+        // Bind the bump to the current epoch: a stale/replayed epoch fails, and once bumped the same signature is
+        // self-invalidating (its epoch is no longer current).
+        if (epoch != _epochOf(st.localSequence)) revert EpochMismatch();
+        if (epoch >= type(uint24).max) revert EpochExhausted();
+
+        bytes32 digest = _computeEpochBumpDigest(account, block.chainid, epoch);
+        (, uint16 scope,) = authenticateActor(account, digest, auth);
+
+        // Only an unrestricted actor (scope 0, admin) may bump; admins are exempt from the epoch check, so the signer
+        // needed here always survives a prior bump.
+        if (scope != 0) revert UnauthorizedActorChange();
+
+        // Advance the epoch and reset the nonce to 0. This invalidates every pending local change (their bound
+        // epoch|nonce no longer matches) and revokes every non-admin actor stamped at the old epoch.
+        st.localSequence = uint64((uint256(epoch) + 1) << EPOCH_SHIFT);
+        emit EpochBumped(account, epoch + 1);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -707,8 +887,10 @@ contract AccountConfiguration {
         if (config.authenticator >= K1_AUTHENTICATOR) return config;
         if (actorId == bytes32(bytes20(account)) && !_isDefaultEoaRevoked(account)) {
             AccountState storage st = _accountState[account];
-            return
-                ActorConfig({authenticator: K1_AUTHENTICATOR, scope: st.defaultEOAScope, expiry: st.defaultEOAExpiry});
+            // The inline k1 self carries no install stamp (it is exempt from the epoch check); report installEpoch 0.
+            return ActorConfig({
+                authenticator: K1_AUTHENTICATOR, expiry: st.defaultEOAExpiry, installEpoch: 0, scope: st.defaultEOAScope
+            });
         }
         return config;
     }
@@ -866,8 +1048,11 @@ contract AccountConfiguration {
             // Initial actors carry scope verbatim (0x00 = unrestricted admin) and never an expiry. When
             // scope & Scopes.POLICY is set, policyData is validated by the same frozen rule as authorizeActor
             // (52 bytes). Authorizing the self-actorId as k1 writes its scope into the inline default-EOA fields.
-            ActorConfig memory config =
-                ActorConfig({authenticator: initialActors[i].authenticator, scope: initialActors[i].scope, expiry: 0});
+            // Creation/import is the bootstrap at epoch 0: initial actors are stamped installEpoch 0 (matching the
+            // localSequence epoch set to 0 on init) and never carry an expiry.
+            ActorConfig memory config = ActorConfig({
+                authenticator: initialActors[i].authenticator, expiry: 0, installEpoch: 0, scope: initialActors[i].scope
+            });
             _authorizeActor(account, initialActors[i].actorId, config, initialActors[i].policyData);
         }
     }
@@ -941,7 +1126,7 @@ contract AccountConfiguration {
     }
 
     /// @dev Emit ActorAuthorized with a tightly packed payload. The base packs to 32 bytes
-    ///      (authenticator(20) || expiry(6) || scope(2) || reserved(4 zero bytes)); the policy gate
+    ///      (authenticator(20) || expiry(6) || installEpoch(3) || scope(2) || reserved(1 zero byte)); the policy gate
     ///      (manager(20) || commitment(32), 52 bytes) is appended only when scope & Scopes.POLICY != 0.
     function _emitActorAuthorized(
         address account,
@@ -951,8 +1136,10 @@ contract AccountConfiguration {
         bytes32 commitment
     ) private {
         bytes memory actorData = (config.scope & Scopes.POLICY != 0)
-            ? abi.encodePacked(config.authenticator, config.expiry, config.scope, bytes4(0), manager, commitment)
-            : abi.encodePacked(config.authenticator, config.expiry, config.scope, bytes4(0));
+            ? abi.encodePacked(
+                config.authenticator, config.expiry, config.installEpoch, config.scope, bytes1(0), manager, commitment
+            )
+            : abi.encodePacked(config.authenticator, config.expiry, config.installEpoch, config.scope, bytes1(0));
         emit ActorAuthorized(account, actorId, actorData);
     }
 
@@ -1060,11 +1247,13 @@ contract AccountConfiguration {
     {
         bytes32[] memory actorHashes = new bytes32[](initialActors.length);
         for (uint256 i; i < initialActors.length; i++) {
-            // Hash the actor's real scope. Expiry is always 0 at import — an actor-provided expiry is never
-            // accepted here. policyData is hashed via keccak256 into the Actor struct hash. The typehash structure
-            // matches the importAccount signature payload in EIP-8130.
+            // Hash the actor's real scope. Expiry and installEpoch are always 0 at import — import is the bootstrap
+            // at epoch 0, and an actor-provided expiry/install epoch is never accepted here. policyData is hashed via
+            // keccak256 into the Actor struct hash. The typehash structure matches the importAccount payload.
             bytes32 configHash = keccak256(
-                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), initialActors[i].scope)
+                abi.encode(
+                    ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), uint24(0), initialActors[i].scope
+                )
             );
             actorHashes[i] = keccak256(
                 abi.encode(ACTOR_TYPEHASH, initialActors[i].actorId, configHash, keccak256(initialActors[i].policyData))
@@ -1129,6 +1318,12 @@ contract AccountConfiguration {
         return keccak256(abi.encode(LOCK_CHANGE_TYPEHASH, account, chainId, op, unlockDelay, sequence));
     }
 
+    /// @dev Computes the digest signed over an applySignedEpochBump call, binding it to `account`, `chainId`, and the
+    ///      epoch being advanced via EPOCH_BUMP_TYPEHASH.
+    function _computeEpochBumpDigest(address account, uint256 chainId, uint24 epoch) internal pure returns (bytes32) {
+        return keccak256(abi.encode(EPOCH_BUMP_TYPEHASH, account, chainId, epoch));
+    }
+
     // ----------------------------------------------------------------------------------------------------------------
     // AUTHENTICATION
     // ----------------------------------------------------------------------------------------------------------------
@@ -1153,7 +1348,10 @@ contract AccountConfiguration {
 
     /// @dev Resolves an explicit _actorConfig-homed actor: requires a matching authenticator and an unexpired entry,
     ///      returning its scope and policy gate target. Shared by the non-k1 (_authenticate) and k1 other-actor
-    ///      (_authenticateK1) paths. Reverts with AuthenticatorMismatch or ActorExpired.
+    ///      (_authenticateK1) paths. Non-admin actors (scope != 0) additionally fail if their installEpoch no longer
+    ///      matches the account's current local epoch (mass-revoked by an epoch bump) — one cold SLOAD paid only by
+    ///      restricted actors; admins (scope 0) skip it. Reverts with AuthenticatorMismatch, ActorExpired, or
+    ///      ActorEpochRevoked.
     function _resolveExplicitActor(address account, bytes32 actorId, address expectedAuthenticator)
         private
         view
@@ -1164,6 +1362,11 @@ contract AccountConfiguration {
         // Expiry is read from the same slot; an expired actor fails authentication. 0 = no expiry.
         if (config.expiry != 0 && block.timestamp > config.expiry) revert ActorExpired();
         scope = config.scope;
+        // Epoch check: a non-admin actor is live only while its install generation is current. Admins are exempt so
+        // the scope==0 signer needed to bump/recover always survives.
+        if (scope != 0 && config.installEpoch != _epochOf(_accountState[account].localSequence)) {
+            revert ActorEpochRevoked();
+        }
         policyTarget = _policyTargetFor(scope, actorId, account);
     }
 

--- a/test/lib/AccountConfigurationTest.sol
+++ b/test/lib/AccountConfigurationTest.sol
@@ -140,6 +140,23 @@ contract AccountConfigurationTest is Test {
         );
     }
 
+    /// @dev Relay an actor-change batch, threading the account's *current* channel sequence (multichain for
+    ///      chainId 0, otherwise the local packed epoch|nonce). Every existing test signs its digest over that same
+    ///      current sequence, so this preserves the pre-epoch call semantics (including replay: a stale `auth`
+    ///      recomputes against the advanced sequence and fails). New epoch/MAX-sentinel tests that need a specific
+    ///      sequence call {AccountConfiguration.applySignedActorChanges} directly with an explicit sequence.
+    function _applyActorChanges(
+        address account,
+        uint256 chainId,
+        AccountConfiguration.ActorChange[] memory changes,
+        bytes memory auth
+    ) internal {
+        uint64 sequence = chainId == 0
+            ? accountConfiguration.getChangeSequences(account).multichain
+            : accountConfiguration.getChangeSequences(account).local;
+        accountConfiguration.applySignedActorChanges(account, chainId, sequence, changes, auth);
+    }
+
     // ── Signed lock-change helpers ──
     //
     // Lock state changes go through applySignedLockChanges: a relayable, admin-authorized (scope 0) signed call.

--- a/test/unit/AccountConfiguration/applyAccountChange.t.sol
+++ b/test/unit/AccountConfiguration/applyAccountChange.t.sol
@@ -34,9 +34,7 @@ contract AccountLockTest is AccountConfigurationTest {
             changeType: 0x01,
             actorId: actorId,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, installEpoch: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });
@@ -50,9 +48,7 @@ contract AccountLockTest is AccountConfigurationTest {
             changeType: 0x01,
             actorId: bytes32(bytes20(newSigner)),
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: scope, expiry: 0, installEpoch: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0}),
                 bytes("")
             )
         });
@@ -259,11 +255,11 @@ contract AccountLockTest is AccountConfigurationTest {
 
         _signedLock(pk, account, delay);
 
-        (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 storedDelay) =
+        (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 storedDelay) =
             accountConfiguration.getLockStatus(account);
         assertTrue(locked);
         assertFalse(hasInitiatedUnlock);
-        assertEq(unlocksAt, type(uint40).max);
+        assertEq(unlocksAt, type(uint48).max);
         assertEq(storedDelay, delay);
         assertTrue(accountConfiguration.isLocked(account));
     }
@@ -308,11 +304,11 @@ contract AccountLockTest is AccountConfigurationTest {
 
         _signedLock(pk, account, secondDelay);
 
-        (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 storedDelay) =
+        (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 storedDelay) =
             accountConfiguration.getLockStatus(account);
         assertTrue(locked);
         assertFalse(hasInitiatedUnlock);
-        assertEq(unlocksAt, type(uint40).max);
+        assertEq(unlocksAt, type(uint48).max);
         assertEq(storedDelay, secondDelay);
     }
 
@@ -329,7 +325,7 @@ contract AccountLockTest is AccountConfigurationTest {
         vm.warp(t0);
         _signedUnlock(pk, account);
 
-        (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 storedDelay) =
+        (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 storedDelay) =
             accountConfiguration.getLockStatus(account);
         assertTrue(locked); // block.timestamp (t0) < unlocksAt (t0 + delay)
         assertTrue(hasInitiatedUnlock);
@@ -419,7 +415,7 @@ contract AccountLockTest is AccountConfigurationTest {
 
     /// @notice getLockStatus reports all-clear for a never-locked account: unlocked, not initiated, zeroed fields.
     function test_getLockStatus_success_whenNeverLocked(address account) public view {
-        (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 unlockDelay) =
+        (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 unlockDelay) =
             accountConfiguration.getLockStatus(account);
         assertFalse(locked);
         assertFalse(hasInitiatedUnlock);
@@ -450,7 +446,7 @@ contract AccountLockTest is AccountConfigurationTest {
 
         vm.warp(t0 + delay + extra); // past unlocksAt, but no onlyUnlocked call to clear it
 
-        (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 storedDelay) =
+        (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 storedDelay) =
             accountConfiguration.getLockStatus(account);
         assertFalse(locked);
         assertTrue(hasInitiatedUnlock);
@@ -495,7 +491,7 @@ contract AccountLockTest is AccountConfigurationTest {
 
         assertTrue(_isActor(account, newActorId));
         // The onlyUnlocked prelude cleared the stale unlock timestamp back to 0.
-        (,, uint40 unlocksAt,) = accountConfiguration.getLockStatus(account);
+        (,, uint48 unlocksAt,) = accountConfiguration.getLockStatus(account);
         assertEq(unlocksAt, 0);
     }
 

--- a/test/unit/AccountConfiguration/applyAccountChange.t.sol
+++ b/test/unit/AccountConfiguration/applyAccountChange.t.sol
@@ -34,7 +34,9 @@ contract AccountLockTest is AccountConfigurationTest {
             changeType: 0x01,
             actorId: actorId,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
+                AccountConfiguration.ActorConfig({
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, installEpoch: 0
+                }),
                 bytes("")
             )
         });
@@ -48,7 +50,9 @@ contract AccountLockTest is AccountConfigurationTest {
             changeType: 0x01,
             actorId: bytes32(bytes20(newSigner)),
             data: abi.encode(
-                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0}),
+                AccountConfiguration.ActorConfig({
+                    authenticator: address(k1Authenticator), scope: scope, expiry: 0, installEpoch: 0
+                }),
                 bytes("")
             )
         });
@@ -56,7 +60,7 @@ contract AccountLockTest is AccountConfigurationTest {
         uint64 seq = accountConfiguration.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, chainId, seq, changes);
         bytes memory auth = _buildK1Auth(ownerPk, digest);
-        accountConfiguration.applySignedActorChanges(account, chainId, changes, auth);
+        _applyActorChanges(account, chainId, changes, auth);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -221,7 +225,7 @@ contract AccountLockTest is AccountConfigurationTest {
         bytes memory auth = _buildK1Auth(pk, digest);
 
         vm.expectRevert(AccountConfiguration.AccountIsLocked.selector);
-        accountConfiguration.applySignedActorChanges(account, chainId, changes, auth);
+        accountConfiguration.applySignedActorChanges(account, chainId, seq, changes, auth);
     }
 
     /// @notice importAccount reverts AccountIsLocked while the target account is hard-locked.
@@ -487,7 +491,7 @@ contract AccountLockTest is AccountConfigurationTest {
         bytes32 digest = _computeActorChangeBatchDigest(account, chainId, seq, changes);
         bytes memory auth = _buildK1Auth(pk, digest);
 
-        accountConfiguration.applySignedActorChanges(account, chainId, changes, auth);
+        _applyActorChanges(account, chainId, changes, auth);
 
         assertTrue(_isActor(account, newActorId));
         // The onlyUnlocked prelude cleared the stale unlock timestamp back to 0.
@@ -522,6 +526,6 @@ contract AccountLockTest is AccountConfigurationTest {
         bytes memory auth = _buildK1Auth(pk, digest);
 
         vm.expectRevert(AccountConfiguration.AccountIsLocked.selector);
-        accountConfiguration.applySignedActorChanges(account, chainId, changes, auth);
+        accountConfiguration.applySignedActorChanges(account, chainId, seq, changes, auth);
     }
 }

--- a/test/unit/AccountConfiguration/applyKeyChange.t.sol
+++ b/test/unit/AccountConfiguration/applyKeyChange.t.sol
@@ -102,8 +102,9 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
 
         AccountConfiguration.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), 0, "");
         bytes memory auth = _authOver(account, pk, ch);
+        uint64 __seqR = accountConfiguration.getChangeSequences(account).local;
         vm.expectRevert(AccountConfiguration.AccountIsLocked.selector);
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), __seqR, ch, auth);
     }
 
     /// @notice Any authorized unrestricted actor, not only the owner, may authorize further actors.
@@ -149,8 +150,9 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
 
         AccountConfiguration.ActorChange[] memory ch = _authorizeChange(targetId, address(k1Authenticator), 0, "");
         bytes memory auth = _authOver(account, actorPk, ch);
+        uint64 __seqR = accountConfiguration.getChangeSequences(account).local;
         vm.expectRevert(AccountConfiguration.UnauthorizedActorChange.selector);
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), __seqR, ch, auth);
     }
 
     /// @notice Re-authorizing an already-configured non-self actor upserts its config in place.
@@ -200,8 +202,9 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         AccountConfiguration.ActorChange[] memory ch = new AccountConfiguration.ActorChange[](1);
         ch[0] = AccountConfiguration.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
         bytes memory auth = _authOver(account, pk, ch);
+        uint64 __seqR = accountConfiguration.getChangeSequences(account).local;
         vm.expectRevert();
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), __seqR, ch, auth);
     }
 
     /// @notice A batch signed by a key that is not an actor on the account reverts.
@@ -215,8 +218,9 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
 
         AccountConfiguration.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), 0, "");
         bytes memory badAuth = _authOver(account, wrongPk, ch);
+        uint64 __seqR = accountConfiguration.getChangeSequences(account).local;
         vm.expectRevert();
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, badAuth);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), __seqR, ch, badAuth);
     }
 
     // ── Implicit EOA (registered by default) ──
@@ -304,8 +308,9 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         AccountConfiguration.ActorChange[] memory ch =
             _authorizeChange(selfActorId, accountConfiguration.K1_AUTHENTICATOR(), 0, "");
         bytes memory auth = _authOver(eoa, eoaPk, ch);
+        uint64 __seqR = accountConfiguration.getChangeSequences(eoa).local;
         vm.expectRevert(AccountConfiguration.UnauthorizedActorChange.selector);
-        accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), ch, auth);
+        accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), __seqR, ch, auth);
     }
 
     /// @notice A never-created EOA can apply a multichain (chainId 0) actor change via its implicit self key.
@@ -317,7 +322,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         AccountConfiguration.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), 0, "");
         uint64 seq = accountConfiguration.getChangeSequences(eoa).multichain;
         bytes32 digest = _computeActorChangeBatchDigest(eoa, 0, seq, ch);
-        accountConfiguration.applySignedActorChanges(eoa, 0, ch, _buildK1Auth(eoaPk, digest));
+        _applyActorChanges(eoa, 0, ch, _buildK1Auth(eoaPk, digest));
         assertTrue(_isActor(eoa, actorId));
     }
 
@@ -463,10 +468,13 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         uint64 seq = accountConfiguration.getChangeSequences(eoa).local;
         bytes32 digest = _computeActorChangeBatchDigest(eoa, uint64(block.chainid), seq, ch);
 
+        uint64 __seqR = accountConfiguration.getChangeSequences(eoa).local;
         vm.expectRevert();
-        accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), ch, _buildK1Auth(eoaPk, digest));
+        accountConfiguration.applySignedActorChanges(
+            eoa, uint64(block.chainid), __seqR, ch, _buildK1Auth(eoaPk, digest)
+        );
 
-        accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), ch, _buildK1Auth(newPk, digest));
+        _applyActorChanges(eoa, uint64(block.chainid), ch, _buildK1Auth(newPk, digest));
         assertTrue(_isActor(eoa, targetId));
     }
 
@@ -487,8 +495,9 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
 
         AccountConfiguration.ActorChange[] memory ch = _authorizeChange(targetId, address(k1Authenticator), 0, "");
         bytes memory auth = _authOver(account, ownerPk, ch);
+        uint64 __seqR = accountConfiguration.getChangeSequences(account).local;
         vm.expectRevert();
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), __seqR, ch, auth);
     }
 
     /// @notice Revoking a non-self actor deletes its config slot.
@@ -519,8 +528,9 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             _authorizeChange(bytes32(bytes20(vm.addr(0xBEEF))), address(k1Authenticator), 0, "");
         bytes memory auth = _buildK1Auth(pk, _computeActorChangeBatchDigest(account, uint64(badChainId), 0, changes));
 
+        uint64 __seqR = accountConfiguration.getChangeSequences(account).local;
         vm.expectRevert(AccountConfiguration.InvalidChainId.selector);
-        accountConfiguration.applySignedActorChanges(account, uint64(badChainId), changes, auth);
+        accountConfiguration.applySignedActorChanges(account, uint64(badChainId), __seqR, changes, auth);
     }
 
     /// @notice Replaying an identical (changes, auth) pair fails once the sequence is consumed.
@@ -533,10 +543,11 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         AccountConfiguration.ActorChange[] memory changes = _authorizeChange(actorId, address(k1Authenticator), 0, "");
         bytes memory auth = _authOver(account, pk, changes);
 
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+        _applyActorChanges(account, uint64(block.chainid), changes, auth);
 
+        uint64 __seqR = accountConfiguration.getChangeSequences(account).local;
         vm.expectRevert();
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), __seqR, changes, auth);
     }
 
     /// @notice A changeType outside {authorize, revoke} reverts with UnknownChangeType (after the scope-0 gate).
@@ -551,8 +562,9 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         });
 
         bytes memory auth = _authOver(account, pk, changes);
+        uint64 __seqR = accountConfiguration.getChangeSequences(account).local;
         vm.expectRevert(AccountConfiguration.UnknownChangeType.selector);
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), __seqR, changes, auth);
     }
 
     /// @notice The admin gate: an authenticated actor may change actors iff its scope == 0.
@@ -580,8 +592,9 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             assertTrue(_isActor(account, targetId));
         } else {
             bytes memory auth = _authOver(account, signerPk, ch);
+            uint64 __seqR = accountConfiguration.getChangeSequences(account).local;
             vm.expectRevert(AccountConfiguration.UnauthorizedActorChange.selector);
-            accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+            accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), __seqR, ch, auth);
         }
     }
 
@@ -593,8 +606,9 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
 
         AccountConfiguration.ActorChange[] memory ch = _authorizeChange(actorId, address(0), 0, "");
         bytes memory auth = _authOver(account, pk, ch);
+        uint64 __seqR = accountConfiguration.getChangeSequences(account).local;
         vm.expectRevert(AccountConfiguration.InvalidAuthenticator.selector);
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), __seqR, ch, auth);
     }
 
     /// @notice An ungated actor (scope & SCOPE_POLICY == 0) with non-empty policyData reverts with InvalidPolicyData.
@@ -610,8 +624,9 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
 
         AccountConfiguration.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), 0, data);
         bytes memory auth = _authOver(account, pk, ch);
+        uint64 __seqR = accountConfiguration.getChangeSequences(account).local;
         vm.expectRevert(AccountConfiguration.InvalidPolicyData.selector);
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), __seqR, ch, auth);
     }
 
     /// @notice A gated actor (scope & SCOPE_POLICY) whose policyData is not exactly 52 bytes reverts.
@@ -628,8 +643,9 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         AccountConfiguration.ActorChange[] memory ch =
             _authorizeChange(actorId, address(k1Authenticator), SCOPE_POLICY, data);
         bytes memory auth = _authOver(account, pk, ch);
+        uint64 __seqR = accountConfiguration.getChangeSequences(account).local;
         vm.expectRevert(AccountConfiguration.InvalidPolicyData.selector);
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), __seqR, ch, auth);
     }
 
     /// @notice A gated actor with a zero manager and zero commitment is valid (relaxed policyData rule).
@@ -766,7 +782,8 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: actorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({authenticator: auth, scope: scope, expiry: 0}), policyData
+                AccountConfiguration.ActorConfig({authenticator: auth, scope: scope, expiry: 0, installEpoch: 0}),
+                policyData
             )
         });
     }
@@ -783,9 +800,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
 
     /// @dev Sign (with pk) and apply a batch on the local chain.
     function _signApply(address account, uint256 pk, AccountConfiguration.ActorChange[] memory changes) internal {
-        accountConfiguration.applySignedActorChanges(
-            account, uint64(block.chainid), changes, _authOver(account, pk, changes)
-        );
+        _applyActorChanges(account, uint64(block.chainid), changes, _authOver(account, pk, changes));
     }
 
     /// @dev Authorize/overwrite the EOA's own inline k1 self-actorId with the given scope, signed by the EOA key.
@@ -796,14 +811,14 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: scope, expiry: 0
+                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: scope, expiry: 0, installEpoch: 0
                 }),
                 bytes("")
             )
         });
         uint64 seq = accountConfiguration.getChangeSequences(eoa).local;
         bytes32 digest = _computeActorChangeBatchDigest(eoa, uint64(block.chainid), seq, changes);
-        accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), changes, _buildK1Auth(eoaPk, digest));
+        _applyActorChanges(eoa, uint64(block.chainid), changes, _buildK1Auth(eoaPk, digest));
     }
 
     function _authorizeActor(address account, uint256 pk, bytes32 newActorId, address authenticator) internal {
@@ -822,7 +837,10 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes("")
+                AccountConfiguration.ActorConfig({
+                    authenticator: authenticator, scope: scope, expiry: 0, installEpoch: 0
+                }),
+                bytes("")
             )
         });
 
@@ -830,7 +848,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
         bytes memory auth = _buildK1Auth(pk, digest);
 
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+        _applyActorChanges(account, uint64(block.chainid), changes, auth);
     }
 
     function _revokeActor(address account, uint256 pk, bytes32 actorId) internal {
@@ -841,7 +859,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
         bytes memory auth = _buildK1Auth(pk, digest);
 
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+        _applyActorChanges(account, uint64(block.chainid), changes, auth);
     }
 
     function _implicitAuthorizeActor(address account, uint256 pk, bytes32 newActorId, address authenticator) internal {
@@ -860,7 +878,10 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes("")
+                AccountConfiguration.ActorConfig({
+                    authenticator: authenticator, scope: scope, expiry: 0, installEpoch: 0
+                }),
+                bytes("")
             )
         });
 
@@ -868,7 +889,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
         bytes memory auth = _buildK1Auth(pk, digest);
 
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+        _applyActorChanges(account, uint64(block.chainid), changes, auth);
     }
 
     /// @dev Hard-lock `account` via the signed lock path, authorized by its admin owner key `pk`.

--- a/test/unit/AccountConfiguration/applyKeyChange.t.sol
+++ b/test/unit/AccountConfiguration/applyKeyChange.t.sol
@@ -553,7 +553,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
     /// @notice A changeType outside {authorize, revoke} reverts with UnknownChangeType (after the scope-0 gate).
     function test_applySignedActorChanges_revert_unknownChangeType(uint256 pk, uint8 changeType) public {
         pk = _boundK1Pk(pk);
-        vm.assume(changeType != 0x01 && changeType != 0x02);
+        vm.assume(changeType != 0x01 && changeType != 0x02 && changeType != 0x03);
         (address account,) = _createK1Account(pk);
 
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
@@ -782,8 +782,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: actorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({authenticator: auth, scope: scope, expiry: 0, installEpoch: 0}),
-                policyData
+                AccountConfiguration.ActorConfig({authenticator: auth, scope: scope, expiry: 0}), policyData
             )
         });
     }
@@ -811,7 +810,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: scope, expiry: 0, installEpoch: 0
+                    authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: scope, expiry: 0
                 }),
                 bytes("")
             )
@@ -837,10 +836,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: authenticator, scope: scope, expiry: 0, installEpoch: 0
-                }),
-                bytes("")
+                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes("")
             )
         });
 
@@ -878,10 +874,7 @@ contract ApplyConfigChangeActorTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: authenticator, scope: scope, expiry: 0, installEpoch: 0
-                }),
-                bytes("")
+                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes("")
             )
         });
 

--- a/test/unit/AccountConfiguration/authenticate.t.sol
+++ b/test/unit/AccountConfiguration/authenticate.t.sol
@@ -941,10 +941,7 @@ contract AuthenticateTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: authenticator, scope: scope, expiry: 0, installEpoch: 0
-                }),
-                bytes("")
+                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes("")
             )
         });
 
@@ -966,10 +963,7 @@ contract AuthenticateTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: authenticator, scope: 0x00, expiry: expiry, installEpoch: 0
-                }),
-                bytes("")
+                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: 0x00, expiry: expiry}), bytes("")
             )
         });
 
@@ -1008,9 +1002,7 @@ contract AuthenticateTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: scope, expiry: 0, installEpoch: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0}),
                 abi.encodePacked(policyManager, commitment)
             )
         });

--- a/test/unit/AccountConfiguration/authenticate.t.sol
+++ b/test/unit/AccountConfiguration/authenticate.t.sol
@@ -941,13 +941,16 @@ contract AuthenticateTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes("")
+                AccountConfiguration.ActorConfig({
+                    authenticator: authenticator, scope: scope, expiry: 0, installEpoch: 0
+                }),
+                bytes("")
             )
         });
 
         uint64 seq = accountConfiguration.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));
+        _applyActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));
     }
 
     /// @dev Authorize `newActorId` under `authenticator` with the given `expiry` (scope 0, no policy), signed by `pk`.
@@ -963,13 +966,16 @@ contract AuthenticateTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: 0x00, expiry: expiry}), bytes("")
+                AccountConfiguration.ActorConfig({
+                    authenticator: authenticator, scope: 0x00, expiry: expiry, installEpoch: 0
+                }),
+                bytes("")
             )
         });
 
         uint64 seq = accountConfiguration.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));
+        _applyActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));
     }
 
     /// @dev Authorize `newActorId` under `authenticator` as an unrestricted owner (scope 0), signed by `pk`.
@@ -984,7 +990,7 @@ contract AuthenticateTest is AccountConfigurationTest {
 
         uint64 seq = accountConfiguration.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));
+        _applyActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));
     }
 
     /// @dev Authorize a K1 policy-gated actor: manager[20] || commitment[32] policy data, signed by the owner `pk`.
@@ -1002,15 +1008,15 @@ contract AuthenticateTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0}),
+                AccountConfiguration.ActorConfig({
+                    authenticator: address(k1Authenticator), scope: scope, expiry: 0, installEpoch: 0
+                }),
                 abi.encodePacked(policyManager, commitment)
             )
         });
 
         uint64 seq = accountConfiguration.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        accountConfiguration.applySignedActorChanges(
-            account, uint64(block.chainid), changes, _buildK1Auth(ownerPk, digest)
-        );
+        _applyActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(ownerPk, digest));
     }
 }

--- a/test/unit/AccountConfiguration/createAccount.t.sol
+++ b/test/unit/AccountConfiguration/createAccount.t.sol
@@ -268,7 +268,7 @@ contract CreateAccountTest is AccountConfigurationTest {
         assertEq(accountConfiguration.getChangeSequences(account).local, 1);
         assertEq(accountConfiguration.getChangeSequences(account).multichain, 0);
 
-        (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 unlockDelay) =
+        (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 unlockDelay) =
             accountConfiguration.getLockStatus(account);
         assertFalse(locked);
         assertFalse(hasInitiatedUnlock);

--- a/test/unit/AccountConfiguration/epoch.t.sol
+++ b/test/unit/AccountConfiguration/epoch.t.sol
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AccountConfiguration} from "../../../src/AccountConfiguration.sol";
+import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
+import {Scopes} from "../../../src/libraries/Scopes.sol";
+
+/// @notice Local-channel epoch expiration: the epoch bump, the MAX-sentinel install channel, and the
+///         non-admin actor epoch check at authentication.
+contract EpochTest is AccountConfigurationTest {
+    bytes32 constant EPOCH_BUMP_TYPEHASH = keccak256("SignedEpochBump(address account,uint256 chainId,uint24 epoch)");
+
+    // ── Helpers ──
+
+    /// @dev Admin-signed sequenced authorize of a scoped, optionally-expiring actor (installEpoch stamped from the
+    ///      current epoch bound in the sequence).
+    function _authorizeScoped(address account, uint256 adminPk, bytes32 actorId, uint16 scope, uint48 expiry) internal {
+        AccountConfiguration.ActorChange[] memory ch = _scopedAuthorizeChange(actorId, scope, expiry);
+        uint64 seq = accountConfiguration.getChangeSequences(account).local;
+        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, ch);
+        accountConfiguration.applySignedActorChanges(
+            account, uint64(block.chainid), seq, ch, _buildK1Auth(adminPk, digest)
+        );
+    }
+
+    function _scopedAuthorizeChange(bytes32 actorId, uint16 scope, uint48 expiry)
+        internal
+        view
+        returns (AccountConfiguration.ActorChange[] memory ch)
+    {
+        ch = new AccountConfiguration.ActorChange[](1);
+        ch[0] = AccountConfiguration.ActorChange({
+            actorId: actorId,
+            changeType: 0x01,
+            data: abi.encode(
+                AccountConfiguration.ActorConfig({
+                    authenticator: address(k1Authenticator), expiry: expiry, installEpoch: 0, scope: scope
+                }),
+                bytes("")
+            )
+        });
+    }
+
+    /// @dev The MAX-sentinel local sequence for `epoch`: epoch bits set, nonce == SEQUENCE_MASK (unordered channel).
+    function _maxSentinelSeq(uint24 epoch) internal view returns (uint64) {
+        return (uint64(epoch) << uint64(accountConfiguration.EPOCH_SHIFT())) | accountConfiguration.SEQUENCE_MASK();
+    }
+
+    function _installViaMaxSentinel(address account, uint256 adminPk, bytes32 actorId, uint16 scope, uint48 expiry)
+        internal
+    {
+        AccountConfiguration.ActorChange[] memory ch = _scopedAuthorizeChange(actorId, scope, expiry);
+        uint24 epoch = uint24(accountConfiguration.getChangeSequences(account).local >> 40);
+        uint64 seq = _maxSentinelSeq(epoch);
+        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, ch);
+        accountConfiguration.applySignedActorChanges(
+            account, uint64(block.chainid), seq, ch, _buildK1Auth(adminPk, digest)
+        );
+    }
+
+    function _bump(address account, uint256 adminPk, uint24 epoch) internal {
+        bytes32 digest = keccak256(abi.encode(EPOCH_BUMP_TYPEHASH, account, block.chainid, epoch));
+        accountConfiguration.applySignedEpochBump(account, epoch, _buildK1Auth(adminPk, digest));
+    }
+
+    // ── Actor epoch check ──
+
+    /// @notice A non-admin actor authorized at epoch 0 stops authenticating after a bump (ActorEpochRevoked), while
+    ///         the admin owner keeps authenticating (admins are exempt from the epoch check).
+    function test_epochBump_revokesNonAdminActor_adminSurvives(uint256 ownerPk, uint256 actorPk, bytes32 hash) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        actorPk = _boundK1Pk(actorPk);
+        vm.assume(ownerPk != actorPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        _authorizeScoped(account, ownerPk, actorId, Scopes.SENDER, 0);
+
+        // Live before the bump.
+        (, uint16 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        assertEq(scope, Scopes.SENDER);
+
+        _bump(account, ownerPk, 0);
+
+        // The non-admin actor is now epoch-revoked; the admin still authenticates.
+        vm.expectRevert(AccountConfiguration.ActorEpochRevoked.selector);
+        accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+
+        (, uint16 ownerScope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(ownerPk, hash));
+        assertEq(ownerScope, 0);
+    }
+
+    /// @notice A non-admin actor authorized after the bump is stamped at the new epoch and authenticates.
+    function test_epochBump_actorAuthorizedAtNewEpoch_isLive(uint256 ownerPk, uint256 actorPk, bytes32 hash) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        actorPk = _boundK1Pk(actorPk);
+        vm.assume(ownerPk != actorPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        _bump(account, ownerPk, 0);
+        _authorizeScoped(account, ownerPk, actorId, Scopes.SENDER, 0);
+
+        (, uint16 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        assertEq(scope, Scopes.SENDER);
+
+        AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, actorId);
+        assertEq(cfg.installEpoch, 1);
+    }
+
+    /// @notice The inline secp256k1 self is exempt from the epoch check even when scoped (it carries no stamp), so a
+    ///         bump driven by a separate admin does not revoke a scoped inline self.
+    function test_epochBump_inlineScopedSelf_exempt(uint256 eoaPk, uint256 adminPk, bytes32 hash) public {
+        eoaPk = _boundK1Pk(eoaPk);
+        adminPk = _boundK1Pk(adminPk);
+        vm.assume(eoaPk != adminPk);
+        address eoa = vm.addr(eoaPk);
+        bytes32 selfActorId = bytes32(bytes20(eoa));
+        bytes32 adminId = bytes32(bytes20(vm.addr(adminPk)));
+        vm.assume(adminId != selfActorId);
+
+        // A separate k1 admin (signed by the implicit self), then scope the inline self down to SENDER.
+        _authorizeScoped(eoa, eoaPk, adminId, 0, 0);
+        _authorizeScoped(eoa, eoaPk, selfActorId, Scopes.SENDER, 0);
+
+        // Bump via the separate admin. A stamped non-admin actor at epoch 0 would die; the inline self is exempt.
+        _bump(eoa, adminPk, 0);
+
+        (, uint16 scope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        assertEq(scope, Scopes.SENDER);
+    }
+
+    // ── applySignedEpochBump ──
+
+    /// @notice A successful bump advances the epoch, resets the nonce to 0, and emits EpochBumped.
+    function test_epochBump_success_advancesEpochResetsNonce(uint256 ownerPk) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        (address account,) = _createK1Account(ownerPk);
+
+        // Consume a couple of nonces so the reset is observable.
+        _authorizeScoped(account, ownerPk, bytes32(uint256(0xA11CE)), Scopes.SENDER, 0);
+        assertEq(accountConfiguration.getChangeSequences(account).local & accountConfiguration.SEQUENCE_MASK(), 2);
+
+        vm.expectEmit(true, false, false, true);
+        emit AccountConfiguration.EpochBumped(account, 1);
+        _bump(account, ownerPk, 0);
+
+        uint64 local = accountConfiguration.getChangeSequences(account).local;
+        assertEq(local >> 40, 1); // epoch advanced
+        assertEq(local & accountConfiguration.SEQUENCE_MASK(), 0); // nonce reset
+    }
+
+    /// @notice A bump bound to a stale epoch reverts EpochMismatch, and a replay of a valid bump self-invalidates.
+    function test_epochBump_revert_staleEpoch_andReplay(uint256 ownerPk) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        (address account,) = _createK1Account(ownerPk);
+
+        // Wrong epoch up front.
+        bytes32 wrongDigest = keccak256(abi.encode(EPOCH_BUMP_TYPEHASH, account, block.chainid, uint24(5)));
+        vm.expectRevert(AccountConfiguration.EpochMismatch.selector);
+        accountConfiguration.applySignedEpochBump(account, 5, _buildK1Auth(ownerPk, wrongDigest));
+
+        // Valid bump, then replay of the same (epoch 0) signature fails once the epoch is 1.
+        bytes32 digest = keccak256(abi.encode(EPOCH_BUMP_TYPEHASH, account, block.chainid, uint24(0)));
+        bytes memory auth = _buildK1Auth(ownerPk, digest);
+        accountConfiguration.applySignedEpochBump(account, 0, auth);
+
+        vm.expectRevert(AccountConfiguration.EpochMismatch.selector);
+        accountConfiguration.applySignedEpochBump(account, 0, auth);
+    }
+
+    /// @notice Only an admin (scope 0) may bump; a non-admin signer reverts UnauthorizedActorChange.
+    function test_epochBump_revert_nonAdminSigner(uint256 ownerPk, uint256 actorPk) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        actorPk = _boundK1Pk(actorPk);
+        vm.assume(ownerPk != actorPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        _authorizeScoped(account, ownerPk, actorId, Scopes.SENDER, 0);
+
+        bytes32 digest = keccak256(abi.encode(EPOCH_BUMP_TYPEHASH, account, block.chainid, uint24(0)));
+        vm.expectRevert(AccountConfiguration.UnauthorizedActorChange.selector);
+        accountConfiguration.applySignedEpochBump(account, 0, _buildK1Auth(actorPk, digest));
+    }
+
+    /// @notice The bump is not gated by lock: it can only remove authority, so it succeeds while the account is locked.
+    function test_epochBump_success_whileLocked(uint256 ownerPk) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        (address account,) = _createK1Account(ownerPk);
+
+        _signedLock(ownerPk, account, 3600);
+        assertTrue(accountConfiguration.isLocked(account));
+
+        _bump(account, ownerPk, 0);
+        assertEq(accountConfiguration.getChangeSequences(account).local >> 40, 1);
+    }
+
+    // ── MAX-sentinel install channel ──
+
+    /// @notice The MAX sentinel installs a scoped, expiring actor without consuming the ordered nonce.
+    function test_maxSentinel_success_installsWithoutConsumingNonce(uint256 ownerPk, uint256 actorPk, bytes32 hash)
+        public
+    {
+        ownerPk = _boundK1Pk(ownerPk);
+        actorPk = _boundK1Pk(actorPk);
+        vm.assume(ownerPk != actorPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        uint64 nonceBefore =
+            accountConfiguration.getChangeSequences(account).local & accountConfiguration.SEQUENCE_MASK();
+        _installViaMaxSentinel(account, ownerPk, actorId, Scopes.SENDER, uint48(block.timestamp + 1 days));
+        uint64 nonceAfter =
+            accountConfiguration.getChangeSequences(account).local & accountConfiguration.SEQUENCE_MASK();
+        assertEq(nonceAfter, nonceBefore); // non-consuming
+
+        (, uint16 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        assertEq(scope, Scopes.SENDER);
+    }
+
+    /// @notice The MAX sentinel is insert-only: it cannot overwrite a live actor.
+    function test_maxSentinel_revert_overwriteExisting(uint256 ownerPk, uint256 actorPk) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        actorPk = _boundK1Pk(actorPk);
+        vm.assume(ownerPk != actorPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        _installViaMaxSentinel(account, ownerPk, actorId, Scopes.SENDER, uint48(block.timestamp + 1 days));
+
+        AccountConfiguration.ActorChange[] memory ch =
+            _scopedAuthorizeChange(actorId, Scopes.SENDER, uint48(block.timestamp + 2 days));
+        uint64 seq = _maxSentinelSeq(0);
+        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, ch);
+        bytes memory auth = _buildK1Auth(ownerPk, digest);
+        vm.expectRevert(AccountConfiguration.InvalidMaxSentinelChange.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), seq, ch, auth);
+    }
+
+    /// @notice The MAX sentinel rejects an admin (scope 0) actor: it is a non-admin-only install channel.
+    function test_maxSentinel_revert_adminActor(uint256 ownerPk, bytes32 actorId) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        AccountConfiguration.ActorChange[] memory ch =
+            _scopedAuthorizeChange(actorId, 0, uint48(block.timestamp + 1 days));
+        uint64 seq = _maxSentinelSeq(0);
+        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, ch);
+        bytes memory auth = _buildK1Auth(ownerPk, digest);
+        vm.expectRevert(AccountConfiguration.InvalidMaxSentinelChange.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), seq, ch, auth);
+    }
+
+    /// @notice The MAX sentinel rejects a non-expiring actor (expiry == 0): durable revocation must stay independent.
+    function test_maxSentinel_revert_nonExpiringActor(uint256 ownerPk, bytes32 actorId) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        AccountConfiguration.ActorChange[] memory ch = _scopedAuthorizeChange(actorId, Scopes.SENDER, 0);
+        uint64 seq = _maxSentinelSeq(0);
+        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, ch);
+        bytes memory auth = _buildK1Auth(ownerPk, digest);
+        vm.expectRevert(AccountConfiguration.InvalidMaxSentinelChange.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), seq, ch, auth);
+    }
+
+    /// @notice The MAX sentinel rejects a revoke: it is an install-only channel.
+    function test_maxSentinel_revert_revokeChange(uint256 ownerPk, uint256 actorPk) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        actorPk = _boundK1Pk(actorPk);
+        vm.assume(ownerPk != actorPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        _authorizeScoped(account, ownerPk, actorId, Scopes.SENDER, 0);
+
+        AccountConfiguration.ActorChange[] memory ch = new AccountConfiguration.ActorChange[](1);
+        ch[0] = AccountConfiguration.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
+        uint64 seq = _maxSentinelSeq(0);
+        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, ch);
+        bytes memory auth = _buildK1Auth(ownerPk, digest);
+        vm.expectRevert(AccountConfiguration.InvalidMaxSentinelChange.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), seq, ch, auth);
+    }
+
+    /// @notice A MAX-sentinel actor is revoked by an epoch bump (its installEpoch goes stale), while an ordered
+    ///         admin change still applies at the new epoch — the bump kills the pending fleet generation.
+    function test_maxSentinel_revokedByBump(uint256 ownerPk, uint256 actorPk, bytes32 hash) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        actorPk = _boundK1Pk(actorPk);
+        vm.assume(ownerPk != actorPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        _installViaMaxSentinel(account, ownerPk, actorId, Scopes.SENDER, uint48(block.timestamp + 1 days));
+        _bump(account, ownerPk, 0);
+
+        vm.expectRevert(AccountConfiguration.ActorEpochRevoked.selector);
+        accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+    }
+
+    // ── sequenced-path epoch binding ──
+
+    /// @notice A sequenced actor change bound to a stale epoch reverts EpochMismatch after a bump.
+    function test_sequenced_revert_staleEpochAfterBump(uint256 ownerPk, bytes32 actorId) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        // Pre-sign a sequenced change at epoch 0, nonce 1, then bump before relaying it.
+        AccountConfiguration.ActorChange[] memory ch = _scopedAuthorizeChange(actorId, Scopes.SENDER, 0);
+        uint64 staleSeq = accountConfiguration.getChangeSequences(account).local; // epoch 0, nonce 1
+        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), staleSeq, ch);
+        bytes memory auth = _buildK1Auth(ownerPk, digest);
+
+        _bump(account, ownerPk, 0);
+
+        vm.expectRevert(AccountConfiguration.EpochMismatch.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), staleSeq, ch, auth);
+    }
+}

--- a/test/unit/AccountConfiguration/epoch.t.sol
+++ b/test/unit/AccountConfiguration/epoch.t.sol
@@ -5,23 +5,10 @@ import {AccountConfiguration} from "../../../src/AccountConfiguration.sol";
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 import {Scopes} from "../../../src/libraries/Scopes.sol";
 
-/// @notice Local-channel epoch expiration: the epoch bump, the MAX-sentinel install channel, and the
-///         non-admin actor epoch check at authentication.
+/// @notice Local-channel epoch: the BUMP_EPOCH change type, the MAX-sentinel install channel, and the epoch's role as
+///         a replay guard for install/change *signatures* (checked at the apply path, never at authentication).
 contract EpochTest is AccountConfigurationTest {
-    bytes32 constant EPOCH_BUMP_TYPEHASH = keccak256("SignedEpochBump(address account,uint256 chainId,uint24 epoch)");
-
     // ── Helpers ──
-
-    /// @dev Admin-signed sequenced authorize of a scoped, optionally-expiring actor (installEpoch stamped from the
-    ///      current epoch bound in the sequence).
-    function _authorizeScoped(address account, uint256 adminPk, bytes32 actorId, uint16 scope, uint48 expiry) internal {
-        AccountConfiguration.ActorChange[] memory ch = _scopedAuthorizeChange(actorId, scope, expiry);
-        uint64 seq = accountConfiguration.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, ch);
-        accountConfiguration.applySignedActorChanges(
-            account, uint64(block.chainid), seq, ch, _buildK1Auth(adminPk, digest)
-        );
-    }
 
     function _scopedAuthorizeChange(bytes32 actorId, uint16 scope, uint48 expiry)
         internal
@@ -34,11 +21,15 @@ contract EpochTest is AccountConfigurationTest {
             changeType: 0x01,
             data: abi.encode(
                 AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), expiry: expiry, installEpoch: 0, scope: scope
+                    authenticator: address(k1Authenticator), expiry: expiry, scope: scope
                 }),
                 bytes("")
             )
         });
+    }
+
+    function _bumpChange() internal pure returns (AccountConfiguration.ActorChange memory) {
+        return AccountConfiguration.ActorChange({actorId: bytes32(0), changeType: 0x03, data: ""});
     }
 
     /// @dev The MAX-sentinel local sequence for `epoch`: epoch bits set, nonce == SEQUENCE_MASK (unordered channel).
@@ -46,133 +37,182 @@ contract EpochTest is AccountConfigurationTest {
         return (uint64(epoch) << uint64(accountConfiguration.EPOCH_SHIFT())) | accountConfiguration.SEQUENCE_MASK();
     }
 
-    function _installViaMaxSentinel(address account, uint256 adminPk, bytes32 actorId, uint16 scope, uint48 expiry)
+    /// @dev Sign and relay `ch` at an explicit `seq`.
+    function _applyAt(address account, uint256 adminPk, uint64 seq, AccountConfiguration.ActorChange[] memory ch)
         internal
     {
-        AccountConfiguration.ActorChange[] memory ch = _scopedAuthorizeChange(actorId, scope, expiry);
-        uint24 epoch = uint24(accountConfiguration.getChangeSequences(account).local >> 40);
-        uint64 seq = _maxSentinelSeq(epoch);
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, ch);
         accountConfiguration.applySignedActorChanges(
             account, uint64(block.chainid), seq, ch, _buildK1Auth(adminPk, digest)
         );
     }
 
-    function _bump(address account, uint256 adminPk, uint24 epoch) internal {
-        bytes32 digest = keccak256(abi.encode(EPOCH_BUMP_TYPEHASH, account, block.chainid, epoch));
-        accountConfiguration.applySignedEpochBump(account, epoch, _buildK1Auth(adminPk, digest));
+    /// @dev Admin-signed sequenced authorize at the account's current local sequence.
+    function _authorizeScoped(address account, uint256 adminPk, bytes32 actorId, uint16 scope, uint48 expiry) internal {
+        _applyAt(
+            account,
+            adminPk,
+            accountConfiguration.getChangeSequences(account).local,
+            _scopedAuthorizeChange(actorId, scope, expiry)
+        );
     }
 
-    // ── Actor epoch check ──
-
-    /// @notice A non-admin actor authorized at epoch 0 stops authenticating after a bump (ActorEpochRevoked), while
-    ///         the admin owner keeps authenticating (admins are exempt from the epoch check).
-    function test_epochBump_revokesNonAdminActor_adminSurvives(uint256 ownerPk, uint256 actorPk, bytes32 hash) public {
-        ownerPk = _boundK1Pk(ownerPk);
-        actorPk = _boundK1Pk(actorPk);
-        vm.assume(ownerPk != actorPk);
-        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
-        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
-
-        _authorizeScoped(account, ownerPk, actorId, Scopes.SENDER, 0);
-
-        // Live before the bump.
-        (, uint16 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
-        assertEq(scope, Scopes.SENDER);
-
-        _bump(account, ownerPk, 0);
-
-        // The non-admin actor is now epoch-revoked; the admin still authenticates.
-        vm.expectRevert(AccountConfiguration.ActorEpochRevoked.selector);
-        accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
-
-        (, uint16 ownerScope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(ownerPk, hash));
-        assertEq(ownerScope, 0);
+    /// @dev Admin-signed sequenced bump at the account's current local sequence.
+    function _bump(address account, uint256 adminPk) internal {
+        AccountConfiguration.ActorChange[] memory ch = new AccountConfiguration.ActorChange[](1);
+        ch[0] = _bumpChange();
+        _applyAt(account, adminPk, accountConfiguration.getChangeSequences(account).local, ch);
     }
 
-    /// @notice A non-admin actor authorized after the bump is stamped at the new epoch and authenticates.
-    function test_epochBump_actorAuthorizedAtNewEpoch_isLive(uint256 ownerPk, uint256 actorPk, bytes32 hash) public {
-        ownerPk = _boundK1Pk(ownerPk);
-        actorPk = _boundK1Pk(actorPk);
-        vm.assume(ownerPk != actorPk);
-        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
-        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
-
-        _bump(account, ownerPk, 0);
-        _authorizeScoped(account, ownerPk, actorId, Scopes.SENDER, 0);
-
-        (, uint16 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
-        assertEq(scope, Scopes.SENDER);
-
-        AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, actorId);
-        assertEq(cfg.installEpoch, 1);
+    function _epoch(address account) internal view returns (uint64) {
+        return accountConfiguration.getChangeSequences(account).local >> 40;
     }
 
-    /// @notice The inline secp256k1 self is exempt from the epoch check even when scoped (it carries no stamp), so a
-    ///         bump driven by a separate admin does not revoke a scoped inline self.
-    function test_epochBump_inlineScopedSelf_exempt(uint256 eoaPk, uint256 adminPk, bytes32 hash) public {
-        eoaPk = _boundK1Pk(eoaPk);
-        adminPk = _boundK1Pk(adminPk);
-        vm.assume(eoaPk != adminPk);
-        address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
-        bytes32 adminId = bytes32(bytes20(vm.addr(adminPk)));
-        vm.assume(adminId != selfActorId);
-
-        // A separate k1 admin (signed by the implicit self), then scope the inline self down to SENDER.
-        _authorizeScoped(eoa, eoaPk, adminId, 0, 0);
-        _authorizeScoped(eoa, eoaPk, selfActorId, Scopes.SENDER, 0);
-
-        // Bump via the separate admin. A stamped non-admin actor at epoch 0 would die; the inline self is exempt.
-        _bump(eoa, adminPk, 0);
-
-        (, uint16 scope,) = accountConfiguration.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
-        assertEq(scope, Scopes.SENDER);
+    function _nonce(address account) internal view returns (uint64) {
+        return accountConfiguration.getChangeSequences(account).local & accountConfiguration.SEQUENCE_MASK();
     }
 
-    // ── applySignedEpochBump ──
+    // ── BUMP_EPOCH change type ──
 
-    /// @notice A successful bump advances the epoch, resets the nonce to 0, and emits EpochBumped.
-    function test_epochBump_success_advancesEpochResetsNonce(uint256 ownerPk) public {
+    /// @notice A BUMP_EPOCH change advances the epoch, resets the nonce to 0, and emits EpochBumped.
+    function test_bump_success_advancesEpochResetsNonce(uint256 ownerPk) public {
         ownerPk = _boundK1Pk(ownerPk);
         (address account,) = _createK1Account(ownerPk);
 
-        // Consume a couple of nonces so the reset is observable.
+        // Consume a nonce so the reset is observable.
         _authorizeScoped(account, ownerPk, bytes32(uint256(0xA11CE)), Scopes.SENDER, 0);
-        assertEq(accountConfiguration.getChangeSequences(account).local & accountConfiguration.SEQUENCE_MASK(), 2);
+        assertEq(_nonce(account), 2);
 
         vm.expectEmit(true, false, false, true);
         emit AccountConfiguration.EpochBumped(account, 1);
-        _bump(account, ownerPk, 0);
+        _bump(account, ownerPk);
 
-        uint64 local = accountConfiguration.getChangeSequences(account).local;
-        assertEq(local >> 40, 1); // epoch advanced
-        assertEq(local & accountConfiguration.SEQUENCE_MASK(), 0); // nonce reset
+        assertEq(_epoch(account), 1); // epoch advanced
+        assertEq(_nonce(account), 0); // nonce reset
     }
 
-    /// @notice A bump bound to a stale epoch reverts EpochMismatch, and a replay of a valid bump self-invalidates.
-    function test_epochBump_revert_staleEpoch_andReplay(uint256 ownerPk) public {
+    /// @notice A bump batch is single-use: a replay binds the pre-bump epoch and now fails EpochMismatch.
+    function test_bump_replay_selfInvalidates(uint256 ownerPk) public {
         ownerPk = _boundK1Pk(ownerPk);
         (address account,) = _createK1Account(ownerPk);
 
-        // Wrong epoch up front.
-        bytes32 wrongDigest = keccak256(abi.encode(EPOCH_BUMP_TYPEHASH, account, block.chainid, uint24(5)));
-        vm.expectRevert(AccountConfiguration.EpochMismatch.selector);
-        accountConfiguration.applySignedEpochBump(account, 5, _buildK1Auth(ownerPk, wrongDigest));
-
-        // Valid bump, then replay of the same (epoch 0) signature fails once the epoch is 1.
-        bytes32 digest = keccak256(abi.encode(EPOCH_BUMP_TYPEHASH, account, block.chainid, uint24(0)));
+        AccountConfiguration.ActorChange[] memory ch = new AccountConfiguration.ActorChange[](1);
+        ch[0] = _bumpChange();
+        uint64 seq = accountConfiguration.getChangeSequences(account).local; // epoch 0, nonce 1
+        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, ch);
         bytes memory auth = _buildK1Auth(ownerPk, digest);
-        accountConfiguration.applySignedEpochBump(account, 0, auth);
+
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), seq, ch, auth);
 
         vm.expectRevert(AccountConfiguration.EpochMismatch.selector);
-        accountConfiguration.applySignedEpochBump(account, 0, auth);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), seq, ch, auth);
     }
 
-    /// @notice Only an admin (scope 0) may bump; a non-admin signer reverts UnauthorizedActorChange.
-    function test_epochBump_revert_nonAdminSigner(uint256 ownerPk, uint256 actorPk) public {
+    /// @notice The epoch is never read at authentication: a live non-admin actor keeps authenticating across a bump.
+    ///         A bump cancels pending signatures, not live agents.
+    function test_bump_doesNotRevokeLiveActor(uint256 ownerPk, uint256 actorPk, bytes32 hash) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        actorPk = _boundK1Pk(actorPk);
+        vm.assume(ownerPk != actorPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        _authorizeScoped(account, ownerPk, actorId, Scopes.SENDER, 0);
+        (, uint16 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        assertEq(scope, Scopes.SENDER);
+
+        _bump(account, ownerPk);
+
+        // Still live after the bump — no auth-time epoch check.
+        (, uint16 scopeAfter,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        assertEq(scopeAfter, Scopes.SENDER);
+    }
+
+    /// @notice [REVOKE_ACTOR(x), BUMP_EPOCH] in one signed batch: x is revoked AND its install signature is
+    ///         permanently dead (a replay of the MAX-sentinel install bound to the old epoch fails EpochMismatch).
+    function test_bump_atomicRevokeAndKillInstallSignature(uint256 ownerPk, uint256 actorPk, bytes32 hash) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        actorPk = _boundK1Pk(actorPk);
+        vm.assume(ownerPk != actorPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        // Install x via the MAX sentinel at epoch 0, keeping the reusable install signature to attempt a replay later.
+        AccountConfiguration.ActorChange[] memory install =
+            _scopedAuthorizeChange(actorId, Scopes.SENDER, uint48(block.timestamp + 365 days));
+        uint64 maxSeq = _maxSentinelSeq(0);
+        bytes32 installDigest = _computeActorChangeBatchDigest(account, uint64(block.chainid), maxSeq, install);
+        bytes memory installAuth = _buildK1Auth(ownerPk, installDigest);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), maxSeq, install, installAuth);
+
+        (, uint16 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        assertEq(scope, Scopes.SENDER);
+
+        // Atomic [revoke(x), bump].
+        AccountConfiguration.ActorChange[] memory batch = new AccountConfiguration.ActorChange[](2);
+        batch[0] = AccountConfiguration.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
+        batch[1] = _bumpChange();
+        _applyAt(account, ownerPk, accountConfiguration.getChangeSequences(account).local, batch);
+
+        // x is gone.
+        assertEq(_epoch(account), 1);
+        vm.expectRevert(AccountConfiguration.AuthenticatorMismatch.selector);
+        accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+
+        // And x's original install signature can never re-install it: it binds the old epoch.
+        vm.expectRevert(AccountConfiguration.EpochMismatch.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), maxSeq, install, installAuth);
+    }
+
+    /// @notice BUMP_EPOCH rejects a non-empty data payload (InvalidBumpChange).
+    function test_bump_revert_nonEmptyData(uint256 ownerPk) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        (address account,) = _createK1Account(ownerPk);
+
+        AccountConfiguration.ActorChange[] memory ch = new AccountConfiguration.ActorChange[](1);
+        ch[0] = AccountConfiguration.ActorChange({actorId: bytes32(0), changeType: 0x03, data: hex"00"});
+        uint64 seq = accountConfiguration.getChangeSequences(account).local;
+        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, ch);
+        bytes memory auth = _buildK1Auth(ownerPk, digest);
+
+        vm.expectRevert(AccountConfiguration.InvalidBumpChange.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), seq, ch, auth);
+    }
+
+    /// @notice BUMP_EPOCH is local-channel only: a multichain (chainId 0) bump reverts InvalidBumpChange.
+    function test_bump_revert_multichainChannel(uint256 ownerPk) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        (address account,) = _createK1Account(ownerPk);
+
+        AccountConfiguration.ActorChange[] memory ch = new AccountConfiguration.ActorChange[](1);
+        ch[0] = _bumpChange();
+        uint64 seq = accountConfiguration.getChangeSequences(account).multichain; // 0
+        bytes32 digest = _computeActorChangeBatchDigest(account, 0, seq, ch);
+        bytes memory auth = _buildK1Auth(ownerPk, digest);
+
+        vm.expectRevert(AccountConfiguration.InvalidBumpChange.selector);
+        accountConfiguration.applySignedActorChanges(account, 0, seq, ch, auth);
+    }
+
+    /// @notice BUMP_EPOCH is not permitted on the unordered MAX-sentinel path (InvalidMaxSentinelChange).
+    function test_bump_revert_onMaxSentinel(uint256 ownerPk) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        (address account,) = _createK1Account(ownerPk);
+
+        AccountConfiguration.ActorChange[] memory ch = new AccountConfiguration.ActorChange[](1);
+        ch[0] = _bumpChange();
+        uint64 seq = _maxSentinelSeq(0);
+        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, ch);
+        bytes memory auth = _buildK1Auth(ownerPk, digest);
+
+        vm.expectRevert(AccountConfiguration.InvalidMaxSentinelChange.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), seq, ch, auth);
+    }
+
+    /// @notice Only an admin (scope 0) may apply a batch containing a bump; a non-admin signer reverts.
+    function test_bump_revert_nonAdminSigner(uint256 ownerPk, uint256 actorPk) public {
         ownerPk = _boundK1Pk(ownerPk);
         actorPk = _boundK1Pk(actorPk);
         vm.assume(ownerPk != actorPk);
@@ -182,21 +222,78 @@ contract EpochTest is AccountConfigurationTest {
 
         _authorizeScoped(account, ownerPk, actorId, Scopes.SENDER, 0);
 
-        bytes32 digest = keccak256(abi.encode(EPOCH_BUMP_TYPEHASH, account, block.chainid, uint24(0)));
+        AccountConfiguration.ActorChange[] memory ch = new AccountConfiguration.ActorChange[](1);
+        ch[0] = _bumpChange();
+        uint64 seq = accountConfiguration.getChangeSequences(account).local;
+        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, ch);
+        bytes memory auth = _buildK1Auth(actorPk, digest);
+
         vm.expectRevert(AccountConfiguration.UnauthorizedActorChange.selector);
-        accountConfiguration.applySignedEpochBump(account, 0, _buildK1Auth(actorPk, digest));
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), seq, ch, auth);
     }
 
-    /// @notice The bump is not gated by lock: it can only remove authority, so it succeeds while the account is locked.
-    function test_epochBump_success_whileLocked(uint256 ownerPk) public {
+    /// @notice A bump rides the ordered channel, so it obeys the lock: it is rejected while the account is locked.
+    function test_bump_revert_whileLocked(uint256 ownerPk) public {
         ownerPk = _boundK1Pk(ownerPk);
         (address account,) = _createK1Account(ownerPk);
 
         _signedLock(ownerPk, account, 3600);
         assertTrue(accountConfiguration.isLocked(account));
 
-        _bump(account, ownerPk, 0);
-        assertEq(accountConfiguration.getChangeSequences(account).local >> 40, 1);
+        AccountConfiguration.ActorChange[] memory ch = new AccountConfiguration.ActorChange[](1);
+        ch[0] = _bumpChange();
+        uint64 seq = accountConfiguration.getChangeSequences(account).local;
+        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, ch);
+        bytes memory auth = _buildK1Auth(ownerPk, digest);
+
+        vm.expectRevert(AccountConfiguration.AccountIsLocked.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), seq, ch, auth);
+    }
+
+    /// @notice A bump reverts EpochExhausted once the local epoch is already at type(uint24).max.
+    function test_bump_revert_epochExhausted(uint256 ownerPk) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        (address account,) = _createK1Account(ownerPk);
+
+        // Force the local epoch to its maximum via direct storage write, preserving the nonce. _accountState is the
+        // 4th declared mapping (slot 3); the whole AccountState struct packs into one slot, with localSequence at
+        // bits [64:128).
+        bytes32 slot = keccak256(abi.encode(account, uint256(3)));
+        uint256 packed = uint256(vm.load(address(accountConfiguration), slot));
+        uint64 nonce = uint64(packed >> 64) & accountConfiguration.SEQUENCE_MASK();
+        uint64 newLocal = (uint64(type(uint24).max) << 40) | nonce;
+        packed = (packed & ~(uint256(type(uint64).max) << 64)) | (uint256(newLocal) << 64);
+        vm.store(address(accountConfiguration), slot, bytes32(packed));
+        assertEq(_epoch(account), type(uint24).max);
+
+        AccountConfiguration.ActorChange[] memory ch = new AccountConfiguration.ActorChange[](1);
+        ch[0] = _bumpChange();
+        uint64 seq = accountConfiguration.getChangeSequences(account).local;
+        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, ch);
+        bytes memory auth = _buildK1Auth(ownerPk, digest);
+
+        vm.expectRevert(AccountConfiguration.EpochExhausted.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), seq, ch, auth);
+    }
+
+    // ── Sequenced-path epoch binding ──
+
+    /// @notice A sequenced actor change bound to a stale epoch reverts EpochMismatch after a bump.
+    function test_sequenced_revert_staleEpochAfterBump(uint256 ownerPk, bytes32 actorId) public {
+        ownerPk = _boundK1Pk(ownerPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        // Pre-sign a sequenced change at epoch 0, nonce 1, then bump before relaying it.
+        AccountConfiguration.ActorChange[] memory ch = _scopedAuthorizeChange(actorId, Scopes.SENDER, 0);
+        uint64 staleSeq = accountConfiguration.getChangeSequences(account).local; // epoch 0, nonce 1
+        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), staleSeq, ch);
+        bytes memory auth = _buildK1Auth(ownerPk, digest);
+
+        _bump(account, ownerPk);
+
+        vm.expectRevert(AccountConfiguration.EpochMismatch.selector);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), staleSeq, ch, auth);
     }
 
     // ── MAX-sentinel install channel ──
@@ -212,12 +309,11 @@ contract EpochTest is AccountConfigurationTest {
         bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
         vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
 
-        uint64 nonceBefore =
-            accountConfiguration.getChangeSequences(account).local & accountConfiguration.SEQUENCE_MASK();
-        _installViaMaxSentinel(account, ownerPk, actorId, Scopes.SENDER, uint48(block.timestamp + 1 days));
-        uint64 nonceAfter =
-            accountConfiguration.getChangeSequences(account).local & accountConfiguration.SEQUENCE_MASK();
-        assertEq(nonceAfter, nonceBefore); // non-consuming
+        uint64 nonceBefore = _nonce(account);
+        AccountConfiguration.ActorChange[] memory ch =
+            _scopedAuthorizeChange(actorId, Scopes.SENDER, uint48(block.timestamp + 1 days));
+        _applyAt(account, ownerPk, _maxSentinelSeq(0), ch);
+        assertEq(_nonce(account), nonceBefore); // non-consuming
 
         (, uint16 scope,) = accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(scope, Scopes.SENDER);
@@ -232,7 +328,12 @@ contract EpochTest is AccountConfigurationTest {
         bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
         vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
 
-        _installViaMaxSentinel(account, ownerPk, actorId, Scopes.SENDER, uint48(block.timestamp + 1 days));
+        _applyAt(
+            account,
+            ownerPk,
+            _maxSentinelSeq(0),
+            _scopedAuthorizeChange(actorId, Scopes.SENDER, uint48(block.timestamp + 1 days))
+        );
 
         AccountConfiguration.ActorChange[] memory ch =
             _scopedAuthorizeChange(actorId, Scopes.SENDER, uint48(block.timestamp + 2 days));
@@ -258,7 +359,8 @@ contract EpochTest is AccountConfigurationTest {
         accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), seq, ch, auth);
     }
 
-    /// @notice The MAX sentinel rejects a non-expiring actor (expiry == 0): durable revocation must stay independent.
+    /// @notice The MAX sentinel rejects a non-expiring actor (expiry == 0): durable revocation must stay independent
+    ///         of the epoch brake, so a perpetual MAX install is disallowed.
     function test_maxSentinel_revert_nonExpiringActor(uint256 ownerPk, bytes32 actorId) public {
         ownerPk = _boundK1Pk(ownerPk);
         (address account, bytes32 ownerId) = _createK1Account(ownerPk);
@@ -292,9 +394,9 @@ contract EpochTest is AccountConfigurationTest {
         accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), seq, ch, auth);
     }
 
-    /// @notice A MAX-sentinel actor is revoked by an epoch bump (its installEpoch goes stale), while an ordered
-    ///         admin change still applies at the new epoch — the bump kills the pending fleet generation.
-    function test_maxSentinel_revokedByBump(uint256 ownerPk, uint256 actorPk, bytes32 hash) public {
+    /// @notice A MAX-sentinel install signature bound to the old epoch dies after a bump (EpochMismatch), while the
+    ///         already-installed live actor is untouched — the bump kills the pending fleet generation's signatures.
+    function test_maxSentinel_installSignatureDiesAfterBump(uint256 ownerPk, uint256 actorPk, bytes32 hash) public {
         ownerPk = _boundK1Pk(ownerPk);
         actorPk = _boundK1Pk(actorPk);
         vm.assume(ownerPk != actorPk);
@@ -302,30 +404,17 @@ contract EpochTest is AccountConfigurationTest {
         bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
         vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
 
-        _installViaMaxSentinel(account, ownerPk, actorId, Scopes.SENDER, uint48(block.timestamp + 1 days));
-        _bump(account, ownerPk, 0);
-
-        vm.expectRevert(AccountConfiguration.ActorEpochRevoked.selector);
-        accountConfiguration.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
-    }
-
-    // ── sequenced-path epoch binding ──
-
-    /// @notice A sequenced actor change bound to a stale epoch reverts EpochMismatch after a bump.
-    function test_sequenced_revert_staleEpochAfterBump(uint256 ownerPk, bytes32 actorId) public {
-        ownerPk = _boundK1Pk(ownerPk);
-        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
-
-        // Pre-sign a sequenced change at epoch 0, nonce 1, then bump before relaying it.
-        AccountConfiguration.ActorChange[] memory ch = _scopedAuthorizeChange(actorId, Scopes.SENDER, 0);
-        uint64 staleSeq = accountConfiguration.getChangeSequences(account).local; // epoch 0, nonce 1
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), staleSeq, ch);
+        // Pre-sign a MAX install at epoch 0 but do not relay it yet.
+        AccountConfiguration.ActorChange[] memory ch =
+            _scopedAuthorizeChange(actorId, Scopes.SENDER, uint48(block.timestamp + 1 days));
+        uint64 seq = _maxSentinelSeq(0);
+        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, ch);
         bytes memory auth = _buildK1Auth(ownerPk, digest);
 
-        _bump(account, ownerPk, 0);
+        _bump(account, ownerPk);
 
+        // The pre-signed install now binds a stale epoch.
         vm.expectRevert(AccountConfiguration.EpochMismatch.selector);
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), staleSeq, ch, auth);
+        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), seq, ch, auth);
     }
 }

--- a/test/unit/AccountConfiguration/importAccount.t.sol
+++ b/test/unit/AccountConfiguration/importAccount.t.sol
@@ -52,12 +52,13 @@ contract ImportAccountTest is AccountConfigurationTest {
     // retains the full Actor/ActorConfig typehash structure; for imported (always unrestricted) actors the config
     // fields are zero and policyData is empty.
     bytes32 constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
-        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
+        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint24 installEpoch,uint16 scope)"
     );
     bytes32 constant ACTOR_TYPEHASH = keccak256(
-        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
+        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint24 installEpoch,uint16 scope)"
     );
-    bytes32 constant ACTORCONFIG_TYPEHASH = keccak256("ActorConfig(address authenticator,uint48 expiry,uint16 scope)");
+    bytes32 constant ACTORCONFIG_TYPEHASH =
+        keccak256("ActorConfig(address authenticator,uint48 expiry,uint24 installEpoch,uint16 scope)");
 
     // ── digest helpers ──
 
@@ -79,7 +80,9 @@ contract ImportAccountTest is AccountConfigurationTest {
         for (uint256 i; i < initialActors.length; i++) {
             // Hash the actor's real scope; expiry is always 0 at import. policyData is hashed into the Actor hash.
             bytes32 configHash = keccak256(
-                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), initialActors[i].scope)
+                abi.encode(
+                    ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), uint24(0), initialActors[i].scope
+                )
             );
             actorHashes[i] = keccak256(
                 abi.encode(ACTOR_TYPEHASH, initialActors[i].actorId, configHash, keccak256(initialActors[i].policyData))
@@ -225,13 +228,15 @@ contract ImportAccountTest is AccountConfigurationTest {
             actorId: bytes32(bytes20(device)),
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
+                AccountConfiguration.ActorConfig({
+                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, installEpoch: 0
+                }),
                 bytes("")
             )
         });
         uint64 seq = accountConfiguration.getChangeSequences(eoa).multichain;
         bytes32 changeDigest = _computeActorChangeBatchDigest(eoa, 0, seq, changes);
-        accountConfiguration.applySignedActorChanges(eoa, 0, changes, _buildK1Auth(eoaPk, changeDigest));
+        _applyActorChanges(eoa, 0, changes, _buildK1Auth(eoaPk, changeDigest));
 
         // Multichain channel advanced; local channel untouched.
         assertEq(accountConfiguration.getChangeSequences(eoa).multichain, 1);

--- a/test/unit/AccountConfiguration/importAccount.t.sol
+++ b/test/unit/AccountConfiguration/importAccount.t.sol
@@ -52,13 +52,12 @@ contract ImportAccountTest is AccountConfigurationTest {
     // retains the full Actor/ActorConfig typehash structure; for imported (always unrestricted) actors the config
     // fields are zero and policyData is empty.
     bytes32 constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
-        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint24 installEpoch,uint16 scope)"
+        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
     );
     bytes32 constant ACTOR_TYPEHASH = keccak256(
-        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint24 installEpoch,uint16 scope)"
+        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
     );
-    bytes32 constant ACTORCONFIG_TYPEHASH =
-        keccak256("ActorConfig(address authenticator,uint48 expiry,uint24 installEpoch,uint16 scope)");
+    bytes32 constant ACTORCONFIG_TYPEHASH = keccak256("ActorConfig(address authenticator,uint48 expiry,uint16 scope)");
 
     // ── digest helpers ──
 
@@ -80,9 +79,7 @@ contract ImportAccountTest is AccountConfigurationTest {
         for (uint256 i; i < initialActors.length; i++) {
             // Hash the actor's real scope; expiry is always 0 at import. policyData is hashed into the Actor hash.
             bytes32 configHash = keccak256(
-                abi.encode(
-                    ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), uint24(0), initialActors[i].scope
-                )
+                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), initialActors[i].scope)
             );
             actorHashes[i] = keccak256(
                 abi.encode(ACTOR_TYPEHASH, initialActors[i].actorId, configHash, keccak256(initialActors[i].policyData))
@@ -150,7 +147,7 @@ contract ImportAccountTest is AccountConfigurationTest {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     /// @notice Verifies importAccount reverts when the account is hard-locked (onlyUnlocked runs before all else).
-    /// @dev A lock op sets unlocksAt = type(uint40).max, so the account stays locked regardless of warp; any non-zero
+    /// @dev A lock op sets unlocksAt = type(uint48).max, so the account stays locked regardless of warp; any non-zero
     ///      unlock delay locks it. The onlyUnlocked modifier trips before the chainId/sequence/signature checks, so
     ///      the account is a controllable EOA (its inline default-EOA self signs the lock) and the actors/sig are
     ///      never reached.
@@ -228,9 +225,7 @@ contract ImportAccountTest is AccountConfigurationTest {
             actorId: bytes32(bytes20(device)),
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: address(k1Authenticator), scope: 0x00, expiry: 0, installEpoch: 0
-                }),
+                AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}),
                 bytes("")
             )
         });

--- a/test/unit/AccountConfiguration/policyAccessors.t.sol
+++ b/test/unit/AccountConfiguration/policyAccessors.t.sol
@@ -643,7 +643,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         bytes32 commitment
     ) internal {
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: scope, expiry: 0, installEpoch: 0
+            authenticator: address(k1Authenticator), scope: scope, expiry: 0
         });
         bytes memory policyData = abi.encodePacked(policyManager, commitment);
 
@@ -669,7 +669,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
     ) internal {
         bytes32 selfActorId = bytes32(bytes20(eoa));
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: scope, expiry: 0, installEpoch: 0
+            authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: scope, expiry: 0
         });
         bytes memory policyData = abi.encodePacked(policyManager, commitment);
 
@@ -690,10 +690,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: AUTHORIZE_ACTOR,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: authenticator, scope: 0x00, expiry: 0, installEpoch: 0
-                }),
-                bytes("")
+                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: 0x00, expiry: 0}), bytes("")
             )
         });
         uint64 seq = accountConfiguration.getChangeSequences(account).local;

--- a/test/unit/AccountConfiguration/policyAccessors.t.sol
+++ b/test/unit/AccountConfiguration/policyAccessors.t.sol
@@ -643,7 +643,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         bytes32 commitment
     ) internal {
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: scope, expiry: 0
+            authenticator: address(k1Authenticator), scope: scope, expiry: 0, installEpoch: 0
         });
         bytes memory policyData = abi.encodePacked(policyManager, commitment);
 
@@ -654,9 +654,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
 
         uint64 seq = accountConfiguration.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        accountConfiguration.applySignedActorChanges(
-            account, uint64(block.chainid), changes, _buildK1Auth(rootPk, digest)
-        );
+        _applyActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(rootPk, digest));
     }
 
     /// @dev Authorize the EOA's self-actorId as a scoped k1 actor carrying a gated policy. The EOA is not
@@ -671,7 +669,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
     ) internal {
         bytes32 selfActorId = bytes32(bytes20(eoa));
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: scope, expiry: 0
+            authenticator: accountConfiguration.K1_AUTHENTICATOR(), scope: scope, expiry: 0, installEpoch: 0
         });
         bytes memory policyData = abi.encodePacked(policyManager, commitment);
 
@@ -682,7 +680,7 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
 
         uint64 seq = accountConfiguration.getChangeSequences(eoa).local;
         bytes32 digest = _computeActorChangeBatchDigest(eoa, uint64(block.chainid), seq, changes);
-        accountConfiguration.applySignedActorChanges(eoa, uint64(block.chainid), changes, _buildK1Auth(eoaPk, digest));
+        _applyActorChanges(eoa, uint64(block.chainid), changes, _buildK1Auth(eoaPk, digest));
     }
 
     /// @dev Authorize an ungated (scope 0) actor under `authenticator`, signed by `pk`.
@@ -692,12 +690,15 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: AUTHORIZE_ACTOR,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: 0x00, expiry: 0}), bytes("")
+                AccountConfiguration.ActorConfig({
+                    authenticator: authenticator, scope: 0x00, expiry: 0, installEpoch: 0
+                }),
+                bytes("")
             )
         });
         uint64 seq = accountConfiguration.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));
+        _applyActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));
     }
 
     /// @dev Revoke `actorId` from `account`, signed by `pk`.
@@ -706,6 +707,6 @@ contract PolicyAccessorsTest is AccountConfigurationTest {
         changes[0] = AccountConfiguration.ActorChange({actorId: actorId, changeType: REVOKE_ACTOR, data: ""});
         uint64 seq = accountConfiguration.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));
+        _applyActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));
     }
 }

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -66,7 +66,10 @@ contract DefaultAccountTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes("")
+                AccountConfiguration.ActorConfig({
+                    authenticator: authenticator, scope: scope, expiry: 0, installEpoch: 0
+                }),
+                bytes("")
             )
         });
 
@@ -74,7 +77,7 @@ contract DefaultAccountTest is AccountConfigurationTest {
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
         bytes memory auth = _buildK1Auth(pk, digest);
 
-        accountConfiguration.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+        _applyActorChanges(account, uint64(block.chainid), changes, auth);
     }
 
     // ══════════════════════════════════════════════

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -66,10 +66,7 @@ contract DefaultAccountTest is AccountConfigurationTest {
             actorId: newActorId,
             changeType: 0x01,
             data: abi.encode(
-                AccountConfiguration.ActorConfig({
-                    authenticator: authenticator, scope: scope, expiry: 0, installEpoch: 0
-                }),
-                bytes("")
+                AccountConfiguration.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes("")
             )
         });
 

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -191,9 +191,8 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
     /// @dev Authorizes a new K1 actor (`newPk`) with `scope` on `account`, signed by the unrestricted
     ///      owner (`ownerPk`) via applySignedActorChanges on the local chain.
     function _authorizeScopedK1Actor(address account, uint256 ownerPk, uint256 newPk, uint8 scope) internal {
-        AccountConfiguration.ActorConfig memory config = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: scope, expiry: 0, installEpoch: 0
-        });
+        AccountConfiguration.ActorConfig memory config =
+            AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0});
 
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -191,8 +191,9 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
     /// @dev Authorizes a new K1 actor (`newPk`) with `scope` on `account`, signed by the unrestricted
     ///      owner (`ownerPk`) via applySignedActorChanges on the local chain.
     function _authorizeScopedK1Actor(address account, uint256 ownerPk, uint256 newPk, uint8 scope) internal {
-        AccountConfiguration.ActorConfig memory config =
-            AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0});
+        AccountConfiguration.ActorConfig memory config = AccountConfiguration.ActorConfig({
+            authenticator: address(k1Authenticator), scope: scope, expiry: 0, installEpoch: 0
+        });
 
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({
@@ -202,6 +203,6 @@ contract DelegateAuthenticatorTest is AccountConfigurationTest {
         uint64 chainId = uint64(block.chainid);
         uint64 sequence = accountConfiguration.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, chainId, sequence, changes);
-        accountConfiguration.applySignedActorChanges(account, chainId, changes, _buildK1Auth(ownerPk, digest));
+        _applyActorChanges(account, chainId, changes, _buildK1Auth(ownerPk, digest));
     }
 }

--- a/test/unit/examples/ExecuteAttested.t.sol
+++ b/test/unit/examples/ExecuteAttested.t.sol
@@ -350,7 +350,7 @@ contract ExecuteAttestedTest is AccountConfigurationTest {
 
     function _authorizePolicyActor(bytes32 actorId, bytes32 commitment, uint48 expiry) internal {
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: expiry, installEpoch: 0
+            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: expiry
         });
         bytes memory policyData = abi.encodePacked(address(manager), commitment);
 

--- a/test/unit/examples/ExecuteAttested.t.sol
+++ b/test/unit/examples/ExecuteAttested.t.sol
@@ -350,7 +350,7 @@ contract ExecuteAttestedTest is AccountConfigurationTest {
 
     function _authorizePolicyActor(bytes32 actorId, bytes32 commitment, uint48 expiry) internal {
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: expiry
+            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: expiry, installEpoch: 0
         });
         bytes memory policyData = abi.encodePacked(address(manager), commitment);
 
@@ -371,6 +371,6 @@ contract ExecuteAttestedTest is AccountConfigurationTest {
         uint64 chainId = uint64(block.chainid);
         uint64 sequence = accountConfiguration.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, chainId, sequence, changes);
-        accountConfiguration.applySignedActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
+        _applyActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
     }
 }

--- a/test/unit/examples/ExternalPolicyCaller.t.sol
+++ b/test/unit/examples/ExternalPolicyCaller.t.sol
@@ -332,7 +332,7 @@ contract ExternalPolicyCallerTest is AccountConfigurationTest {
 
     function _authorizeProvider(address account, address policyManager, bytes32 commitment, uint48 expiry) internal {
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: EXTERNAL_POLICY_AUTHENTICATOR, scope: SCOPE_POLICY, expiry: expiry
+            authenticator: EXTERNAL_POLICY_AUTHENTICATOR, scope: SCOPE_POLICY, expiry: expiry, installEpoch: 0
         });
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({
@@ -354,6 +354,6 @@ contract ExternalPolicyCallerTest is AccountConfigurationTest {
         uint64 chainId = uint64(block.chainid);
         uint64 sequence = accountConfiguration.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, chainId, sequence, changes);
-        accountConfiguration.applySignedActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
+        _applyActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
     }
 }

--- a/test/unit/examples/ExternalPolicyCaller.t.sol
+++ b/test/unit/examples/ExternalPolicyCaller.t.sol
@@ -332,7 +332,7 @@ contract ExternalPolicyCallerTest is AccountConfigurationTest {
 
     function _authorizeProvider(address account, address policyManager, bytes32 commitment, uint48 expiry) internal {
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: EXTERNAL_POLICY_AUTHENTICATOR, scope: SCOPE_POLICY, expiry: expiry, installEpoch: 0
+            authenticator: EXTERNAL_POLICY_AUTHENTICATOR, scope: SCOPE_POLICY, expiry: expiry
         });
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({

--- a/test/unit/examples/PolicyManager.t.sol
+++ b/test/unit/examples/PolicyManager.t.sol
@@ -300,7 +300,7 @@ contract PolicyManagerTest is AccountConfigurationTest {
 
     function _authorizePolicyActor(bytes32 actorId, bytes32 commitment, uint48 expiry) internal {
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: expiry
+            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: expiry, installEpoch: 0
         });
         bytes memory policyData = abi.encodePacked(address(manager), commitment);
 
@@ -312,7 +312,7 @@ contract PolicyManagerTest is AccountConfigurationTest {
         uint64 chainId = uint64(block.chainid);
         uint64 sequence = accountConfiguration.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, chainId, sequence, changes);
-        accountConfiguration.applySignedActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
+        _applyActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
     }
 
     function _createAttackerAccount() internal returns (address attacker, uint256 attackerOwnerPk) {
@@ -334,8 +334,9 @@ contract PolicyManagerTest is AccountConfigurationTest {
     }
 
     function _authorizePolicyActorOn(address target_, uint256 ownerPk, bytes32 actorId, bytes32 commitment) internal {
-        AccountConfiguration.ActorConfig memory cfg =
-            AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0});
+        AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
+            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0, installEpoch: 0
+        });
         bytes memory policyData = abi.encodePacked(address(manager), commitment);
 
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
@@ -346,7 +347,7 @@ contract PolicyManagerTest is AccountConfigurationTest {
         uint64 chainId = uint64(block.chainid);
         uint64 sequence = accountConfiguration.getChangeSequences(target_).local;
         bytes32 digest = _computeActorChangeBatchDigest(target_, chainId, sequence, changes);
-        accountConfiguration.applySignedActorChanges(target_, chainId, changes, _buildK1Auth(ownerPk, digest));
+        _applyActorChanges(target_, chainId, changes, _buildK1Auth(ownerPk, digest));
     }
 
     function _revokePolicyActor(bytes32 actorId) internal {
@@ -356,6 +357,6 @@ contract PolicyManagerTest is AccountConfigurationTest {
         uint64 chainId = uint64(block.chainid);
         uint64 sequence = accountConfiguration.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, chainId, sequence, changes);
-        accountConfiguration.applySignedActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
+        _applyActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
     }
 }

--- a/test/unit/examples/PolicyManager.t.sol
+++ b/test/unit/examples/PolicyManager.t.sol
@@ -300,7 +300,7 @@ contract PolicyManagerTest is AccountConfigurationTest {
 
     function _authorizePolicyActor(bytes32 actorId, bytes32 commitment, uint48 expiry) internal {
         AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: expiry, installEpoch: 0
+            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: expiry
         });
         bytes memory policyData = abi.encodePacked(address(manager), commitment);
 
@@ -334,9 +334,8 @@ contract PolicyManagerTest is AccountConfigurationTest {
     }
 
     function _authorizePolicyActorOn(address target_, uint256 ownerPk, bytes32 actorId, bytes32 commitment) internal {
-        AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0, installEpoch: 0
-        });
+        AccountConfiguration.ActorConfig memory cfg =
+            AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0});
         bytes memory policyData = abi.encodePacked(address(manager), commitment);
 
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);

--- a/test/unit/examples/SessionPolicy.t.sol
+++ b/test/unit/examples/SessionPolicy.t.sol
@@ -746,8 +746,9 @@ contract SessionPolicyTest is AccountConfigurationTest {
         });
         bytes32 commitment = manager.commitmentOf(binding);
 
-        AccountConfiguration.ActorConfig memory cfg =
-            AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0});
+        AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
+            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0, installEpoch: 0
+        });
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({
             actorId: actorId,
@@ -757,6 +758,6 @@ contract SessionPolicyTest is AccountConfigurationTest {
         uint64 chainId = uint64(block.chainid);
         uint64 sequence = accountConfiguration.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, chainId, sequence, changes);
-        accountConfiguration.applySignedActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
+        _applyActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
     }
 }

--- a/test/unit/examples/SessionPolicy.t.sol
+++ b/test/unit/examples/SessionPolicy.t.sol
@@ -746,9 +746,8 @@ contract SessionPolicyTest is AccountConfigurationTest {
         });
         bytes32 commitment = manager.commitmentOf(binding);
 
-        AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0, installEpoch: 0
-        });
+        AccountConfiguration.ActorConfig memory cfg =
+            AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0});
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({
             actorId: actorId,

--- a/test/unit/examples/SessionPolicyGas.t.sol
+++ b/test/unit/examples/SessionPolicyGas.t.sol
@@ -369,8 +369,9 @@ contract SessionPolicyGasTest is AccountConfigurationTest {
         });
         bytes32 commitment = manager.commitmentOf(binding);
 
-        AccountConfiguration.ActorConfig memory cfg =
-            AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0});
+        AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
+            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0, installEpoch: 0
+        });
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({
             actorId: actorId,
@@ -380,6 +381,6 @@ contract SessionPolicyGasTest is AccountConfigurationTest {
         uint64 chainId = uint64(block.chainid);
         uint64 sequence = accountConfiguration.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, chainId, sequence, changes);
-        accountConfiguration.applySignedActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
+        _applyActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
     }
 }

--- a/test/unit/examples/SessionPolicyGas.t.sol
+++ b/test/unit/examples/SessionPolicyGas.t.sol
@@ -369,9 +369,8 @@ contract SessionPolicyGasTest is AccountConfigurationTest {
         });
         bytes32 commitment = manager.commitmentOf(binding);
 
-        AccountConfiguration.ActorConfig memory cfg = AccountConfiguration.ActorConfig({
-            authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0, installEpoch: 0
-        });
+        AccountConfiguration.ActorConfig memory cfg =
+            AccountConfiguration.ActorConfig({authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0});
         AccountConfiguration.ActorChange[] memory changes = new AccountConfiguration.ActorChange[](1);
         changes[0] = AccountConfiguration.ActorChange({
             actorId: actorId,


### PR DESCRIPTION
Stacked on top of #48 (`refactor/scopes-lib-uint16-remove-isactor-verifysig`). Implements the contract side of [chunter-cb/EIPs#15](https://github.com/chunter-cb/EIPs/pull/15/files): an epoch-based mass-revocation system so there is no coordination issues for installations of local keys.

## Summary

- **`local_sequence` is reinterpreted as packed `epoch|nonce`** (`epoch = bits[63:40]` `uint24`, `nonce = bits[39:0]` `uint40`; `EPOCH_SHIFT = 40`, `SEQUENCE_MASK = (1<<40)-1`). No `AccountState` struct change — offset/width are unchanged, so node raw-slot lock tiering is unaffected. `multichain_sequence` stays a plain counter.
- **`ActorConfig` gains `uint24 installEpoch`** (layout `authenticator[0..19] ‖ expiry[20..25] ‖ installEpoch[26..28] ‖ scope[29..30] ‖ reserved[31]`). It is **never a caller input** on authorize: it is stamped from the epoch bound in the change's `sequence`/digest, never the live epoch, so `[bump, replay]` can't resurrect a change at a fresh generation.
- **Epoch check at authentication**: a non-admin actor (`scope != 0`) fails with `ActorEpochRevoked` once its `installEpoch != current epoch`. Admins (`scope == 0`) and the inline secp256k1 self are exempt (one cold SLOAD, paid only by restricted actors).
- **`applySignedActorChanges` takes an explicit `sequence`** and dispatches on the nonce: **sequenced** (`< SEQUENCE_MASK`; epoch+nonce must match current; consumes, carry-guarded) vs **MAX sentinel** (`== SEQUENCE_MASK`; epoch must match; non-consuming). The MAX path is restricted to `AUTHORIZE_ACTOR`, non-admin (`scope != 0`), expiring (`expiry != 0`), insert-only actors (`InvalidMaxSentinelChange`).
- **New `applySignedEpochBump(account, epoch, auth)`**: admin-authorized, relayable; requires `epoch == current epoch` and `epoch < type(uint24).max`; sets `localSequence = (epoch+1) << EPOCH_SHIFT` and emits `EpochBumped`. Epoch-bound (self-invalidating on replay), consumes no nonce, and — unlike the other config paths — is **not** gated by lock (purely destructive).
- **Ripples**: `ACTORCONFIG_/ACTOR_/ACTOR_INITIALIZATION_TYPEHASH` and import `configHash` (`installEpoch = 0` at bootstrap), `ActorAuthorized` payload (`authenticator ‖ expiry ‖ installEpoch ‖ scope ‖ reserved`), `applySignedLockChanges` carry guard, new errors (`ActorEpochRevoked`, `EpochMismatch`, `EpochExhausted`, `SequenceExhausted`, `InvalidSequence`, `InvalidMaxSentinelChange`).

## Test changes

- Migrated the suite to the explicit-`sequence` API via a base `_applyActorChanges` wrapper (threads the account's current channel sequence, preserving pre-epoch semantics including replay); revert-path call sites pre-compute the sequence before `vm.expectRevert`.
- Added `test/unit/AccountConfiguration/epoch.t.sol` (14 tests): epoch revocation of non-admin actors with admin/inline-self exemption, re-stamp at the new epoch, epoch bump success/stale/replay/non-admin/while-locked, and the MAX-sentinel channel (install-without-consume, insert-only, admin/non-expiring/revoke rejection, revoked-by-bump).

## Test plan

- [x] `forge build`
- [x] `forge test` — 349 passing (335 existing + 14 new)
- [ ] Confirm the epoch-check exemption set (admins + inline self)
- [ ] Confirm MAX-sentinel restrictions and the carry-guard boundary
- [ ] Confirm `installEpoch` stamping is digest-bound, not live
- [ ] Confirm byte layout (sums to 32) and typehash/commitment ripples

> Note: `default_eoa_scope` in the inline account-state slot stays `uint16` (from the stacked base PR), a superset of the spec PR's `uint8`; it is orthogonal to epochs (the inline self carries no stamp and is exempt).