### PR TITLE
feat: getActorConfig returns empty config for expired actors

### DIFF
--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -842,29 +842,47 @@ contract AccountConfiguration {
     // STORAGE VIEWS
     // ----------------------------------------------------------------------------------------------------------------
 
-    /// @notice Resolves the effective ActorConfig for `actorId` on `account`.
+    /// @notice Resolves the effective ActorConfig for `actorId` on `account`, or the all-zero (empty) config when the
+    ///         actor is not live.
     ///
     /// @dev With a populated _actorConfig entry, returns it verbatim (any non-self actor, or a non-k1 self). For the
     ///      self-actorId without such an entry, the k1 self lives inline in AccountState: a live one (flag unset)
     ///      reports as a native ecrecover owner carrying its inline scope/expiry (all-zero = full owner); a
     ///      disabled one, or any unknown actor, reports as the all-zero (empty) config, keeping live-vs-disabled
     ///      unambiguous without a sentinel.
+    /// @dev An *expired* actor (non-zero expiry with block.timestamp > expiry) resolves to the empty config, exactly
+    ///      as if it had never been authorized — matching authentication (which reverts ActorExpired) so liveness has
+    ///      one meaning across the read and hot paths. This makes the view a pure function of (raw storage,
+    ///      block.timestamp): an expired slot carries no live authority, so it can be reclaimed/pruned without
+    ///      changing any observable answer, and the whole accessor can migrate to a precompile that reads the raw
+    ///      account/actor storage and applies the same expiry rule.
     ///
     /// @param account The account to read.
     /// @param actorId The actor identifier to resolve.
     ///
-    /// @return The resolved actor configuration, or the all-zero config if the actor is not live.
+    /// @return The resolved actor configuration, or the all-zero config if the actor is not live (unknown, disabled,
+    ///         or expired).
     function getActorConfig(address account, bytes32 actorId) external view returns (ActorConfig memory) {
         ActorConfig memory config = _actorConfig[actorId][account];
         // Non-zero authenticator = a stored entry. Uses the same `>= K1_AUTHENTICATOR` namespace idiom as _isActor:
         // every stored authenticator is K1_AUTHENTICATOR (0x1) or a contract, so this is equivalent to != address(0).
-        if (config.authenticator >= K1_AUTHENTICATOR) return config;
+        if (config.authenticator >= K1_AUTHENTICATOR) {
+            // An expired stored actor reports as empty (as if never authorized), never its stale config.
+            if (_isExpired(config.expiry)) return _emptyActorConfig();
+            return config;
+        }
         if (actorId == bytes32(bytes20(account)) && !_isDefaultEoaRevoked(account)) {
             AccountState storage st = _accountState[account];
+            if (_isExpired(st.defaultEOAExpiry)) return _emptyActorConfig();
             return
                 ActorConfig({authenticator: K1_AUTHENTICATOR, expiry: st.defaultEOAExpiry, scope: st.defaultEOAScope});
         }
         return config;
+    }
+
+    /// @dev The all-zero ActorConfig returned for a non-live actor (unknown, disabled, or expired).
+    function _emptyActorConfig() private pure returns (ActorConfig memory) {
+        return ActorConfig({authenticator: address(0), expiry: 0, scope: 0});
     }
 
     /// @notice Resolves an actor's policy gate target (manager) and signed commitment.
@@ -1317,7 +1335,7 @@ contract AccountConfiguration {
         ActorConfig memory config = _actorConfig[actorId][account];
         if (config.authenticator != expectedAuthenticator) revert AuthenticatorMismatch();
         // Expiry is read from the same slot; an expired actor fails authentication. 0 = no expiry.
-        if (config.expiry != 0 && block.timestamp > config.expiry) revert ActorExpired();
+        if (_isExpired(config.expiry)) revert ActorExpired();
         scope = config.scope;
         policyTarget = _policyTargetFor(scope, actorId, account);
     }
@@ -1349,7 +1367,7 @@ contract AccountConfiguration {
             // inline scope/expiry govern (all-zero = full owner).
             AccountState storage st = _accountState[account];
             if (st.flags & FLAG_REVOKE_DEFAULT_EOA != 0) revert DefaultEoaRevoked();
-            if (st.defaultEOAExpiry != 0 && block.timestamp > st.defaultEOAExpiry) revert ActorExpired();
+            if (_isExpired(st.defaultEOAExpiry)) revert ActorExpired();
             bytes32 selfActorId = bytes32(bytes20(account));
             uint16 selfScope = st.defaultEOAScope;
             return (selfActorId, selfScope, _policyTargetFor(selfScope, selfActorId, account));
@@ -1363,6 +1381,12 @@ contract AccountConfiguration {
     /// @dev True if the account's default (implicit) EOA has been revoked via the AccountState flag.
     function _isDefaultEoaRevoked(address account) internal view returns (bool) {
         return _accountState[account].flags & FLAG_REVOKE_DEFAULT_EOA != 0;
+    }
+
+    /// @dev The single actor-expiry rule shared by authentication and {getActorConfig}: an actor is expired when it
+    ///      carries a non-zero `expiry` and the current block timestamp is past it. `expiry == 0` means no expiry.
+    function _isExpired(uint48 expiry) internal view returns (bool) {
+        return expiry != 0 && block.timestamp > expiry;
     }
 
     /// @dev Recovers the ECDSA signer from a 65-byte r‖s‖v signature over `hash`, enforcing EIP-2 (low-s only,

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -126,19 +126,20 @@ contract DefaultAccount is Receiver {
     //  INTERNALS
     // ══════════════════════════════════════════════
 
-    /// @dev Authorized if `caller` is the account itself, or holds the TRUSTED_EXECUTOR authenticator with an
-    ///      unexpired config AND operational (sender) authority. Expiry: 0 means none; a non-zero expiry is enforced
-    ///      so a user-set expiry is honored on the execution path. Scope: driving execution requires sender
-    ///      authority — the unrestricted admin (scope == 0x00) or an actor with Scopes.SENDER that is not gated by a
-    ///      policy (Scopes.POLICY unset). A POLICY-gated actor must route every call through its manager, so granting
-    ///      it direct executeBatch would bypass that gate; fail closed. This mirrors the operational-actor definition
-    ///      in {isValidSignature}, keeping the execution and signing authorization surfaces aligned.
+    /// @dev Authorized if `caller` is the account itself, or holds the TRUSTED_EXECUTOR authenticator AND operational
+    ///      (sender) authority. Expiry is enforced by getActorConfig, which returns the empty config (zero
+    ///      authenticator) for an expired actor — so an expired caller fails the TRUSTED_EXECUTOR check below, and a
+    ///      user-set expiry is honored on the execution path without a separate comparison here. Scope: driving
+    ///      execution requires sender authority — the unrestricted admin (scope == 0x00) or an actor with
+    ///      Scopes.SENDER that is not gated by a policy (Scopes.POLICY unset). A POLICY-gated actor must route every
+    ///      call through its manager, so granting it direct executeBatch would bypass that gate; fail closed. This
+    ///      mirrors the operational-actor definition in {isValidSignature}, keeping the execution and signing
+    ///      authorization surfaces aligned.
     function _isAuthorizedCaller(address caller) internal view virtual returns (bool) {
         if (caller == address(this)) return true;
         AccountConfiguration.ActorConfig memory config =
             ACCOUNT_CONFIGURATION.getActorConfig(address(this), bytes32(bytes20(caller)));
         if (config.authenticator != TRUSTED_EXECUTOR) return false;
-        if (config.expiry != 0 && block.timestamp > config.expiry) return false;
         uint16 scope = config.scope;
         return scope == 0 || ((scope & Scopes.SENDER != 0) && (scope & Scopes.POLICY == 0));
     }

--- a/src/policies/PolicyManager.sol
+++ b/src/policies/PolicyManager.sol
@@ -284,11 +284,14 @@ contract PolicyManager is ReentrancyGuard {
         _enforce(binding, commitment, executionData, caller);
     }
 
-    /// @dev Reject when the acting actor's stored expiry has passed. Required on the external path (no protocol
-    ///      auth); omitted on {execute}, where authentication already enforced expiry before dispatch.
+    /// @dev Reject when the acting actor's expiry has passed. Required on the external path (no protocol auth);
+    ///      omitted on {execute}, where authentication already enforced expiry before dispatch. getActorConfig
+    ///      returns the empty config (zero authenticator) for an expired actor, so an absent authenticator here means
+    ///      the actor has expired — the commitment match performed above already proved it was an authorized,
+    ///      policy-gated actor, so expiry is the only remaining reason the config would be empty.
     function _requireNotExpired(address account, bytes32 actorId) internal view {
         AccountConfiguration.ActorConfig memory config = ACCOUNT_CONFIGURATION.getActorConfig(account, actorId);
-        if (config.expiry != 0 && block.timestamp > config.expiry) revert ActorExpired(actorId);
+        if (config.authenticator == address(0)) revert ActorExpired(actorId);
     }
 
     /// @dev Common enforcement: enforce the binding's validity window (authenticated by the commitment check at the

--- a/test/unit/AccountConfiguration/authenticate.t.sol
+++ b/test/unit/AccountConfiguration/authenticate.t.sol
@@ -894,6 +894,73 @@ contract AuthenticateTest is AccountConfigurationTest {
         assertEq(cfg.scope, uint8(0x00));
     }
 
+    /// @notice getActorConfig returns the live config before expiry and the empty config once expired, for a stored
+    ///         (_actorConfig-homed) actor — as if it had never been authorized.
+    function test_getActorConfig_success_expiredStoredActorReturnsEmpty(uint256 ownerSeed, uint256 actorSeed) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 actorPk = _boundK1Pk(actorSeed);
+        vm.assume(ownerPk != actorPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        uint48 expiry = uint48(block.timestamp + 1 days);
+        _authorizeActorWithExpiry(account, ownerPk, actorId, address(k1Authenticator), expiry);
+
+        // Live before expiry.
+        AccountConfiguration.ActorConfig memory live = accountConfiguration.getActorConfig(account, actorId);
+        assertEq(live.authenticator, address(k1Authenticator));
+        assertEq(live.expiry, expiry);
+
+        // Past expiry -> empty, indistinguishable from an unknown actor.
+        vm.warp(uint256(expiry) + 1);
+        AccountConfiguration.ActorConfig memory dead = accountConfiguration.getActorConfig(account, actorId);
+        assertEq(dead.authenticator, address(0));
+        assertEq(dead.expiry, uint48(0));
+        assertEq(dead.scope, uint16(0));
+    }
+
+    /// @notice getActorConfig returns the empty config once an *inline self* (defaultEOA) config is expired, matching
+    ///         the stored-actor behavior and authentication (which reverts ActorExpired).
+    function test_getActorConfig_success_expiredInlineSelfReturnsEmpty(uint256 ownerSeed) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        (address account,) = _createK1Account(ownerPk);
+        bytes32 selfId = bytes32(bytes20(account));
+
+        // Re-enable the inline self (scope 0) with an expiry.
+        uint48 expiry = uint48(block.timestamp + 1 days);
+        _authorizeActorWithExpiry(account, ownerPk, selfId, accountConfiguration.K1_AUTHENTICATOR(), expiry);
+
+        AccountConfiguration.ActorConfig memory live = accountConfiguration.getActorConfig(account, selfId);
+        assertEq(live.authenticator, accountConfiguration.K1_AUTHENTICATOR());
+        assertEq(live.expiry, expiry);
+
+        vm.warp(uint256(expiry) + 1);
+        AccountConfiguration.ActorConfig memory dead = accountConfiguration.getActorConfig(account, selfId);
+        assertEq(dead.authenticator, address(0));
+        assertEq(dead.expiry, uint48(0));
+        assertEq(dead.scope, uint16(0));
+    }
+
+    /// @notice A non-zero expiry that is still in the future returns the live config verbatim (boundary: expiry == now
+    ///         is NOT past, so still live).
+    function test_getActorConfig_success_atExpiryBoundaryStillLive(uint256 ownerSeed, uint256 actorSeed) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 actorPk = _boundK1Pk(actorSeed);
+        vm.assume(ownerPk != actorPk);
+        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
+        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+
+        uint48 expiry = uint48(block.timestamp + 1 days);
+        _authorizeActorWithExpiry(account, ownerPk, actorId, address(k1Authenticator), expiry);
+
+        vm.warp(expiry); // exactly at expiry: block.timestamp > expiry is false
+        AccountConfiguration.ActorConfig memory cfg = accountConfiguration.getActorConfig(account, actorId);
+        assertEq(cfg.authenticator, address(k1Authenticator));
+        assertEq(cfg.expiry, expiry);
+    }
+
     /// @notice isActor reports the implicit self-actorId of a never-created EOA as live.
     /// @dev No _actorConfig entry, actorId == self, flag unset -> true.
     function test_isActor_success_implicitEoaTrue(uint256 eoaSeed) public view {


### PR DESCRIPTION
## Summary
Stacked on #49. Makes `getActorConfig` resolve an **expired** actor (non-zero `expiry`, `block.timestamp` past it) to the all-zero config — exactly as if it had never been authorized, identical to an unknown actor.

- Liveness now has **one meaning** across the read path and the hot path: `getActorConfig` returning empty lines up with authentication reverting `ActorExpired`.
- The accessor becomes a pure function of `(raw storage, block.timestamp)`: an expired slot carries no live authority, so it can be reclaimed/pruned without changing any observable answer, and the whole view can eventually migrate to a **precompile** that reads raw account/actor storage and applies the same expiry rule.

## Changes
- Extract the shared `_isExpired(expiry)` rule and use it in `getActorConfig` (both the stored `_actorConfig` home and the inline default-EOA self) and in both authentication paths (`_resolveExplicitActor`, `_authenticateK1`).
- Update consumers that previously re-read `.expiry` off `getActorConfig`:
  - `PolicyManager._requireNotExpired` now treats an absent authenticator as expired (the commitment match already proved the actor was authorized).
  - `DefaultAccount._isAuthorizedCaller` drops its now-dead expiry comparison — an expired actor already resolves to a zero authenticator, failing the `TRUSTED_EXECUTOR` check.

## Test plan
- [x] `forge build` clean
- [x] `forge test` — 355 passing (added: expired stored actor → empty, expired inline self → empty, at-expiry boundary still live)
- [ ] Confirm the empty-on-expiry semantics match the intended precompile storage-read contract