### PR TITLE
refactor: normalize policy-layer timestamps to uint48

### DIFF
--- a/src/policies/PolicyManager.sol
+++ b/src/policies/PolicyManager.sol
@@ -77,9 +77,9 @@ contract PolicyManager is ReentrancyGuard {
         /// @dev Committed, opaque policy configuration interpreted by `policy`.
         bytes policyConfig;
         /// @dev Earliest timestamp (seconds) at which execution is allowed. Zero = no lower bound.
-        uint40 validAfter;
+        uint48 validAfter;
         /// @dev Timestamp (seconds) at/after which execution is disallowed. Zero = no upper bound.
-        uint40 validUntil;
+        uint48 validUntil;
         /// @dev Salt allowing multiple distinct bindings for the same (account, policy, config).
         uint256 salt;
     }
@@ -90,7 +90,7 @@ contract PolicyManager is ReentrancyGuard {
     event ExecutionSkipped(address indexed account, address indexed policy, bytes32 indexed actorId);
 
     /// @notice The current time is outside the binding's `[validAfter, validUntil)` execution window.
-    error OutsideValidityWindow(uint40 validAfter, uint40 validUntil, uint256 timestamp);
+    error OutsideValidityWindow(uint48 validAfter, uint48 validUntil, uint256 timestamp);
     /// @notice The supplied binding does not recompute to the actor's live signed commitment.
     error BindingCommitmentMismatch(bytes32 expected, bytes32 actual);
     /// @notice {execute} requires `binding.account == msg.sender` (the protocol-dispatched account).

--- a/src/policies/RecurringAllowance.sol
+++ b/src/policies/RecurringAllowance.sol
@@ -13,19 +13,19 @@ library RecurringAllowance {
         /// @dev Maximum spend per period window.
         uint160 allowance;
         /// @dev Period length in seconds.
-        uint40 period;
+        uint48 period;
         /// @dev Start timestamp (seconds) inclusive.
-        uint40 start;
+        uint48 start;
         /// @dev End timestamp (seconds) exclusive.
-        uint40 end;
+        uint48 end;
     }
 
     /// @notice Stored usage snapshot for a particular active period.
     struct PeriodUsage {
         /// @dev Period start timestamp (seconds).
-        uint40 start;
+        uint48 start;
         /// @dev Period end timestamp (seconds).
-        uint40 end;
+        uint48 end;
         /// @dev Amount spent during the period window.
         uint160 spend;
     }
@@ -43,13 +43,13 @@ library RecurringAllowance {
     error ZeroAllowance();
 
     /// @notice Thrown when `start >= end` in the limit bounds.
-    error InvalidStartEnd(uint40 start, uint40 end);
+    error InvalidStartEnd(uint48 start, uint48 end);
 
     /// @notice Thrown when the current timestamp is before the allowance window.
-    error BeforeStart(uint40 currentTimestamp, uint40 start);
+    error BeforeStart(uint48 currentTimestamp, uint48 start);
 
     /// @notice Thrown when the current timestamp is at or past the allowance window end.
-    error AfterEnd(uint40 currentTimestamp, uint40 end);
+    error AfterEnd(uint48 currentTimestamp, uint48 end);
 
     /// @notice Thrown when the spend value is zero.
     error ZeroValue();
@@ -99,7 +99,7 @@ library RecurringAllowance {
         view
         returns (PeriodUsage memory)
     {
-        uint40 currentTimestamp = uint40(block.timestamp);
+        uint48 currentTimestamp = uint48(block.timestamp);
         if (currentTimestamp < limit.start) revert BeforeStart(currentTimestamp, limit.start);
         if (currentTimestamp >= limit.end) revert AfterEnd(currentTimestamp, limit.end);
 
@@ -108,10 +108,10 @@ library RecurringAllowance {
         bool lastStillActive = currentTimestamp < lastUpdated.end;
         if (lastExists && lastStillActive) return lastUpdated;
 
-        uint40 currentPeriodProgress = (currentTimestamp - limit.start) % limit.period;
-        uint40 start = currentTimestamp - currentPeriodProgress;
+        uint48 currentPeriodProgress = (currentTimestamp - limit.start) % limit.period;
+        uint48 start = currentTimestamp - currentPeriodProgress;
         bool endOverflow = uint256(start) + uint256(limit.period) > limit.end;
-        uint40 end = endOverflow ? limit.end : start + limit.period;
+        uint48 end = endOverflow ? limit.end : start + limit.period;
         return PeriodUsage({start: start, end: end, spend: 0});
     }
 }

--- a/src/policies/SessionPolicy.sol
+++ b/src/policies/SessionPolicy.sol
@@ -59,7 +59,7 @@ contract SessionPolicy is Policy {
         /// @dev Maximum spend per period (one-time: total cap). Must fit uint160.
         uint256 limit;
         /// @dev Recurring period in seconds. 0 = one-time (a single cumulative cap that never resets).
-        uint40 period;
+        uint48 period;
     }
 
     /// @notice A function selector and an optional recipient allowlist.
@@ -102,9 +102,9 @@ contract SessionPolicy is Policy {
     bytes4 internal constant TRANSFER_FROM = IERC20.transferFrom.selector; // transferFrom(address,address,uint256)
     bytes4 internal constant APPROVE = IERC20.approve.selector; // approve(address,uint256)
 
-    /// @dev One-time limits are modeled as a never-resetting window: period is type(uint40).max so the cumulative
+    /// @dev One-time limits are modeled as a never-resetting window: period is type(uint48).max so the cumulative
     ///      spend never refreshes within representable time.
-    uint40 internal constant ONE_TIME_PERIOD = type(uint40).max;
+    uint48 internal constant ONE_TIME_PERIOD = type(uint48).max;
 
     /// @notice The action's `target` is not in the committed call-target allowlist.
     error TargetNotAllowed(address target);
@@ -207,7 +207,7 @@ contract SessionPolicy is Policy {
     function getTokenLimit(Config calldata config, address token)
         external
         pure
-        returns (bool set, uint160 allowance, uint40 period)
+        returns (bool set, uint160 allowance, uint48 period)
     {
         for (uint256 i; i < config.tokenLimits.length; i++) {
             TokenLimit calldata tl = config.tokenLimits[i];
@@ -232,10 +232,10 @@ contract SessionPolicy is Policy {
             return RecurringAllowance.PeriodUsage({start: 0, end: 0, spend: 0});
         }
         if (limit.limit > type(uint160).max) revert LimitTooLarge(limit.token, limit.limit);
-        uint40 period = limit.period == 0 ? ONE_TIME_PERIOD : limit.period;
+        uint48 period = limit.period == 0 ? ONE_TIME_PERIOD : limit.period;
         return _usage.getCurrentPeriod(
             _spendKey(commitment, limit.token),
-            RecurringAllowance.Limit({allowance: uint160(limit.limit), period: period, start: 0, end: type(uint40).max})
+            RecurringAllowance.Limit({allowance: uint160(limit.limit), period: period, start: 0, end: type(uint48).max})
         );
     }
 
@@ -284,7 +284,7 @@ contract SessionPolicy is Policy {
             // 3a. ERC-20 spend limit: consume the target token's cap for decodable spend selectors. Note `approve`
             // debits at grant time; a standing allowance can still be reused across periods (see contract NatSpec).
             if (_isErc20Selector(selector)) {
-                (bool set, uint160 allowance, uint40 period) = _findTokenLimit(config, action.target);
+                (bool set, uint160 allowance, uint48 period) = _findTokenLimit(config, action.target);
                 if (set) {
                     (, uint256 amount) = _decodeErc20(selector, action.data);
                     _consume(commitment, action.target, allowance, period, amount);
@@ -297,7 +297,7 @@ contract SessionPolicy is Policy {
 
         // 3b. Native-ETH spend limit: consume from the call value, independent of calldata.
         if (action.value > 0) {
-            (bool set, uint160 allowance, uint40 period) = _findTokenLimit(config, address(0));
+            (bool set, uint160 allowance, uint48 period) = _findTokenLimit(config, address(0));
             if (set) _consume(commitment, address(0), allowance, period, action.value);
         }
 
@@ -351,11 +351,11 @@ contract SessionPolicy is Policy {
     }
 
     /// @dev Consume `amount` against a token's cap. Skips zero amounts (the library rejects zero-value spends).
-    function _consume(bytes32 commitment, address token, uint160 allowance, uint40 period, uint256 amount) internal {
+    function _consume(bytes32 commitment, address token, uint160 allowance, uint48 period, uint256 amount) internal {
         if (amount == 0) return;
         _usage.useLimit(
             _spendKey(commitment, token),
-            RecurringAllowance.Limit({allowance: allowance, period: period, start: 0, end: type(uint40).max}),
+            RecurringAllowance.Limit({allowance: allowance, period: period, start: 0, end: type(uint48).max}),
             amount
         );
     }
@@ -375,7 +375,7 @@ contract SessionPolicy is Policy {
     function _findTokenLimit(Config memory config, address token)
         internal
         pure
-        returns (bool set, uint160 allowance, uint40 period)
+        returns (bool set, uint160 allowance, uint48 period)
     {
         for (uint256 i; i < config.tokenLimits.length; i++) {
             TokenLimit memory tl = config.tokenLimits[i];

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -321,7 +321,7 @@ contract AccountLockTest is KeystoreTest {
         (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
         assertTrue(locked); // block.timestamp (t0) < unlocksAt (t0 + delay)
         assertTrue(hasInitiatedUnlock);
-        assertEq(unlocksAt, uint40(t0 + delay));
+        assertEq(unlocksAt, uint48(t0 + delay));
         assertEq(storedDelay, 0);
         assertTrue(keystore.isLocked(account));
     }
@@ -339,7 +339,7 @@ contract AccountLockTest is KeystoreTest {
 
         bytes memory auth = _unlockAuth(pk, account);
         vm.expectEmit(true, false, false, true, address(keystore));
-        emit Keystore.AccountUnlockInitiated(account, uint40(t0 + delay));
+        emit Keystore.AccountUnlockInitiated(account, uint48(t0 + delay));
         keystore.applySignedLockChanges(account, Keystore.LockOp.Unlock, 0, auth);
     }
 
@@ -440,7 +440,7 @@ contract AccountLockTest is KeystoreTest {
         (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
         assertFalse(locked);
         assertTrue(hasInitiatedUnlock);
-        assertEq(unlocksAt, uint40(t0 + delay));
+        assertEq(unlocksAt, uint48(t0 + delay));
         assertEq(storedDelay, 0);
     }
 

--- a/test/unit/examples/ExecuteAttested.t.sol
+++ b/test/unit/examples/ExecuteAttested.t.sol
@@ -64,7 +64,7 @@ contract ExecuteAttestedTest is KeystoreTest {
 
     uint8 internal constant SCOPE_POLICY = 0x02;
 
-    uint40 internal constant MONTH = 30 days;
+    uint48 internal constant MONTH = 30 days;
 
     function setUp() public override {
         super.setUp();
@@ -179,23 +179,23 @@ contract ExecuteAttestedTest is KeystoreTest {
     }
 
     function test_executeAttested_revertsBeforeValidAfter() public {
-        uint40 validAfter = uint40(block.timestamp + 1 days);
+        uint48 validAfter = uint48(block.timestamp + 1 days);
         (bytes32 actorId, PolicyManager.PolicyBinding memory binding) = _installSessionWithWindow(1, validAfter, 0);
 
         vm.expectRevert(
-            abi.encodeWithSelector(PolicyManager.OutsideValidityWindow.selector, validAfter, uint40(0), block.timestamp)
+            abi.encodeWithSelector(PolicyManager.OutsideValidityWindow.selector, validAfter, uint48(0), block.timestamp)
         );
         vm.prank(account, bundler);
         manager.executeAttested(actorId, binding, _transfer(1));
     }
 
     function test_executeAttested_revertsAfterValidUntil() public {
-        uint40 validUntil = uint40(block.timestamp + 1 days);
+        uint48 validUntil = uint48(block.timestamp + 1 days);
         (bytes32 actorId, PolicyManager.PolicyBinding memory binding) = _installSessionWithWindow(1, 0, validUntil);
 
         vm.warp(uint256(validUntil));
         vm.expectRevert(
-            abi.encodeWithSelector(PolicyManager.OutsideValidityWindow.selector, uint40(0), validUntil, block.timestamp)
+            abi.encodeWithSelector(PolicyManager.OutsideValidityWindow.selector, uint48(0), validUntil, block.timestamp)
         );
         vm.prank(account, bundler);
         manager.executeAttested(actorId, binding, _transfer(1));
@@ -312,7 +312,7 @@ contract ExecuteAttestedTest is KeystoreTest {
         _authorizePolicyActor(actorId, commitment, expiry);
     }
 
-    function _installSessionWithWindow(uint256 salt, uint40 validAfter, uint40 validUntil)
+    function _installSessionWithWindow(uint256 salt, uint48 validAfter, uint48 validUntil)
         internal
         returns (bytes32 actorId, PolicyManager.PolicyBinding memory binding)
     {

--- a/test/unit/examples/ExternalPolicyCaller.t.sol
+++ b/test/unit/examples/ExternalPolicyCaller.t.sol
@@ -42,7 +42,7 @@ contract ExternalPolicyCallerTest is KeystoreTest {
     uint8 internal constant SCOPE_POLICY = 0x02;
 
     bytes4 internal constant TRANSFER = bytes4(keccak256("transfer(address,uint256)"));
-    uint40 internal constant MONTH = 30 days;
+    uint48 internal constant MONTH = 30 days;
 
     PolicyManager.PolicyBinding internal lastBinding;
 
@@ -257,11 +257,11 @@ contract ExternalPolicyCallerTest is KeystoreTest {
     /// @dev SessionPolicy config: `transfer` only on `token`, with a USDC-style recurring spend limit. The struct
     ///      build is split from the abi.encode so the deeply-nested encoder (Config → CallScope[] → SelectorRule[]
     ///      → address[]) runs in its own minimal-local frame, staying within the via-IR stack limit.
-    function _config(uint256 limit, uint40 period) internal view returns (bytes memory) {
+    function _config(uint256 limit, uint48 period) internal view returns (bytes memory) {
         return abi.encode(_sessionConfig(limit, period));
     }
 
-    function _sessionConfig(uint256 limit, uint40 period) internal view returns (SessionPolicy.Config memory) {
+    function _sessionConfig(uint256 limit, uint48 period) internal view returns (SessionPolicy.Config memory) {
         SessionPolicy.TokenLimit[] memory limits = new SessionPolicy.TokenLimit[](1);
         limits[0] = SessionPolicy.TokenLimit({token: address(token), limit: limit, period: period});
         SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
@@ -271,7 +271,7 @@ contract ExternalPolicyCallerTest is KeystoreTest {
         return SessionPolicy.Config({tokenLimits: limits, callScopes: scopes});
     }
 
-    function _binding(address account, uint256 salt, uint256 limit, uint40 period)
+    function _binding(address account, uint256 salt, uint256 limit, uint48 period)
         internal
         view
         returns (PolicyManager.PolicyBinding memory binding, bytes32 commitment)
@@ -289,11 +289,11 @@ contract ExternalPolicyCallerTest is KeystoreTest {
 
     /// @dev Full opt-in for one subscriber: create the account, mint it tokens, and authorize the provider as an
     ///      external-policy actor gated to this manager with the binding commitment.
-    function _optIn(bytes32 accountSalt, uint256 limit, uint40 period) internal returns (address account) {
+    function _optIn(bytes32 accountSalt, uint256 limit, uint48 period) internal returns (address account) {
         return _optInWithExpiry(accountSalt, limit, period, 0);
     }
 
-    function _optInWithExpiry(bytes32 accountSalt, uint256 limit, uint40 period, uint48 expiry)
+    function _optInWithExpiry(bytes32 accountSalt, uint256 limit, uint48 period, uint48 expiry)
         internal
         returns (address account)
     {

--- a/test/unit/examples/PolicyManager.t.sol
+++ b/test/unit/examples/PolicyManager.t.sol
@@ -135,25 +135,25 @@ contract PolicyManagerTest is KeystoreTest {
     }
 
     function test_execute_revertsBeforeValidAfter() public {
-        uint40 validAfter = uint40(block.timestamp + 1 days);
+        uint48 validAfter = uint48(block.timestamp + 1 days);
         (bytes32 actorId, PolicyManager.PolicyBinding memory binding) = _installSessionWithWindow(1, validAfter, 0);
         _mockActingActor(actorId);
 
         vm.expectRevert(
-            abi.encodeWithSelector(PolicyManager.OutsideValidityWindow.selector, validAfter, uint40(0), block.timestamp)
+            abi.encodeWithSelector(PolicyManager.OutsideValidityWindow.selector, validAfter, uint48(0), block.timestamp)
         );
         vm.prank(account);
         manager.execute(binding, _action());
     }
 
     function test_execute_revertsAfterValidUntil() public {
-        uint40 validUntil = uint40(block.timestamp + 1 days);
+        uint48 validUntil = uint48(block.timestamp + 1 days);
         (bytes32 actorId, PolicyManager.PolicyBinding memory binding) = _installSessionWithWindow(2, 0, validUntil);
         _mockActingActor(actorId);
 
         vm.warp(uint256(validUntil));
         vm.expectRevert(
-            abi.encodeWithSelector(PolicyManager.OutsideValidityWindow.selector, uint40(0), validUntil, block.timestamp)
+            abi.encodeWithSelector(PolicyManager.OutsideValidityWindow.selector, uint48(0), validUntil, block.timestamp)
         );
         vm.prank(account);
         manager.execute(binding, _action());
@@ -258,7 +258,7 @@ contract PolicyManagerTest is KeystoreTest {
         _authorizePolicyActor(actorId, manager.commitmentOf(binding), expiry);
     }
 
-    function _installSessionWithWindow(uint256 salt, uint40 validAfter, uint40 validUntil)
+    function _installSessionWithWindow(uint256 salt, uint48 validAfter, uint48 validUntil)
         internal
         returns (bytes32 actorId, PolicyManager.PolicyBinding memory binding)
     {

--- a/test/unit/examples/SessionPolicy.t.sol
+++ b/test/unit/examples/SessionPolicy.t.sol
@@ -73,7 +73,7 @@ contract SessionPolicyTest is KeystoreTest {
     uint8 internal constant SCOPE_POLICY = 0x02;
 
     bytes4 internal constant TRANSFER = bytes4(keccak256("transfer(address,uint256)"));
-    uint40 internal constant WEEK = 7 days;
+    uint48 internal constant WEEK = 7 days;
 
     uint256 internal saltNonce;
     PolicyManager.PolicyBinding internal lastBinding;
@@ -297,7 +297,7 @@ contract SessionPolicyTest is KeystoreTest {
         // A second ERC-20 plays the role of USDC (6 decimals); `token` (minted in setUp) is the MyApp token.
         SessionMockERC20 usdc = new SessionMockERC20();
         usdc.mint(account, 1_000e6);
-        uint40 monthPeriod = 30 days;
+        uint48 monthPeriod = 30 days;
         uint256 fiveUsdc = 5e6; // $5 at 6 decimals
 
         // Spend limits: only USDC ($5/month). The MyApp token has no entry, so its transfers are uncapped.
@@ -592,7 +592,7 @@ contract SessionPolicyTest is KeystoreTest {
         assertTrue(policy.isRecipientAllowed(cfg, address(token), TRANSFER, bob));
         assertFalse(policy.isRecipientAllowed(cfg, address(token), TRANSFER, mallory));
 
-        (bool set, uint160 allowance, uint40 period) = policy.getTokenLimit(cfg, address(token));
+        (bool set, uint160 allowance, uint48 period) = policy.getTokenLimit(cfg, address(token));
         assertTrue(set);
         assertEq(allowance, 500e18);
         assertEq(period, WEEK);
@@ -613,9 +613,9 @@ contract SessionPolicyTest is KeystoreTest {
         assertFalse(otherAllowed);
 
         // A one-time (period == 0) native cap is normalized to the never-resetting ONE_TIME period.
-        (bool set,, uint40 period) = policy.getTokenLimit(cfg, address(0));
+        (bool set,, uint48 period) = policy.getTokenLimit(cfg, address(0));
         assertTrue(set);
-        assertEq(period, type(uint40).max);
+        assertEq(period, type(uint48).max);
     }
 
     // ── Helpers ──
@@ -669,7 +669,7 @@ contract SessionPolicyTest is KeystoreTest {
         return new SessionPolicy.TokenLimit[](0);
     }
 
-    function _limit(address tkn, uint256 lim, uint40 period)
+    function _limit(address tkn, uint256 lim, uint48 period)
         internal
         pure
         returns (SessionPolicy.TokenLimit[] memory limits)

--- a/test/unit/examples/SessionPolicyGas.t.sol
+++ b/test/unit/examples/SessionPolicyGas.t.sol
@@ -44,7 +44,7 @@ contract SessionPolicyGasTest is KeystoreTest {
     uint8 internal constant SCOPE_POLICY = 0x02;
 
     bytes4 internal constant TRANSFER = bytes4(keccak256("transfer(address,uint256)"));
-    uint40 internal constant WEEK = 7 days;
+    uint48 internal constant WEEK = 7 days;
 
     uint256 internal saltNonce;
     PolicyManager.PolicyBinding internal lastBinding;
@@ -301,7 +301,7 @@ contract SessionPolicyGasTest is KeystoreTest {
         return new SessionPolicy.TokenLimit[](0);
     }
 
-    function _limit(address tkn, uint256 lim, uint40 period)
+    function _limit(address tkn, uint256 lim, uint48 period)
         internal
         pure
         returns (SessionPolicy.TokenLimit[] memory limits)


### PR DESCRIPTION
Stacked on #51.

Follow-up to the type-normalization discussion: the canonical `Keystore` uses `uint48` for every Unix-second timestamp, while the example policy layer used `uint40`. This aligns them on a single convention.

## Scope
- `RecurringAllowance`: `Limit.{period,start,end}`, `PeriodUsage.{start,end}`, error params, `block.timestamp` casts, arithmetic locals → `uint48`
- `SessionPolicy`: `TokenLimit.period`, `ONE_TIME_PERIOD = type(uint48).max`, the `end: type(uint48).max` sentinel, accessor return types → `uint48`
- `PolicyManager`: `PolicyBinding.{validAfter,validUntil}` and `OutsideValidityWindow` → `uint48`
- Tests: example-policy time values + a few leftover `uint40` casts of the `uint48` `unlocksAt` in the Keystore lock tests

## Why this is safe (the two things we cared about)
- **No extra SLOAD/SSTORE.** The only *stored* time struct is `RecurringAllowance.PeriodUsage`: `uint48 start (6B) + uint48 end (6B) + uint160 spend (20B) = 32B` → still exactly one slot (previously 30B in one slot). `Limit` / `Config` / `TokenLimit` / `PolicyBinding` are memory/calldata; `PolicyManager` is stateless.
- **No digest change.** `keccak256(policyConfig)` and `_commitment(...)` are built with `abi.encode`, which left-pads every integer to 32 bytes *by value* — so widening the Solidity field type produces identical encoded bytes and identical commitments. Existing signed bindings remain valid.

`amount`/`allowance`/`spend` stay `uint160` (a deliberate packing choice, self-consistent).

## Test plan
- [x] `forge build` (clean)
- [x] `forge test` — 355 passed, 0 failed