### PR TITLE
Harden key install: future expiry, reject empty bytecode, import write ordering

### DIFF
--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -358,6 +358,10 @@ contract Keystore {
     /// @notice The actor's expiry has passed.
     error ActorExpired();
 
+    /// @notice An authorize named a non-zero expiry that is not strictly in the future (`expiry <= block.timestamp`),
+    ///         which would install an already-dead key. A perpetual key uses `expiry == 0`.
+    error ExpiryInPast();
+
     /// @notice A local-channel signed change bound an epoch that is not the account's current epoch (stale/replayed).
     error EpochMismatch();
 
@@ -386,6 +390,10 @@ contract Keystore {
 
     /// @notice The provided account bytecode exceeds the maximum encodable length.
     error BytecodeTooLarge();
+
+    /// @notice createAccount was called with empty bytecode, which would deploy an actor-initialized account with no
+    ///         code.
+    error EmptyBytecode();
 
     /// @notice CREATE2 did not deploy code at the expected account address (e.g. bytecode too large per EIP-170,
     ///      leading 0xEF byte per EIP-3541, or out of gas). Reverting unwinds all state writes so no orphaned
@@ -438,6 +446,7 @@ contract Keystore {
     ///         always 0 at create — scoped-with-expiry keys are added afterwards via applySignedActorChanges. The
     ///         implicit default-EOA key is disabled on creation.
     ///
+    /// @dev Reverts with EmptyBytecode when `bytecode` is empty.
     /// @dev Reverts with BytecodeTooLarge when `bytecode` exceeds the maximum encodable length.
     /// @dev Reverts with AlreadyInitialized when the account already has EIP-8130 state.
     /// @dev Reverts with NoInitialActors when `initialActors` is empty.
@@ -454,6 +463,9 @@ contract Keystore {
         external
         returns (address account)
     {
+        // Reject empty bytecode: it would deploy a code-less account that is nonetheless initialized with actors.
+        if (bytecode.length == 0) revert EmptyBytecode();
+
         bytes32 effectiveSalt;
         bytes memory deploymentCode;
         (account, effectiveSalt, deploymentCode) = _prepareDeployment(userSalt, bytecode, initialActors);
@@ -510,8 +522,10 @@ contract Keystore {
 
         // Import is a one-time bootstrap for accounts with no 8130 state yet.
         if (_isInitialized(account)) revert AlreadyInitialized();
-        _accountState[account].localSequence = 1;
 
+        // Validate the account's ERC-1271 import signature BEFORE writing any 8130 state. No storage is touched until
+        // the staticcall returns, so a read-only reentrant call made during it can never observe a half-initialized
+        // account (localSequence set but actors not yet written).
         bytes32 digest = _computeImportDigest(account, chainId, initialActors);
         (bool success, bytes memory result) =
             account.staticcall(abi.encodeWithSelector(ERC1271_SELECTOR, digest, signature));
@@ -519,11 +533,12 @@ contract Keystore {
             revert InvalidImportSignature();
         }
 
-        // Disable the implicit default-EOA path (parity with createAccount). Set *after* the ERC-1271 check: for an
-        // EIP-7702 delegated EOA its own k1 signature (the implicit full owner) is the only authenticator available
-        // at import time, so it must stay live for that check. An owner who wants to keep using the key can include
-        // the self-actorId as an explicit k1 actor in initialActors (still a full owner, now via its config), or
-        // re-enable it later. Folds into the same slot as localSequence.
+        // Mark initialized (localSequence = 1) and disable the implicit default-EOA path (parity with createAccount),
+        // folded into one slot write. Both are set *after* the ERC-1271 check: for an EIP-7702 delegated EOA its own
+        // k1 signature (the implicit full owner) is the only authenticator available at import time, so it must stay
+        // live for that check. An owner who wants to keep using the key can include the self-actorId as an explicit
+        // k1 actor in initialActors (still a full owner, now via its config), or re-enable it later.
+        _accountState[account].localSequence = 1;
         _accountState[account].flags = FLAG_REVOKE_DEFAULT_EOA;
 
         _initializeAccount(account, initialActors);
@@ -562,7 +577,7 @@ contract Keystore {
     /// @dev Reverts with InvalidBumpChange when a ChangeType.BumpEpoch change carries data or is on the multichain
     ///      channel, or EpochExhausted when the epoch is already at its maximum.
     /// @dev Reverts with UnknownChangeType when a change carries an unrecognized changeType.
-    /// @dev Reverts with InvalidAuthenticator or InvalidPolicyData on a malformed authorize.
+    /// @dev Reverts with InvalidAuthenticator, ExpiryInPast, or InvalidPolicyData on a malformed authorize.
     /// @dev Reverts with UnknownActor when revoking an actor that is not authorized.
     ///
     /// @param account The account whose configuration is changed.
@@ -1045,7 +1060,7 @@ contract Keystore {
     /// @dev Authorizes (upserts) `actorId` with `config` and optional `policyData`, emitting ActorAuthorized. Rejects
     ///      a sub-K1 authenticator. The self-actorId is routed by authenticator type (a k1 self inline in
     ///      AccountState, a non-k1 self in _actorConfig) and the two are kept mutually exclusive; every other actor
-    ///      lives in _actorConfig. Reverts with InvalidAuthenticator or InvalidPolicyData.
+    ///      lives in _actorConfig. Reverts with InvalidAuthenticator, ExpiryInPast, or InvalidPolicyData.
     function _authorizeActor(address account, bytes32 actorId, ActorConfig memory config, bytes memory policyData)
         internal
         nonZeroAccount(account)
@@ -1055,6 +1070,10 @@ contract Keystore {
         // codeless sentinels (e.g. EXTERNAL_POLICY_AUTHENTICATOR). A bad authenticator simply fails fail-closed at
         // authentication time, mirroring the reference PolicyManager's treatment of a zero-commitment policy actor.
         if (config.authenticator < K1_AUTHENTICATOR) revert InvalidAuthenticator();
+
+        // A set expiry must be strictly in the future: installing a key that is already expired (or expires this very
+        // block) is never useful and getActorConfig would immediately report it empty. expiry == 0 = perpetual.
+        if (config.expiry != 0 && config.expiry <= block.timestamp) revert ExpiryInPast();
 
         // Slice the signed policy by scope & Scopes.POLICY. The commitment is opaque to the protocol. This contract
         // does not reject scope combinations (e.g. Scopes.POLICY | Scopes.SELF_PAYER) — any use-time exclusivity between

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -564,6 +564,38 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         keystore.applySignedActorChanges(account, uint64(block.chainid), __seqR, changes, auth);
     }
 
+    /// @notice Authorizing an actor with a non-zero expiry that is not strictly in the future reverts ExpiryInPast.
+    /// @dev Covers both the past and the at-now boundary (expiry == block.timestamp), proving the strict `>` rule; a
+    ///      perpetual (expiry == 0) actor is unaffected and exercised throughout the rest of the suite.
+    function test_applySignedActorChanges_revert_expiryInPast(
+        uint256 pk,
+        bytes32 targetId,
+        uint256 nowSeed,
+        uint256 expirySeed
+    ) public {
+        pk = _boundK1Pk(pk);
+        (address account, bytes32 ownerId) = _createK1Account(pk);
+        vm.assume(targetId != ownerId && targetId != bytes32(bytes20(account)));
+
+        uint256 nowTs = bound(nowSeed, 2, uint256(type(uint48).max));
+        vm.warp(nowTs);
+        uint48 expiry = uint48(bound(expirySeed, 1, nowTs)); // non-zero, at or before now
+
+        Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](1);
+        ch[0] = Keystore.ActorChange({
+            actorId: targetId,
+            changeType: Keystore.ChangeType.Authorize,
+            data: abi.encode(
+                Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: 0, expiry: expiry}), bytes("")
+            )
+        });
+
+        bytes memory auth = _authOver(account, pk, ch);
+        uint64 seq = keystore.getChangeSequences(account).local;
+        vm.expectRevert(Keystore.ExpiryInPast.selector);
+        keystore.applySignedActorChanges(account, uint64(block.chainid), seq, ch, auth);
+    }
+
     /// @notice The admin gate: an authenticated actor may change actors iff its scope == 0.
     /// @dev Fuzzes the signer's scope (SCOPE_POLICY masked out) and asserts success only when scope is 0.
     function test_applySignedActorChanges_adminGate_acrossScopes(

--- a/test/unit/Keystore/authenticate.t.sol
+++ b/test/unit/Keystore/authenticate.t.sol
@@ -174,7 +174,7 @@ contract AuthenticateTest is KeystoreTest {
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
 
-        uint48 expiry = uint48(bound(uint256(expirySeed), 1, uint256(type(uint48).max) - 1));
+        uint48 expiry = uint48(bound(uint256(expirySeed), block.timestamp + 1, uint256(type(uint48).max) - 1));
         // Authorize the self-actorId as a scoped-0 K1 actor carrying an expiry (re-enables the inline self).
         _authorizeActorWithExpiry(eoa, eoaPk, selfActorId, address(k1Authenticator), expiry);
 
@@ -198,7 +198,7 @@ contract AuthenticateTest is KeystoreTest {
 
         (address account,) = _createK1Account(ownerPk);
         bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
-        uint48 expiry = uint48(bound(uint256(expirySeed), 1, uint256(type(uint48).max) - 1));
+        uint48 expiry = uint48(bound(uint256(expirySeed), block.timestamp + 1, uint256(type(uint48).max) - 1));
         _authorizeActorWithExpiry(account, ownerPk, sessionActorId, address(k1Authenticator), expiry);
 
         vm.warp(uint256(expiry) + bound(warpSeed, 1, 1_000_000));
@@ -219,7 +219,7 @@ contract AuthenticateTest is KeystoreTest {
         uint256 pk = _boundP256Pk(pkSeed);
 
         (address account,) = _createK1Account(ownerPk);
-        uint48 expiry = uint48(bound(uint256(expirySeed), 1, uint256(type(uint48).max) - 1));
+        uint48 expiry = uint48(bound(uint256(expirySeed), block.timestamp + 1, uint256(type(uint48).max) - 1));
         _authorizeActorWithExpiry(account, ownerPk, _p256ActorId(pk), address(p256Authenticator), expiry);
 
         vm.warp(uint256(expiry) + bound(warpSeed, 1, 1_000_000));

--- a/test/unit/Keystore/createAccount.t.sol
+++ b/test/unit/Keystore/createAccount.t.sol
@@ -70,6 +70,16 @@ contract CreateAccountTest is KeystoreTest {
         keystore.createAccount(salt, bytecode, actors);
     }
 
+    /// @notice Verifies createAccount reverts on empty bytecode, which would deploy a code-less but actor-initialized
+    ///         account.
+    /// @dev The EmptyBytecode guard trips before deployment; no state is written and nothing is deployed.
+    function test_createAccount_revert_emptyBytecode(bytes32 salt) public {
+        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(1))));
+
+        vm.expectRevert(Keystore.EmptyBytecode.selector);
+        keystore.createAccount(salt, "", actors);
+    }
+
     /// @notice Verifies re-creating an account at an address that already holds 8130 state reverts
     /// @dev localSequence is set to 1 on first create and doubles as the initialized flag; the guard trips on retry
     function test_createAccount_revert_alreadyInitialized(uint256 pk, bytes32 salt, uint256 lenSeed, bytes32 content)


### PR DESCRIPTION
## Summary

Three install-path hardening changes, stacked on #51. Unlike #51 (pure naming/style), this PR is **behavioral** and adds two new revert reasons.

- **Future-expiry on install.** `_authorizeActor` (the single choke point for `createAccount` / `importAccount` / `applySignedActorChanges`) now requires a set expiry to be strictly in the future. Installing an already-dead key (`expiry != 0 && expiry <= block.timestamp`) reverts `ExpiryInPast`. `expiry == 0` remains perpetual; initial actors are always `expiry == 0` and are unaffected. The MAX sentinel's existing `expiry != 0` requirement composes with this to require a live, expiring key.
- **Reject empty bytecode.** `createAccount` reverts `EmptyBytecode` rather than deploying a code-less account that is nonetheless initialized with actors.
- **Import write ordering.** `importAccount` performs the account's ERC-1271 staticcall *before* writing any 8130 state (`localSequence` / `flags`). A read-only reentrant call made during the staticcall can no longer observe a half-initialized account (initialized flag set, actors not yet written).

## Test plan

- [x] `forge build` clean
- [x] `forge test` — 357 passing (+2 new)
- [x] New: `test_applySignedActorChanges_revert_expiryInPast` (past + at-now boundary)
- [x] New: `test_createAccount_revert_emptyBytecode`
- [x] Updated authentication expiry tests to install a future expiry, then warp past it