### PR TITLE
Scope uint16 + normative slot layout; expired actors read empty; drop public isActor

### DIFF
--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -20,11 +20,12 @@ contract Keystore {
         uint64 local; // chain_id == block.chainid; starts at 1 once initialized (created/imported), 0 = uninitialized
     }
 
-    /// @notice An actor's authorization: authenticator, scope, and expiry.
+    /// @notice An actor's authorization: authenticator, expiry, and scope. Field order matches the normative
+    ///         `actor_config` slot layout: authenticator(20) ‖ expiry(6) ‖ scope(2) ‖ reserved(4).
     struct ActorConfig {
         address authenticator;
-        uint8 scope;
         uint48 expiry; // Unix seconds; 0 = no expiry. Actor invalid once block.timestamp > expiry
+        uint16 scope;
     }
 
     /// @notice Initial actor for account creation and import. Carries its scope and, when scope & SCOPE_POLICY is
@@ -33,7 +34,7 @@ contract Keystore {
     struct InitialActor {
         bytes32 actorId;
         address authenticator;
-        uint8 scope; // 0x00 = unrestricted admin
+        uint16 scope; // 0x00 = unrestricted admin
         bytes policyData; // empty unless scope & SCOPE_POLICY; then manager(20) || commitment(32)
     }
 
@@ -56,8 +57,8 @@ contract Keystore {
     ///
     /// @dev Packed into a single storage slot; the field layout is normative (nodes read the raw slot for mempool
     ///      rate-limit tiering, see the EIP's Account Lock section). Field order and widths match the spec's
-    ///      account-state table: multichainSequence, localSequence, flags, lockUnion, defaultEOAScope,
-    ///      defaultEOAExpiry, then 3 reserved bytes that MUST stay zero.
+    ///      account-state table: multichainSequence, localSequence, flags, lockUnion, defaultEOAExpiry,
+    ///      defaultEOAScope, then 2 reserved bytes that MUST stay zero.
     ///      localSequence > 0 doubles as the account initialized flag.
     ///      `flags` is a bitfield: bit 0 (FLAG_REVOKE_DEFAULT_EOA) disables the k1 self key; bit 1 (FLAG_LOCKED)
     ///      freezes actor configuration; bit 2 (FLAG_UNLOCK_INITIATED) selects how `lockUnion` is interpreted.
@@ -75,9 +76,9 @@ contract Keystore {
         uint64 localSequence; // 8 bytes – also serves as initialized flag
         uint8 flags; // 1 byte – bitfield: bit 0 REVOKE_DEFAULT_EOA, bit 1 LOCKED, bit 2 UNLOCK_INITIATED
         uint40 lockUnion; // 5 bytes – union: unlockDelay while UNLOCK_INITIATED clear, else unlocksAt (timestamp)
-        uint8 defaultEOAScope; // 1 byte – inline self k1 scope (0 = full owner)
         uint48 defaultEOAExpiry; // 6 bytes – inline self k1 expiry (Unix seconds; 0 = no expiry)
-        // 3 bytes reserved (remaining slot bytes); MUST stay zero.
+        uint16 defaultEOAScope; // 2 bytes – inline self k1 scope (0 = full owner)
+        // 2 bytes reserved (remaining slot bytes); MUST stay zero.
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -94,17 +95,17 @@ contract Keystore {
     ///      import signature cannot be replayed on another chain. Initial actors are hashed structurally via
     ///      ACTOR_TYPEHASH / ACTORCONFIG_TYPEHASH below.
     bytes32 public constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
-        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry)"
+        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
     );
 
     /// @notice Typehash used to structurally hash each Actor within an ActorInitialization import digest.
     bytes32 public constant ACTOR_TYPEHASH = keccak256(
-        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry)"
+        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
     );
 
     /// @notice Typehash used to structurally hash an Actor's ActorConfig within an import digest.
     bytes32 public constant ACTORCONFIG_TYPEHASH =
-        keccak256("ActorConfig(address authenticator,uint8 scope,uint48 expiry)");
+        keccak256("ActorConfig(address authenticator,uint48 expiry,uint16 scope)");
 
     /// @notice Typehash binding a signed actor-change batch to its account, chainId, and sequence.
     ///
@@ -150,31 +151,31 @@ contract Keystore {
     // ----------------------------------------------------------------------------------------------------------------
 
     /// @notice Actor can initiate transactions with account as sender
-    uint8 public constant SCOPE_SENDER = 0x01;
+    uint16 public constant SCOPE_SENDER = 0x0001;
 
     /// @notice Actor is gated to a policy: every call it makes must land on the resolved manager (this contract
     ///         stores manager + commitment; the protocol enforces that the actor's calls only ever reach that
     ///         target). This contract does not reject scope combinations (e.g. SCOPE_POLICY | SCOPE_SELF_PAYER) — any
     ///         use-time exclusivity between SCOPE_POLICY and the account's other capabilities is protocol-side, not
     ///         enforced here.
-    uint8 public constant SCOPE_POLICY = 0x02;
+    uint16 public constant SCOPE_POLICY = 0x0002;
 
     /// @notice Permits a restricted (non-admin) actor to use sequenced `nonce_key`s for sender-context transactions;
     ///         without it a restricted actor may use only the nonce-free key (NONCE_KEY_MAX), while admin actors are
     ///         unconstrained. This contract stores the scope bit verbatim and does not interpret it — nonce semantics
     ///         are enforced entirely protocol-side.
-    uint8 public constant SCOPE_NONCE = 0x04;
+    uint16 public constant SCOPE_NONCE = 0x0004;
 
     /// @notice Actor can self-pay gas for the account's own operations (payer == sender).
-    uint8 public constant SCOPE_SELF_PAYER = 0x08;
+    uint16 public constant SCOPE_SELF_PAYER = 0x0008;
 
     /// @notice Actor can sponsor gas on behalf of a different sender (payer != sender).
-    uint8 public constant SCOPE_SPONSOR_PAYER = 0x10;
+    uint16 public constant SCOPE_SPONSOR_PAYER = 0x0010;
 
     // ERC-1271 signing rides on operational authority (admin scope == 0x00, or a SENDER actor without POLICY);
     // it is not its own scope bit. See verifySignature.
 
-    // 0x20, 0x40, 0x80 are spare (unused).
+    // 0x0020 through 0x8000 are spare (unused). Scope is a uint16, so the vocabulary is append-only up to 16 bits.
 
     /// @notice The single secp256k1 authenticator. The default EOA and every k1 actor share this one identity; the
     ///         actor config alone distinguishes a full-owner EOA from a scoped key. Signed with a K1_AUTHENTICATOR
@@ -223,7 +224,7 @@ contract Keystore {
     /// @param account The account whose actor was authorized.
     /// @param actorId The authorized actor's identifier.
     /// @param actorData Tightly packed authorization surface, mirroring the wire packing:
-    ///        authenticator(20) || scope(1) || expiry(6) || reserved(5 zero bytes) = 32 bytes, and, only when
+    ///        authenticator(20) || expiry(6) || scope(2) || reserved(4 zero bytes) = 32 bytes, and, only when
     ///        scope & SCOPE_POLICY != 0, followed by the resolved policy gate manager(20) || commitment(32). So the
     ///        payload is 32 bytes for an ungated actor and 84 bytes for a policy-gated one.
     event ActorAuthorized(address indexed account, bytes32 indexed actorId, bytes actorData);
@@ -516,7 +517,7 @@ contract Keystore {
 
         // Compute digest and authenticate
         bytes32 digest = _computeSignedActorChangesDigest(account, chainId, sequence, actorChanges);
-        (, uint8 scope,) = authenticateActor(account, digest, auth);
+        (, uint16 scope,) = authenticateActor(account, digest, auth);
 
         // Only an unrestricted actor (scope 0) may change actors; there is no elevated "admin" scope bit.
         if (scope != 0) revert UnauthorizedActorChange();
@@ -574,7 +575,7 @@ contract Keystore {
         uint64 sequence = _accountState[account].localSequence++;
 
         bytes32 digest = _computeSignedLockChangesDigest(account, block.chainid, op, unlockDelay, sequence);
-        (, uint8 scope,) = authenticateActor(account, digest, auth);
+        (, uint16 scope,) = authenticateActor(account, digest, auth);
 
         // Only an unrestricted actor (scope 0) may change the lock; there is no elevated "admin" scope bit.
         if (scope != 0) revert UnauthorizedLockChange();
@@ -631,7 +632,7 @@ contract Keystore {
     {
         // Authenticate against the account-scoped digest (see {replaySafeHash}), not the raw hash.
         try this.authenticateActor(account, replaySafeHash(account, hash), signature) returns (
-            bytes32, uint8 scope, address
+            bytes32, uint16 scope, address
         ) {
             // ERC-1271 signing is authorized for any operational actor: the admin (scope == 0x00), or a SENDER actor
             // that is not gated by a policy (SCOPE_SENDER set AND SCOPE_POLICY unset). Signing is an encoding of
@@ -707,7 +708,7 @@ contract Keystore {
     function authenticateActor(address account, bytes32 hash, bytes calldata auth)
         public
         view
-        returns (bytes32 actorId, uint8 scope, address policyTarget)
+        returns (bytes32 actorId, uint16 scope, address policyTarget)
     {
         if (auth.length < 20) revert InvalidAuthLength();
         return _authenticate(account, hash, address(bytes20(auth[:20])), auth[20:]);
@@ -735,24 +736,6 @@ contract Keystore {
     // STORAGE VIEWS
     // ----------------------------------------------------------------------------------------------------------------
 
-    /// @notice Returns whether `actorId` is currently authorized on `account` (a stored actor entry exists, or the
-    ///         inline k1 self is enabled).
-    ///
-    /// @dev Does NOT check expiry: an expired-but-not-revoked actor still returns true. This is intentional —
-    ///      _revokeActor relies on it to revoke expired actors — so callers needing liveness must check expiry too.
-    ///
-    /// @param account The account to check.
-    /// @param actorId The actor identifier to check.
-    ///
-    /// @return True if the actor is authorized (possibly expired).
-    function isActor(address account, bytes32 actorId) public view returns (bool) {
-        // A populated _actorConfig entry is always live: any non-self actor, or a non-k1 self authenticator.
-        if (_actorConfig[actorId][account].authenticator >= K1_AUTHENTICATOR) return true;
-        // No _actorConfig entry: the self-actorId's k1 key lives inline in AccountState, live unless the flag is set.
-        if (actorId == bytes32(bytes20(account))) return !_isDefaultEoaRevoked(account);
-        return false;
-    }
-
     /// @notice Resolves the effective ActorConfig for `actorId` on `account`.
     ///
     /// @dev With a populated _actorConfig entry, returns it verbatim (any non-self actor, or a non-k1 self). For the
@@ -764,18 +747,29 @@ contract Keystore {
     /// @param account The account to read.
     /// @param actorId The actor identifier to resolve.
     ///
-    /// @return The resolved actor configuration, or the all-zero config if the actor is not live.
+    /// @return The resolved actor configuration, or the all-zero config if the actor is not live (unknown, disabled,
+    ///         or expired).
     function getActorConfig(address account, bytes32 actorId) external view returns (ActorConfig memory) {
         ActorConfig memory config = _actorConfig[actorId][account];
-        // Non-zero authenticator = a stored entry. Uses the same `>= K1_AUTHENTICATOR` namespace idiom as isActor:
+        // Non-zero authenticator = a stored entry. Uses the same `>= K1_AUTHENTICATOR` namespace idiom as _isActor:
         // every stored authenticator is K1_AUTHENTICATOR (0x1) or a contract, so this is equivalent to != address(0).
-        if (config.authenticator >= K1_AUTHENTICATOR) return config;
+        if (config.authenticator >= K1_AUTHENTICATOR) {
+            // An expired stored actor reports as empty (as if never authorized), never its stale config.
+            if (_isExpired(config.expiry)) return _emptyActorConfig();
+            return config;
+        }
         if (actorId == bytes32(bytes20(account)) && !_isDefaultEoaRevoked(account)) {
             AccountState storage st = _accountState[account];
+            if (_isExpired(st.defaultEOAExpiry)) return _emptyActorConfig();
             return
                 ActorConfig({authenticator: K1_AUTHENTICATOR, scope: st.defaultEOAScope, expiry: st.defaultEOAExpiry});
         }
         return config;
+    }
+
+    /// @dev The all-zero ActorConfig returned for a non-live actor (unknown, disabled, or expired).
+    function _emptyActorConfig() private pure returns (ActorConfig memory) {
+        return ActorConfig({authenticator: address(0), expiry: 0, scope: 0});
     }
 
     /// @notice Resolves an actor's policy gate target (manager) and signed commitment.
@@ -1006,7 +1000,7 @@ contract Keystore {
     }
 
     /// @dev Emit ActorAuthorized with a tightly packed payload. The base packs to 32 bytes
-    ///      (authenticator(20) || scope(1) || expiry(6) || reserved(5 zero bytes)); the policy gate
+    ///      (authenticator(20) || expiry(6) || scope(2) || reserved(4 zero bytes)); the policy gate
     ///      (manager(20) || commitment(32), 52 bytes) is appended only when scope & SCOPE_POLICY != 0.
     function _emitActorAuthorized(
         address account,
@@ -1016,8 +1010,8 @@ contract Keystore {
         bytes32 commitment
     ) private {
         bytes memory actorData = (config.scope & SCOPE_POLICY != 0)
-            ? abi.encodePacked(config.authenticator, config.scope, config.expiry, bytes5(0), manager, commitment)
-            : abi.encodePacked(config.authenticator, config.scope, config.expiry, bytes5(0));
+            ? abi.encodePacked(config.authenticator, config.expiry, config.scope, bytes4(0), manager, commitment)
+            : abi.encodePacked(config.authenticator, config.expiry, config.scope, bytes4(0));
         emit ActorAuthorized(account, actorId, actorData);
     }
 
@@ -1026,7 +1020,7 @@ contract Keystore {
     ///      commitment), written verbatim. Neither field need be non-zero: a zero commitment is a valid "no
     ///      params" and a zero manager gates the actor to address(0). Only a length mismatch reverts. The protocol
     ///      does not interpret the commitment value; self-enforcement is expressed as manager == account.
-    function _slicePolicy(uint8 scope, bytes memory policyData)
+    function _slicePolicy(uint16 scope, bytes memory policyData)
         internal
         pure
         returns (address manager, bytes32 commitment)
@@ -1042,11 +1036,23 @@ contract Keystore {
         }
     }
 
+    /// @dev Returns whether `actorId` is currently authorized on `account` (a stored actor entry exists, or the
+    ///      inline k1 self is enabled). Does NOT check expiry: an expired-but-not-revoked actor still returns true —
+    ///      intentional, since _revokeActor relies on it to revoke expired actors. Off-chain liveness checks should
+    ///      read {getActorConfig} (authenticator != 0) and enforce expiry themselves.
+    function _isActor(address account, bytes32 actorId) private view returns (bool) {
+        // A populated _actorConfig entry is always live: any non-self actor, or a non-k1 self authenticator.
+        if (_actorConfig[actorId][account].authenticator >= K1_AUTHENTICATOR) return true;
+        // No _actorConfig entry: the self-actorId's k1 key lives inline in AccountState, live unless the flag is set.
+        if (actorId == bytes32(bytes20(account))) return !_isDefaultEoaRevoked(account);
+        return false;
+    }
+
     /// @dev Revokes `actorId` from `account`, clearing its config and policy slots and emitting ActorRevoked. For the
     ///      self-actorId it also disables the inline k1 self (sets FLAG_REVOKE_DEFAULT_EOA and zeroes the inline
     ///      fields). Reverts with UnknownActor when the actor is not currently live.
     function _revokeActor(address account, bytes32 actorId) internal nonZeroAccount(account) {
-        if (!isActor(account, actorId)) revert UnknownActor();
+        if (!_isActor(account, actorId)) revert UnknownActor();
         delete _actorConfig[actorId][account];
         // Policy state is keyed by (account, actorId) and cleared exactly on revoke.
         delete _policyCommitment[actorId][account];
@@ -1086,7 +1092,7 @@ contract Keystore {
     }
 
     /// @dev Packed commitment over the initial actor set. Per-actor contribution is
-    ///      actorId (32) || authenticator (20) || scope (1) || policyData, where policyData is empty (POLICY unset)
+    ///      actorId (32) || authenticator (20) || scope (2) || policyData, where policyData is empty (POLICY unset)
     ///      or exactly 52 bytes (POLICY set), so the length is unambiguous. Expiry does not participate (always 0
     ///      for initial actors).
     function _computeActorsCommitment(InitialActor[] calldata initialActors) internal pure returns (bytes32) {
@@ -1117,7 +1123,7 @@ contract Keystore {
             // accepted here. policyData is hashed via keccak256 into the Actor struct hash. The typehash structure
             // matches the importAccount signature payload in EIP-8130.
             bytes32 configHash = keccak256(
-                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, initialActors[i].scope, uint48(0))
+                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), initialActors[i].scope)
             );
             actorHashes[i] = keccak256(
                 abi.encode(ACTOR_TYPEHASH, initialActors[i].actorId, configHash, keccak256(initialActors[i].policyData))
@@ -1193,14 +1199,14 @@ contract Keystore {
     function _authenticate(address account, bytes32 hash, address authenticator, bytes calldata data)
         internal
         view
-        returns (bytes32, uint8, address)
+        returns (bytes32, uint16, address)
     {
         if (authenticator == K1_AUTHENTICATOR) return _authenticateK1(account, hash, data);
 
         bytes32 actorId = IAuthenticator(authenticator).authenticate(hash, data);
         if (actorId == bytes32(0)) revert AuthenticationFailed();
 
-        (uint8 scope, address policyTarget) = _resolveExplicitActor(account, actorId, authenticator);
+        (uint16 scope, address policyTarget) = _resolveExplicitActor(account, actorId, authenticator);
         return (actorId, scope, policyTarget);
     }
 
@@ -1210,19 +1216,19 @@ contract Keystore {
     function _resolveExplicitActor(address account, bytes32 actorId, address expectedAuthenticator)
         private
         view
-        returns (uint8 scope, address policyTarget)
+        returns (uint16 scope, address policyTarget)
     {
         ActorConfig memory config = _actorConfig[actorId][account];
         if (config.authenticator != expectedAuthenticator) revert AuthenticatorMismatch();
         // Expiry is read from the same slot; an expired actor fails authentication. 0 = no expiry.
-        if (config.expiry != 0 && block.timestamp > config.expiry) revert ActorExpired();
+        if (_isExpired(config.expiry)) revert ActorExpired();
         scope = config.scope;
         policyTarget = _policyTargetFor(scope, actorId, account);
     }
 
     /// @dev Resolves the policy gate target for an actor: the policy manager for a policy-gated actor
     ///      (scope & SCOPE_POLICY != 0), or address(0) otherwise. Non-policy actors (incl. admin) skip the SLOAD.
-    function _policyTargetFor(uint8 scope, bytes32 actorId, address account) private view returns (address) {
+    function _policyTargetFor(uint16 scope, bytes32 actorId, address account) private view returns (address) {
         return (scope & SCOPE_POLICY != 0) ? _policyManager[actorId][account] : address(0);
     }
 
@@ -1237,7 +1243,7 @@ contract Keystore {
     function _authenticateK1(address account, bytes32 hash, bytes calldata data)
         internal
         view
-        returns (bytes32, uint8, address)
+        returns (bytes32, uint16, address)
     {
         address recovered = _recoverSigner(hash, data);
         if (recovered == address(0)) revert InvalidSignature();
@@ -1247,20 +1253,25 @@ contract Keystore {
             // inline scope/expiry govern (all-zero = full owner).
             AccountState storage st = _accountState[account];
             if (st.flags & FLAG_REVOKE_DEFAULT_EOA != 0) revert DefaultEoaRevoked();
-            if (st.defaultEOAExpiry != 0 && block.timestamp > st.defaultEOAExpiry) revert ActorExpired();
+            if (_isExpired(st.defaultEOAExpiry)) revert ActorExpired();
             bytes32 selfActorId = bytes32(bytes20(account));
-            uint8 selfScope = st.defaultEOAScope;
+            uint16 selfScope = st.defaultEOAScope;
             return (selfActorId, selfScope, _policyTargetFor(selfScope, selfActorId, account));
         }
 
         bytes32 actorId = bytes32(bytes20(recovered));
-        (uint8 scope, address policyTarget) = _resolveExplicitActor(account, actorId, K1_AUTHENTICATOR);
+        (uint16 scope, address policyTarget) = _resolveExplicitActor(account, actorId, K1_AUTHENTICATOR);
         return (actorId, scope, policyTarget);
     }
 
     /// @dev True if the account's default (implicit) EOA has been revoked via the AccountState flag.
     function _isDefaultEoaRevoked(address account) internal view returns (bool) {
         return _accountState[account].flags & FLAG_REVOKE_DEFAULT_EOA != 0;
+    }
+
+    /// @dev True when `expiry` is set (non-zero) and has passed. A zero expiry means no expiry.
+    function _isExpired(uint48 expiry) internal view returns (bool) {
+        return expiry != 0 && block.timestamp > expiry;
     }
 
     /// @dev Recovers the ECDSA signer from a 65-byte r‖s‖v signature over `hash`, enforcing EIP-2 (low-s only,

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -517,7 +517,7 @@ contract Keystore {
 
         // Compute digest and authenticate
         bytes32 digest = _computeSignedActorChangesDigest(account, chainId, sequence, actorChanges);
-        (, uint16 scope,) = authenticateActor(account, digest, auth);
+        (, uint16 scope) = authenticateActor(account, digest, auth);
 
         // Only an unrestricted actor (scope 0) may change actors; there is no elevated "admin" scope bit.
         if (scope != 0) revert UnauthorizedActorChange();
@@ -575,7 +575,7 @@ contract Keystore {
         uint64 sequence = _accountState[account].localSequence++;
 
         bytes32 digest = _computeSignedLockChangesDigest(account, block.chainid, op, unlockDelay, sequence);
-        (, uint16 scope,) = authenticateActor(account, digest, auth);
+        (, uint16 scope) = authenticateActor(account, digest, auth);
 
         // Only an unrestricted actor (scope 0) may change the lock; there is no elevated "admin" scope bit.
         if (scope != 0) revert UnauthorizedLockChange();
@@ -631,9 +631,7 @@ contract Keystore {
         returns (bool verified)
     {
         // Authenticate against the account-scoped digest (see {replaySafeHash}), not the raw hash.
-        try this.authenticateActor(account, replaySafeHash(account, hash), signature) returns (
-            bytes32, uint16 scope, address
-        ) {
+        try this.authenticateActor(account, replaySafeHash(account, hash), signature) returns (bytes32, uint16 scope) {
             // ERC-1271 signing is authorized for any operational actor: the admin (scope == 0x00), or a SENDER actor
             // that is not gated by a policy (SCOPE_SENDER set AND SCOPE_POLICY unset). Signing is an encoding of
             // authority a SENDER actor already holds via calls, not a separate grant, so it needs no dedicated scope
@@ -682,18 +680,16 @@ contract Keystore {
     }
 
     /// @notice Authenticates that an account approved `hash` using auth in `authenticator(20) || data` format,
-    ///         returning the verified actor's identity and authorization surface so a consumer (e.g. an ERC-4337
-    ///         account on a non-8130 chain) can decide authorization AND drive the policy flow from a single call,
-    ///         without re-deriving (or re-invoking the authenticator to recover) the actorId.
+    ///         returning the verified actor's identity and scope so a consumer (e.g. an ERC-4337 account on a
+    ///         non-8130 chain) can decide authorization without re-deriving (or re-invoking the authenticator to
+    ///         recover) the actorId.
     ///
     /// @dev `actorId` is the resolved actor identifier — the same value an 8130 chain surfaces via the tx-context
-    ///      precompile. It lets an off-8130 consumer read `getPolicyCommitment(account, actorId)` (an execution-time
-    ///      read) for a policy-gated actor, reaching parity with the native hot path.
+    ///      precompile. It lets an off-8130 consumer read `getPolicyManager` / `getPolicyCommitment(account, actorId)`
+    ///      (execution-time reads) for a policy-gated actor, reaching parity with the native hot path.
     /// @dev `scope` is the actor's capability set, stored verbatim and never interpreted by this contract —
     ///      protocol-side semantics for bits like SCOPE_NONCE live outside this contract. Consumers decide policy
-    ///      gating via `scope & SCOPE_POLICY`, NOT via `policyTarget != 0`.
-    /// @dev `policyTarget` is the resolved policy manager, never the signed commitment (an execution-time read via
-    ///      getPolicy). It MAY be address(0) for a policy-gated actor deliberately gated to address(0).
+    ///      gating via `scope & SCOPE_POLICY`, then resolve the gate target separately via {getPolicyManager}.
     /// @dev Reverts with InvalidAuthLength when `auth` is shorter than 20 bytes.
     /// @dev Reverts with AuthenticationFailed, AuthenticatorMismatch, ActorExpired, DefaultEoaRevoked, or
     ///      InvalidSignature when the actor cannot be authenticated.
@@ -704,11 +700,10 @@ contract Keystore {
     ///
     /// @return actorId The identifier of the verified actor.
     /// @return scope The scope of the verified actor (0x00 = unrestricted).
-    /// @return policyTarget The actor's policy gate target (manager), or address(0).
     function authenticateActor(address account, bytes32 hash, bytes calldata auth)
         public
         view
-        returns (bytes32 actorId, uint16 scope, address policyTarget)
+        returns (bytes32 actorId, uint16 scope)
     {
         if (auth.length < 20) revert InvalidAuthLength();
         return _authenticate(account, hash, address(bytes20(auth[:20])), auth[20:]);
@@ -1193,43 +1188,35 @@ contract Keystore {
     // ----------------------------------------------------------------------------------------------------------------
 
     /// @dev Resolves and authenticates the actor behind `authenticator`/`data`, returning its
-    ///      (actorId, scope, policyTarget). Routes the K1 sentinel to _authenticateK1; otherwise calls the
+    ///      (actorId, scope). Routes the K1 sentinel to _authenticateK1; otherwise calls the
     ///      IAuthenticator and requires the resolved actorId to carry a matching, unexpired _actorConfig entry.
     ///      Reverts with AuthenticationFailed, AuthenticatorMismatch, or ActorExpired.
     function _authenticate(address account, bytes32 hash, address authenticator, bytes calldata data)
         internal
         view
-        returns (bytes32, uint16, address)
+        returns (bytes32, uint16)
     {
         if (authenticator == K1_AUTHENTICATOR) return _authenticateK1(account, hash, data);
 
         bytes32 actorId = IAuthenticator(authenticator).authenticate(hash, data);
         if (actorId == bytes32(0)) revert AuthenticationFailed();
 
-        (uint16 scope, address policyTarget) = _resolveExplicitActor(account, actorId, authenticator);
-        return (actorId, scope, policyTarget);
+        return (actorId, _resolveExplicitActor(account, actorId, authenticator));
     }
 
     /// @dev Resolves an explicit _actorConfig-homed actor: requires a matching authenticator and an unexpired entry,
-    ///      returning its scope and policy gate target. Shared by the non-k1 (_authenticate) and k1 other-actor
-    ///      (_authenticateK1) paths. Reverts with AuthenticatorMismatch or ActorExpired.
+    ///      returning its scope. Shared by the non-k1 (_authenticate) and k1 other-actor (_authenticateK1) paths.
+    ///      Reverts with AuthenticatorMismatch or ActorExpired.
     function _resolveExplicitActor(address account, bytes32 actorId, address expectedAuthenticator)
         private
         view
-        returns (uint16 scope, address policyTarget)
+        returns (uint16 scope)
     {
         ActorConfig memory config = _actorConfig[actorId][account];
         if (config.authenticator != expectedAuthenticator) revert AuthenticatorMismatch();
         // Expiry is read from the same slot; an expired actor fails authentication. 0 = no expiry.
         if (_isExpired(config.expiry)) revert ActorExpired();
         scope = config.scope;
-        policyTarget = _policyTargetFor(scope, actorId, account);
-    }
-
-    /// @dev Resolves the policy gate target for an actor: the policy manager for a policy-gated actor
-    ///      (scope & SCOPE_POLICY != 0), or address(0) otherwise. Non-policy actors (incl. admin) skip the SLOAD.
-    function _policyTargetFor(uint16 scope, bytes32 actorId, address account) private view returns (address) {
-        return (scope & SCOPE_POLICY != 0) ? _policyManager[actorId][account] : address(0);
     }
 
     /// @dev The single secp256k1 ("K1") path. Recovers the signer (EIP-2 enforced), then resolves the actor:
@@ -1238,12 +1225,11 @@ contract Keystore {
     ///          owner; non-zero = a scoped self). A non-k1 self is unreachable here by construction (it requires
     ///          its own authenticator), and mutual exclusion keeps the flag set whenever one is live.
     ///        - otherwise the signer's actorId must carry an explicit K1 config in _actorConfig (any other k1 actor).
-    ///      Both the common self and other-actor paths cost a single SLOAD; the policy-manager slot is read only for a
-    ///      policy-gated actor (`scope & SCOPE_POLICY != 0`), so non-policy authentications avoid the extra SLOAD.
+    ///      Both the common self and other-actor paths cost a single SLOAD.
     function _authenticateK1(address account, bytes32 hash, bytes calldata data)
         internal
         view
-        returns (bytes32, uint16, address)
+        returns (bytes32, uint16)
     {
         address recovered = _recoverSigner(hash, data);
         if (recovered == address(0)) revert InvalidSignature();
@@ -1254,14 +1240,11 @@ contract Keystore {
             AccountState storage st = _accountState[account];
             if (st.flags & FLAG_REVOKE_DEFAULT_EOA != 0) revert DefaultEoaRevoked();
             if (_isExpired(st.defaultEOAExpiry)) revert ActorExpired();
-            bytes32 selfActorId = bytes32(bytes20(account));
-            uint16 selfScope = st.defaultEOAScope;
-            return (selfActorId, selfScope, _policyTargetFor(selfScope, selfActorId, account));
+            return (bytes32(bytes20(account)), st.defaultEOAScope);
         }
 
         bytes32 actorId = bytes32(bytes20(recovered));
-        (uint16 scope, address policyTarget) = _resolveExplicitActor(account, actorId, K1_AUTHENTICATOR);
-        return (actorId, scope, policyTarget);
+        return (actorId, _resolveExplicitActor(account, actorId, K1_AUTHENTICATOR));
     }
 
     /// @dev True if the account's default (implicit) EOA has been revoked via the AccountState flag.

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -46,8 +46,8 @@ contract DefaultAccount is Receiver {
     /// @dev Local mirrors of {Keystore.SCOPE_SENDER} / {Keystore.SCOPE_POLICY}: a contract's
     ///      public constants are not accessible via its type, and reading the getters would add external calls to the
     ///      execution hot path. Kept in sync with Keystore.
-    uint8 private constant SCOPE_SENDER = 0x01;
-    uint8 private constant SCOPE_POLICY = 0x02;
+    uint16 private constant SCOPE_SENDER = 0x0001;
+    uint16 private constant SCOPE_POLICY = 0x0002;
 
     /// @notice The caller is neither the account itself nor a registered TRUSTED_EXECUTOR actor.
     error UnauthorizedCaller();
@@ -140,7 +140,7 @@ contract DefaultAccount is Receiver {
         Keystore.ActorConfig memory config = KEYSTORE.getActorConfig(address(this), bytes32(bytes20(caller)));
         if (config.authenticator != TRUSTED_EXECUTOR) return false;
         if (config.expiry != 0 && block.timestamp > config.expiry) return false;
-        uint8 scope = config.scope;
+        uint16 scope = config.scope;
         return scope == 0 || ((scope & SCOPE_SENDER != 0) && (scope & SCOPE_POLICY == 0));
     }
 }

--- a/src/authenticators/DelegateAuthenticator.sol
+++ b/src/authenticators/DelegateAuthenticator.sol
@@ -59,7 +59,7 @@ contract DelegateAuthenticator is IAuthenticator {
         // vouch requires admin to preserve non-escalation): an operational SENDER key can sign for its own account,
         // yet it must NOT be able to vouch as a delegate here. authenticateActor reverts on any auth failure and
         // otherwise returns the resolved scope, so we require scope == 0x00 explicitly.
-        try KEYSTORE.authenticateActor(delegate, hash, nestedAuth) returns (bytes32, uint8 nestedScope, address) {
+        try KEYSTORE.authenticateActor(delegate, hash, nestedAuth) returns (bytes32, uint16 nestedScope, address) {
             if (nestedScope != 0) revert InvalidNestedSignature();
         } catch {
             revert InvalidNestedSignature();

--- a/src/authenticators/DelegateAuthenticator.sol
+++ b/src/authenticators/DelegateAuthenticator.sol
@@ -59,7 +59,7 @@ contract DelegateAuthenticator is IAuthenticator {
         // vouch requires admin to preserve non-escalation): an operational SENDER key can sign for its own account,
         // yet it must NOT be able to vouch as a delegate here. authenticateActor reverts on any auth failure and
         // otherwise returns the resolved scope, so we require scope == 0x00 explicitly.
-        try KEYSTORE.authenticateActor(delegate, hash, nestedAuth) returns (bytes32, uint16 nestedScope, address) {
+        try KEYSTORE.authenticateActor(delegate, hash, nestedAuth) returns (bytes32, uint16 nestedScope) {
             if (nestedScope != 0) revert InvalidNestedSignature();
         } catch {
             revert InvalidNestedSignature();

--- a/src/policies/PolicyManager.sol
+++ b/src/policies/PolicyManager.sol
@@ -217,15 +217,15 @@ contract PolicyManager is ReentrancyGuard {
         if (signed == bytes32(0)) revert NoActivePolicy(actorId);
         if (signed != commitment) revert BindingCommitmentMismatch(signed, commitment);
 
-        _requireNotExpired(account, actorId);
+        _requireActiveActor(account, actorId);
         _enforce(binding, commitment, executionData, caller);
     }
 
-    /// @dev Reject when the acting actor's stored expiry has passed. Required on the external path (no protocol
-    ///      auth); omitted on {execute}, where authentication already enforced expiry before dispatch.
-    function _requireNotExpired(address account, bytes32 actorId) internal view {
-        Keystore.ActorConfig memory config = KEYSTORE.getActorConfig(account, actorId);
-        if (config.expiry != 0 && block.timestamp > config.expiry) revert ActorExpired(actorId);
+    /// @dev Reject when the acting actor is no longer active. Required on the external path (no protocol auth);
+    ///      omitted on {execute}, where authentication already enforced liveness before dispatch. getActorConfig
+    ///      resolves an expired (or revoked) actor to the all-zero config, so a zero authenticator means "not active".
+    function _requireActiveActor(address account, bytes32 actorId) internal view {
+        if (KEYSTORE.getActorConfig(account, actorId).authenticator == address(0)) revert ActorExpired(actorId);
     }
 
     /// @dev Common enforcement: enforce the binding's validity window (authenticated by the commitment check at the

--- a/test/lib/KeystoreTest.sol
+++ b/test/lib/KeystoreTest.sol
@@ -52,6 +52,15 @@ contract KeystoreTest is Test {
         defaultAccountImplementation = address(new DefaultAccount(address(keystore)));
     }
 
+    // ── Actor liveness helper ──
+
+    /// @dev Liveness check via the public getActorConfig (authenticator != 0). Replaces the removed public isActor
+    ///      getter. Unlike the old isActor, this honors expiry (getActorConfig resolves an expired actor to empty),
+    ///      which is the intended public liveness semantics.
+    function _isActor(address account, bytes32 actorId) internal view returns (bool) {
+        return keystore.getActorConfig(account, actorId).authenticator != address(0);
+    }
+
     // ── Bytecode helpers ──
 
     function _computeERC1167Bytecode(address implementation) internal pure returns (bytes memory) {

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -36,7 +36,7 @@ contract AccountLockTest is KeystoreTest {
 
     /// @dev Authorize a k1 actor (actorId = bytes32(bytes20(newSigner))) with `scope` on `account`, signed by the
     ///      account's admin owner `ownerPk`.
-    function _authorizeK1ActorWithScope(address account, uint256 ownerPk, address newSigner, uint8 scope) internal {
+    function _authorizeK1ActorWithScope(address account, uint256 ownerPk, address newSigner, uint16 scope) internal {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             changeType: 0x01,
@@ -477,7 +477,7 @@ contract AccountLockTest is KeystoreTest {
 
         keystore.applySignedActorChanges(account, chainId, changes, auth);
 
-        assertTrue(keystore.isActor(account, newActorId));
+        assertTrue(_isActor(account, newActorId));
         // The onlyUnlocked prelude cleared the stale unlock timestamp back to 0.
         (,, uint40 unlocksAt,) = keystore.getLockStatus(account);
         assertEq(unlocksAt, 0);

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -5,11 +5,11 @@ import {Keystore} from "../../../src/Keystore.sol";
 import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
 contract ApplyConfigChangeActorTest is KeystoreTest {
-    uint8 constant SCOPE_SENDER = 0x01;
-    uint8 constant SCOPE_POLICY = 0x02;
-    uint8 constant SCOPE_NONCE = 0x04;
-    uint8 constant SCOPE_SELF_PAYER = 0x08;
-    uint8 constant SCOPE_SPONSOR_PAYER = 0x10;
+    uint16 constant SCOPE_SENDER = 0x01;
+    uint16 constant SCOPE_POLICY = 0x02;
+    uint16 constant SCOPE_NONCE = 0x04;
+    uint16 constant SCOPE_SELF_PAYER = 0x08;
+    uint16 constant SCOPE_SPONSOR_PAYER = 0x10;
 
     /// @notice Authorizing a non-self actor registers it with the given authenticator and unrestricted scope.
     function test_authorizeActor_success_unrestricted(uint256 pk, bytes32 actorId) public {
@@ -27,11 +27,11 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
 
     /// @notice Authorizing an actor stores the requested non-zero scope verbatim.
     /// @dev SCOPE_POLICY is masked out because a policy-bearing scope requires policyData (covered elsewhere).
-    function test_authorizeActor_success_withScope(uint256 pk, bytes32 actorId, uint8 scope) public {
+    function test_authorizeActor_success_withScope(uint256 pk, bytes32 actorId, uint16 scope) public {
         pk = _boundK1Pk(pk);
         (address account, bytes32 ownerId) = _createK1Account(pk);
         vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
-        scope = uint8(bound(uint256(scope), 1, 255)) & ~SCOPE_POLICY;
+        scope = uint16(bound(uint256(scope), 1, 255)) & ~SCOPE_POLICY;
         vm.assume(scope != 0);
 
         Keystore.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), scope, "");
@@ -48,13 +48,13 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         (address account, bytes32 ownerId) = _createK1Account(pk);
         vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
         _authorizeActor(account, pk, actorId, address(k1Authenticator));
-        assertTrue(keystore.isActor(account, actorId));
+        assertTrue(_isActor(account, actorId));
 
         Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](1);
         ch[0] = Keystore.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
         _signApply(account, pk, ch);
 
-        assertFalse(keystore.isActor(account, actorId));
+        assertFalse(_isActor(account, actorId));
     }
 
     /// @notice A batch of multiple authorize operations applies every element.
@@ -70,8 +70,8 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         ch[1] = _authorizeChange(idB, address(k1Authenticator), 0, "")[0];
         _signApply(account, pk, ch);
 
-        assertTrue(keystore.isActor(account, idA));
-        assertTrue(keystore.isActor(account, idB));
+        assertTrue(_isActor(account, idA));
+        assertTrue(_isActor(account, idB));
     }
 
     /// @notice Each applied batch increments the account's local change sequence by one.
@@ -124,7 +124,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
 
         Keystore.ActorChange[] memory ch = _authorizeChange(targetId, address(k1Authenticator), 0, "");
         _signApply(account, actorPk, ch);
-        assertTrue(keystore.isActor(account, targetId));
+        assertTrue(_isActor(account, targetId));
     }
 
     /// @notice Any scoped (non-zero) actor cannot authorize actors; admin is exactly scope == 0.
@@ -132,7 +132,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
     function test_applySignedActorChanges_revert_scopedActorCannotAuthorize(
         uint256 ownerPk,
         uint256 actorPk,
-        uint8 scope,
+        uint16 scope,
         bytes32 targetId
     ) public {
         ownerPk = _boundK1Pk(ownerPk);
@@ -142,7 +142,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
         vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
         vm.assume(targetId != ownerId && targetId != actorId && targetId != bytes32(bytes20(account)));
-        scope = uint8(bound(uint256(scope), 1, 255)) & ~SCOPE_POLICY;
+        scope = uint16(bound(uint256(scope), 1, 255)) & ~SCOPE_POLICY;
         vm.assume(scope != 0);
 
         _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), scope);
@@ -159,7 +159,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account, bytes32 ownerId) = _createK1Account(pk);
 
-        uint8 newScope = SCOPE_SENDER;
+        uint16 newScope = SCOPE_SENDER;
         Keystore.ActorChange[] memory ch = _authorizeChange(ownerId, address(k1Authenticator), newScope, "");
         _signApply(account, pk, ch);
 
@@ -182,13 +182,13 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         assertEq(keystore.getActorConfig(eoa, selfActorId).scope, firstScope);
 
         // Second admin-signed change rescopes the live self actor in place to a non-admin scope.
-        uint8 newScope = SCOPE_SENDER | SCOPE_SELF_PAYER;
+        uint16 newScope = SCOPE_SENDER | SCOPE_SELF_PAYER;
         _rescopeSelf(eoa, eoaPk, newScope);
 
         Keystore.ActorConfig memory cfg = keystore.getActorConfig(eoa, selfActorId);
         assertEq(cfg.scope, newScope);
         assertEq(cfg.authenticator, keystore.K1_AUTHENTICATOR());
-        assertTrue(keystore.isActor(eoa, selfActorId));
+        assertTrue(_isActor(eoa, selfActorId));
     }
 
     /// @notice Revoking an actor that was never authorized reverts.
@@ -232,7 +232,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         vm.assume(actorId != bytes32(bytes20(eoa)));
 
         _signApply(eoa, eoaPk, _authorizeChange(actorId, address(k1Authenticator), 0, ""));
-        assertTrue(keystore.isActor(eoa, actorId));
+        assertTrue(_isActor(eoa, actorId));
     }
 
     /// @notice The implicit EOA self key can be revoked via the default-EOA flag using another key.
@@ -245,13 +245,13 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         bytes32 selfActorId = bytes32(bytes20(eoa));
         bytes32 newActorId = bytes32(bytes20(vm.addr(newPk)));
         vm.assume(newActorId != selfActorId);
-        assertTrue(keystore.isActor(eoa, selfActorId));
+        assertTrue(_isActor(eoa, selfActorId));
 
         _implicitAuthorizeActor(eoa, eoaPk, newActorId, address(k1Authenticator));
         _revokeActor(eoa, newPk, selfActorId);
 
-        assertFalse(keystore.isActor(eoa, selfActorId));
-        assertTrue(keystore.isActor(eoa, newActorId));
+        assertFalse(_isActor(eoa, selfActorId));
+        assertTrue(_isActor(eoa, newActorId));
 
         Keystore.ActorConfig memory cfg = keystore.getActorConfig(eoa, selfActorId);
         assertEq(cfg.authenticator, address(0));
@@ -271,32 +271,32 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
 
     /// @notice The account's own key can be downgraded to a scoped actor via the self-actorId.
     /// @dev With a single k1 path the config alone decides the scope; there is no implicit full-owner escape.
-    function test_selfActorId_success_scopeViaK1(uint256 eoaPk, uint8 scope, bytes32 hash) public {
+    function test_selfActorId_success_scopeViaK1(uint256 eoaPk, uint16 scope, bytes32 hash) public {
         eoaPk = _boundK1Pk(eoaPk);
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
-        scope = uint8(bound(uint256(scope), 1, 255)) & ~SCOPE_POLICY;
+        scope = uint16(bound(uint256(scope), 1, 255)) & ~SCOPE_POLICY;
         vm.assume(scope != 0);
-        assertTrue(keystore.isActor(eoa, selfActorId));
+        assertTrue(_isActor(eoa, selfActorId));
 
         _implicitAuthorizeActorWithScope(eoa, eoaPk, selfActorId, address(k1Authenticator), scope);
 
-        assertTrue(keystore.isActor(eoa, selfActorId));
+        assertTrue(_isActor(eoa, selfActorId));
         Keystore.ActorConfig memory cfg = keystore.getActorConfig(eoa, selfActorId);
         assertEq(cfg.authenticator, address(k1Authenticator));
         assertEq(cfg.scope, scope);
 
-        (, uint8 outScope,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint16 outScope,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(outScope, scope);
     }
 
     /// @notice A self key scoped to any non-zero scope can no longer authorize, including re-authorizing itself.
     /// @dev Reverts with UnauthorizedActorChange: the downgraded self fails the scope-0 (admin) gate.
-    function test_selfActorId_revert_scopedSelfCannotReauthorize(uint256 eoaPk, uint8 scope) public {
+    function test_selfActorId_revert_scopedSelfCannotReauthorize(uint256 eoaPk, uint16 scope) public {
         eoaPk = _boundK1Pk(eoaPk);
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
-        scope = uint8(bound(uint256(scope), 1, 255)) & ~SCOPE_POLICY;
+        scope = uint16(bound(uint256(scope), 1, 255)) & ~SCOPE_POLICY;
         vm.assume(scope != 0);
 
         _implicitAuthorizeActorWithScope(eoa, eoaPk, selfActorId, address(k1Authenticator), scope);
@@ -317,7 +317,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         uint64 seq = keystore.getChangeSequences(eoa).multichain;
         bytes32 digest = _computeActorChangeBatchDigest(eoa, 0, seq, ch);
         keystore.applySignedActorChanges(eoa, 0, ch, _buildK1Auth(eoaPk, digest));
-        assertTrue(keystore.isActor(eoa, actorId));
+        assertTrue(_isActor(eoa, actorId));
     }
 
     // ── Default EOA self-actorId semantics ──
@@ -334,7 +334,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
         bytes32 selfActorId = bytes32(bytes20(account));
 
-        assertFalse(keystore.isActor(account, selfActorId));
+        assertFalse(_isActor(account, selfActorId));
         Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, selfActorId);
         assertEq(cfg.authenticator, address(0));
         assertEq(cfg.scope, 0);
@@ -345,11 +345,11 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         bytes32 selfActorId = bytes32(bytes20(account));
-        assertFalse(keystore.isActor(account, selfActorId));
+        assertFalse(_isActor(account, selfActorId));
 
         _authorizeActor(account, pk, selfActorId, keystore.K1_AUTHENTICATOR());
 
-        assertTrue(keystore.isActor(account, selfActorId));
+        assertTrue(_isActor(account, selfActorId));
         Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, selfActorId);
         assertEq(cfg.authenticator, keystore.K1_AUTHENTICATOR());
         assertEq(cfg.scope, 0);
@@ -365,19 +365,19 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         bytes32 selfActorId = bytes32(bytes20(eoa));
         bytes32 newActorId = bytes32(bytes20(vm.addr(newPk)));
         vm.assume(newActorId != selfActorId);
-        assertTrue(keystore.isActor(eoa, selfActorId));
+        assertTrue(_isActor(eoa, selfActorId));
 
         _implicitAuthorizeActor(eoa, eoaPk, newActorId, address(k1Authenticator));
         _revokeActor(eoa, newPk, selfActorId);
-        assertFalse(keystore.isActor(eoa, selfActorId));
+        assertFalse(_isActor(eoa, selfActorId));
 
         vm.expectRevert();
         keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
 
         _authorizeActor(eoa, newPk, selfActorId, keystore.K1_AUTHENTICATOR());
-        assertTrue(keystore.isActor(eoa, selfActorId));
+        assertTrue(_isActor(eoa, selfActorId));
 
-        (, uint8 scope,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint16 scope,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(scope, 0);
     }
 
@@ -393,8 +393,8 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         vm.assume(deviceActorId != selfActorId);
 
         // Phase 0: the default EOA is live and authenticates with its own k1 signature.
-        assertTrue(keystore.isActor(eoa, selfActorId));
-        (, uint8 scope0,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        assertTrue(_isActor(eoa, selfActorId));
+        (, uint16 scope0,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(scope0, 0);
 
         // Phase 1: in one batch signed by the EOA, add the device key as a full owner and revoke the default EOA.
@@ -403,19 +403,19 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         switchChanges[1] = Keystore.ActorChange({actorId: selfActorId, changeType: 0x02, data: ""});
         _signApply(eoa, eoaPk, switchChanges);
 
-        assertFalse(keystore.isActor(eoa, selfActorId));
-        assertTrue(keystore.isActor(eoa, deviceActorId));
+        assertFalse(_isActor(eoa, selfActorId));
+        assertTrue(_isActor(eoa, deviceActorId));
         vm.expectRevert();
         keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
-        (, uint8 scope1,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(devicePk, hash));
+        (, uint16 scope1,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(devicePk, hash));
         assertEq(scope1, 0);
 
         // Phase 2: the device key re-enables the K1 key by authorizing the self-actorId as a native k1 owner.
         Keystore.ActorChange[] memory reEnable = _authorizeChange(selfActorId, keystore.K1_AUTHENTICATOR(), 0, "");
         _signApply(eoa, devicePk, reEnable);
 
-        assertTrue(keystore.isActor(eoa, selfActorId));
-        (, uint8 scope2,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        assertTrue(_isActor(eoa, selfActorId));
+        (, uint16 scope2,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(scope2, 0);
     }
 
@@ -434,8 +434,8 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         ch[1] = Keystore.ActorChange({actorId: selfActorId, changeType: 0x02, data: ""});
         _signApply(eoa, eoaPk, ch);
 
-        assertFalse(keystore.isActor(eoa, selfActorId));
-        assertTrue(keystore.isActor(eoa, newActorId));
+        assertFalse(_isActor(eoa, selfActorId));
+        assertTrue(_isActor(eoa, newActorId));
 
         Keystore.ActorConfig memory cfg = keystore.getActorConfig(eoa, selfActorId);
         assertEq(cfg.authenticator, address(0));
@@ -465,7 +465,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         keystore.applySignedActorChanges(eoa, uint64(block.chainid), ch, _buildK1Auth(eoaPk, digest));
 
         keystore.applySignedActorChanges(eoa, uint64(block.chainid), ch, _buildK1Auth(newPk, digest));
-        assertTrue(keystore.isActor(eoa, targetId));
+        assertTrue(_isActor(eoa, targetId));
     }
 
     /// @notice A revoked signer key can no longer authorize actor changes.
@@ -557,7 +557,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
     function test_applySignedActorChanges_adminGate_acrossScopes(
         uint256 ownerPk,
         uint256 signerPk,
-        uint8 signerScope,
+        uint16 signerScope,
         bytes32 targetId
     ) public {
         ownerPk = _boundK1Pk(ownerPk);
@@ -574,7 +574,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         Keystore.ActorChange[] memory ch = _authorizeChange(targetId, address(k1Authenticator), 0, "");
         if (signerScope == 0) {
             _signApply(account, signerPk, ch);
-            assertTrue(keystore.isActor(account, targetId));
+            assertTrue(_isActor(account, targetId));
         } else {
             bytes memory auth = _authOver(account, signerPk, ch);
             vm.expectRevert(Keystore.UnauthorizedActorChange.selector);
@@ -656,7 +656,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         ch[0] = _authorizeChange(actorId, address(k1Authenticator), 0, "")[0];
         ch[1] = Keystore.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
         _signApply(account, pk, ch);
-        assertFalse(keystore.isActor(account, actorId));
+        assertFalse(_isActor(account, actorId));
 
         // Pre-authorize, then [revoke A, authorize A] → A ends live.
         _authorizeActor(account, pk, actorId, address(k1Authenticator));
@@ -664,7 +664,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         ch2[0] = Keystore.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
         ch2[1] = _authorizeChange(actorId, address(k1Authenticator), 0, "")[0];
         _signApply(account, pk, ch2);
-        assertTrue(keystore.isActor(account, actorId));
+        assertTrue(_isActor(account, actorId));
     }
 
     /// @notice An unrestricted (scope 0) signer may revoke itself mid-batch; the scope gate is evaluated once,
@@ -689,8 +689,8 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         ch[1] = _authorizeChange(bId, address(k1Authenticator), 0, "")[0];
         _signApply(account, signerPk, ch);
 
-        assertFalse(keystore.isActor(account, signerId));
-        assertTrue(keystore.isActor(account, bId));
+        assertFalse(_isActor(account, signerId));
+        assertTrue(_isActor(account, bId));
     }
 
     /// @notice Self-actorId flip: k1 self → non-k1 (p256) self → k1 self; the non-k1 config replaces then is replaced.
@@ -716,7 +716,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         // Flip self → k1 owner: deletes the non-k1 config, restores inline k1 (flag cleared); k1 self lives again.
         _authorizeActor(eoa, adminPk, selfId, keystore.K1_AUTHENTICATOR());
         assertEq(keystore.getActorConfig(eoa, selfId).authenticator, keystore.K1_AUTHENTICATOR());
-        (, uint8 scope,) = keystore.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
+        (, uint16 scope,) = keystore.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
         assertEq(scope, 0);
     }
 
@@ -749,7 +749,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
     // ── Helpers ──
 
     /// @dev Build a one-element authorize batch with a full ActorConfig + policyData (expiry fixed at 0).
-    function _authorizeChange(bytes32 actorId, address auth, uint8 scope, bytes memory policyData)
+    function _authorizeChange(bytes32 actorId, address auth, uint16 scope, bytes memory policyData)
         internal
         pure
         returns (Keystore.ActorChange[] memory changes)
@@ -778,7 +778,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
     }
 
     /// @dev Authorize/overwrite the EOA's own inline k1 self-actorId with the given scope, signed by the EOA key.
-    function _rescopeSelf(address eoa, uint256 eoaPk, uint8 scope) internal {
+    function _rescopeSelf(address eoa, uint256 eoaPk, uint16 scope) internal {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: bytes32(bytes20(eoa)),
@@ -801,7 +801,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         uint256 pk,
         bytes32 newActorId,
         address authenticator,
-        uint8 scope
+        uint16 scope
     ) internal {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
@@ -837,7 +837,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         uint256 pk,
         bytes32 newActorId,
         address authenticator,
-        uint8 scope
+        uint16 scope
     ) internal {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -286,7 +286,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         assertEq(cfg.authenticator, address(k1Authenticator));
         assertEq(cfg.scope, scope);
 
-        (, uint16 outScope,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint16 outScope) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(outScope, scope);
     }
 
@@ -377,7 +377,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         _authorizeActor(eoa, newPk, selfActorId, keystore.K1_AUTHENTICATOR());
         assertTrue(_isActor(eoa, selfActorId));
 
-        (, uint16 scope,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint16 scope) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(scope, 0);
     }
 
@@ -394,7 +394,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
 
         // Phase 0: the default EOA is live and authenticates with its own k1 signature.
         assertTrue(_isActor(eoa, selfActorId));
-        (, uint16 scope0,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint16 scope0) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(scope0, 0);
 
         // Phase 1: in one batch signed by the EOA, add the device key as a full owner and revoke the default EOA.
@@ -407,7 +407,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         assertTrue(_isActor(eoa, deviceActorId));
         vm.expectRevert();
         keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
-        (, uint16 scope1,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(devicePk, hash));
+        (, uint16 scope1) = keystore.authenticateActor(eoa, hash, _buildK1Auth(devicePk, hash));
         assertEq(scope1, 0);
 
         // Phase 2: the device key re-enables the K1 key by authorizing the self-actorId as a native k1 owner.
@@ -415,7 +415,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         _signApply(eoa, devicePk, reEnable);
 
         assertTrue(_isActor(eoa, selfActorId));
-        (, uint16 scope2,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint16 scope2) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(scope2, 0);
     }
 
@@ -716,7 +716,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         // Flip self → k1 owner: deletes the non-k1 config, restores inline k1 (flag cleared); k1 self lives again.
         _authorizeActor(eoa, adminPk, selfId, keystore.K1_AUTHENTICATOR());
         assertEq(keystore.getActorConfig(eoa, selfId).authenticator, keystore.K1_AUTHENTICATOR());
-        (, uint16 scope,) = keystore.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
+        (, uint16 scope) = keystore.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
         assertEq(scope, 0);
     }
 

--- a/test/unit/Keystore/authenticate.t.sol
+++ b/test/unit/Keystore/authenticate.t.sol
@@ -349,15 +349,14 @@ contract AuthenticateTest is KeystoreTest {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     /// @notice A never-created EOA authenticates via the implicit self key as a full owner (all-zero inline config).
-    /// @dev _authenticateK1 inline-self branch: recovered == account, flag unset, expiry 0 -> (0, address(0)).
+    /// @dev _authenticateK1 inline-self branch: recovered == account, flag unset, expiry 0 -> scope 0.
     function test_authenticateActor_success_implicitEoaSelf(uint256 eoaSeed, bytes32 hash) public view {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
 
-        (, uint16 scope, address policyTarget) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint16 scope) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
 
-        assertEq(scope, uint8(0x00));
-        assertEq(policyTarget, address(0));
+        assertEq(scope, uint16(0x00));
     }
 
     /// @notice A registered non-self K1 owner (scope 0) authenticates on a created account.
@@ -373,7 +372,7 @@ contract AuthenticateTest is KeystoreTest {
         vm.assume(vm.addr(actorPk) != account);
         _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), 0x00);
 
-        (, uint16 scope,) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        (, uint16 scope) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
@@ -391,7 +390,7 @@ contract AuthenticateTest is KeystoreTest {
         _authorizeActorWithScope(account, ownerPk, _p256ActorId(pk), address(p256Authenticator), scope);
 
         bytes memory auth = abi.encodePacked(address(p256Authenticator), _p256SignData(pk, hash));
-        (, uint16 outScope,) = keystore.authenticateActor(account, hash, auth);
+        (, uint16 outScope) = keystore.authenticateActor(account, hash, auth);
         assertEq(outScope, scope);
     }
 
@@ -411,7 +410,7 @@ contract AuthenticateTest is KeystoreTest {
         _authorizeActorWithScope(account, ownerPk, _p256ActorId(pk), address(webAuthnAuthenticator), scope);
 
         bytes memory auth = abi.encodePacked(address(webAuthnAuthenticator), _webauthnSignData(pk, hash));
-        (, uint16 outScope,) = keystore.authenticateActor(account, hash, auth);
+        (, uint16 outScope) = keystore.authenticateActor(account, hash, auth);
         assertEq(outScope, scope);
     }
 
@@ -433,7 +432,7 @@ contract AuthenticateTest is KeystoreTest {
         vm.assume(vm.addr(actorPk) != account);
         _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), scope);
 
-        (, uint16 outScope,) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        (, uint16 outScope) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(outScope, scope);
     }
 
@@ -450,7 +449,7 @@ contract AuthenticateTest is KeystoreTest {
         vm.assume(vm.addr(actorPk) != account);
         _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), 0x00);
 
-        (, uint16 scope,) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        (, uint16 scope) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
@@ -471,7 +470,7 @@ contract AuthenticateTest is KeystoreTest {
         _authorizeActorWithExpiry(account, ownerPk, bytes32(bytes20(vm.addr(sessionPk))), address(k1Authenticator), 0);
 
         vm.warp(block.timestamp + bound(warpSeed, 1, 3650 days));
-        (, uint16 scope,) = keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
+        (, uint16 scope) = keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
@@ -495,13 +494,13 @@ contract AuthenticateTest is KeystoreTest {
         );
 
         vm.warp(expiry);
-        (, uint16 scope,) = keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
+        (, uint16 scope) = keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
-    /// @notice A policy-gated actor surfaces its scope and resolved policy target (manager).
-    /// @dev policyTarget resolves to the stored manager; the commitment is not returned here (execution-time read).
-    function test_authenticateActor_success_gatedActorReturnsScopePolicyTarget(
+    /// @notice A policy-gated actor surfaces its scope; the policy target is resolved separately via getPolicyManager.
+    /// @dev authenticateActor returns (actorId, scope) only; the manager is an execution-time read (getPolicyManager).
+    function test_authenticateActor_success_gatedActorReturnsScope(
         uint256 ownerSeed,
         uint256 sessionSeed,
         uint8 scopeSeed,
@@ -522,23 +521,22 @@ contract AuthenticateTest is KeystoreTest {
         bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
         _authorizeGatedActor(account, ownerPk, sessionActorId, scope, manager, commitment);
 
-        (, uint16 outScope, address outTarget) =
-            keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
+        (, uint16 outScope) = keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
 
         assertEq(outScope, scope);
-        assertEq(outTarget, manager);
+        assertEq(keystore.getPolicyManager(account, sessionActorId), manager);
     }
 
-    /// @notice An ungated actor authenticates with a zero policy target.
-    /// @dev No manager slot is written for an ungated actor, so policyTarget is address(0).
-    function test_authenticateActor_success_ungatedActorReturnsZeroPolicy(uint256 eoaSeed, bytes32 hash) public view {
+    /// @notice An ungated actor authenticates and returns only its scope (no policy manager slot written).
+    /// @dev getPolicyManager is address(0) for an ungated actor.
+    function test_authenticateActor_success_ungatedActorReturnsScope(uint256 eoaSeed, bytes32 hash) public view {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
 
-        (, uint16 scope, address policyTarget) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint16 scope) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
 
-        assertEq(scope, uint8(0x00));
-        assertEq(policyTarget, address(0));
+        assertEq(scope, uint16(0x00));
+        assertEq(keystore.getPolicyManager(eoa, bytes32(bytes20(eoa))), address(0));
     }
 
     /// @notice Scoping the account's own key downgrades it: the inline self returns the reduced scope, never owner.
@@ -552,7 +550,7 @@ contract AuthenticateTest is KeystoreTest {
 
         _authorizeActorWithScope(eoa, eoaPk, selfActorId, address(k1Authenticator), scope);
 
-        (, uint16 outScope,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint16 outScope) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(outScope, scope);
     }
 
@@ -568,7 +566,7 @@ contract AuthenticateTest is KeystoreTest {
 
         _implicitAuthorizeActor(eoa, eoaPk, bytes32(bytes20(vm.addr(bobPk))), address(k1Authenticator));
 
-        (, uint16 scope,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(bobPk, hash));
+        (, uint16 scope) = keystore.authenticateActor(eoa, hash, _buildK1Auth(bobPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
@@ -585,8 +583,8 @@ contract AuthenticateTest is KeystoreTest {
         vm.assume(accountA != accountB);
 
         bytes memory auth = _buildK1Auth(ownerPk, hash);
-        (, uint16 scopeA,) = keystore.authenticateActor(accountA, hash, auth);
-        (, uint16 scopeB,) = keystore.authenticateActor(accountB, hash, auth);
+        (, uint16 scopeA) = keystore.authenticateActor(accountA, hash, auth);
+        (, uint16 scopeB) = keystore.authenticateActor(accountB, hash, auth);
         assertEq(scopeA, uint16(0x00));
         assertEq(scopeB, uint16(0x00));
     }
@@ -603,7 +601,7 @@ contract AuthenticateTest is KeystoreTest {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
 
-        (bytes32 actorId,,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (bytes32 actorId,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(actorId, bytes32(bytes20(eoa)));
     }
 
@@ -620,7 +618,7 @@ contract AuthenticateTest is KeystoreTest {
         bytes32 expectedActorId = bytes32(bytes20(vm.addr(actorPk)));
         _authorizeActorWithScope(account, ownerPk, expectedActorId, address(k1Authenticator), 0x00);
 
-        (bytes32 actorId,,) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        (bytes32 actorId,) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(actorId, expectedActorId);
     }
 
@@ -636,7 +634,7 @@ contract AuthenticateTest is KeystoreTest {
         _authorizeActorWithScope(account, ownerPk, expectedActorId, address(p256Authenticator), 0x00);
 
         bytes memory auth = abi.encodePacked(address(p256Authenticator), _p256SignData(pk, hash));
-        (bytes32 actorId,,) = keystore.authenticateActor(account, hash, auth);
+        (bytes32 actorId,) = keystore.authenticateActor(account, hash, auth);
         assertEq(actorId, expectedActorId);
     }
 
@@ -652,7 +650,7 @@ contract AuthenticateTest is KeystoreTest {
         _authorizeActorWithScope(account, ownerPk, expectedActorId, address(webAuthnAuthenticator), 0x00);
 
         bytes memory auth = abi.encodePacked(address(webAuthnAuthenticator), _webauthnSignData(pk, hash));
-        (bytes32 actorId,,) = keystore.authenticateActor(account, hash, auth);
+        (bytes32 actorId,) = keystore.authenticateActor(account, hash, auth);
         assertEq(actorId, expectedActorId);
     }
 
@@ -673,7 +671,7 @@ contract AuthenticateTest is KeystoreTest {
         bytes32 expectedActorId = bytes32(bytes20(vm.addr(actorPk)));
         _authorizeActorWithScope(account, ownerPk, expectedActorId, address(k1Authenticator), scope);
 
-        (bytes32 actorId, uint16 outScope,) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        (bytes32 actorId, uint16 outScope) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(actorId, expectedActorId);
         assertEq(outScope, scope);
     }
@@ -691,7 +689,7 @@ contract AuthenticateTest is KeystoreTest {
 
         _authorizeActorWithScope(eoa, eoaPk, selfActorId, address(k1Authenticator), scope);
 
-        (bytes32 actorId, uint16 outScope,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (bytes32 actorId, uint16 outScope) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(actorId, selfActorId);
         assertEq(outScope, scope);
     }

--- a/test/unit/Keystore/authenticate.t.sol
+++ b/test/unit/Keystore/authenticate.t.sol
@@ -19,11 +19,11 @@ import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 ///         The authentication functions are `view` and emit no events, so there are no event assertions here;
 ///         events (ActorAuthorized / ActorRevoked) belong to the applyKeyChange suite that drives the config writes.
 contract AuthenticateTest is KeystoreTest {
-    uint8 constant SCOPE_SENDER = 0x01;
-    uint8 constant SCOPE_POLICY = 0x02;
-    uint8 constant SCOPE_NONCE = 0x04;
-    uint8 constant SCOPE_SELF_PAYER = 0x08;
-    uint8 constant SCOPE_SPONSOR_PAYER = 0x10;
+    uint16 constant SCOPE_SENDER = 0x01;
+    uint16 constant SCOPE_POLICY = 0x02;
+    uint16 constant SCOPE_NONCE = 0x04;
+    uint16 constant SCOPE_SELF_PAYER = 0x08;
+    uint16 constant SCOPE_SPONSOR_PAYER = 0x10;
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // REVERTS (source order)
@@ -354,7 +354,7 @@ contract AuthenticateTest is KeystoreTest {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
 
-        (, uint8 scope, address policyTarget) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint16 scope, address policyTarget) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
 
         assertEq(scope, uint8(0x00));
         assertEq(policyTarget, address(0));
@@ -373,7 +373,7 @@ contract AuthenticateTest is KeystoreTest {
         vm.assume(vm.addr(actorPk) != account);
         _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), 0x00);
 
-        (, uint8 scope,) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        (, uint16 scope,) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
@@ -385,13 +385,13 @@ contract AuthenticateTest is KeystoreTest {
     {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
         uint256 pk = _boundP256Pk(pkSeed);
-        uint8 scope = uint8(bound(uint256(scopeSeed), 0, 255)) & ~SCOPE_POLICY;
+        uint16 scope = uint16(bound(uint256(scopeSeed), 0, 255)) & ~SCOPE_POLICY;
 
         (address account,) = _createK1Account(ownerPk);
         _authorizeActorWithScope(account, ownerPk, _p256ActorId(pk), address(p256Authenticator), scope);
 
         bytes memory auth = abi.encodePacked(address(p256Authenticator), _p256SignData(pk, hash));
-        (, uint8 outScope,) = keystore.authenticateActor(account, hash, auth);
+        (, uint16 outScope,) = keystore.authenticateActor(account, hash, auth);
         assertEq(outScope, scope);
     }
 
@@ -405,13 +405,13 @@ contract AuthenticateTest is KeystoreTest {
     ) public {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
         uint256 pk = _boundP256Pk(pkSeed);
-        uint8 scope = uint8(bound(uint256(scopeSeed), 0, 255)) & ~SCOPE_POLICY;
+        uint16 scope = uint16(bound(uint256(scopeSeed), 0, 255)) & ~SCOPE_POLICY;
 
         (address account,) = _createK1Account(ownerPk);
         _authorizeActorWithScope(account, ownerPk, _p256ActorId(pk), address(webAuthnAuthenticator), scope);
 
         bytes memory auth = abi.encodePacked(address(webAuthnAuthenticator), _webauthnSignData(pk, hash));
-        (, uint8 outScope,) = keystore.authenticateActor(account, hash, auth);
+        (, uint16 outScope,) = keystore.authenticateActor(account, hash, auth);
         assertEq(outScope, scope);
     }
 
@@ -427,13 +427,13 @@ contract AuthenticateTest is KeystoreTest {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
         uint256 actorPk = _boundK1Pk(actorSeed);
         vm.assume(vm.addr(ownerPk) != vm.addr(actorPk));
-        uint8 scope = uint8(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_POLICY;
+        uint16 scope = uint16(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_POLICY;
 
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(actorPk) != account);
         _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), scope);
 
-        (, uint8 outScope,) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        (, uint16 outScope,) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(outScope, scope);
     }
 
@@ -450,7 +450,7 @@ contract AuthenticateTest is KeystoreTest {
         vm.assume(vm.addr(actorPk) != account);
         _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), 0x00);
 
-        (, uint8 scope,) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        (, uint16 scope,) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
@@ -471,7 +471,7 @@ contract AuthenticateTest is KeystoreTest {
         _authorizeActorWithExpiry(account, ownerPk, bytes32(bytes20(vm.addr(sessionPk))), address(k1Authenticator), 0);
 
         vm.warp(block.timestamp + bound(warpSeed, 1, 3650 days));
-        (, uint8 scope,) = keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
+        (, uint16 scope,) = keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
@@ -495,7 +495,7 @@ contract AuthenticateTest is KeystoreTest {
         );
 
         vm.warp(expiry);
-        (, uint8 scope,) = keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
+        (, uint16 scope,) = keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
@@ -515,14 +515,15 @@ contract AuthenticateTest is KeystoreTest {
         vm.assume(manager != address(0));
         vm.assume(commitment != bytes32(0));
         // A policy-bearing actor's scope carries SCOPE_POLICY; other bits are arbitrary.
-        uint8 scope = uint8(scopeSeed) | SCOPE_POLICY;
+        uint16 scope = uint16(scopeSeed) | SCOPE_POLICY;
 
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(sessionPk) != account);
         bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
         _authorizeGatedActor(account, ownerPk, sessionActorId, scope, manager, commitment);
 
-        (, uint8 outScope, address outTarget) = keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
+        (, uint16 outScope, address outTarget) =
+            keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
 
         assertEq(outScope, scope);
         assertEq(outTarget, manager);
@@ -534,7 +535,7 @@ contract AuthenticateTest is KeystoreTest {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
 
-        (, uint8 scope, address policyTarget) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint16 scope, address policyTarget) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
 
         assertEq(scope, uint8(0x00));
         assertEq(policyTarget, address(0));
@@ -546,12 +547,12 @@ contract AuthenticateTest is KeystoreTest {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
-        uint8 scope = uint8(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_POLICY;
+        uint16 scope = uint16(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_POLICY;
         vm.assume(scope != 0);
 
         _authorizeActorWithScope(eoa, eoaPk, selfActorId, address(k1Authenticator), scope);
 
-        (, uint8 outScope,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint16 outScope,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(outScope, scope);
     }
 
@@ -567,7 +568,7 @@ contract AuthenticateTest is KeystoreTest {
 
         _implicitAuthorizeActor(eoa, eoaPk, bytes32(bytes20(vm.addr(bobPk))), address(k1Authenticator));
 
-        (, uint8 scope,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(bobPk, hash));
+        (, uint16 scope,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(bobPk, hash));
         assertEq(scope, uint8(0x00));
     }
 
@@ -584,10 +585,10 @@ contract AuthenticateTest is KeystoreTest {
         vm.assume(accountA != accountB);
 
         bytes memory auth = _buildK1Auth(ownerPk, hash);
-        (, uint8 scopeA,) = keystore.authenticateActor(accountA, hash, auth);
-        (, uint8 scopeB,) = keystore.authenticateActor(accountB, hash, auth);
-        assertEq(scopeA, uint8(0x00));
-        assertEq(scopeB, uint8(0x00));
+        (, uint16 scopeA,) = keystore.authenticateActor(accountA, hash, auth);
+        (, uint16 scopeB,) = keystore.authenticateActor(accountB, hash, auth);
+        assertEq(scopeA, uint16(0x00));
+        assertEq(scopeB, uint16(0x00));
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -665,14 +666,14 @@ contract AuthenticateTest is KeystoreTest {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
         uint256 actorPk = _boundK1Pk(actorSeed);
         vm.assume(vm.addr(ownerPk) != vm.addr(actorPk));
-        uint8 scope = uint8(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_POLICY;
+        uint16 scope = uint16(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_POLICY;
 
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(actorPk) != account);
         bytes32 expectedActorId = bytes32(bytes20(vm.addr(actorPk)));
         _authorizeActorWithScope(account, ownerPk, expectedActorId, address(k1Authenticator), scope);
 
-        (bytes32 actorId, uint8 outScope,) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        (bytes32 actorId, uint16 outScope,) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(actorId, expectedActorId);
         assertEq(outScope, scope);
     }
@@ -686,11 +687,11 @@ contract AuthenticateTest is KeystoreTest {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
-        uint8 scope = uint8(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_POLICY;
+        uint16 scope = uint16(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_POLICY;
 
         _authorizeActorWithScope(eoa, eoaPk, selfActorId, address(k1Authenticator), scope);
 
-        (bytes32 actorId, uint8 outScope,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (bytes32 actorId, uint16 outScope,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(actorId, selfActorId);
         assertEq(outScope, scope);
     }
@@ -713,7 +714,7 @@ contract AuthenticateTest is KeystoreTest {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
         uint256 actorPk = _boundK1Pk(actorSeed);
         vm.assume(vm.addr(ownerPk) != vm.addr(actorPk));
-        uint8 scope = uint8(bound(uint256(scopeSeed), 0, 255)) & ~SCOPE_POLICY;
+        uint16 scope = uint16(bound(uint256(scopeSeed), 0, 255)) & ~SCOPE_POLICY;
 
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(actorPk) != account);
@@ -835,7 +836,7 @@ contract AuthenticateTest is KeystoreTest {
         vm.assume(vm.addr(ownerPk) != vm.addr(sessionPk));
         vm.assume(manager != address(0));
         vm.assume(commitment != bytes32(0));
-        uint8 scope = uint8(scopeSeed) | SCOPE_POLICY;
+        uint16 scope = uint16(scopeSeed) | SCOPE_POLICY;
 
         (address account,) = _createK1Account(ownerPk);
         bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
@@ -891,7 +892,7 @@ contract AuthenticateTest is KeystoreTest {
     /// @dev No _actorConfig entry, actorId == self, flag unset -> true.
     function test_isActor_success_implicitEoaTrue(uint256 eoaSeed) public view {
         address eoa = vm.addr(_boundK1Pk(eoaSeed));
-        assertTrue(keystore.isActor(eoa, bytes32(bytes20(eoa))));
+        assertTrue(_isActor(eoa, bytes32(bytes20(eoa))));
     }
 
     /// @notice isActor reports a non-self actorId on a never-created EOA as not live.
@@ -899,7 +900,7 @@ contract AuthenticateTest is KeystoreTest {
     function test_isActor_success_nonSelfActorIdNotImplicit(uint256 eoaSeed, bytes32 randomActorId) public view {
         address eoa = vm.addr(_boundK1Pk(eoaSeed));
         vm.assume(randomActorId != bytes32(bytes20(eoa)));
-        assertFalse(keystore.isActor(eoa, randomActorId));
+        assertFalse(_isActor(eoa, randomActorId));
     }
 
     /// @notice isActor reports the self-actorId as not live after the self key has been revoked.
@@ -911,7 +912,7 @@ contract AuthenticateTest is KeystoreTest {
 
         _revokeActor(eoa, eoaPk, selfActorId);
 
-        assertFalse(keystore.isActor(eoa, selfActorId));
+        assertFalse(_isActor(eoa, selfActorId));
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -927,7 +928,7 @@ contract AuthenticateTest is KeystoreTest {
         uint256 pk,
         bytes32 newActorId,
         address authenticator,
-        uint8 scope
+        uint16 scope
     ) internal {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
@@ -984,7 +985,7 @@ contract AuthenticateTest is KeystoreTest {
         address account,
         uint256 ownerPk,
         bytes32 newActorId,
-        uint8 scope,
+        uint16 scope,
         address policyManager,
         bytes32 commitment
     ) internal {

--- a/test/unit/Keystore/createAccount.t.sol
+++ b/test/unit/Keystore/createAccount.t.sol
@@ -176,7 +176,7 @@ contract CreateAccountTest is KeystoreTest {
         assertEq(predicted.code.length, 0);
         assertEq(keystore.getChangeSequences(predicted).local, 0);
         assertEq(keystore.getChangeSequences(predicted).multichain, 0);
-        assertFalse(keystore.isActor(predicted, actorId));
+        assertFalse(_isActor(predicted, actorId));
 
         // The writes were unwound, so the re-init guard is not tripped: the retry re-attempts the deploy and fails
         // again on the same invalid bytecode rather than reverting AlreadyInitialized.
@@ -201,7 +201,7 @@ contract CreateAccountTest is KeystoreTest {
 
         assertTrue(account != address(0));
         assertGt(account.code.length, 0);
-        assertTrue(keystore.isActor(account, actorId));
+        assertTrue(_isActor(account, actorId));
     }
 
     /// @notice Verifies an account with many sorted initial actors deploys and registers every actor as live
@@ -218,7 +218,7 @@ contract CreateAccountTest is KeystoreTest {
 
         assertGt(account.code.length, 0);
         for (uint256 i; i < count; i++) {
-            assertTrue(keystore.isActor(account, actors[i].actorId));
+            assertTrue(_isActor(account, actors[i].actorId));
         }
     }
 
@@ -243,7 +243,7 @@ contract CreateAccountTest is KeystoreTest {
         assertEq(cfg.authenticator, authenticator);
         assertEq(cfg.scope, 0x00);
         assertEq(cfg.expiry, 0);
-        assertTrue(keystore.isActor(account, actorId));
+        assertTrue(_isActor(account, actorId));
     }
 
     /// @notice Verifies initial actors are unrestricted owners and the account is initialized with safe lock defaults
@@ -287,7 +287,7 @@ contract CreateAccountTest is KeystoreTest {
 
         // The account's own self-actorId is not the seeded actor, so the inline k1 self stays disabled.
         vm.assume(bytes32(bytes20(account)) != actorId);
-        assertFalse(keystore.isActor(account, bytes32(bytes20(account))));
+        assertFalse(_isActor(account, bytes32(bytes20(account))));
     }
 
     /// @notice Verifies arbitrary valid runtime bytecode of a fuzzed length/content deploys successfully

--- a/test/unit/Keystore/importAccount.t.sol
+++ b/test/unit/Keystore/importAccount.t.sol
@@ -557,7 +557,7 @@ contract ImportAccountTest is KeystoreTest {
         // The same key still authenticates as a full owner — now via its explicit self config, not the (disabled)
         // implicit fallback.
         bytes32 h = keccak256("post import");
-        (, uint16 scope,) = keystore.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
+        (, uint16 scope) = keystore.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
         assertEq(scope, 0);
     }
 }

--- a/test/unit/Keystore/importAccount.t.sol
+++ b/test/unit/Keystore/importAccount.t.sol
@@ -52,12 +52,12 @@ contract ImportAccountTest is KeystoreTest {
     // retains the full Actor/ActorConfig typehash structure; for imported (always unrestricted) actors the config
     // fields are zero and policyData is empty.
     bytes32 constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
-        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry)"
+        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
     );
     bytes32 constant ACTOR_TYPEHASH = keccak256(
-        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint8 scope,uint48 expiry)"
+        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
     );
-    bytes32 constant ACTORCONFIG_TYPEHASH = keccak256("ActorConfig(address authenticator,uint8 scope,uint48 expiry)");
+    bytes32 constant ACTORCONFIG_TYPEHASH = keccak256("ActorConfig(address authenticator,uint48 expiry,uint16 scope)");
 
     // ── digest helpers ──
 
@@ -79,7 +79,7 @@ contract ImportAccountTest is KeystoreTest {
         for (uint256 i; i < initialActors.length; i++) {
             // Hash the actor's real scope; expiry is always 0 at import. policyData is hashed into the Actor hash.
             bytes32 configHash = keccak256(
-                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, initialActors[i].scope, uint48(0))
+                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), initialActors[i].scope)
             );
             actorHashes[i] = keccak256(
                 abi.encode(ACTOR_TYPEHASH, initialActors[i].actorId, configHash, keccak256(initialActors[i].policyData))
@@ -402,7 +402,7 @@ contract ImportAccountTest is KeystoreTest {
         keystore.importAccount(address(wallet), block.chainid, actors, sig);
 
         assertEq(keystore.getChangeSequences(address(wallet)).local, 1);
-        assertTrue(keystore.isActor(address(wallet), bytes32(bytes20(vm.addr(ownerPk)))));
+        assertTrue(_isActor(address(wallet), bytes32(bytes20(vm.addr(ownerPk)))));
     }
 
     /// @notice Verifies a chainId == 0 (multichain) import signature authorizes import and still sets localSequence.
@@ -417,7 +417,7 @@ contract ImportAccountTest is KeystoreTest {
 
         assertEq(keystore.getChangeSequences(address(wallet)).local, 1);
         assertEq(keystore.getChangeSequences(address(wallet)).multichain, 0);
-        assertTrue(keystore.isActor(address(wallet), bytes32(bytes20(vm.addr(ownerPk)))));
+        assertTrue(_isActor(address(wallet), bytes32(bytes20(vm.addr(ownerPk)))));
     }
 
     /// @notice Verifies importAccount emits AccountImported(account) exactly once on the happy path.
@@ -444,7 +444,7 @@ contract ImportAccountTest is KeystoreTest {
         keystore.importAccount(address(wallet), chainId, actors, sig);
 
         // The implicit default EOA (self-actorId) is disabled by default on import.
-        assertFalse(keystore.isActor(address(wallet), bytes32(bytes20(address(wallet)))));
+        assertFalse(_isActor(address(wallet), bytes32(bytes20(address(wallet)))));
         Keystore.ActorConfig memory selfConfig =
             keystore.getActorConfig(address(wallet), bytes32(bytes20(address(wallet))));
         assertEq(selfConfig.authenticator, address(0));
@@ -469,7 +469,7 @@ contract ImportAccountTest is KeystoreTest {
         assertEq(keystore.getChangeSequences(address(wallet)).local, 1);
         for (uint256 i; i < count; i++) {
             bytes32 actorId = actors[i].actorId;
-            assertTrue(keystore.isActor(address(wallet), actorId));
+            assertTrue(_isActor(address(wallet), actorId));
             Keystore.ActorConfig memory config = keystore.getActorConfig(address(wallet), actorId);
             assertEq(config.authenticator, address(k1Authenticator));
             assertEq(config.scope, 0);
@@ -498,8 +498,8 @@ contract ImportAccountTest is KeystoreTest {
         keystore.importAccount(eoa, uint64(block.chainid), actors, sig);
 
         assertEq(keystore.getChangeSequences(eoa).local, 1);
-        assertTrue(keystore.isActor(eoa, bytes32(bytes20(device))));
-        assertFalse(keystore.isActor(eoa, bytes32(bytes20(eoa))));
+        assertTrue(_isActor(eoa, bytes32(bytes20(device))));
+        assertFalse(_isActor(eoa, bytes32(bytes20(eoa))));
     }
 
     /// @notice Verifies a real EIP-7702 EOA delegated to DefaultAccount can self-import with its own k1 signature.
@@ -522,8 +522,8 @@ contract ImportAccountTest is KeystoreTest {
         );
 
         assertEq(keystore.getChangeSequences(eoa).local, 1);
-        assertTrue(keystore.isActor(eoa, bytes32(bytes20(device))));
-        assertFalse(keystore.isActor(eoa, bytes32(bytes20(eoa))));
+        assertTrue(_isActor(eoa, bytes32(bytes20(device))));
+        assertFalse(_isActor(eoa, bytes32(bytes20(eoa))));
 
         // The implicit default EOA is disabled after import: its own k1 sig now finds no config.
         bytes32 h = keccak256("post import");
@@ -552,12 +552,12 @@ contract ImportAccountTest is KeystoreTest {
 
         assertEq(keystore.getChangeSequences(eoa).local, 1);
         // The self-actorId is a live explicit owner.
-        assertTrue(keystore.isActor(eoa, bytes32(bytes20(eoa))));
+        assertTrue(_isActor(eoa, bytes32(bytes20(eoa))));
 
         // The same key still authenticates as a full owner — now via its explicit self config, not the (disabled)
         // implicit fallback.
         bytes32 h = keccak256("post import");
-        (, uint8 scope,) = keystore.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
+        (, uint16 scope,) = keystore.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
         assertEq(scope, 0);
     }
 }

--- a/test/unit/Keystore/policyAccessors.t.sol
+++ b/test/unit/Keystore/policyAccessors.t.sol
@@ -36,7 +36,7 @@ contract PolicyAccessorsTest is KeystoreTest {
         (address account,) = _createK1Account(rootPk);
         actorId = _boundExplicitActorId(account, rootPk, actorId);
 
-        uint8 scope = _boundGatedScope(scopeSeed);
+        uint16 scope = _boundGatedScope(scopeSeed);
         address manager = _boundNonZeroAddress(managerSeed);
         bytes32 commitment = _boundNonZeroWord(commitmentSeed);
 
@@ -83,7 +83,7 @@ contract PolicyAccessorsTest is KeystoreTest {
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
 
-        uint8 scope = _boundGatedScope(scopeSeed);
+        uint16 scope = _boundGatedScope(scopeSeed);
         address manager = _boundNonZeroAddress(managerSeed);
         bytes32 commitment = _boundNonZeroWord(commitmentSeed);
 
@@ -348,7 +348,7 @@ contract PolicyAccessorsTest is KeystoreTest {
         (address account,) = _createK1Account(rootPk);
         actorId = _boundExplicitActorId(account, rootPk, actorId);
 
-        uint8 scope = _boundGatedScope(scopeSeed);
+        uint16 scope = _boundGatedScope(scopeSeed);
         address manager = _boundNonZeroAddress(managerSeed);
         bytes32 commitment = _boundNonZeroWord(commitmentSeed);
         address newManager = _boundNonZeroAddress(newManagerSeed);
@@ -394,13 +394,13 @@ contract PolicyAccessorsTest is KeystoreTest {
         address manager = _boundNonZeroAddress(managerSeed);
         bytes32 commitment = _boundNonZeroWord(commitmentSeed);
 
-        uint8[4] memory otherScopes =
+        uint16[4] memory otherScopes =
             [uint8(0), keystore.SCOPE_SELF_PAYER(), keystore.SCOPE_SPONSOR_PAYER(), keystore.SCOPE_NONCE()];
         for (uint256 i; i < otherScopes.length; i++) {
             // Policy actors are keyed by actorId only; no signing key is needed, so a distinct address-shaped id
             // avoids the vm.addr curve-order bound on an unbounded rootPk + i.
             bytes32 actorId = bytes32(bytes20(address(uint160(1000 + i))));
-            uint8 scope = otherScopes[i] | keystore.SCOPE_POLICY();
+            uint16 scope = otherScopes[i] | keystore.SCOPE_POLICY();
             _authorizePolicyActor(account, rootPk, actorId, scope, manager, commitment);
 
             assertEq(keystore.getPolicyManager(account, actorId), manager);
@@ -429,7 +429,7 @@ contract PolicyAccessorsTest is KeystoreTest {
         actorB = _boundExplicitActorId(account, rootPk, actorB);
         vm.assume(actorA != actorB);
 
-        uint8 scope = _boundGatedScope(scopeSeed);
+        uint16 scope = _boundGatedScope(scopeSeed);
         address managerA = _boundNonZeroAddress(managerSeedA);
         bytes32 commitmentA = _boundNonZeroWord(commitmentSeedA);
         address managerB = _boundNonZeroAddress(managerSeedB);
@@ -467,7 +467,7 @@ contract PolicyAccessorsTest is KeystoreTest {
         vm.assume(sharedActorId != bytes32(bytes20(accountA)));
         vm.assume(sharedActorId != bytes32(bytes20(accountB)));
 
-        uint8 scope = _boundGatedScope(scopeSeed);
+        uint16 scope = _boundGatedScope(scopeSeed);
         address managerA = _boundNonZeroAddress(managerSeedA);
         bytes32 commitmentA = _boundNonZeroWord(commitmentSeedA);
         address managerB = _boundNonZeroAddress(managerSeedB);
@@ -511,7 +511,7 @@ contract PolicyAccessorsTest is KeystoreTest {
             account, rootPk, sessionActorId, _boundGatedScope(scopeSeed), manager, _boundNonZeroWord(commitmentSeed)
         );
 
-        (, uint8 outScope, address policyTarget) =
+        (, uint16 outScope, address policyTarget) =
             keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
         assertTrue(outScope & keystore.SCOPE_POLICY() != 0);
         assertEq(policyTarget, manager);
@@ -564,7 +564,7 @@ contract PolicyAccessorsTest is KeystoreTest {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
 
-        (, uint8 outScope, address policyTarget) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        (, uint16 outScope, address policyTarget) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(outScope, uint8(0x00));
         assertEq(policyTarget, address(0));
     }
@@ -574,8 +574,8 @@ contract PolicyAccessorsTest is KeystoreTest {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     /// @dev A policy-bearing actor's scope: always carries SCOPE_POLICY, with arbitrary other bits mixed in.
-    function _boundGatedScope(uint8 seed) internal view returns (uint8) {
-        return uint8(seed) | keystore.SCOPE_POLICY();
+    function _boundGatedScope(uint8 seed) internal view returns (uint16) {
+        return uint16(seed) | keystore.SCOPE_POLICY();
     }
 
     /// @dev A non-zero policy manager address (so a written slot is distinguishable from an unwritten one).
@@ -637,13 +637,12 @@ contract PolicyAccessorsTest is KeystoreTest {
         address account,
         uint256 rootPk,
         bytes32 actorId,
-        uint8 scope,
+        uint16 scope,
         address policyManager,
         bytes32 commitment
     ) internal {
-        Keystore.ActorConfig memory cfg = Keystore.ActorConfig({
-            authenticator: address(k1Authenticator), scope: scope, expiry: 0
-        });
+        Keystore.ActorConfig memory cfg =
+            Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0});
         bytes memory policyData = abi.encodePacked(policyManager, commitment);
 
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
@@ -661,7 +660,7 @@ contract PolicyAccessorsTest is KeystoreTest {
     function _authorizeInlineSelfWithPolicy(
         address eoa,
         uint256 eoaPk,
-        uint8 scope,
+        uint16 scope,
         address policyManager,
         bytes32 commitment
     ) internal {

--- a/test/unit/Keystore/policyAccessors.t.sol
+++ b/test/unit/Keystore/policyAccessors.t.sol
@@ -7,8 +7,7 @@ import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 /// @notice Fully-fuzzed unit tests for the policy accessors on `Keystore`:
 ///           - `getPolicy(account, actorId)`           — off-chain aggregate: (manager, commitment)
 ///           - `getPolicyCommitment(account, actorId)` — single-SLOAD hot-path read
-///           - `getPolicyManager(account, actorId)`    — single-SLOAD hot-path read
-///           - policyTarget                            — surfaced as the third return of `authenticateActor`
+///           - `getPolicyManager(account, actorId)`    — single-SLOAD hot-path read (the resolved policy target)
 ///
 ///         All are `view`; there are no events to assert. Every test fuzzes its inputs (managers, commitments,
 ///         actorIds, keys, scopes). Gating is determined by the SCOPE_POLICY bit, never by "slot non-zero": a
@@ -483,13 +482,13 @@ contract PolicyAccessorsTest is KeystoreTest {
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // policyTarget — surfaced as the third return of authenticateActor
+    // policyTarget — resolved via getPolicyManager (an execution-time read, not an authenticateActor return)
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     //
-    // authenticateActor returns the stored policy manager as its third value (address(0) when unwritten).
+    // authenticateActor returns (actorId, scope); the policy manager is resolved separately via getPolicyManager
+    // (address(0) when unwritten). These tests authenticate to confirm the actor is live, then read the manager.
 
-    /// @notice A gated non-self actor authenticates; policyTarget resolves to the stored manager, equal to the
-    ///         granular getPolicyManager read.
+    /// @notice A gated non-self actor authenticates; getPolicyManager resolves to the stored manager.
     function test_policyTarget_success_gatedExplicitActor_returnsManager(
         uint256 rootSeed,
         uint256 sessionSeed,
@@ -511,14 +510,12 @@ contract PolicyAccessorsTest is KeystoreTest {
             account, rootPk, sessionActorId, _boundGatedScope(scopeSeed), manager, _boundNonZeroWord(commitmentSeed)
         );
 
-        (, uint16 outScope, address policyTarget) =
-            keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
+        (, uint16 outScope) = keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
         assertTrue(outScope & keystore.SCOPE_POLICY() != 0);
-        assertEq(policyTarget, manager);
-        assertEq(policyTarget, keystore.getPolicyManager(account, sessionActorId));
+        assertEq(keystore.getPolicyManager(account, sessionActorId), manager);
     }
 
-    /// @notice An ungated non-self actor authenticates; policyTarget is address(0) (no manager slot written).
+    /// @notice An ungated non-self actor authenticates; getPolicyManager is address(0) (no manager slot written).
     function test_policyTarget_success_ungatedActor_returnsZero(uint256 rootSeed, uint256 sessionSeed, bytes32 hash)
         public
     {
@@ -532,11 +529,11 @@ contract PolicyAccessorsTest is KeystoreTest {
 
         _authorizeUngatedActor(account, rootPk, sessionActorId, address(k1Authenticator));
 
-        (,, address policyTarget) = keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
-        assertEq(policyTarget, address(0));
+        keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
+        assertEq(keystore.getPolicyManager(account, sessionActorId), address(0));
     }
 
-    /// @notice A gated inline self authenticates; policyTarget resolves to the stored manager via the inline home.
+    /// @notice A gated inline self authenticates; getPolicyManager resolves to the stored manager via the inline home.
     function test_policyTarget_success_inlineSelfGated_returnsManager(
         uint256 eoaSeed,
         uint8 scopeSeed,
@@ -553,20 +550,19 @@ contract PolicyAccessorsTest is KeystoreTest {
             eoa, eoaPk, _boundGatedScope(scopeSeed), manager, _boundNonZeroWord(commitmentSeed)
         );
 
-        (,, address policyTarget) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
-        assertEq(policyTarget, manager);
-        assertEq(policyTarget, keystore.getPolicyManager(eoa, selfActorId));
+        keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        assertEq(keystore.getPolicyManager(eoa, selfActorId), manager);
     }
 
-    /// @notice A fresh EOA (implicit full owner, ungated) authenticates; policyTarget is address(0) over untouched
-    ///         state.
+    /// @notice A fresh EOA (implicit full owner, ungated) authenticates; getPolicyManager is address(0) over
+    ///         untouched state.
     function test_policyTarget_success_inlineSelfFullOwner_returnsZero(uint256 eoaSeed, bytes32 hash) public view {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
 
-        (, uint16 outScope, address policyTarget) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
-        assertEq(outScope, uint8(0x00));
-        assertEq(policyTarget, address(0));
+        (, uint16 outScope) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
+        assertEq(outScope, uint16(0x00));
+        assertEq(keystore.getPolicyManager(eoa, bytes32(bytes20(eoa))), address(0));
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -28,9 +28,9 @@ contract DefaultAccountTest is KeystoreTest {
 
     // Scope bits: ERC-1271 signing is operational (admin scope == 0x00, or SENDER without POLICY). SELF_PAYER and
     // SPONSOR_PAYER are non-SENDER capability scopes that are not operational on their own.
-    uint8 constant SCOPE_SENDER = 0x01;
-    uint8 constant SCOPE_SELF_PAYER = 0x08;
-    uint8 constant SCOPE_SPONSOR_PAYER = 0x10;
+    uint16 constant SCOPE_SENDER = 0x01;
+    uint16 constant SCOPE_SELF_PAYER = 0x08;
+    uint16 constant SCOPE_SPONSOR_PAYER = 0x10;
 
     // TRUSTED_EXECUTOR sentinel: the authenticator value that marks an actor as a direct-execution caller.
     address constant TRUSTED_EXECUTOR = address(uint160(uint256(keccak256("trustedExecutor"))));
@@ -59,7 +59,7 @@ contract DefaultAccountTest is KeystoreTest {
         uint256 pk,
         bytes32 newActorId,
         address authenticator,
-        uint8 scope
+        uint16 scope
     ) internal {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -19,11 +19,11 @@ import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 ///         + an explicit scope == 0 check): verifySignature is now operational (a SENDER-without-POLICY key can
 ///         sign), but such a key must NOT be able to vouch as a delegate, so a non-admin nested actor reverts.
 contract DelegateAuthenticatorTest is KeystoreTest {
-    uint8 constant SCOPE_SENDER = 0x01;
-    uint8 constant SCOPE_POLICY = 0x02;
-    uint8 constant SCOPE_NONCE = 0x04;
-    uint8 constant SCOPE_SELF_PAYER = 0x08;
-    uint8 constant SCOPE_SPONSOR_PAYER = 0x10;
+    uint16 constant SCOPE_SENDER = 0x01;
+    uint16 constant SCOPE_POLICY = 0x02;
+    uint16 constant SCOPE_NONCE = 0x04;
+    uint16 constant SCOPE_SELF_PAYER = 0x08;
+    uint16 constant SCOPE_SPONSOR_PAYER = 0x10;
     uint8 constant AUTHORIZE_ACTOR = 0x01;
 
     // ── Guard 1: require(data.length >= 40) ──
@@ -111,7 +111,7 @@ contract DelegateAuthenticatorTest is KeystoreTest {
 
         // Any non-zero scope → non-admin → the delegate vouch must revert. Clear POLICY so the scoped actor
         // needs no policyData at authorization time.
-        uint8 scope = uint8(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_POLICY;
+        uint16 scope = uint16(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_POLICY;
         vm.assume(scope != 0);
 
         (address delegateAccount,) = _createK1Account(ownerPk);
@@ -189,7 +189,7 @@ contract DelegateAuthenticatorTest is KeystoreTest {
 
     /// @dev Authorizes a new K1 actor (`newPk`) with `scope` on `account`, signed by the unrestricted
     ///      owner (`ownerPk`) via applySignedActorChanges on the local chain.
-    function _authorizeScopedK1Actor(address account, uint256 ownerPk, uint256 newPk, uint8 scope) internal {
+    function _authorizeScopedK1Actor(address account, uint256 ownerPk, uint256 newPk, uint16 scope) internal {
         Keystore.ActorConfig memory config =
             Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0});
 

--- a/test/unit/examples/ExternalPolicyCaller.t.sol
+++ b/test/unit/examples/ExternalPolicyCaller.t.sol
@@ -240,7 +240,9 @@ contract ExternalPolicyCallerTest is KeystoreTest {
     }
 
     /// @dev SessionPolicy config: `transfer` only on `token`, with a USDC-style recurring spend limit.
-    function _config(uint256 limit, uint40 period) internal view returns (bytes memory) {
+    /// @dev `public` and invoked via `this._config(...)` from `_binding` so its nested-struct abi.encode stays in its
+    ///      own stack frame; inlining it merges that frame into every test and trips a via_ir stack-too-deep.
+    function _config(uint256 limit, uint40 period) public view returns (bytes memory) {
         SessionPolicy.TokenLimit[] memory limits = new SessionPolicy.TokenLimit[](1);
         limits[0] = SessionPolicy.TokenLimit({token: address(token), limit: limit, period: period});
         SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
@@ -258,7 +260,7 @@ contract ExternalPolicyCallerTest is KeystoreTest {
         binding = PolicyManager.PolicyBinding({
             account: account,
             policy: address(policy),
-            policyConfig: _config(limit, period),
+            policyConfig: this._config(limit, period),
             validAfter: 0,
             validUntil: 0,
             salt: salt


### PR DESCRIPTION
## Changes
- **Widen scope `uint8` → `uint16` + normative reorder.** `ActorConfig` / `InitialActor` / `AccountState` fields are reordered to the normative slot layout `authenticator ‖ expiry ‖ scope ‖ reserved`. Updated the `ACTOR*_TYPEHASH` strings, the import digest / actors-commitment encodings, and the `ActorAuthorized` event packing to match. `SCOPE_*` constants are now `uint16`.
- **Expired actors read as empty.** `getActorConfig` resolves an actor with a non-zero, elapsed expiry to the all-zero config — identical to an unknown actor — for both stored actors and the inline default-EOA self. `PolicyManager`'s external-path gate is now a presence check (`_requireActiveActor`, authenticator `!= 0`) since expiry is no longer observable through `getActorConfig`.
- **Drop the public `isActor` getter.** Kept as an internal `_isActor` for the revoke path. Off-chain/test liveness reads `getActorConfig(account, actorId).authenticator != 0`.

## Notes
- Signed-message digests for actor changes are computed from opaque `abi.encode`d data, so the struct reorder is handled automatically; the import-digest test mirror was updated to the new field order/width.
- One test helper (`ExternalPolicyCaller`) needed a small refactor (`_config` invoked via an external self-call) to keep its nested-struct `abi.encode` in its own stack frame — the `uint16` cleanup temporary otherwise tips a `via_ir` stack-too-deep in the inlined test frames.

All 333 tests pass; `forge fmt --check` clean.