### PR TITLE
refactor: extract actor scope vocabulary into a Scopes library

### DIFF
--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -727,7 +727,7 @@ contract Keystore {
     ///         or expired).
     function getActorConfig(address account, bytes32 actorId) external view returns (ActorConfig memory) {
         ActorConfig memory config = _actorConfig[actorId][account];
-        // Non-zero authenticator = a stored entry. Uses the same `>= K1_AUTHENTICATOR` namespace idiom as isActor:
+        // Non-zero authenticator = a stored entry. Uses the same `>= K1_AUTHENTICATOR` namespace idiom as _isAuthorized:
         // every stored authenticator is K1_AUTHENTICATOR (0x1) or a contract, so this is equivalent to != address(0).
         if (config.authenticator >= K1_AUTHENTICATOR) {
             // An expired stored actor reports as empty (as if never authorized), never its stale config.
@@ -746,29 +746,6 @@ contract Keystore {
     /// @dev The all-zero ActorConfig returned for a non-live actor (unknown, disabled, or expired).
     function _emptyActorConfig() private pure returns (ActorConfig memory) {
         return ActorConfig({authenticator: address(0), expiry: 0, scope: 0});
-    }
-
-    /// @notice Returns whether `actorId` is currently a live actor on `account`: a stored actor entry (or the inline
-    ///         k1 self) that exists, is enabled, and has not expired.
-    ///
-    /// @dev Liveness, not mere authorization — an expired, revoked, or disabled actor returns false, matching the
-    ///      empty config {getActorConfig} reports for it. Equivalent to
-    ///      `getActorConfig(account, actorId).authenticator != address(0)`, resolved directly from storage. This is
-    ///      the actor-presence check for consumers on non-8130 chains where authentication does not run first (e.g. a
-    ///      policy manager gating an auth-less subscription path); native 8130 dispatch already enforces liveness at
-    ///      authentication.
-    ///
-    /// @param account The account to read.
-    /// @param actorId The actor identifier to resolve.
-    ///
-    /// @return True iff the actor is currently live on the account.
-    function isActor(address account, bytes32 actorId) external view returns (bool) {
-        ActorConfig storage config = _actorConfig[actorId][account];
-        if (config.authenticator >= K1_AUTHENTICATOR) return !_isExpired(config.expiry);
-        if (actorId == bytes32(bytes20(account)) && !_isDefaultEoaRevoked(account)) {
-            return !_isExpired(_accountState[account].defaultEOAExpiry);
-        }
-        return false;
     }
 
     /// @notice Resolves an actor's policy gate target (manager) and signed commitment.
@@ -1038,7 +1015,7 @@ contract Keystore {
     /// @dev Returns whether `actorId` has an authorization entry on `account` (a stored actor config, or the inline
     ///      k1 self is enabled), IGNORING expiry: an expired-but-not-revoked actor still returns true — intentional,
     ///      since _revokeActor relies on it to revoke expired actors and reclaim their slots. Callers that want
-    ///      liveness (expiry-aware) use {isActor} or {getActorConfig} instead.
+    ///      liveness (expiry-aware) read {getActorConfig} (authenticator != 0) instead.
     function _isAuthorized(address account, bytes32 actorId) private view returns (bool) {
         // A populated _actorConfig entry is always live: any non-self actor, or a non-k1 self authenticator.
         if (_actorConfig[actorId][account].authenticator >= K1_AUTHENTICATOR) return true;

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.36;
 
 import {IAuthenticator} from "./interfaces/IAuthenticator.sol";
+import {Scopes} from "./libraries/Scopes.sol";
 
 /// @notice Keystore system contract for EIP-8130.
 ///         Manages actor authorization, account creation, change sequencing, and account lock. This contract is
@@ -28,21 +29,21 @@ contract Keystore {
         uint16 scope;
     }
 
-    /// @notice Initial actor for account creation and import. Carries its scope and, when scope & SCOPE_POLICY is
+    /// @notice Initial actor for account creation and import. Carries its scope and, when scope & Scopes.POLICY is
     ///         set, its policy data; expiry is always 0 for initial actors (scoped-with-expiry keys are added later
     ///         via applySignedActorChanges).
     struct InitialActor {
         bytes32 actorId;
         address authenticator;
         uint16 scope; // 0x00 = unrestricted admin
-        bytes policyData; // empty unless scope & SCOPE_POLICY; then manager(20) || commitment(32)
+        bytes policyData; // empty unless scope & Scopes.POLICY; then manager(20) || commitment(32)
     }
 
     /// @notice A full actor record: identifier, config, and policy data.
     struct Actor {
         bytes32 actorId;
         ActorConfig config;
-        // Sliced by scope: empty when scope & SCOPE_POLICY == 0; manager[20] || commitment[32] when set.
+        // Sliced by scope: empty when scope & Scopes.POLICY == 0; manager[20] || commitment[32] when set.
         bytes policyData;
     }
 
@@ -67,7 +68,7 @@ contract Keystore {
     ///      The defaultEOA* fields are the inline home for the account's own secp256k1 ("self") key — the actor whose
     ///      actorId is bytes32(bytes20(account)). When FLAG_REVOKE_DEFAULT_EOA is unset, a k1 signature recovering to
     ///      the account authenticates with this inline config (all-zero = full owner; non-zero scope/expiry = a
-    ///      scoped self key), resolved in a single SLOAD. Policy gating (when scope & SCOPE_POLICY != 0) is still keyed
+    ///      scoped self key), resolved in a single SLOAD. Policy gating (when scope & Scopes.POLICY != 0) is still keyed
     ///      by actorId in the shared _policyManager/_policyCommitment keyspace. The separate _actorConfig[self][account]
     ///      slot is reserved for a *non-k1* self authenticator (e.g. a post-quantum verifier returning the
     ///      self-actorId); the two homes are mutually exclusive (see _authorizeActor).
@@ -147,35 +148,15 @@ contract Keystore {
     uint8 public constant UNLOCK_OP = 0x02;
 
     // ----------------------------------------------------------------------------------------------------------------
-    // ACTOR SCOPE BITS
+    // ACTOR SCOPE
     // ----------------------------------------------------------------------------------------------------------------
 
-    /// @notice Actor can initiate transactions with account as sender
-    uint16 public constant SCOPE_SENDER = 0x0001;
-
-    /// @notice Actor is gated to a policy: every call it makes must land on the resolved manager (this contract
-    ///         stores manager + commitment; the protocol enforces that the actor's calls only ever reach that
-    ///         target). This contract does not reject scope combinations (e.g. SCOPE_POLICY | SCOPE_SELF_PAYER) — any
-    ///         use-time exclusivity between SCOPE_POLICY and the account's other capabilities is protocol-side, not
-    ///         enforced here.
-    uint16 public constant SCOPE_POLICY = 0x0002;
-
-    /// @notice Permits a restricted (non-admin) actor to use sequenced `nonce_key`s for sender-context transactions;
-    ///         without it a restricted actor may use only the nonce-free key (NONCE_KEY_MAX), while admin actors are
-    ///         unconstrained. This contract stores the scope bit verbatim and does not interpret it — nonce semantics
-    ///         are enforced entirely protocol-side.
-    uint16 public constant SCOPE_NONCE = 0x0004;
-
-    /// @notice Actor can self-pay gas for the account's own operations (payer == sender).
-    uint16 public constant SCOPE_SELF_PAYER = 0x0008;
-
-    /// @notice Actor can sponsor gas on behalf of a different sender (payer != sender).
-    uint16 public constant SCOPE_SPONSOR_PAYER = 0x0010;
-
-    // ERC-1271 signing rides on operational authority (admin scope == 0x00, or a SENDER actor without POLICY);
-    // it is not its own scope bit. See verifySignature.
-
-    // 0x0020 through 0x8000 are spare (unused). Scope is a uint16, so the vocabulary is append-only up to 16 bits.
+    // This contract is deliberately scope-agnostic. `scope == 0` is the admin predicate (the only scope value it
+    // acts on for config/lock changes), and it interprets exactly one grant bit — Scopes.POLICY — to slice and
+    // store an actor's policy data. Every other named grant (SENDER, NONCE, SELF_PAYER, SPONSOR_PAYER, and future
+    // bits) is stored verbatim and never read here; its meaning is enforced by whoever consumes it (protocol nodes,
+    // account contracts, policy managers). The full uint16 grant vocabulary lives in {Scopes}. This contract does
+    // not reject scope combinations — any use-time exclusivity is protocol-side.
 
     /// @notice The single secp256k1 authenticator. The default EOA and every k1 actor share this one identity; the
     ///         actor config alone distinguishes a full-owner EOA from a scoped key. Signed with a K1_AUTHENTICATOR
@@ -225,7 +206,7 @@ contract Keystore {
     /// @param actorId The authorized actor's identifier.
     /// @param actorData Tightly packed authorization surface, mirroring the wire packing:
     ///        authenticator(20) || expiry(6) || scope(2) || reserved(4 zero bytes) = 32 bytes, and, only when
-    ///        scope & SCOPE_POLICY != 0, followed by the resolved policy gate manager(20) || commitment(32). So the
+    ///        scope & Scopes.POLICY != 0, followed by the resolved policy gate manager(20) || commitment(32). So the
     ///        payload is 32 bytes for an ungated actor and 84 bytes for a policy-gated one.
     event ActorAuthorized(address indexed account, bytes32 indexed actorId, bytes actorData);
 
@@ -317,7 +298,7 @@ contract Keystore {
 
     /// @notice An actor config named an authenticator below the K1 sentinel (i.e. address(0)).
     error InvalidAuthenticator();
-    /// @notice The policyData length did not match `scope & SCOPE_POLICY` (52 bytes when set, empty when unset).
+    /// @notice The policyData length did not match `scope & Scopes.POLICY` (52 bytes when set, empty when unset).
     error InvalidPolicyData();
 
     /// @notice The referenced actor is not currently authorized on the account.
@@ -354,11 +335,11 @@ contract Keystore {
     /// @dev Account must be inner-most mapping key to pass ERC-7562 storage access rules for ERC-4337 compatibility.
     mapping(bytes32 actorId => mapping(address account => ActorConfig)) internal _actorConfig;
 
-    /// @notice Per-actor signed policy commitment. Set when the actor's scope carries SCOPE_POLICY.
+    /// @notice Per-actor signed policy commitment. Set when the actor's scope carries Scopes.POLICY.
     /// @dev Read only during execution (via getPolicy), never during signature validity checks.
     mapping(bytes32 actorId => mapping(address account => bytes32)) internal _policyCommitment;
 
-    /// @notice Per-actor policy manager address. Set when the actor's scope carries SCOPE_POLICY.
+    /// @notice Per-actor policy manager address. Set when the actor's scope carries Scopes.POLICY.
     mapping(bytes32 actorId => mapping(address account => address)) internal _policyManager;
 
     /// @notice Per-account state: sequences, lock status (single slot per account)
@@ -387,7 +368,7 @@ contract Keystore {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     /// @notice Deploys a new account with its initial actors. Each initial actor is registered with its declared
-    ///         `scope` and, when `scope & SCOPE_POLICY` is set, its `policyData` (an external `manager` is expressible
+    ///         `scope` and, when `scope & Scopes.POLICY` is set, its `policyData` (an external `manager` is expressible
     ///         at create; `manager = account` is not, as the address is unknown at commitment time). `expiry` is
     ///         always 0 at create — scoped-with-expiry keys are added afterwards via applySignedActorChanges. The
     ///         implicit default-EOA key is disabled on creation.
@@ -633,11 +614,11 @@ contract Keystore {
         // Authenticate against the account-scoped digest (see {replaySafeHash}), not the raw hash.
         try this.authenticateActor(account, replaySafeHash(account, hash), signature) returns (bytes32, uint16 scope) {
             // ERC-1271 signing is authorized for any operational actor: the admin (scope == 0x00), or a SENDER actor
-            // that is not gated by a policy (SCOPE_SENDER set AND SCOPE_POLICY unset). Signing is an encoding of
+            // that is not gated by a policy (Scopes.SENDER set AND Scopes.POLICY unset). Signing is an encoding of
             // authority a SENDER actor already holds via calls, not a separate grant, so it needs no dedicated scope
             // bit. A POLICY-bearing actor is not operational and cannot sign: a signature acts outside its policy
             // gate, so honoring one would let it act off its gate.
-            return scope == 0 || ((scope & SCOPE_SENDER != 0) && (scope & SCOPE_POLICY == 0));
+            return scope == 0 || ((scope & Scopes.SENDER != 0) && (scope & Scopes.POLICY == 0));
         } catch {
             return false;
         }
@@ -688,8 +669,8 @@ contract Keystore {
     ///      precompile. It lets an off-8130 consumer read `getPolicyManager` / `getPolicyCommitment(account, actorId)`
     ///      (execution-time reads) for a policy-gated actor, reaching parity with the native hot path.
     /// @dev `scope` is the actor's capability set, stored verbatim and never interpreted by this contract —
-    ///      protocol-side semantics for bits like SCOPE_NONCE live outside this contract. Consumers decide policy
-    ///      gating via `scope & SCOPE_POLICY`, then resolve the gate target separately via {getPolicyManager}.
+    ///      protocol-side semantics for bits like Scopes.NONCE live outside this contract. Consumers decide policy
+    ///      gating via `scope & Scopes.POLICY`, then resolve the gate target separately via {getPolicyManager}.
     /// @dev Reverts with InvalidAuthLength when `auth` is shorter than 20 bytes.
     /// @dev Reverts with AuthenticationFailed, AuthenticatorMismatch, ActorExpired, DefaultEoaRevoked, or
     ///      InvalidSignature when the actor cannot be authenticated.
@@ -746,7 +727,7 @@ contract Keystore {
     ///         or expired).
     function getActorConfig(address account, bytes32 actorId) external view returns (ActorConfig memory) {
         ActorConfig memory config = _actorConfig[actorId][account];
-        // Non-zero authenticator = a stored entry. Uses the same `>= K1_AUTHENTICATOR` namespace idiom as _isActor:
+        // Non-zero authenticator = a stored entry. Uses the same `>= K1_AUTHENTICATOR` namespace idiom as isActor:
         // every stored authenticator is K1_AUTHENTICATOR (0x1) or a contract, so this is equivalent to != address(0).
         if (config.authenticator >= K1_AUTHENTICATOR) {
             // An expired stored actor reports as empty (as if never authorized), never its stale config.
@@ -767,6 +748,29 @@ contract Keystore {
         return ActorConfig({authenticator: address(0), expiry: 0, scope: 0});
     }
 
+    /// @notice Returns whether `actorId` is currently a live actor on `account`: a stored actor entry (or the inline
+    ///         k1 self) that exists, is enabled, and has not expired.
+    ///
+    /// @dev Liveness, not mere authorization — an expired, revoked, or disabled actor returns false, matching the
+    ///      empty config {getActorConfig} reports for it. Equivalent to
+    ///      `getActorConfig(account, actorId).authenticator != address(0)`, resolved directly from storage. This is
+    ///      the actor-presence check for consumers on non-8130 chains where authentication does not run first (e.g. a
+    ///      policy manager gating an auth-less subscription path); native 8130 dispatch already enforces liveness at
+    ///      authentication.
+    ///
+    /// @param account The account to read.
+    /// @param actorId The actor identifier to resolve.
+    ///
+    /// @return True iff the actor is currently live on the account.
+    function isActor(address account, bytes32 actorId) external view returns (bool) {
+        ActorConfig storage config = _actorConfig[actorId][account];
+        if (config.authenticator >= K1_AUTHENTICATOR) return !_isExpired(config.expiry);
+        if (actorId == bytes32(bytes20(account)) && !_isDefaultEoaRevoked(account)) {
+            return !_isExpired(_accountState[account].defaultEOAExpiry);
+        }
+        return false;
+    }
+
     /// @notice Resolves an actor's policy gate target (manager) and signed commitment.
     ///
     /// @dev Convenience aggregator for off-chain consumers, equivalent to `(getPolicyManager, getPolicyCommitment)`.
@@ -774,7 +778,7 @@ contract Keystore {
     ///      target validates presented parameters against. The policy manager/commitment are keyed by actorId, so
     ///      the inline k1 self and a non-k1 self share that keyspace; mutual exclusion guarantees at most one is
     ///      live, so the active gate is read by actorId. Both slots are non-zero only when the actor's scope carries
-    ///      SCOPE_POLICY (see _authorizeActor / _revokeActor); either MAY still be zero for an actor deliberately
+    ///      Scopes.POLICY (see _authorizeActor / _revokeActor); either MAY still be zero for an actor deliberately
     ///      gated to a zero manager or a zero (no-params) commitment. On-chain consumers should prefer the
     ///      single-SLOAD `getPolicyCommitment` / `getPolicyManager` accessors directly.
     ///
@@ -790,9 +794,9 @@ contract Keystore {
     /// @notice Resolves an actor's signed policy commitment, or bytes32(0) if ungated / no actor / zero commitment.
     ///
     /// @dev Single SLOAD. Intended for a policy manager's per-tx validation read on the protocol-dispatched
-    ///      8130 tx path. This slot is non-zero only when the actor's scope carries SCOPE_POLICY (see _authorizeActor /
+    ///      8130 tx path. This slot is non-zero only when the actor's scope carries Scopes.POLICY (see _authorizeActor /
     ///      _revokeActor), but MAY be zero for a policy-gated actor with a zero (no-params) commitment; gating is
-    ///      therefore determined by the SCOPE_POLICY bit, not by this slot being non-zero.
+    ///      therefore determined by the Scopes.POLICY bit, not by this slot being non-zero.
     ///
     /// @param account The account to read.
     /// @param actorId The actor identifier to resolve.
@@ -901,7 +905,7 @@ contract Keystore {
 
     /// @dev Registers the bootstrap actor set shared by createAccount and importAccount: requires a non-empty,
     ///      strictly ascending-by-actorId list (rejecting unsorted or duplicate entries) and authorizes each entry
-    ///      with its declared scope and (when scope & SCOPE_POLICY is set) policyData. Expiry is always 0 for
+    ///      with its declared scope and (when scope & Scopes.POLICY is set) policyData. Expiry is always 0 for
     ///      initial actors; scoped-with-expiry keys are added later via applySignedActorChanges. Reverts with
     ///      NoInitialActors or ActorsNotSortedOrDuplicate.
     function _initializeAccount(address account, InitialActor[] calldata initialActors)
@@ -918,7 +922,7 @@ contract Keystore {
             previousActorId = initialActors[i].actorId;
 
             // Initial actors carry scope verbatim (0x00 = unrestricted admin) and never an expiry. When
-            // scope & SCOPE_POLICY is set, policyData is validated by the same frozen rule as authorizeActor
+            // scope & Scopes.POLICY is set, policyData is validated by the same frozen rule as authorizeActor
             // (52 bytes). Authorizing the self-actorId as k1 writes its scope into the inline default-EOA fields.
             ActorConfig memory config =
                 ActorConfig({authenticator: initialActors[i].authenticator, scope: initialActors[i].scope, expiry: 0});
@@ -940,9 +944,9 @@ contract Keystore {
         // authentication time, mirroring the reference PolicyManager's treatment of a zero-commitment policy actor.
         if (config.authenticator < K1_AUTHENTICATOR) revert InvalidAuthenticator();
 
-        // Slice the signed policy by scope & SCOPE_POLICY. The commitment is opaque to the protocol. This contract
-        // does not reject scope combinations (e.g. SCOPE_POLICY | SCOPE_SELF_PAYER) — any use-time exclusivity between
-        // SCOPE_POLICY and the account's other capabilities is protocol-side, not enforced here.
+        // Slice the signed policy by scope & Scopes.POLICY. The commitment is opaque to the protocol. This contract
+        // does not reject scope combinations (e.g. Scopes.POLICY | Scopes.SELF_PAYER) — any use-time exclusivity between
+        // Scopes.POLICY and the account's other capabilities is protocol-side, not enforced here.
         (address manager, bytes32 commitment) = _slicePolicy(config.scope, policyData);
 
         if (actorId == bytes32(bytes20(account))) {
@@ -980,7 +984,7 @@ contract Keystore {
     /// @dev Writes an actor's policy slots verbatim. `_slicePolicy` yields a zero manager/commitment for a non-policy
     ///      scope, so an ungated actor simply zeroes the slots — a single unconditional write both installs a new gate
     ///      and clears any stale one when an actor moves policy-gated -> ungated or re-keys to a different manager,
-    ///      preserving the "policy slots are non-zero iff scope & SCOPE_POLICY != 0" invariant.
+    ///      preserving the "policy slots are non-zero iff scope & Scopes.POLICY != 0" invariant.
     function _writePolicySlots(bytes32 actorId, address account, address manager, bytes32 commitment) private {
         _policyCommitment[actorId][account] = commitment;
         _policyManager[actorId][account] = manager;
@@ -996,7 +1000,7 @@ contract Keystore {
 
     /// @dev Emit ActorAuthorized with a tightly packed payload. The base packs to 32 bytes
     ///      (authenticator(20) || expiry(6) || scope(2) || reserved(4 zero bytes)); the policy gate
-    ///      (manager(20) || commitment(32), 52 bytes) is appended only when scope & SCOPE_POLICY != 0.
+    ///      (manager(20) || commitment(32), 52 bytes) is appended only when scope & Scopes.POLICY != 0.
     function _emitActorAuthorized(
         address account,
         bytes32 actorId,
@@ -1004,13 +1008,13 @@ contract Keystore {
         address manager,
         bytes32 commitment
     ) private {
-        bytes memory actorData = (config.scope & SCOPE_POLICY != 0)
+        bytes memory actorData = (config.scope & Scopes.POLICY != 0)
             ? abi.encodePacked(config.authenticator, config.expiry, config.scope, bytes4(0), manager, commitment)
             : abi.encodePacked(config.authenticator, config.expiry, config.scope, bytes4(0));
         emit ActorAuthorized(account, actorId, actorData);
     }
 
-    /// @dev Validates `policyData` against `scope & SCOPE_POLICY` and returns (manager, commitment).
+    /// @dev Validates `policyData` against `scope & Scopes.POLICY` and returns (manager, commitment).
     ///      Unset: empty data -> (0, 0). Set: exactly 52 bytes manager[20] || commitment[32] -> (manager,
     ///      commitment), written verbatim. Neither field need be non-zero: a zero commitment is a valid "no
     ///      params" and a zero manager gates the actor to address(0). Only a length mismatch reverts. The protocol
@@ -1020,7 +1024,7 @@ contract Keystore {
         pure
         returns (address manager, bytes32 commitment)
     {
-        if (scope & SCOPE_POLICY == 0) {
+        if (scope & Scopes.POLICY == 0) {
             if (policyData.length != 0) revert InvalidPolicyData();
             return (address(0), bytes32(0));
         }
@@ -1031,11 +1035,11 @@ contract Keystore {
         }
     }
 
-    /// @dev Returns whether `actorId` is currently authorized on `account` (a stored actor entry exists, or the
-    ///      inline k1 self is enabled). Does NOT check expiry: an expired-but-not-revoked actor still returns true —
-    ///      intentional, since _revokeActor relies on it to revoke expired actors. Off-chain liveness checks should
-    ///      read {getActorConfig} (authenticator != 0) and enforce expiry themselves.
-    function _isActor(address account, bytes32 actorId) private view returns (bool) {
+    /// @dev Returns whether `actorId` has an authorization entry on `account` (a stored actor config, or the inline
+    ///      k1 self is enabled), IGNORING expiry: an expired-but-not-revoked actor still returns true — intentional,
+    ///      since _revokeActor relies on it to revoke expired actors and reclaim their slots. Callers that want
+    ///      liveness (expiry-aware) use {isActor} or {getActorConfig} instead.
+    function _isAuthorized(address account, bytes32 actorId) private view returns (bool) {
         // A populated _actorConfig entry is always live: any non-self actor, or a non-k1 self authenticator.
         if (_actorConfig[actorId][account].authenticator >= K1_AUTHENTICATOR) return true;
         // No _actorConfig entry: the self-actorId's k1 key lives inline in AccountState, live unless the flag is set.
@@ -1047,7 +1051,7 @@ contract Keystore {
     ///      self-actorId it also disables the inline k1 self (sets FLAG_REVOKE_DEFAULT_EOA and zeroes the inline
     ///      fields). Reverts with UnknownActor when the actor is not currently live.
     function _revokeActor(address account, bytes32 actorId) internal nonZeroAccount(account) {
-        if (!_isActor(account, actorId)) revert UnknownActor();
+        if (!_isAuthorized(account, actorId)) revert UnknownActor();
         delete _actorConfig[actorId][account];
         // Policy state is keyed by (account, actorId) and cleared exactly on revoke.
         delete _policyCommitment[actorId][account];

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -124,18 +124,17 @@ contract DefaultAccount is Receiver {
     // ══════════════════════════════════════════════
 
     /// @dev Authorized if `caller` is the account itself, or holds the TRUSTED_EXECUTOR authenticator with an
-    ///      unexpired config AND operational (sender) authority. Expiry: 0 means none; a non-zero expiry is enforced
-    ///      so a user-set expiry is honored on the execution path. Scope: driving execution requires sender
-    ///      authority — the unrestricted admin (scope == 0x00) or an actor with Scopes.SENDER that is not gated by a
-    ///      policy (Scopes.POLICY unset). A POLICY-gated actor must route every call through its manager, so granting
-    ///      it direct executeBatch would bypass that gate; fail closed. This mirrors the operational-actor definition
-    ///      in Keystore.verifySignature, keeping the execution and signing authorization surfaces aligned.
+    ///      unexpired config AND operational authority. Expiry: 0 means none; a non-zero expiry is enforced so a
+    ///      user-set expiry is honored on the execution path. Scope: driving execution requires operational
+    ///      authority ({Scopes.isOperational}) — the unrestricted admin (scope == 0x00) or a SENDER actor not gated
+    ///      by a policy. A POLICY-gated actor must route every call through its manager, so granting it direct
+    ///      executeBatch would bypass that gate; fail closed. Sharing {Scopes.isOperational} keeps the execution and
+    ///      signing (ERC-1271) authorization surfaces aligned.
     function _isAuthorizedCaller(address caller) internal view virtual returns (bool) {
         if (caller == address(this)) return true;
         Keystore.ActorConfig memory config = KEYSTORE.getActorConfig(address(this), bytes32(bytes20(caller)));
         if (config.authenticator != TRUSTED_EXECUTOR) return false;
         if (config.expiry != 0 && block.timestamp > config.expiry) return false;
-        uint16 scope = config.scope;
-        return scope == 0 || ((scope & Scopes.SENDER != 0) && (scope & Scopes.POLICY == 0));
+        return Scopes.isOperational(config.scope);
     }
 }

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.36;
 import {Receiver} from "solady/accounts/Receiver.sol";
 
 import {Keystore} from "../Keystore.sol";
+import {Scopes} from "../libraries/Scopes.sol";
 
 /// @notice A single call in an execution batch.
 struct Call {
@@ -42,12 +43,6 @@ address constant TRUSTED_EXECUTOR = address(uint160(uint256(keccak256("trustedEx
 contract DefaultAccount is Receiver {
     /// @notice The Keystore system contract that owns this account's authorization state.
     Keystore public immutable KEYSTORE;
-
-    /// @dev Local mirrors of {Keystore.SCOPE_SENDER} / {Keystore.SCOPE_POLICY}: a contract's
-    ///      public constants are not accessible via its type, and reading the getters would add external calls to the
-    ///      execution hot path. Kept in sync with Keystore.
-    uint16 private constant SCOPE_SENDER = 0x0001;
-    uint16 private constant SCOPE_POLICY = 0x0002;
 
     /// @notice The caller is neither the account itself nor a registered TRUSTED_EXECUTOR actor.
     error UnauthorizedCaller();
@@ -131,8 +126,8 @@ contract DefaultAccount is Receiver {
     /// @dev Authorized if `caller` is the account itself, or holds the TRUSTED_EXECUTOR authenticator with an
     ///      unexpired config AND operational (sender) authority. Expiry: 0 means none; a non-zero expiry is enforced
     ///      so a user-set expiry is honored on the execution path. Scope: driving execution requires sender
-    ///      authority — the unrestricted admin (scope == 0x00) or an actor with SCOPE_SENDER that is not gated by a
-    ///      policy (SCOPE_POLICY unset). A POLICY-gated actor must route every call through its manager, so granting
+    ///      authority — the unrestricted admin (scope == 0x00) or an actor with Scopes.SENDER that is not gated by a
+    ///      policy (Scopes.POLICY unset). A POLICY-gated actor must route every call through its manager, so granting
     ///      it direct executeBatch would bypass that gate; fail closed. This mirrors the operational-actor definition
     ///      in Keystore.verifySignature, keeping the execution and signing authorization surfaces aligned.
     function _isAuthorizedCaller(address caller) internal view virtual returns (bool) {
@@ -141,6 +136,6 @@ contract DefaultAccount is Receiver {
         if (config.authenticator != TRUSTED_EXECUTOR) return false;
         if (config.expiry != 0 && block.timestamp > config.expiry) return false;
         uint16 scope = config.scope;
-        return scope == 0 || ((scope & SCOPE_SENDER != 0) && (scope & SCOPE_POLICY == 0));
+        return scope == 0 || ((scope & Scopes.SENDER != 0) && (scope & Scopes.POLICY == 0));
     }
 }

--- a/src/libraries/Scopes.sol
+++ b/src/libraries/Scopes.sol
@@ -39,4 +39,20 @@ library Scopes {
     uint16 internal constant SPONSOR_PAYER = 0x0010;
 
     // 0x0020..0x8000 (bits 5–15) are spare, reserved for future pure grants.
+
+    /// @notice Whether `scope` grants operational authority — the authority to drive execution and to sign
+    ///         (ERC-1271) as the account.
+    ///
+    /// @dev Operational means either the unrestricted admin (`scope == 0`) or a {SENDER} actor that is not gated by
+    ///      a policy ({POLICY} unset). A POLICY-gated actor is deliberately not operational: it must route every
+    ///      call through its policy manager, so letting it drive execution or vouch a signature would act outside
+    ///      that gate. This is the single shared definition consumers use to keep the execution and signing
+    ///      authorization surfaces aligned (see DefaultAccount).
+    ///
+    /// @param scope The actor scope bitmask to test.
+    ///
+    /// @return True iff `scope` carries operational authority.
+    function isOperational(uint16 scope) internal pure returns (bool) {
+        return scope == 0 || ((scope & SENDER != 0) && (scope & POLICY == 0));
+    }
 }

--- a/src/libraries/Scopes.sol
+++ b/src/libraries/Scopes.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.36;
+
+/// @notice Canonical EIP-8130 actor scope grants: the named bits of the `uint16` scope bitmask carried in an
+///         actor's config.
+///
+/// @dev Reference vocabulary, not enforcement. Keystore is deliberately scope-agnostic: it treats `scope == 0` as
+///      the admin predicate and interprets only {POLICY} (to slice/store policy data). Every other bit's *meaning*
+///      is enforced by whoever reads it — protocol nodes for the transaction paths, account contracts for ERC-1271,
+///      policy managers for gating. This library only gives those consumers a shared set of names so the same value
+///      is not re-declared as a magic number at each site.
+///
+///      Delegation for agent fleets is expressed via the external-policy pattern (an account authorizes a hub as a
+///      single POLICY-gated external actor that drives it through a policy manager), so no dedicated delegate grant
+///      is defined here.
+///
+///      The assignment is append-only: a value once given a name keeps it, and new grants take the next free bit.
+///      That is safe against the immutable Keystore deployment because unknown bits grant nothing and are stored
+///      verbatim (see the EIP's Actor Scope section), so adding a bit here can never change how an already-deployed
+///      config behaves. Admin is intentionally absent — it is the *absence* of grants (`scope == 0`), a predicate
+///      rather than a pure grant.
+///
+/// @author Coinbase
+library Scopes {
+    /// @notice Ungated initiation (`sender_auth`): may originate transactions to any `call.to`.
+    uint16 internal constant SENDER = 0x0001;
+
+    /// @notice Gated initiation (`sender_auth`): may originate transactions only to the actor's `policy_manager`.
+    ///         The one bit Keystore itself interprets, to slice and store the actor's policy data.
+    uint16 internal constant POLICY = 0x0002;
+
+    /// @notice Permits a restricted actor to use sequenced `nonce_key`s for sender-context transactions.
+    uint16 internal constant NONCE = 0x0004;
+
+    /// @notice Self-pay gas: authorizes paying the account's own gas when `payer == sender`.
+    uint16 internal constant SELF_PAYER = 0x0008;
+
+    /// @notice Sponsor gas: authorizes acting as `payer_auth` for a different sender (`payer != sender`).
+    uint16 internal constant SPONSOR_PAYER = 0x0010;
+
+    // 0x0020..0x8000 (bits 5–15) are spare, reserved for future pure grants.
+}

--- a/src/policies/Policy.sol
+++ b/src/policies/Policy.sol
@@ -20,7 +20,7 @@ import {PolicyManager} from "./PolicyManager.sol";
 ///      Mutable execution state (e.g. spend counters) is the exception that belongs in storage, keyed by
 ///      commitment.
 ///
-///      This is the example/reference shape for an EIP-8130 actor policy (`scope & SCOPE_POLICY != 0`): the
+///      This is the example/reference shape for an EIP-8130 actor policy (`scope & Scopes.POLICY != 0`): the
 ///      manager is the single call target a restricted actor may reach, and policies express *what* that actor
 ///      may do. All hooks are callable only by the configured {PolicyManager}.
 abstract contract Policy {

--- a/src/policies/PolicyManager.sol
+++ b/src/policies/PolicyManager.sol
@@ -28,7 +28,7 @@ address constant EXTERNAL_POLICY_AUTHENTICATOR = address(uint160(uint256(keccak2
 /// @dev Role in the EIP-8130 flow:
 ///      - The manager is registered as an execution-enabled actor on the account (an actor whose authenticator is
 ///        `TRUSTED_EXECUTOR`), so it may drive the account via `executeBatch`.
-///      - A restricted session-key actor is configured with `scope & SCOPE_POLICY != 0` and `policy_manager =
+///      - A restricted session-key actor is configured with `scope & Scopes.POLICY != 0` and `policy_manager =
 ///        address(this)`, so the protocol gate forces every call that actor makes to land on this manager.
 ///      - When the session key transacts, the protocol dispatches its call *as the account*, so `msg.sender`
 ///        here is the account itself. That is the authorization boundary: only a gated session-key transaction
@@ -42,7 +42,7 @@ address constant EXTERNAL_POLICY_AUTHENTICATOR = address(uint160(uint256(keccak2
 ///        itself (`actorId == bytes20(msg.sender)`) and `account` comes from the supplied binding.
 ///
 ///      Commitment binding: the account authorizes a {PolicyBinding}; its `keccak256` is the `commitment`. When the
-///      account authorizes the session-key actor it stores `scope & SCOPE_POLICY != 0`, `policy_manager =
+///      account authorizes the session-key actor it stores `scope & Scopes.POLICY != 0`, `policy_manager =
 ///      address(this)`, and `policy_commitment = commitment` in Keystore. That signed actor change *is*
 ///      the authorization — there is no separate install step and no manager-side install bit. At every execute path
 ///      the manager recomputes the commitment from the supplied binding and requires it to equal the live signed
@@ -217,15 +217,11 @@ contract PolicyManager is ReentrancyGuard {
         if (signed == bytes32(0)) revert NoActivePolicy(actorId);
         if (signed != commitment) revert BindingCommitmentMismatch(signed, commitment);
 
-        _requireActiveActor(account, actorId);
+        // Reject when the acting actor is no longer live. Required on the external path (no protocol auth); omitted on
+        // {execute}, where authentication already enforced liveness before dispatch. Keystore.isActor is expiry-aware
+        // (an expired or revoked actor reports false), so this is the actor-presence check.
+        if (!KEYSTORE.isActor(account, actorId)) revert ActorExpired(actorId);
         _enforce(binding, commitment, executionData, caller);
-    }
-
-    /// @dev Reject when the acting actor is no longer active. Required on the external path (no protocol auth);
-    ///      omitted on {execute}, where authentication already enforced liveness before dispatch. getActorConfig
-    ///      resolves an expired (or revoked) actor to the all-zero config, so a zero authenticator means "not active".
-    function _requireActiveActor(address account, bytes32 actorId) internal view {
-        if (KEYSTORE.getActorConfig(account, actorId).authenticator == address(0)) revert ActorExpired(actorId);
     }
 
     /// @dev Common enforcement: enforce the binding's validity window (authenticated by the commitment check at the

--- a/src/policies/PolicyManager.sol
+++ b/src/policies/PolicyManager.sol
@@ -8,14 +8,16 @@ import {Keystore} from "../Keystore.sol";
 import {ITransactionContext, TX_CONTEXT_ADDRESS} from "../interfaces/ITransactionContext.sol";
 import {Policy} from "./Policy.sol";
 
-/// @dev Recommended `authenticator` for an actor that represents an *external caller* governed by a policy (e.g. a
+/// @dev Required `authenticator` for an actor that represents an *external caller* governed by a policy (e.g. a
 ///      subscription provider): an address that may act ONLY through its policy manager's external entrypoints, never
 ///      directly. Distinct from `TRUSTED_EXECUTOR` (which grants direct `executeBatch`): this is a
 ///      no-code, hash-derived sentinel, so the actor is recognized by Keystore (non-zero authenticator)
 ///      yet cannot drive the account directly and cannot authenticate an 8130 transaction (its `authenticate()` would
-///      call into empty code and fail). Only the account-side authorization (and these examples/tests) ever reference
-///      it; neither the account nor the manager runtime reads it — `executeFor` authorizes purely on
-///      `actorId == bytes20(msg.sender)`, `policy_manager == this`, and a matching binding commitment.
+///      call into empty code and fail). `executeFor` / `executeForMany` require the acting actor's stored
+///      authenticator to equal this sentinel: that restricts the external path to actors the account explicitly
+///      provisioned as external-pull, so a native signing key gated to the same manager cannot be driven through the
+///      auth-less external path. Authorization then also requires `actorId == bytes20(msg.sender)`,
+///      `policy_manager == this`, and a matching binding commitment.
 address constant EXTERNAL_POLICY_AUTHENTICATOR = address(uint160(uint256(keccak256("externalPolicyCaller"))));
 
 /// @title PolicyManager
@@ -99,9 +101,9 @@ contract PolicyManager is ReentrancyGuard {
     ///         is not policy-gated, or (on the external path) the account did not gate this manager for it, or its
     ///         signed commitment is zero.
     error NoActivePolicy(bytes32 actorId);
-    /// @notice The acting actor is not currently live on the account (unknown, revoked, or expired). Enforced on the
-    ///         external path ({executeFor} / {executeForMany}), which has no protocol auth to reject it first; the
-    ///         commitment is not cleared on expiry (only on revoke), so the manager checks liveness itself.
+    /// @notice The acting actor is not a live external-pull actor of the account: it is unknown, revoked, or expired,
+    ///         or its stored authenticator is not {EXTERNAL_POLICY_AUTHENTICATOR}. Enforced on the external path
+    ///         ({executeFor} / {executeForMany}), which has no protocol auth to reject it first.
     error InvalidActor(bytes32 actorId);
     /// @notice {executeForMany} array length mismatch between `bindings` and `executionData`.
     error LengthMismatch();
@@ -156,7 +158,8 @@ contract PolicyManager is ReentrancyGuard {
     ///
     /// @dev The acting identity is the caller itself — `actorId == bytes20(msg.sender)` — and `account` is
     ///      `binding.account`. There is no protocol routing on this path, so unlike {execute} this re-verifies that
-    ///      the account gated *this* manager for the caller and that the actor is unexpired.
+    ///      the caller is a live external-pull actor (authenticator == {EXTERNAL_POLICY_AUTHENTICATOR}) and that the
+    ///      account gated *this* manager for it.
     ///
     /// @param binding       Full account-authorized binding (config + window + salt).
     /// @param executionData Per-use action parameters interpreted by the policy.
@@ -202,7 +205,8 @@ contract PolicyManager is ReentrancyGuard {
         _enforceExternal(binding, actorId, executionData, caller);
     }
 
-    /// @dev External-path validation: actor liveness, manager-match, live commitment vs binding, then enforce.
+    /// @dev External-path validation: live external-pull actor, manager-match, live commitment vs binding, then
+    ///      enforce.
     function _enforceExternal(
         PolicyBinding calldata binding,
         bytes32 actorId,
@@ -211,12 +215,18 @@ contract PolicyManager is ReentrancyGuard {
     ) internal {
         address account = binding.account;
 
-        // Liveness precondition. The external path has no protocol auth (omitted on {execute}, where authentication
-        // already enforced liveness before dispatch), so the manager rejects a caller that is not a live actor of the
-        // account. Keystore.isActor is expiry-aware — an unknown, revoked, or expired actor reports false — so this
-        // is the single actor-presence gate, checked before the policy-binding checks so those stay specific to a
-        // live actor.
-        if (!KEYSTORE.isActor(account, actorId)) revert InvalidActor(actorId);
+        // Liveness + verifier precondition. The external path has no protocol auth (omitted on {execute}, where
+        // authentication already enforced this before dispatch), so the manager itself gates the caller. It requires
+        // the actor to be provisioned with EXTERNAL_POLICY_AUTHENTICATOR — the no-code sentinel that marks an
+        // external-pull actor (one that can act ONLY through this path and can never authenticate a native 8130 tx).
+        // getActorConfig resolves an unknown, revoked, or expired actor to the all-zero config (authenticator 0), so
+        // this single read both enforces liveness AND restricts executeFor to actors the account explicitly opted
+        // into external pull. A native signing key gated to this manager (a real authenticator) is therefore not
+        // drivable through the auth-less external path, where it would bypass protocol replay protection. Checked
+        // before the policy-binding checks so those stay specific to a live external-pull actor.
+        if (KEYSTORE.getActorConfig(account, actorId).authenticator != EXTERNAL_POLICY_AUTHENTICATOR) {
+            revert InvalidActor(actorId);
+        }
 
         if (KEYSTORE.getPolicyManager(account, actorId) != address(this)) {
             revert NoActivePolicy(actorId);

--- a/src/policies/PolicyManager.sol
+++ b/src/policies/PolicyManager.sol
@@ -95,13 +95,14 @@ contract PolicyManager is ReentrancyGuard {
     error BindingCommitmentMismatch(bytes32 expected, bytes32 actual);
     /// @notice {execute} requires `binding.account == msg.sender` (the protocol-dispatched account).
     error InvalidBindingAccount(address expected, address actual);
-    /// @notice The acting actor has no live policy commitment for the account — i.e. it is not a gated actor of this
-    ///         account, was revoked, or (on the external path) the account did not gate this manager for it.
+    /// @notice The acting actor is a live actor of the account but has no policy binding that routes here — either it
+    ///         is not policy-gated, or (on the external path) the account did not gate this manager for it, or its
+    ///         signed commitment is zero.
     error NoActivePolicy(bytes32 actorId);
-    /// @notice The acting actor's `ActorConfig.expiry` has passed. Commitment is not cleared on expiry (only on
-    ///         revoke), so the manager must enforce this itself on {executeFor} / {executeForMany}, which have no
-    ///         protocol auth path.
-    error ActorExpired(bytes32 actorId);
+    /// @notice The acting actor is not currently live on the account (unknown, revoked, or expired). Enforced on the
+    ///         external path ({executeFor} / {executeForMany}), which has no protocol auth to reject it first; the
+    ///         commitment is not cleared on expiry (only on revoke), so the manager checks liveness itself.
+    error InvalidActor(bytes32 actorId);
     /// @notice {executeForMany} array length mismatch between `bindings` and `executionData`.
     error LengthMismatch();
     /// @notice The per-account self-call boundary used by {executeForMany} was invoked by someone other than this
@@ -125,12 +126,13 @@ contract PolicyManager is ReentrancyGuard {
     ///      {PolicyBinding}; recomputing its commitment and comparing to the live signed commitment authenticates
     ///      config, validity window, and owning account in one check.
     ///
-    ///      Actor expiry is not re-checked here: protocol authentication already rejects expired actors before
-    ///      dispatch. `Keystore._authenticate` reverts `ActorExpired`, so a protocol-dispatched call's
-    ///      sender actor was expiry-checked at authentication in the same transaction (same `block.timestamp`, so
-    ///      no gap), and any non-dispatched call yields `actorId == 0` → {NoActivePolicy}. This trades defense-in-depth
-    ///      for one SLOAD; soundness rests on the spec-level invariant that every conforming implementation enforces
-    ///      expiry at authentication. {executeFor} retains a local expiry check because it has no protocol auth.
+    ///      Actor liveness is not re-checked here: protocol authentication already rejects expired (or otherwise
+    ///      non-live) actors before dispatch. `Keystore._authenticate` reverts `ActorExpired`, so a protocol-dispatched
+    ///      call's sender actor was liveness-checked at authentication in the same transaction (same `block.timestamp`,
+    ///      so no gap), and any non-dispatched call yields `actorId == 0` → {NoActivePolicy}. This trades
+    ///      defense-in-depth for one SLOAD; soundness rests on the spec-level invariant that every conforming
+    ///      implementation enforces expiry at authentication. {executeFor} retains a local liveness check
+    ///      ({InvalidActor}) because it has no protocol auth.
     ///
     /// @param binding       Full account-authorized binding (config + window + salt).
     /// @param executionData Per-use action parameters interpreted by the policy.
@@ -200,7 +202,7 @@ contract PolicyManager is ReentrancyGuard {
         _enforceExternal(binding, actorId, executionData, caller);
     }
 
-    /// @dev External-path validation: manager-match, live commitment vs binding, actor expiry, then enforce.
+    /// @dev External-path validation: actor liveness, manager-match, live commitment vs binding, then enforce.
     function _enforceExternal(
         PolicyBinding calldata binding,
         bytes32 actorId,
@@ -208,6 +210,14 @@ contract PolicyManager is ReentrancyGuard {
         address caller
     ) internal {
         address account = binding.account;
+
+        // Liveness precondition. The external path has no protocol auth (omitted on {execute}, where authentication
+        // already enforced liveness before dispatch), so the manager rejects a caller that is not a live actor of the
+        // account. Keystore.isActor is expiry-aware — an unknown, revoked, or expired actor reports false — so this
+        // is the single actor-presence gate, checked before the policy-binding checks so those stay specific to a
+        // live actor.
+        if (!KEYSTORE.isActor(account, actorId)) revert InvalidActor(actorId);
+
         if (KEYSTORE.getPolicyManager(account, actorId) != address(this)) {
             revert NoActivePolicy(actorId);
         }
@@ -217,10 +227,6 @@ contract PolicyManager is ReentrancyGuard {
         if (signed == bytes32(0)) revert NoActivePolicy(actorId);
         if (signed != commitment) revert BindingCommitmentMismatch(signed, commitment);
 
-        // Reject when the acting actor is no longer live. Required on the external path (no protocol auth); omitted on
-        // {execute}, where authentication already enforced liveness before dispatch. Keystore.isActor is expiry-aware
-        // (an expired or revoked actor reports false), so this is the actor-presence check.
-        if (!KEYSTORE.isActor(account, actorId)) revert ActorExpired(actorId);
         _enforce(binding, commitment, executionData, caller);
     }
 

--- a/src/policies/README.md
+++ b/src/policies/README.md
@@ -2,17 +2,17 @@
 
 Reference, **unaudited** example of a policy manager for EIP-8130 restricted actors.
 
-In EIP-8130, a restricted actor (e.g. a session key) is configured with `scope & SCOPE_POLICY != 0`, which stores a
+In EIP-8130, a restricted actor (e.g. a session key) is configured with `scope & Scopes.POLICY != 0`, which stores a
 `policy_manager` address and an opaque `policy_commitment` in the Keystore contract. The protocol
 gate forces every call that actor makes to land on that single manager. These contracts are an example of what
-that manager can be: one that enforces application-specific limits and then drives the account. `SCOPE_POLICY`
-(`0x02`) may be combined with other scope bits (e.g. `SCOPE_POLICY | SCOPE_SELF_PAYER`) — `Keystore` does
+that manager can be: one that enforces application-specific limits and then drives the account. `Scopes.POLICY`
+(`0x02`) may be combined with other scope bits (e.g. `Scopes.POLICY | Scopes.SELF_PAYER`) — `Keystore` does
 not reject scope combinations; use-time exclusivity between policy gating and an actor's other capabilities is
 protocol-side, not enforced by this contract.
 
 ## Flow
 
-1. **Authorize + commit.** The account authorizes the session key with `scope = SCOPE_POLICY`,
+1. **Authorize + commit.** The account authorizes the session key with `scope = Scopes.POLICY`,
    `policy_manager = PolicyManager`, and `policy_commitment = keccak256` of an account-authorized
    [`PolicyBinding`](./PolicyManager.sol). The Keystore contract exposes this via
    [`getPolicy(account, actorId)`](../../Keystore.sol). That signed actor change *is* the
@@ -134,14 +134,14 @@ then `executeFor` — so the account never needs to send a transaction. The acco
 // actorId = bytes20(provider). The provider never signs an 8130 tx; it acts by being msg.sender.
 Keystore.ActorConfig({
     authenticator: EXTERNAL_POLICY_AUTHENTICATOR, // recognized actor; NO direct executeBatch; not 8130-usable
-    scope:         0x02,                          // SCOPE_POLICY — gated initiation only (MAY also OR SCOPE_SELF_PAYER
+    scope:         0x02,                          // Scopes.POLICY — gated initiation only (MAY also OR Scopes.SELF_PAYER
                                                   //   for self-pay; SHOULD NOT combine with SENDER — POLICY gates
                                                   //   regardless, so SENDER adds no authority the protocol will honor)
     expiry:        0
 });
 ```
 
-`SCOPE_NONCE` (`0x04`) is a separate, orthogonal scope bit: it permits a restricted actor to use sequenced
+`Scopes.NONCE` (`0x04`) is a separate, orthogonal scope bit: it permits a restricted actor to use sequenced
 `nonce_key`s. This contract stores the bit verbatim and never interprets it — nonce semantics are entirely
 protocol-side — so it isn't part of the policy flow above and is only mentioned here for completeness.
 

--- a/test/lib/KeystoreTest.sol
+++ b/test/lib/KeystoreTest.sol
@@ -54,10 +54,10 @@ contract KeystoreTest is Test {
 
     // ── Actor liveness helper ──
 
-    /// @dev Liveness check via the public {Keystore.isActor} (expiry-aware: an expired, revoked, or disabled actor
-    ///      reports false, matching the empty config getActorConfig resolves for it).
+    /// @dev Liveness check via the public getActorConfig (authenticator != 0). Expiry-aware: getActorConfig resolves
+    ///      an expired, revoked, or disabled actor to the all-zero config.
     function _isActor(address account, bytes32 actorId) internal view returns (bool) {
-        return keystore.isActor(account, actorId);
+        return keystore.getActorConfig(account, actorId).authenticator != address(0);
     }
 
     // ── Bytecode helpers ──

--- a/test/lib/KeystoreTest.sol
+++ b/test/lib/KeystoreTest.sol
@@ -54,11 +54,10 @@ contract KeystoreTest is Test {
 
     // ── Actor liveness helper ──
 
-    /// @dev Liveness check via the public getActorConfig (authenticator != 0). Replaces the removed public isActor
-    ///      getter. Unlike the old isActor, this honors expiry (getActorConfig resolves an expired actor to empty),
-    ///      which is the intended public liveness semantics.
+    /// @dev Liveness check via the public {Keystore.isActor} (expiry-aware: an expired, revoked, or disabled actor
+    ///      reports false, matching the empty config getActorConfig resolves for it).
     function _isActor(address account, bytes32 actorId) internal view returns (bool) {
-        return keystore.getActorConfig(account, actorId).authenticator != address(0);
+        return keystore.isActor(account, actorId);
     }
 
     // ── Bytecode helpers ──

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {Keystore} from "../../../src/Keystore.sol";
+import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
 /// @notice Branch-complete, fuzz-by-default suite for the account lock surface: applySignedLockChanges (op = lock /
@@ -70,7 +71,7 @@ contract AccountLockTest is KeystoreTest {
         address scopedSigner = vm.addr(scopedPk);
         vm.assume(scopedSigner != account);
 
-        _authorizeK1ActorWithScope(account, ownerPk, scopedSigner, keystore.SCOPE_SENDER());
+        _authorizeK1ActorWithScope(account, ownerPk, scopedSigner, Scopes.SENDER);
 
         bytes memory auth = _lockAuth(scopedPk, account, delay);
         vm.expectRevert(Keystore.UnauthorizedLockChange.selector);

--- a/test/unit/Keystore/authenticate.t.sol
+++ b/test/unit/Keystore/authenticate.t.sol
@@ -6,7 +6,7 @@ import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
 /// @notice Fuzzed, branch-complete suite for the authentication paths of Keystore:
 ///         authenticateActor -> _authenticate -> {_authenticateK1, IAuthenticator} -> _recoverSigner, plus the
-///         verifySignature / getActorConfig / getPolicy / isActor views that read the same actor resolution.
+///         verifySignature / getActorConfig / getPolicy views that read the same actor resolution.
 ///
 ///         Source-order revert coverage (as declared / hit through authenticateActor):
 ///           1. InvalidAuthLength      authenticateActor: auth.length < 20

--- a/test/unit/Keystore/policyAccessors.t.sol
+++ b/test/unit/Keystore/policyAccessors.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {Keystore} from "../../../src/Keystore.sol";
+import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
 /// @notice Fully-fuzzed unit tests for the policy accessors on `Keystore`:
@@ -372,13 +373,13 @@ contract PolicyAccessorsTest is KeystoreTest {
         (address account,) = _createK1Account(rootPk);
         actorId = _boundExplicitActorId(account, rootPk, actorId);
 
-        _authorizePolicyActor(account, rootPk, actorId, keystore.SCOPE_POLICY(), address(0), bytes32(0));
+        _authorizePolicyActor(account, rootPk, actorId, Scopes.POLICY, address(0), bytes32(0));
 
         // Slots are zero, yet the actor is gated by the SCOPE_POLICY bit.
         assertEq(keystore.getPolicyManager(account, actorId), address(0));
         assertEq(keystore.getPolicyCommitment(account, actorId), bytes32(0));
         Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, actorId);
-        assertTrue(cfg.scope & keystore.SCOPE_POLICY() != 0);
+        assertTrue(cfg.scope & Scopes.POLICY != 0);
     }
 
     /// @notice This contract does not reject scope combinations: an actor may carry SCOPE_POLICY alongside any
@@ -393,13 +394,12 @@ contract PolicyAccessorsTest is KeystoreTest {
         address manager = _boundNonZeroAddress(managerSeed);
         bytes32 commitment = _boundNonZeroWord(commitmentSeed);
 
-        uint16[4] memory otherScopes =
-            [uint8(0), keystore.SCOPE_SELF_PAYER(), keystore.SCOPE_SPONSOR_PAYER(), keystore.SCOPE_NONCE()];
+        uint16[4] memory otherScopes = [uint16(0), Scopes.SELF_PAYER, Scopes.SPONSOR_PAYER, Scopes.NONCE];
         for (uint256 i; i < otherScopes.length; i++) {
             // Policy actors are keyed by actorId only; no signing key is needed, so a distinct address-shaped id
             // avoids the vm.addr curve-order bound on an unbounded rootPk + i.
             bytes32 actorId = bytes32(bytes20(address(uint160(1000 + i))));
-            uint16 scope = otherScopes[i] | keystore.SCOPE_POLICY();
+            uint16 scope = otherScopes[i] | Scopes.POLICY;
             _authorizePolicyActor(account, rootPk, actorId, scope, manager, commitment);
 
             assertEq(keystore.getPolicyManager(account, actorId), manager);
@@ -511,7 +511,7 @@ contract PolicyAccessorsTest is KeystoreTest {
         );
 
         (, uint16 outScope) = keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
-        assertTrue(outScope & keystore.SCOPE_POLICY() != 0);
+        assertTrue(outScope & Scopes.POLICY != 0);
         assertEq(keystore.getPolicyManager(account, sessionActorId), manager);
     }
 
@@ -569,9 +569,9 @@ contract PolicyAccessorsTest is KeystoreTest {
     // Fuzz-input bounding helpers
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @dev A policy-bearing actor's scope: always carries SCOPE_POLICY, with arbitrary other bits mixed in.
-    function _boundGatedScope(uint8 seed) internal view returns (uint16) {
-        return uint16(seed) | keystore.SCOPE_POLICY();
+    /// @dev A policy-bearing actor's scope: always carries Scopes.POLICY, with arbitrary other bits mixed in.
+    function _boundGatedScope(uint8 seed) internal pure returns (uint16) {
+        return uint16(seed) | Scopes.POLICY;
     }
 
     /// @dev A non-zero policy manager address (so a written slot is distinguishable from an unwritten one).

--- a/test/unit/examples/ExternalPolicyCaller.t.sol
+++ b/test/unit/examples/ExternalPolicyCaller.t.sol
@@ -72,9 +72,9 @@ contract ExternalPolicyCallerTest is KeystoreTest {
     function test_executeFor_revertsForUnauthorizedCaller() public {
         address account = _optIn(bytes32(uint256(1)), 100e6, MONTH);
 
-        // A different external address was never authorized by the account → no manager binding for its actorId.
+        // A different external address was never authorized by the account → not a live actor of it.
         address stranger = address(0xBAD);
-        vm.expectRevert(abi.encodeWithSelector(PolicyManager.NoActivePolicy.selector, bytes32(bytes20(stranger))));
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.InvalidActor.selector, bytes32(bytes20(stranger))));
         vm.prank(stranger);
         manager.executeFor(lastBinding, _pull(1));
     }
@@ -108,18 +108,20 @@ contract ExternalPolicyCallerTest is KeystoreTest {
 
         _revokeProvider(account);
 
-        vm.expectRevert(abi.encodeWithSelector(PolicyManager.NoActivePolicy.selector, bytes32(bytes20(provider))));
+        // A revoked provider is no longer a live actor of the account.
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.InvalidActor.selector, bytes32(bytes20(provider))));
         vm.prank(provider);
         manager.executeFor(lastBinding, _pull(1));
     }
 
     function test_executeFor_revertsWhenActorExpired() public {
-        // External path has no protocol auth, so expiry must be enforced in the manager.
+        // External path has no protocol auth, so liveness must be enforced in the manager; an expired actor is
+        // rejected as InvalidActor.
         uint48 expiry = uint48(block.timestamp + 1 days);
         address account = _optInWithExpiry(bytes32(uint256(1)), 100e6, MONTH, expiry);
 
         vm.warp(uint256(expiry) + 1);
-        vm.expectRevert(abi.encodeWithSelector(PolicyManager.ActorExpired.selector, bytes32(bytes20(provider))));
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.InvalidActor.selector, bytes32(bytes20(provider))));
         vm.prank(provider);
         manager.executeFor(lastBinding, _pull(1));
     }
@@ -152,7 +154,7 @@ contract ExternalPolicyCallerTest is KeystoreTest {
     // ── Cross-account best-effort batch ──
 
     function test_executeForMany_bestEffort_isolatesFailures() public {
-        // Three subscribers; the middle one opts in then revokes, so its pull reverts (NoActivePolicy) and must be
+        // Three subscribers; the middle one opts in then revokes, so its pull reverts (InvalidActor) and must be
         // skipped without blocking the other two.
         address a1 = _optIn(bytes32(uint256(1)), 100e6, MONTH);
         address a2 = _optIn(bytes32(uint256(2)), 100e6, MONTH);

--- a/test/unit/examples/ExternalPolicyCaller.t.sol
+++ b/test/unit/examples/ExternalPolicyCaller.t.sol
@@ -126,6 +126,19 @@ contract ExternalPolicyCallerTest is KeystoreTest {
         manager.executeFor(lastBinding, _pull(1));
     }
 
+    function test_executeFor_revertsForNonExternalPullActor() public {
+        // The provider is a live, policy-gated actor of the account, correctly gated to this manager with a matching
+        // commitment — but it was provisioned with a *signing* authenticator, not EXTERNAL_POLICY_AUTHENTICATOR. Such
+        // a native key must act through the protocol-authenticated path, never the auth-less external pull.
+        address account = _createAccount(bytes32(uint256(1)));
+        (PolicyManager.PolicyBinding memory binding, bytes32 commitment) = _binding(account, 1, 100e6, MONTH);
+        _authorizeProviderWithAuthenticator(account, address(k1Authenticator), address(manager), commitment, 0);
+
+        vm.expectRevert(abi.encodeWithSelector(PolicyManager.InvalidActor.selector, bytes32(bytes20(provider))));
+        vm.prank(provider);
+        manager.executeFor(binding, _pull(1));
+    }
+
     function test_executeFor_revertsOverBudget() public {
         address account = _optIn(bytes32(uint256(1)), 50e6, MONTH);
 
@@ -312,8 +325,22 @@ contract ExternalPolicyCallerTest is KeystoreTest {
     }
 
     function _authorizeProvider(address account, address policyManager, bytes32 commitment, uint48 expiry) internal {
-        Keystore.ActorConfig memory cfg =
-            Keystore.ActorConfig({authenticator: EXTERNAL_POLICY_AUTHENTICATOR, scope: SCOPE_POLICY, expiry: expiry});
+        _authorizeProviderWithAuthenticator(account, EXTERNAL_POLICY_AUTHENTICATOR, policyManager, commitment, expiry);
+    }
+
+    /// @dev Authorize the provider actor with an arbitrary `authenticator` (an external-pull actor MUST use
+    ///      {EXTERNAL_POLICY_AUTHENTICATOR}; used by tests to provision a non-external-pull actor and assert the
+    ///      manager rejects it on the external path).
+    function _authorizeProviderWithAuthenticator(
+        address account,
+        address authenticator,
+        address policyManager,
+        bytes32 commitment,
+        uint48 expiry
+    ) internal {
+        Keystore.ActorConfig memory cfg = Keystore.ActorConfig({
+            authenticator: authenticator, scope: SCOPE_POLICY, expiry: expiry
+        });
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: bytes32(bytes20(provider)),


### PR DESCRIPTION
Rebased onto `main` now that #55 has merged. Pure refactor — no behavior or wire-format change to scopes.

## Scopes library
- Add `src/libraries/Scopes.sol` as the single canonical, append-only source of the `uint16` actor scope grants: `SENDER`, `POLICY`, `NONCE`, `SELF_PAYER`, `SPONSOR_PAYER`. Admin remains the *absence* of grants (`scope == 0`), so it is intentionally not a bit.
- `Keystore` stays fully scope-agnostic in code: it interprets only `Scopes.POLICY` (to slice/store policy data) and stores every other bit verbatim. Its inline public `SCOPE_*` constants are removed in favor of `Scopes.*`.
- `DefaultAccount` drops its local `SCOPE_` mirrors and references `Scopes.*` directly. Library constants inline at compile time, so there is no new external call on the execution/1271 hot path (the reason the mirrors existed).
- Prose in `Policy` / `PolicyManager` / `src/policies/README.md` updated to `Scopes.*`.
- Test wiring: suites that use scope in `uint16` contexts (`applyAccountChange`, `policyAccessors`) reference `Scopes.*`; `uint8`-fuzz suites keep their local constants.

## Public `isActor` + PolicyManager
- Re-add a public liveness getter `Keystore.isActor(account, actorId)` — **expiry-aware**, equivalent to `getActorConfig(...).authenticator != address(0)` resolved directly from storage (an expired/revoked/disabled actor reports `false`).
- The expiry-**agnostic** internal predicate (used only by `_revokeActor`, so an expired-but-stored actor can still be revoked to reclaim its slots) is renamed `_isActor` → `_isAuthorized` to keep the two semantics unambiguous.
- `PolicyManager` drops the `_requireActiveActor` helper and calls `KEYSTORE.isActor` on the auth-less external path (`executeFor`/`executeForMany`) instead. Same behavior — expired/revoked actors are still rejected — now expressed through the public getter.

## Notes
- 1271 verification is left exactly where it is on `main` (`Keystore.verifySignature`); this PR does not relocate or restructure it.
- `DELEGATE` is intentionally omitted (fleet delegation uses the external-policy/hub pattern).
- No wire-format change: the bit values are identical (`0x0001..0x0010`), so signed digests and stored scopes are unchanged.

## Test plan
- [x] `forge build` clean
- [x] `forge test` — 333 passing, 0 failing
- [x] `forge fmt --check` clean