### PR TITLE
Simplify replaySafeHash to the 8130 non-EIP-712 signed-message convention

### DIFF
--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -656,7 +656,7 @@ contract AccountConfiguration {
     ///      signed-message typehashes. `account` closes cross-account replay; the current chainId closes cross-chain
     ///      replay.
     bytes32 public constant SIGNED_MESSAGE_TYPEHASH =
-        keccak256("SignedMessage(address account,uint256 chainId,bytes32 hash)");
+        keccak256("EIP8130SignedMessage(address account,uint256 chainId,bytes32 hash)");
 
     /// @notice Account-scoped digest to sign for `hash` to be accepted by {verifySignature}: `hash` bound to
     ///         `account` and the current chainId under {SIGNED_MESSAGE_TYPEHASH}.

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -644,40 +644,27 @@ contract AccountConfiguration {
         }
     }
 
-    // Account-scoped ERC-1271: signatures are authenticated against replaySafeHash(account, hash), an EIP-712
-    // digest with verifyingContract = account, binding a 1271 signature to a single account. This is the EIP-7739
-    // PersonalSign digest; TypedDataSign is not implemented. The registry's own signed messages (actor changes,
-    // import, lock) bind context in-struct and do not use this domain.
+    // Account-scoped ERC-1271: signatures are authenticated against replaySafeHash(account, hash), a digest binding a
+    // 1271 signature to a single account and chain. Deliberately NOT EIP-712 (no 0x1901 / domain separator): a fixed
+    // typehash provides domain separation while keeping eth_signTypedData from producing these digests (anti-phishing),
+    // consistent with the registry's other signed-message typehashes (import, actor changes, lock). Readable
+    // (EIP-7739 TypedDataSign) rendering is intentionally not offered here; it is an account-layer concern.
 
-    /// @dev EIP-712 domain typehash.
-    bytes32 private constant _EIP712_DOMAIN_TYPEHASH =
-        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    /// @notice Typehash binding a 1271 signature to its account and chainId.
+    ///
+    /// @dev NOT compliant with EIP-712, to mitigate eth_signTypedData phishing, consistent with the other 8130
+    ///      signed-message typehashes. `account` closes cross-account replay; the current chainId closes cross-chain
+    ///      replay.
+    bytes32 public constant SIGNED_MESSAGE_TYPEHASH =
+        keccak256("SignedMessage(address account,uint256 chainId,bytes32 hash)");
 
-    /// @dev keccak256("PersonalSign(bytes prefixed)").
-    bytes32 private constant _PERSONAL_SIGN_TYPEHASH =
-        0x983e65e5148e570cd828ead231ee759a8d7958721a768f93bc4483ba005c32de;
-
-    /// @dev Account ERC-1271 domain name/version, fixed for all accounts.
-    bytes32 private constant _ACCOUNT_DOMAIN_NAME_HASH = keccak256("EIP8130Account");
-    bytes32 private constant _ACCOUNT_DOMAIN_VERSION_HASH = keccak256("1");
-
-    /// @notice Account-scoped digest to sign for `hash` to be accepted by {verifySignature}: `hash` wrapped in an
-    ///         EIP-712 domain with verifyingContract = `account` and the current chainId.
+    /// @notice Account-scoped digest to sign for `hash` to be accepted by {verifySignature}: `hash` bound to
+    ///         `account` and the current chainId under {SIGNED_MESSAGE_TYPEHASH}.
     /// @param account Account the signature is bound to.
     /// @param hash Raw message digest.
     /// @return The digest to sign.
     function replaySafeHash(address account, bytes32 hash) public view returns (bytes32) {
-        bytes32 structHash = keccak256(abi.encode(_PERSONAL_SIGN_TYPEHASH, hash));
-        return keccak256(abi.encodePacked(hex"1901", _accountDomainSeparator(account), structHash));
-    }
-
-    /// @dev EIP-712 domain separator for `account`'s ERC-1271 domain (verifyingContract = account, current chainId).
-    function _accountDomainSeparator(address account) internal view returns (bytes32) {
-        return keccak256(
-            abi.encode(
-                _EIP712_DOMAIN_TYPEHASH, _ACCOUNT_DOMAIN_NAME_HASH, _ACCOUNT_DOMAIN_VERSION_HASH, block.chainid, account
-            )
-        );
+        return keccak256(abi.encode(SIGNED_MESSAGE_TYPEHASH, account, block.chainid, hash));
     }
 
     /// @notice Authenticates that an account approved `hash` using auth in `authenticator(20) || data` format,

--- a/src/AccountConfiguration.sol
+++ b/src/AccountConfiguration.sol
@@ -648,7 +648,7 @@ contract AccountConfiguration {
     // 1271 signature to a single account and chain. Deliberately NOT EIP-712 (no 0x1901 / domain separator): a fixed
     // typehash provides domain separation while keeping eth_signTypedData from producing these digests (anti-phishing),
     // consistent with the registry's other signed-message typehashes (import, actor changes, lock). Readable
-    // (EIP-7739 TypedDataSign) rendering is intentionally not offered here; it is an account-layer concern.
+    // typed-data signature rendering is intentionally not offered here; it is an account-layer concern.
 
     /// @notice Typehash binding a 1271 signature to its account and chainId.
     ///

--- a/test/unit/AccountConfiguration/authenticate.t.sol
+++ b/test/unit/AccountConfiguration/authenticate.t.sol
@@ -725,7 +725,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), scope);
 
         bool expected = scope == 0 || (scope & SCOPE_SENDER != 0);
-        // verifySignature applies the account-scoped EIP-7739 wrap.
+        // verifySignature applies the account-scoped replaySafeHash wrap.
         bytes memory auth = _buildK1Auth(actorPk, accountConfiguration.replaySafeHash(account, hash));
         assertEq(accountConfiguration.verifySignature(account, hash, auth), expected);
     }
@@ -744,7 +744,7 @@ contract AuthenticateTest is AccountConfigurationTest {
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(actorPk) != account);
         bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
-        // verifySignature applies the account-scoped EIP-7739 wrap; replaySafeHash(account, hash) is scope-independent.
+        // verifySignature applies the account-scoped replaySafeHash wrap; replaySafeHash(account, hash) is scope-independent.
         bytes memory auth = _buildK1Auth(actorPk, accountConfiguration.replaySafeHash(account, hash));
 
         _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_SENDER);

--- a/test/unit/AccountConfiguration/erc7739.t.sol
+++ b/test/unit/AccountConfiguration/erc7739.t.sol
@@ -3,11 +3,12 @@ pragma solidity ^0.8.30;
 
 import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 
-/// @notice Draft: registry-native EIP-7739 (PersonalSign) rehashing in AccountConfiguration.verifySignature.
+/// @notice Registry-native account- and chain-scoping of ERC-1271 signatures in AccountConfiguration.verifySignature.
 ///
-/// @dev Demonstrates that ERC-1271 signatures are now bound to a specific account at the singleton level, so
-///      cross-account replay is closed for EVERY consumer of verifySignature — including registry-direct verifiers
-///      (e.g. precompile-based permits) that cannot call account bytecode.
+/// @dev Demonstrates that ERC-1271 signatures are bound to a specific account and chain at the singleton level
+///      (via replaySafeHash), so cross-account and cross-chain replay are closed for EVERY consumer of
+///      verifySignature, including registry-direct verifiers (e.g. precompile-based permits) that cannot call
+///      account bytecode.
 contract AccountConfigurationERC7739Test is AccountConfigurationTest {
     uint256 constant OWNER_PK = 0xA11CE;
 
@@ -47,8 +48,8 @@ contract AccountConfigurationERC7739Test is AccountConfigurationTest {
         );
     }
 
-    /// @dev replaySafeHash is account-scoped: the same message yields different digests per account (and per chain,
-    ///      via the EIP-712 domain).
+    /// @dev replaySafeHash is account-scoped: the same message yields different digests per account. Chain-scoping
+    ///      is covered by test_replaySafeHash_isChainScoped.
     function test_replaySafeHash_isAccountScoped() public {
         (address accountA,) = _createK1AccountWithSalt(OWNER_PK, bytes32(uint256(0xA)));
         (address accountB,) = _createK1AccountWithSalt(OWNER_PK, bytes32(uint256(0xB)));
@@ -71,5 +72,33 @@ contract AccountConfigurationERC7739Test is AccountConfigurationTest {
             accountConfiguration.verifySignature(account, appHash, _buildK1Auth(0xBEEF, signable)),
             "a non-owner signature must be rejected"
         );
+    }
+
+    /// @dev A signature bound to one chain does NOT validate on another: replaySafeHash mixes in block.chainid, so
+    ///      the same (account, appHash) yields a different digest per chain and a chain-A signature is rejected on
+    ///      chain B. Mirrors {test_verifySignature_blocksCrossAccountReplay} on the chain axis.
+    function test_verifySignature_blocksCrossChainReplay() public {
+        (address account,) = _createK1AccountWithSalt(OWNER_PK, bytes32(uint256(1)));
+        bytes32 appHash = keccak256("sign in to dapp");
+
+        bytes memory sig = _buildK1Auth(OWNER_PK, accountConfiguration.replaySafeHash(account, appHash));
+        assertTrue(accountConfiguration.verifySignature(account, appHash, sig), "valid on the signing chain");
+
+        vm.chainId(block.chainid + 1);
+        assertFalse(
+            accountConfiguration.verifySignature(account, appHash, sig), "must NOT replay onto another chain"
+        );
+    }
+
+    /// @dev replaySafeHash is chain-scoped: the same (account, message) yields different digests per chain.
+    function test_replaySafeHash_isChainScoped() public {
+        (address account,) = _createK1AccountWithSalt(OWNER_PK, bytes32(uint256(1)));
+        bytes32 appHash = keccak256("msg");
+
+        bytes32 digestChainA = accountConfiguration.replaySafeHash(account, appHash);
+        vm.chainId(block.chainid + 1);
+        bytes32 digestChainB = accountConfiguration.replaySafeHash(account, appHash);
+
+        assertTrue(digestChainA != digestChainB, "digests must differ by chain");
     }
 }

--- a/test/unit/AccountConfiguration/replaySafeHash.t.sol
+++ b/test/unit/AccountConfiguration/replaySafeHash.t.sol
@@ -9,7 +9,7 @@ import {AccountConfigurationTest} from "../../lib/AccountConfigurationTest.sol";
 ///      (via replaySafeHash), so cross-account and cross-chain replay are closed for EVERY consumer of
 ///      verifySignature, including registry-direct verifiers (e.g. precompile-based permits) that cannot call
 ///      account bytecode.
-contract AccountConfigurationERC7739Test is AccountConfigurationTest {
+contract AccountConfigurationReplaySafeHashTest is AccountConfigurationTest {
     uint256 constant OWNER_PK = 0xA11CE;
 
     /// @dev verifySignature now rehashes: a signature over the RAW app hash is rejected; the signer must sign the

--- a/test/unit/accounts/CanonicalHighRatePayerAccount.t.sol
+++ b/test/unit/accounts/CanonicalHighRatePayerAccount.t.sol
@@ -156,7 +156,7 @@ contract CanonicalHighRatePayerAccountTest is AccountConfigurationTest {
         (address account,) = _createHighRatePayerK1Account(ACTOR_PK);
 
         bytes32 hash = keccak256("validate me");
-        // verifySignature applies the account-scoped EIP-7739 wrap, so sign the replaySafeHash digest.
+        // verifySignature applies the account-scoped replaySafeHash wrap, so sign the replaySafeHash digest.
         bytes memory authData = _buildK1Auth(ACTOR_PK, accountConfiguration.replaySafeHash(account, hash));
 
         bytes4 result = CanonicalHighRatePayerAccount(payable(account)).isValidSignature(hash, authData);

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -312,7 +312,7 @@ contract DefaultAccountTest is AccountConfigurationTest {
         // Authorize the actor with SENDER scope only (no POLICY) — it is operational and can validate signatures.
         _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(actor)), k1Authenticator, SCOPE_SENDER);
 
-        // verifySignature applies the account-scoped EIP-7739 wrap, so sign the replaySafeHash digest.
+        // verifySignature applies the account-scoped replaySafeHash wrap, so sign the replaySafeHash digest.
         bytes memory authData = _buildK1Auth(actorPk, accountConfiguration.replaySafeHash(account, hash));
 
         bytes4 result = DefaultAccount(payable(account)).isValidSignature(hash, authData);
@@ -346,7 +346,7 @@ contract DefaultAccountTest is AccountConfigurationTest {
         uint256 pk = _boundK1Pk(pkSeed);
         (address account,) = _createK1Account(pk);
 
-        // verifySignature applies the account-scoped EIP-7739 wrap, so sign the replaySafeHash digest.
+        // verifySignature applies the account-scoped replaySafeHash wrap, so sign the replaySafeHash digest.
         bytes memory authData = _buildK1Auth(pk, accountConfiguration.replaySafeHash(account, hash));
 
         bytes4 result = DefaultAccount(payable(account)).isValidSignature(hash, authData);


### PR DESCRIPTION
## Summary

Simplify `AccountConfiguration.replaySafeHash` from a full EIP-712 digest to the 8130 non-EIP-712 signed-message convention, binding a 1271 signature to `account` + `chainId` under a fixed typehash.

## Motivation

`replaySafeHash` was the lone EIP-712 signed-message digest in `AccountConfiguration`. Every other signed message (`ActorInitialization`/import, `SignedActorChanges`, `SignedLockChange`) is deliberately **non-EIP-712** "to mitigate eth_signTypedData phishing." This aligns the ERC-1271 wrap with that house convention and removes now-redundant machinery.

- Binds using only `account` + `chainId` (`verifyingContract` already uniquely identifies the account; name/version added nothing).
- The fixed typehash provides domain separation; the deliberate absence of `0x1901` keeps `eth_signTypedData` from producing these digests (anti-phishing), matching the other signed-message typehashes.
- Cross-account replay closed by `account`; cross-chain replay closed by `block.chainid`.

## Changes

- Replace the EIP-712 `replaySafeHash` with `keccak256(abi.encode(SIGNED_MESSAGE_TYPEHASH, account, block.chainid, hash))`.
- Add `SIGNED_MESSAGE_TYPEHASH = keccak256("SignedMessage(address account,uint256 chainId,bytes32 hash)")`.
- Remove now-unused `_EIP712_DOMAIN_TYPEHASH`, `_PERSONAL_SIGN_TYPEHASH`, `_ACCOUNT_DOMAIN_NAME_HASH`, `_ACCOUNT_DOMAIN_VERSION_HASH`, and `_accountDomainSeparator`.
- `verifySignature` and `DefaultAccount.isValidSignature` are unchanged (the account already forwards to `verifySignature`).

## Out of scope / decisions

- ERC-7739 TypedDataSign (readable signatures) intentionally not added; it is an account-layer concern, not core, and its readability benefit is marginal for passkey-backed / first-party-curated accounts.
- A "replayable wrapper" (wildcard `account`/`chainId`) was considered and declined: it inverts the containment the wrap exists for, and can be added later at the account layer via `authenticateActor` if a concrete use case arises.

## Testing

- `forge build` clean.
- `forge test` — all 325 unit tests pass. Tests derive digests from the contract's `replaySafeHash`, so behavior adapts automatically to the new formula.
