### PR TITLE
feat: single-call execute + verbatim revert bubbling

### DIFF
--- a/src/accounts/CanonicalHighRatePayerAccount.sol
+++ b/src/accounts/CanonicalHighRatePayerAccount.sol
@@ -19,11 +19,29 @@ contract CanonicalHighRatePayerAccount is DefaultAccount {
 
     constructor(address keystore) DefaultAccount(keystore) {}
 
+    /// @notice Executes a single call from the account, blocking an outbound value transfer while locked.
+    ///
+    /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a TRUSTED_EXECUTOR actor.
+    /// @dev Reverts with AccountLocked when the call carries non-zero value and the account is locked.
+    /// @dev On failure, bubbles the callee's revert data verbatim; a revert with no returndata surfaces as CallFailed.
+    ///
+    /// @param target Address the account calls.
+    /// @param value Wei forwarded with the call.
+    /// @param data Calldata passed to `target`.
+    function execute(address target, uint256 value, bytes calldata data) external override {
+        if (!_isAuthorizedCaller(msg.sender)) revert UnauthorizedCaller();
+        if (value > 0) {
+            (bool locked,,,) = KEYSTORE.getLockStatus(address(this));
+            if (locked) revert AccountLocked();
+        }
+        _call(target, value, data);
+    }
+
     /// @notice Executes a batch of calls from the account, blocking outbound value transfers while locked.
     ///
     /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a TRUSTED_EXECUTOR actor.
     /// @dev Reverts with AccountLocked when a call carries non-zero value and the account is locked.
-    /// @dev Reverts with CallFailed when any inner call reverts.
+    /// @dev On failure, bubbles the callee's revert data verbatim; a revert with no returndata surfaces as CallFailed.
     ///
     /// @param calls Ordered calls to execute, each as (target, value, data).
     function executeBatch(Call[] calldata calls) external override {
@@ -33,8 +51,7 @@ contract CanonicalHighRatePayerAccount is DefaultAccount {
                 (bool locked,,,) = KEYSTORE.getLockStatus(address(this));
                 if (locked) revert AccountLocked();
             }
-            (bool success,) = calls[i].target.call{value: calls[i].value}(calls[i].data);
-            if (!success) revert CallFailed();
+            _call(calls[i].target, calls[i].value, calls[i].data);
         }
     }
 }

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -52,10 +52,10 @@ contract DefaultAccount is Receiver {
     /// @notice The caller is neither the account itself nor a registered TRUSTED_EXECUTOR actor.
     error UnauthorizedCaller();
 
-    /// @notice An inner call in the executed batch reverted.
+    /// @notice A call reverted with no returndata to bubble.
     error CallFailed();
 
-    /// @notice Deploys the account implementation bound to an Keystore instance.
+    /// @notice Deploys the account implementation bound to a Keystore instance.
     /// @param keystore Address of the Keystore system contract.
     constructor(address keystore) {
         KEYSTORE = Keystore(keystore);
@@ -65,17 +65,32 @@ contract DefaultAccount is Receiver {
     //  EXECUTION
     // ══════════════════════════════════════════════
 
+    /// @notice Executes a single call from the account.
+    ///
+    /// @dev Selector-compatible with the widely deployed CoinbaseSmartWallet V1 `execute(address,uint256,bytes)`
+    ///      (0xb61d27f6), so integrations that call that ABI directly (e.g. SpendPermissionManager) keep working.
+    ///      Equivalent to a one-element {executeBatch}.
+    /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a TRUSTED_EXECUTOR actor.
+    /// @dev On failure, bubbles the callee's revert data verbatim; a revert with no returndata surfaces as CallFailed.
+    ///
+    /// @param target Address the account calls.
+    /// @param value Wei forwarded with the call.
+    /// @param data Calldata passed to `target`.
+    function execute(address target, uint256 value, bytes calldata data) external virtual {
+        if (!_isAuthorizedCaller(msg.sender)) revert UnauthorizedCaller();
+        _call(target, value, data);
+    }
+
     /// @notice Executes a batch of calls from the account; reverts the entire batch if any call fails.
     ///
     /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a TRUSTED_EXECUTOR actor.
-    /// @dev Reverts with CallFailed when any inner call reverts.
+    /// @dev On failure, bubbles the callee's revert data verbatim; a revert with no returndata surfaces as CallFailed.
     ///
     /// @param calls Ordered calls to execute, each as (target, value, data).
     function executeBatch(Call[] calldata calls) external virtual {
         if (!_isAuthorizedCaller(msg.sender)) revert UnauthorizedCaller();
         for (uint256 i; i < calls.length; i++) {
-            (bool success,) = calls[i].target.call{value: calls[i].value}(calls[i].data);
-            if (!success) revert CallFailed();
+            _call(calls[i].target, calls[i].value, calls[i].data);
         }
     }
 
@@ -150,5 +165,18 @@ contract DefaultAccount is Receiver {
         Keystore.ActorConfig memory config = KEYSTORE.getActorConfig(address(this), bytes32(bytes20(caller)));
         if (config.authenticator != TRUSTED_EXECUTOR) return false;
         return Scopes.isOperational(config.scope);
+    }
+
+    /// @dev Performs a single call from the account, bubbling the callee's revert data verbatim on failure so callers
+    ///      observe the original error (Error(string), Panic(uint256), or a custom error). A revert carrying no
+    ///      returndata (e.g. a bare `revert()` or an out-of-gas at the callee) surfaces as CallFailed.
+    function _call(address target, uint256 value, bytes calldata data) internal {
+        (bool success, bytes memory result) = target.call{value: value}(data);
+        if (!success) {
+            if (result.length == 0) revert CallFailed();
+            assembly ("memory-safe") {
+                revert(add(result, 0x20), mload(result))
+            }
+        }
     }
 }

--- a/test/unit/accounts/CanonicalHighRatePayerAccount.t.sol
+++ b/test/unit/accounts/CanonicalHighRatePayerAccount.t.sol
@@ -16,6 +16,13 @@ contract HighRatePayerMockTarget {
     function reverting() external pure {
         revert("boom");
     }
+
+    /// @dev Reverts with empty returndata to exercise the CallFailed fallback in _call.
+    function revertingEmpty() external pure {
+        assembly {
+            revert(0, 0)
+        }
+    }
 }
 
 contract CanonicalHighRatePayerAccountTest is KeystoreTest {
@@ -106,9 +113,18 @@ contract CanonicalHighRatePayerAccountTest is KeystoreTest {
         (address account,) = _createHighRatePayerK1Account(ACTOR_PK);
 
         vm.prank(account);
-        vm.expectRevert(DefaultAccount.CallFailed.selector);
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "boom"));
         CanonicalHighRatePayerAccount(payable(account))
             .executeBatch(_singleCall(address(target), 0, abi.encodeCall(HighRatePayerMockTarget.reverting, ())));
+    }
+
+    function test_executeBatch_emptyReturndataSurfacesCallFailed() public {
+        (address account,) = _createHighRatePayerK1Account(ACTOR_PK);
+
+        vm.prank(account);
+        vm.expectRevert(DefaultAccount.CallFailed.selector);
+        CanonicalHighRatePayerAccount(payable(account))
+            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(HighRatePayerMockTarget.revertingEmpty, ())));
     }
 
     function test_executeBatch_blocksETHWhenLocked() public {
@@ -146,6 +162,71 @@ contract CanonicalHighRatePayerAccountTest is KeystoreTest {
             .executeBatch(
                 _singleCall(address(target), 0.5 ether, abi.encodeCall(HighRatePayerMockTarget.setValue, (1)))
             );
+
+        assertEq(address(target).balance, 0.5 ether);
+    }
+
+    // ── execute (single call) ──
+
+    function test_execute_success() public {
+        (address account,) = _createHighRatePayerK1Account(ACTOR_PK);
+
+        vm.prank(account);
+        CanonicalHighRatePayerAccount(payable(account))
+            .execute(address(target), 0, abi.encodeCall(HighRatePayerMockTarget.setValue, (42)));
+
+        assertEq(target.value(), 42);
+    }
+
+    function test_execute_revertsFromNonSelf() public {
+        (address account,) = _createHighRatePayerK1Account(ACTOR_PK);
+
+        vm.prank(address(0xdead));
+        vm.expectRevert(DefaultAccount.UnauthorizedCaller.selector);
+        CanonicalHighRatePayerAccount(payable(account))
+            .execute(address(target), 0, abi.encodeCall(HighRatePayerMockTarget.setValue, (1)));
+    }
+
+    function test_execute_bubblesReason() public {
+        (address account,) = _createHighRatePayerK1Account(ACTOR_PK);
+
+        vm.prank(account);
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "boom"));
+        CanonicalHighRatePayerAccount(payable(account))
+            .execute(address(target), 0, abi.encodeCall(HighRatePayerMockTarget.reverting, ()));
+    }
+
+    function test_execute_blocksETHWhenLocked() public {
+        (address account,) = _createHighRatePayerK1Account(ACTOR_PK);
+        vm.deal(account, 1 ether);
+
+        _lockAccount(ACTOR_PK, account, 1 hours);
+
+        vm.prank(account);
+        vm.expectRevert(CanonicalHighRatePayerAccount.AccountLocked.selector);
+        CanonicalHighRatePayerAccount(payable(account))
+            .execute(address(target), 0.1 ether, abi.encodeCall(HighRatePayerMockTarget.setValue, (1)));
+    }
+
+    function test_execute_allowsZeroValueCallWhenLocked() public {
+        (address account,) = _createHighRatePayerK1Account(ACTOR_PK);
+
+        _lockAccount(ACTOR_PK, account, 1 hours);
+
+        vm.prank(account);
+        CanonicalHighRatePayerAccount(payable(account))
+            .execute(address(target), 0, abi.encodeCall(HighRatePayerMockTarget.setValue, (99)));
+
+        assertEq(target.value(), 99);
+    }
+
+    function test_execute_allowsETHWhenUnlocked() public {
+        (address account,) = _createHighRatePayerK1Account(ACTOR_PK);
+        vm.deal(account, 1 ether);
+
+        vm.prank(account);
+        CanonicalHighRatePayerAccount(payable(account))
+            .execute(address(target), 0.5 ether, abi.encodeCall(HighRatePayerMockTarget.setValue, (1)));
 
         assertEq(address(target).balance, 0.5 ether);
     }

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -17,6 +17,13 @@ contract MockTarget {
     function reverting() external pure {
         revert("boom");
     }
+
+    /// @dev Reverts with empty returndata to exercise the CallFailed fallback in _call.
+    function revertingEmpty() external pure {
+        assembly {
+            revert(0, 0)
+        }
+    }
 }
 
 contract DefaultAccountTest is KeystoreTest {
@@ -123,21 +130,32 @@ contract DefaultAccountTest is KeystoreTest {
             .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (1))));
     }
 
-    /// @notice A failing inner call aborts the whole batch.
-    /// @dev Exercises the false leg of `require(success)`; fuzzes the ETH value carried by the failing call.
-    function test_executeBatch_revert_failedInnerCall(uint256 value) public {
+    /// @notice A failing inner call aborts the whole batch and bubbles the callee's revert reason verbatim.
+    /// @dev The callee reverts with Error("boom"); executeBatch surfaces that data, not a generic CallFailed. Uses
+    ///      zero value so the (pure) callee actually runs — a non-zero value would fail its payability check first
+    ///      with empty returndata, which the emptyReturndata test covers separately.
+    function test_executeBatch_revert_failedInnerCall() public {
         (address account,) = _createK1Account(ACTOR_PK);
-        value = bound(value, 0, 1e24);
-        vm.deal(account, value);
+
+        vm.prank(account);
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "boom"));
+        DefaultAccount(payable(account))
+            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.reverting, ())));
+    }
+
+    /// @notice A callee that reverts with no returndata surfaces as CallFailed (the bubble fallback).
+    /// @dev Exercises the `result.length == 0` leg of _call.
+    function test_executeBatch_revert_emptyReturndataSurfacesCallFailed() public {
+        (address account,) = _createK1Account(ACTOR_PK);
 
         vm.prank(account);
         vm.expectRevert(DefaultAccount.CallFailed.selector);
         DefaultAccount(payable(account))
-            .executeBatch(_singleCall(address(target), value, abi.encodeCall(MockTarget.reverting, ())));
+            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.revertingEmpty, ())));
     }
 
     /// @notice A failed call late in the batch rolls back state written by earlier successful calls.
-    /// @dev The whole executeBatch reverts, so the earlier setValue is rolled back.
+    /// @dev The whole executeBatch reverts (bubbling the callee reason), so the earlier setValue is rolled back.
     function test_executeBatch_revert_failedInnerCallRollsBackPriorState(uint256 v) public {
         (address account,) = _createK1Account(ACTOR_PK);
         v = bound(v, 1, type(uint256).max); // non-zero so the rollback assertion is meaningful
@@ -147,7 +165,7 @@ contract DefaultAccountTest is KeystoreTest {
         calls[1] = Call(address(target), 0, abi.encodeCall(MockTarget.reverting, ()));
 
         vm.prank(account);
-        vm.expectRevert(DefaultAccount.CallFailed.selector);
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "boom"));
         DefaultAccount(payable(account)).executeBatch(calls);
 
         assertEq(target.value(), 0);
@@ -249,6 +267,100 @@ contract DefaultAccountTest is KeystoreTest {
         DefaultAccount(payable(account)).executeBatch(_singleCall(t, 0, abi.encodeCall(MockTarget.setValue, (1))));
 
         assertEq(t.code.length, 0);
+    }
+
+    // ══════════════════════════════════════════════
+    //  execute — single call
+    // ══════════════════════════════════════════════
+
+    /// @notice Any caller that is neither the account nor a trusted executor reverts.
+    /// @dev Mirrors the executeBatch authorization check on the single-call path.
+    function test_execute_revert_unauthorizedCaller(address caller, uint256 value, bytes calldata data) public {
+        (address account,) = _createK1Account(ACTOR_PK);
+        vm.assume(caller != account);
+        value = bound(value, 0, type(uint128).max);
+
+        vm.prank(caller);
+        vm.expectRevert(DefaultAccount.UnauthorizedCaller.selector);
+        DefaultAccount(payable(account)).execute(address(target), value, data);
+    }
+
+    /// @notice The account calling itself executes a single call.
+    /// @dev Covers the caller == address(this) authorization branch.
+    function test_execute_success_selfCaller(uint256 v) public {
+        (address account,) = _createK1Account(ACTOR_PK);
+
+        vm.prank(account);
+        DefaultAccount(payable(account)).execute(address(target), 0, abi.encodeCall(MockTarget.setValue, (v)));
+
+        assertEq(target.value(), v);
+    }
+
+    /// @notice execute forwards ETH value to the target.
+    /// @dev Confirms the call{value:} wiring on the single-call path.
+    function test_execute_success_withETHValue(uint256 amount) public {
+        (address account,) = _createK1Account(ACTOR_PK);
+        amount = bound(amount, 0, 1e30);
+        vm.deal(account, amount);
+
+        vm.prank(account);
+        DefaultAccount(payable(account)).execute(address(target), amount, abi.encodeCall(MockTarget.setValue, (7)));
+
+        assertEq(address(target).balance, amount);
+        assertEq(account.balance, 0);
+        assertEq(target.value(), 7);
+    }
+
+    /// @notice A plain ETH transfer to a codeless EOA (empty calldata) succeeds.
+    /// @dev The generic call path does not require the target to have code, unlike helpers that gate on returndata.
+    function test_execute_success_valueTransferToEoa(address to, uint256 amount) public {
+        (address account,) = _createK1Account(ACTOR_PK);
+        vm.assume(uint160(to) > 0xffff); // avoid precompiles
+        vm.assume(to != account && to != address(vm) && to.code.length == 0);
+        amount = bound(amount, 0, 1e30);
+        vm.deal(account, amount);
+        uint256 toBalBefore = to.balance;
+
+        vm.prank(account);
+        DefaultAccount(payable(account)).execute(to, amount, "");
+
+        assertEq(to.balance, toBalBefore + amount);
+        assertEq(account.balance, 0);
+    }
+
+    /// @notice A registered TRUSTED_EXECUTOR actor may drive the single-call path directly.
+    /// @dev Covers the config-driven authorization branch on execute.
+    function test_execute_success_trustedExecutor(uint256 execSeed, uint256 v) public {
+        (address account,) = _createK1Account(ACTOR_PK);
+
+        address executor = address(uint160(bound(execSeed, 10, type(uint160).max)));
+        vm.assume(executor != account && executor != vm.addr(ACTOR_PK));
+        _authorizeActor(account, ACTOR_PK, bytes32(bytes20(executor)), TRUSTED_EXECUTOR);
+
+        vm.prank(executor);
+        DefaultAccount(payable(account)).execute(address(target), 0, abi.encodeCall(MockTarget.setValue, (v)));
+
+        assertEq(target.value(), v);
+    }
+
+    /// @notice execute bubbles the callee's revert reason verbatim.
+    /// @dev The callee reverts with Error("boom"); execute surfaces that data, not a generic CallFailed.
+    function test_execute_revert_bubblesReason() public {
+        (address account,) = _createK1Account(ACTOR_PK);
+
+        vm.prank(account);
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "boom"));
+        DefaultAccount(payable(account)).execute(address(target), 0, abi.encodeCall(MockTarget.reverting, ()));
+    }
+
+    /// @notice A callee that reverts with no returndata surfaces as CallFailed on the single-call path.
+    /// @dev Exercises the `result.length == 0` leg of _call via execute.
+    function test_execute_revert_emptyReturndataSurfacesCallFailed() public {
+        (address account,) = _createK1Account(ACTOR_PK);
+
+        vm.prank(account);
+        vm.expectRevert(DefaultAccount.CallFailed.selector);
+        DefaultAccount(payable(account)).execute(address(target), 0, abi.encodeCall(MockTarget.revertingEmpty, ()));
     }
 
     // ══════════════════════════════════════════════


### PR DESCRIPTION
## Summary
Stacked on #57 (`refactor/keystore-clean-org`). Adds a single-call `execute` entry point and fixes revert-reason opacity on the execution path.

- **`execute(address target, uint256 value, bytes data)`** added to `DefaultAccount` and overridden in `CanonicalHighRatePayerAccount`. Selector `0xb61d27f6` is ABI-compatible with CoinbaseSmartWallet V1, so integrations that call `execute(address,uint256,bytes)` directly (e.g. SpendPermissionManager) work against 8130 accounts without a batch wrapper.
- **Verbatim revert bubbling.** A shared internal `_call` helper backs both `execute` and `executeBatch`. On failure it bubbles the callee's revert data verbatim (`Error(string)`, `Panic(uint256)`, or custom errors) via `revert(add(result, 0x20), mload(result))`, falling back to `CallFailed()` only when the revert carries no returndata (bare `revert()`, non-payable value rejection, etc.). Previously every inner-call failure was flattened to `CallFailed()`, discarding the reason.
- **High-rate lock gate preserved.** The single-call path keeps the `AccountLocked` check for non-zero-value calls while locked, matching `executeBatch`.

## Notes
- `CallFailed` doc updated: it now means "a call reverted with no returndata to bubble."
- `_call` is `internal` so the high-rate subclass reuses it after its lock check.

## Test plan
- [x] `execute` on both accounts: self-caller, trusted-executor, ETH value forwarding, plain value transfer to a codeless EOA, unauthorized caller.
- [x] Bubbling: reverting callee surfaces `Error("boom")` verbatim on both `execute` and `executeBatch`.
- [x] Fallback: callee reverting with empty returndata surfaces `CallFailed()`.
- [x] High-rate lock gate on `execute`: blocks non-zero value while locked, allows zero-value while locked, allows value while unlocked.
- [x] Full suite: 336 tests passing.