### PR TITLE
Enums for change/lock ops, typehash naming, policies reframe

### DIFF
--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -51,10 +51,10 @@ contract Keystore {
     ///
     /// @dev ABI-encodes as uint8, so the wire values are preserved (Authorize = 0x01, Revoke = 0x02) and the
     ///      SignedActorChanges typehash keeps `uint8 changeType` — digests and the external ABI selector are
-    ///      unchanged. Invalid (0) is the reachable "unrecognized" case, rejected in-handler with {UnknownChangeType};
+    ///      unchanged. Invalid (0) is the reachable "unrecognized" case, rejected in-handler with {UnknownActorChangeType};
     ///      out-of-range wire values (>= 3) can never reach the handler — the enum decoder rejects them (reverts)
     ///      while ABI-decoding the calldata.
-    enum ChangeType {
+    enum ActorChangeType {
         Invalid,
         Authorize,
         Revoke
@@ -64,10 +64,10 @@ contract Keystore {
     ///
     /// @dev ABI-encodes as uint8, so the wire values are preserved (Lock = 0x01, Unlock = 0x02) and the
     ///      SignedLockChange typehash keeps `uint8 op` — digests and the external ABI selector are unchanged.
-    ///      Invalid (0) is the reachable "unrecognized" case, rejected in-handler with {UnknownLockOp}; out-of-range
+    ///      Invalid (0) is the reachable "unrecognized" case, rejected in-handler with {UnknownLockChangeType}; out-of-range
     ///      wire values (>= 3) can never reach the handler — the enum decoder rejects them (reverts) while
     ///      ABI-decoding the calldata.
-    enum LockOp {
+    enum LockChangeType {
         Invalid,
         Lock,
         Unlock
@@ -75,7 +75,7 @@ contract Keystore {
 
     /// @notice A single authorize/revoke operation within a signed batch.
     struct ActorChange {
-        ChangeType changeType; // Authorize or Revoke (Invalid rejected in-handler)
+        ActorChangeType changeType; // Authorize or Revoke (Invalid rejected in-handler)
         bytes32 actorId;
         bytes data; // operation-specific: ActorConfig || policyData for authorize, empty for revoke
     }
@@ -271,8 +271,8 @@ contract Keystore {
     /// @notice The authenticated actor lacks the scope required to change actors.
     error UnauthorizedActorChange();
 
-    /// @notice An ActorChange carried ChangeType.Invalid (0). Other unrecognized wire values revert at ABI-decode.
-    error UnknownChangeType();
+    /// @notice An ActorChange carried ActorChangeType.Invalid (0). Other unrecognized wire values revert at ABI-decode.
+    error UnknownActorChangeType();
 
     /// @notice The importAccount ERC-1271 signature check did not return the magic value.
     error InvalidImportSignature();
@@ -284,8 +284,8 @@ contract Keystore {
     ///         FLAG_UNLOCK_INITIATED clear) — i.e. never locked, or an unlock was already initiated.
     error NotLocked();
 
-    /// @notice applySignedLockChanges carried LockOp.Invalid (0). Other unrecognized wire values revert at ABI-decode.
-    error UnknownLockOp();
+    /// @notice applySignedLockChanges carried LockChangeType.Invalid (0). Other unrecognized wire values revert at ABI-decode.
+    error UnknownLockChangeType();
 
     /// @notice An unlock op (op = 2) carried a non-zero unlock delay (unlock delay is set only by the lock op).
     error InvalidUnlockDelay();
@@ -482,7 +482,7 @@ contract Keystore {
     /// @dev Reverts with InvalidAuthLength, InvalidSignature, AuthenticationFailed, AuthenticatorMismatch,
     ///      ActorExpired, or DefaultEoaRevoked when `auth` fails to authenticate a live actor.
     /// @dev Reverts with UnauthorizedActorChange when the authenticated actor is not unrestricted (scope != 0).
-    /// @dev Reverts with UnknownChangeType when a change carries an unrecognized changeType.
+    /// @dev Reverts with UnknownActorChangeType when a change carries an unrecognized changeType.
     /// @dev Reverts with InvalidAuthenticator or InvalidPolicyData on a malformed authorize.
     /// @dev Reverts with UnknownActor when revoking an actor that is not authorized.
     ///
@@ -509,17 +509,17 @@ contract Keystore {
         // Only an unrestricted actor (scope 0) may change actors; there is no elevated "admin" scope bit.
         if (scope != 0) revert UnauthorizedActorChange();
 
-        // Apply actorChanges. Out-of-range changeType values revert at ABI-decode, so only ChangeType.Invalid reaches
+        // Apply actorChanges. Out-of-range changeType values revert at ABI-decode, so only ActorChangeType.Invalid reaches
         // the fall-through revert here.
         for (uint256 i; i < actorChanges.length; i++) {
-            if (actorChanges[i].changeType == ChangeType.Authorize) {
+            if (actorChanges[i].changeType == ActorChangeType.Authorize) {
                 (ActorConfig memory newActorConfig, bytes memory policyData) =
                     abi.decode(actorChanges[i].data, (ActorConfig, bytes));
                 _authorizeActor(account, actorChanges[i].actorId, newActorConfig, policyData);
-            } else if (actorChanges[i].changeType == ChangeType.Revoke) {
+            } else if (actorChanges[i].changeType == ActorChangeType.Revoke) {
                 _revokeActor(account, actorChanges[i].actorId);
             } else {
-                revert UnknownChangeType();
+                revert UnknownActorChangeType();
             }
         }
     }
@@ -538,9 +538,9 @@ contract Keystore {
     ///      stay coherent on the same counter). Because both entry points share this counter, a pre-signed local
     ///      actor change and a lock op contend for the same sequence: whichever is relayed first consumes it and
     ///      invalidates the other until it is re-signed at the next sequence.
-    /// @dev op = LockOp.Lock (1): only from the unlocked state (reverts AccountIsLocked if currently locked). Sets
+    /// @dev op = LockChangeType.Lock (1): only from the unlocked state (reverts AccountIsLocked if currently locked). Sets
     ///      FLAG_LOCKED and stores `unlockDelay` in `lockUnion`. Emits AccountLocked.
-    /// @dev op = LockOp.Unlock (2): only from the hard-locked state with no pending unlock (reverts NotLocked
+    /// @dev op = LockChangeType.Unlock (2): only from the hard-locked state with no pending unlock (reverts NotLocked
     ///      otherwise); `unlockDelay` MUST be 0. Sets FLAG_UNLOCK_INITIATED and overwrites `lockUnion` with
     ///      unlocksAt = block.timestamp + storedDelay. Emits AccountUnlockInitiated.
     /// @dev Reverts with InvalidAuthLength, InvalidSignature, AuthenticationFailed, AuthenticatorMismatch,
@@ -550,14 +550,16 @@ contract Keystore {
     /// @dev Reverts with AccountIsLocked when a lock op targets an already-locked account.
     /// @dev Reverts with InvalidUnlockDelay when an unlock op carries a non-zero unlock delay.
     /// @dev Reverts with NotLocked when an unlock op targets an account that is not hard-locked.
-    /// @dev Reverts with UnknownLockOp when `op` is LockOp.Invalid.
+    /// @dev Reverts with UnknownLockChangeType when `op` is LockChangeType.Invalid.
     ///
     /// @param account The account whose lock state is changed.
-    /// @param op The lock operation: LockOp.Lock (1) to hard-lock, LockOp.Unlock (2) to initiate an unlock.
+    /// @param op The lock operation: LockChangeType.Lock (1) to hard-lock, LockChangeType.Unlock (2) to initiate an unlock.
     /// @param unlockDelay Delay in seconds before the account unlocks after an unlock is initiated (lock op only,
     ///        max uint16, ~18 hours); MUST be 0 for the unlock op.
     /// @param auth Authenticator(20) || authenticator-specific data authenticating an unrestricted actor.
-    function applySignedLockChanges(address account, LockOp op, uint16 unlockDelay, bytes calldata auth) external {
+    function applySignedLockChanges(address account, LockChangeType op, uint16 unlockDelay, bytes calldata auth)
+        external
+    {
         // Local channel only: bind the digest to the current chain and consume the local sequence (post-increment,
         // hashing the pre-increment value — identical to applySignedActorChanges so both paths share one counter).
         uint64 sequence = _accountState[account].localSequence++;
@@ -570,8 +572,8 @@ contract Keystore {
 
         AccountState storage config = _accountState[account];
 
-        // Out-of-range op values revert at ABI-decode, so only LockOp.Invalid reaches the fall-through revert below.
-        if (op == LockOp.Lock) {
+        // Out-of-range op values revert at ABI-decode, so only LockChangeType.Invalid reaches the fall-through revert below.
+        if (op == LockChangeType.Lock) {
             // Lock only from the unlocked state; lazily clear any elapsed unlock (also clears LOCKED) first.
             if (_checkAndClearLock(account)) revert AccountIsLocked();
             // Require non-zero unlock delay.
@@ -581,7 +583,7 @@ contract Keystore {
             config.flags |= FLAG_LOCKED;
             config.lockUnion = unlockDelay;
             emit AccountLocked(account, unlockDelay);
-        } else if (op == LockOp.Unlock) {
+        } else if (op == LockChangeType.Unlock) {
             // The unlock op never sets the delay; it consumes the delay stored by the lock op.
             if (unlockDelay != 0) revert InvalidUnlockDelay();
             // Require the account is hard-locked (LOCKED set) with no unlock already initiated (UNLOCK_INITIATED clear).
@@ -594,7 +596,7 @@ contract Keystore {
             config.lockUnion = unlocksAt;
             emit AccountUnlockInitiated(account, unlocksAt);
         } else {
-            revert UnknownLockOp();
+            revert UnknownLockChangeType();
         }
     }
 
@@ -1165,7 +1167,7 @@ contract Keystore {
     function _computeSignedLockChangesDigest(
         address account,
         uint256 chainId,
-        LockOp op,
+        LockChangeType op,
         uint16 unlockDelay,
         uint64 sequence
     ) internal pure returns (bytes32) {

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -47,9 +47,35 @@ contract Keystore {
         bytes policyData;
     }
 
+    /// @notice The operation an {ActorChange} applies within an {applySignedActorChanges} batch.
+    ///
+    /// @dev ABI-encodes as uint8, so the wire values are preserved (Authorize = 0x01, Revoke = 0x02) and the
+    ///      SignedActorChanges typehash keeps `uint8 changeType` — digests and the external ABI selector are
+    ///      unchanged. Invalid (0) is the reachable "unrecognized" case, rejected in-handler with {UnknownChangeType};
+    ///      out-of-range wire values (>= 3) can never reach the handler — the enum decoder rejects them (reverts)
+    ///      while ABI-decoding the calldata.
+    enum ChangeType {
+        Invalid,
+        Authorize,
+        Revoke
+    }
+
+    /// @notice The operation an {applySignedLockChanges} call applies.
+    ///
+    /// @dev ABI-encodes as uint8, so the wire values are preserved (Lock = 0x01, Unlock = 0x02) and the
+    ///      SignedLockChange typehash keeps `uint8 op` — digests and the external ABI selector are unchanged.
+    ///      Invalid (0) is the reachable "unrecognized" case, rejected in-handler with {UnknownLockOp}; out-of-range
+    ///      wire values (>= 3) can never reach the handler — the enum decoder rejects them (reverts) while
+    ///      ABI-decoding the calldata.
+    enum LockOp {
+        Invalid,
+        Lock,
+        Unlock
+    }
+
     /// @notice A single authorize/revoke operation within a signed batch.
     struct ActorChange {
-        uint8 changeType; // 0x01 = authorizeActor, 0x02 = revokeActor
+        ChangeType changeType; // Authorize or Revoke (Invalid rejected in-handler)
         bytes32 actorId;
         bytes data; // operation-specific: ActorConfig || policyData for authorize, empty for revoke
     }
@@ -94,7 +120,7 @@ contract Keystore {
     ///
     /// @dev NOT compliant with EIP-712, to mitigate eth_signTypedData phishing. Bound to the current chainId so an
     ///      import signature cannot be replayed on another chain. Initial actors are hashed structurally via
-    ///      ACTOR_TYPEHASH / ACTORCONFIG_TYPEHASH below.
+    ///      ACTOR_TYPEHASH / ACTOR_CONFIG_TYPEHASH below.
     bytes32 public constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
         "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
     );
@@ -105,7 +131,7 @@ contract Keystore {
     );
 
     /// @notice Typehash used to structurally hash an Actor's ActorConfig within an import digest.
-    bytes32 public constant ACTORCONFIG_TYPEHASH =
+    bytes32 public constant ACTOR_CONFIG_TYPEHASH =
         keccak256("ActorConfig(address authenticator,uint48 expiry,uint16 scope)");
 
     /// @notice Typehash binding a signed actor-change batch to its account, chainId, and sequence.
@@ -117,7 +143,7 @@ contract Keystore {
     );
 
     /// @notice Typehash used to structurally hash each ActorChange within a SignedActorChanges batch.
-    bytes32 public constant ACTORCHANGE_TYPEHASH =
+    bytes32 public constant ACTOR_CHANGE_TYPEHASH =
         keccak256("ActorChange(uint8 changeType,bytes32 actorId,bytes data)");
 
     /// @notice Typehash binding a signed lock-state change to its account, chainId, op, unlock delay, and sequence.
@@ -126,26 +152,6 @@ contract Keystore {
     ///      digest always binds the current chainId (there is no multichain lock).
     bytes32 public constant LOCK_CHANGE_TYPEHASH =
         keccak256("SignedLockChange(address account,uint256 chainId,uint8 op,uint16 unlockDelay,uint64 sequence)");
-
-    // ----------------------------------------------------------------------------------------------------------------
-    // ACTOR CHANGE TYPES
-    // ----------------------------------------------------------------------------------------------------------------
-
-    /// @notice Authorize an actor to the account
-    uint8 public constant AUTHORIZE_ACTOR = 0x01;
-
-    /// @notice Revoke an actor from the account
-    uint8 public constant REVOKE_ACTOR = 0x02;
-
-    // ----------------------------------------------------------------------------------------------------------------
-    // LOCK CHANGE OPS
-    // ----------------------------------------------------------------------------------------------------------------
-
-    /// @notice applySignedLockChanges op that hard-locks the account.
-    uint8 public constant LOCK_OP = 0x01;
-
-    /// @notice applySignedLockChanges op that initiates the unlock of a hard-locked account.
-    uint8 public constant UNLOCK_OP = 0x02;
 
     // ----------------------------------------------------------------------------------------------------------------
     // ACTOR SCOPE
@@ -265,7 +271,7 @@ contract Keystore {
     /// @notice The authenticated actor lacks the scope required to change actors.
     error UnauthorizedActorChange();
 
-    /// @notice An ActorChange carried an unrecognized changeType.
+    /// @notice An ActorChange carried ChangeType.Invalid (0). Other unrecognized wire values revert at ABI-decode.
     error UnknownChangeType();
 
     /// @notice The importAccount ERC-1271 signature check did not return the magic value.
@@ -278,7 +284,7 @@ contract Keystore {
     ///         FLAG_UNLOCK_INITIATED clear) — i.e. never locked, or an unlock was already initiated.
     error NotLocked();
 
-    /// @notice applySignedLockChanges carried an unrecognized op (neither LOCK_OP nor UNLOCK_OP).
+    /// @notice applySignedLockChanges carried LockOp.Invalid (0). Other unrecognized wire values revert at ABI-decode.
     error UnknownLockOp();
 
     /// @notice An unlock op (op = 2) carried a non-zero unlock delay (unlock delay is set only by the lock op).
@@ -503,13 +509,14 @@ contract Keystore {
         // Only an unrestricted actor (scope 0) may change actors; there is no elevated "admin" scope bit.
         if (scope != 0) revert UnauthorizedActorChange();
 
-        // Apply actorChanges
+        // Apply actorChanges. Out-of-range changeType values revert at ABI-decode, so only ChangeType.Invalid reaches
+        // the fall-through revert here.
         for (uint256 i; i < actorChanges.length; i++) {
-            if (actorChanges[i].changeType == AUTHORIZE_ACTOR) {
+            if (actorChanges[i].changeType == ChangeType.Authorize) {
                 (ActorConfig memory newActorConfig, bytes memory policyData) =
                     abi.decode(actorChanges[i].data, (ActorConfig, bytes));
                 _authorizeActor(account, actorChanges[i].actorId, newActorConfig, policyData);
-            } else if (actorChanges[i].changeType == REVOKE_ACTOR) {
+            } else if (actorChanges[i].changeType == ChangeType.Revoke) {
                 _revokeActor(account, actorChanges[i].actorId);
             } else {
                 revert UnknownChangeType();
@@ -531,9 +538,9 @@ contract Keystore {
     ///      stay coherent on the same counter). Because both entry points share this counter, a pre-signed local
     ///      actor change and a lock op contend for the same sequence: whichever is relayed first consumes it and
     ///      invalidates the other until it is re-signed at the next sequence.
-    /// @dev op = LOCK_OP (1): only from the unlocked state (reverts AccountIsLocked if currently locked). Sets
+    /// @dev op = LockOp.Lock (1): only from the unlocked state (reverts AccountIsLocked if currently locked). Sets
     ///      FLAG_LOCKED and stores `unlockDelay` in `lockUnion`. Emits AccountLocked.
-    /// @dev op = UNLOCK_OP (2): only from the hard-locked state with no pending unlock (reverts NotLocked
+    /// @dev op = LockOp.Unlock (2): only from the hard-locked state with no pending unlock (reverts NotLocked
     ///      otherwise); `unlockDelay` MUST be 0. Sets FLAG_UNLOCK_INITIATED and overwrites `lockUnion` with
     ///      unlocksAt = block.timestamp + storedDelay. Emits AccountUnlockInitiated.
     /// @dev Reverts with InvalidAuthLength, InvalidSignature, AuthenticationFailed, AuthenticatorMismatch,
@@ -543,14 +550,14 @@ contract Keystore {
     /// @dev Reverts with AccountIsLocked when a lock op targets an already-locked account.
     /// @dev Reverts with InvalidUnlockDelay when an unlock op carries a non-zero unlock delay.
     /// @dev Reverts with NotLocked when an unlock op targets an account that is not hard-locked.
-    /// @dev Reverts with UnknownLockOp when `op` is neither LOCK_OP nor UNLOCK_OP.
+    /// @dev Reverts with UnknownLockOp when `op` is LockOp.Invalid.
     ///
     /// @param account The account whose lock state is changed.
-    /// @param op The lock operation: LOCK_OP (1) to hard-lock, UNLOCK_OP (2) to initiate an unlock.
+    /// @param op The lock operation: LockOp.Lock (1) to hard-lock, LockOp.Unlock (2) to initiate an unlock.
     /// @param unlockDelay Delay in seconds before the account unlocks after an unlock is initiated (lock op only,
     ///        max uint16, ~18 hours); MUST be 0 for the unlock op.
     /// @param auth Authenticator(20) || authenticator-specific data authenticating an unrestricted actor.
-    function applySignedLockChanges(address account, uint8 op, uint16 unlockDelay, bytes calldata auth) external {
+    function applySignedLockChanges(address account, LockOp op, uint16 unlockDelay, bytes calldata auth) external {
         // Local channel only: bind the digest to the current chain and consume the local sequence (post-increment,
         // hashing the pre-increment value — identical to applySignedActorChanges so both paths share one counter).
         uint64 sequence = _accountState[account].localSequence++;
@@ -563,7 +570,8 @@ contract Keystore {
 
         AccountState storage config = _accountState[account];
 
-        if (op == LOCK_OP) {
+        // Out-of-range op values revert at ABI-decode, so only LockOp.Invalid reaches the fall-through revert below.
+        if (op == LockOp.Lock) {
             // Lock only from the unlocked state; lazily clear any elapsed unlock (also clears LOCKED) first.
             if (_checkAndClearLock(account)) revert AccountIsLocked();
             // Require non-zero unlock delay.
@@ -573,7 +581,7 @@ contract Keystore {
             config.flags |= FLAG_LOCKED;
             config.lockUnion = unlockDelay;
             emit AccountLocked(account, unlockDelay);
-        } else if (op == UNLOCK_OP) {
+        } else if (op == LockOp.Unlock) {
             // The unlock op never sets the delay; it consumes the delay stored by the lock op.
             if (unlockDelay != 0) revert InvalidUnlockDelay();
             // Require the account is hard-locked (LOCKED set) with no unlock already initiated (UNLOCK_INITIATED clear).
@@ -1099,7 +1107,7 @@ contract Keystore {
             // accepted here. policyData is hashed via keccak256 into the Actor struct hash. The typehash structure
             // matches the importAccount signature payload in EIP-8130.
             bytes32 configHash = keccak256(
-                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), initialActors[i].scope)
+                abi.encode(ACTOR_CONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), initialActors[i].scope)
             );
             actorHashes[i] = keccak256(
                 abi.encode(ACTOR_TYPEHASH, initialActors[i].actorId, configHash, keccak256(initialActors[i].policyData))
@@ -1131,7 +1139,7 @@ contract Keystore {
         for (uint256 i; i < actorChanges.length; i++) {
             actorChangeHashes[i] = keccak256(
                 abi.encode(
-                    ACTORCHANGE_TYPEHASH,
+                    ACTOR_CHANGE_TYPEHASH,
                     actorChanges[i].changeType,
                     actorChanges[i].actorId,
                     keccak256(actorChanges[i].data)
@@ -1157,7 +1165,7 @@ contract Keystore {
     function _computeSignedLockChangesDigest(
         address account,
         uint256 chainId,
-        uint8 op,
+        LockOp op,
         uint16 unlockDelay,
         uint64 sequence
     ) internal pure returns (bytes32) {

--- a/src/policies/README.md
+++ b/src/policies/README.md
@@ -1,11 +1,11 @@
-# Example Policies (EIP-8130 actor policies)
+# Policies (EIP-8130 actor policies)
 
-Reference, **unaudited** example of a policy manager for EIP-8130 restricted actors.
+A policy manager for EIP-8130 restricted actors.
 
 In EIP-8130, a restricted actor (e.g. a session key) is configured with `scope & Scopes.POLICY != 0`, which stores a
 `policy_manager` address and an opaque `policy_commitment` in the Keystore contract. The protocol
-gate forces every call that actor makes to land on that single manager. These contracts are an example of what
-that manager can be: one that enforces application-specific limits and then drives the account. `Scopes.POLICY`
+gate forces every call that actor makes to land on that single manager. These contracts are one realization of
+that manager: it enforces application-specific limits and then drives the account. `Scopes.POLICY`
 (`0x02`) may be combined with other scope bits (e.g. `Scopes.POLICY | Scopes.SELF_PAYER`) — `Keystore` does
 not reject scope combinations; use-time exclusivity between policy gating and an actor's other capabilities is
 protocol-side, not enforced by this contract.
@@ -104,7 +104,7 @@ reverts `ExceededAllowance`, a third MyApp selector reverts `SelectorNotAllowed`
 `TargetNotAllowed`. Two choices to note: modeling "full token access" as *any selector* also permits `approve` /
 `transferFrom` on that token (use a single `transfer` rule to restrict to transfers); and USDC is pinned to
 `transfer` precisely so the cap is airtight. End-to-end test:
-[`test_workedExample_fullTokenAccess_monthlyUsdc_appSelectors`](../../../test/unit/examples/SessionPolicy.t.sol).
+[`test_workedExample_fullTokenAccess_monthlyUsdc_appSelectors`](../../../test/unit/policies/SessionPolicy.t.sol).
 
 ### External callers (subscriptions)
 
@@ -150,7 +150,7 @@ Critically, the provider must **not** be registered with `TRUSTED_EXECUTOR` — 
 is a no-code sentinel: the actor is recognized (non-zero authenticator) but can neither drive the account directly
 nor authenticate an 8130 transaction. Give the provider its **own salt** so its commitment — and therefore its
 spend budget — is isolated from any session keys on the account. End-to-end tests:
-[`ExternalPolicyCaller.t.sol`](../../../test/unit/examples/ExternalPolicyCaller.t.sol).
+[`ExternalPolicyCaller.t.sol`](../../../test/unit/policies/ExternalPolicyCaller.t.sol).
 
 > Out of scope for this reference: signature-based replacement and uninstall. See
 > [base/account-policies](https://github.com/base/account-policies) for a fuller policy framework.

--- a/test/lib/KeystoreTest.sol
+++ b/test/lib/KeystoreTest.sol
@@ -35,13 +35,15 @@ contract KeystoreTest is Test {
         "ActorChange(uint8 changeType,bytes32 actorId,bytes data)"
     );
 
-    bytes32 constant ACTORCHANGE_TYPEHASH = keccak256("ActorChange(uint8 changeType,bytes32 actorId,bytes data)");
+    bytes32 constant ACTOR_CHANGE_TYPEHASH = keccak256("ActorChange(uint8 changeType,bytes32 actorId,bytes data)");
 
     bytes32 constant LOCK_CHANGE_TYPEHASH =
         keccak256("SignedLockChange(address account,uint256 chainId,uint8 op,uint16 unlockDelay,uint64 sequence)");
 
-    uint8 constant LOCK_OP = 0x01;
-    uint8 constant UNLOCK_OP = 0x02;
+    // Wire values for the LockOp enum (which ABI-encodes as uint8). Used to compute the signed digest, whose typehash
+    // binds `uint8 op`; the applySignedLockChanges call itself takes the typed Keystore.LockOp.
+    uint8 constant LOCK_OP = uint8(Keystore.LockOp.Lock);
+    uint8 constant UNLOCK_OP = uint8(Keystore.LockOp.Unlock);
 
     function setUp() public virtual {
         keystore = new Keystore();
@@ -119,7 +121,7 @@ contract KeystoreTest is Test {
         for (uint256 i; i < actorChanges.length; i++) {
             actorChangeHash[i] = keccak256(
                 abi.encode(
-                    ACTORCHANGE_TYPEHASH,
+                    ACTOR_CHANGE_TYPEHASH,
                     actorChanges[i].changeType,
                     actorChanges[i].actorId,
                     keccak256(actorChanges[i].data)
@@ -163,12 +165,12 @@ contract KeystoreTest is Test {
 
     /// @dev Relay a signed lock op (op = 1) authorized by `pk`.
     function _signedLock(uint256 pk, address account, uint16 unlockDelay) internal {
-        keystore.applySignedLockChanges(account, LOCK_OP, unlockDelay, _lockAuth(pk, account, unlockDelay));
+        keystore.applySignedLockChanges(account, Keystore.LockOp.Lock, unlockDelay, _lockAuth(pk, account, unlockDelay));
     }
 
     /// @dev Relay a signed unlock op (op = 2) authorized by `pk`.
     function _signedUnlock(uint256 pk, address account) internal {
-        keystore.applySignedLockChanges(account, UNLOCK_OP, 0, _unlockAuth(pk, account));
+        keystore.applySignedLockChanges(account, Keystore.LockOp.Unlock, 0, _unlockAuth(pk, account));
     }
 
     // ── Fuzzed key bounding ──

--- a/test/lib/KeystoreTest.sol
+++ b/test/lib/KeystoreTest.sol
@@ -40,10 +40,10 @@ contract KeystoreTest is Test {
     bytes32 constant LOCK_CHANGE_TYPEHASH =
         keccak256("SignedLockChange(address account,uint256 chainId,uint8 op,uint16 unlockDelay,uint64 sequence)");
 
-    // Wire values for the LockOp enum (which ABI-encodes as uint8). Used to compute the signed digest, whose typehash
-    // binds `uint8 op`; the applySignedLockChanges call itself takes the typed Keystore.LockOp.
-    uint8 constant LOCK_OP = uint8(Keystore.LockOp.Lock);
-    uint8 constant UNLOCK_OP = uint8(Keystore.LockOp.Unlock);
+    // Wire values for the LockChangeType enum (which ABI-encodes as uint8). Used to compute the signed digest, whose typehash
+    // binds `uint8 op`; the applySignedLockChanges call itself takes the typed Keystore.LockChangeType.
+    uint8 constant LOCK_OP = uint8(Keystore.LockChangeType.Lock);
+    uint8 constant UNLOCK_OP = uint8(Keystore.LockChangeType.Unlock);
 
     function setUp() public virtual {
         keystore = new Keystore();
@@ -165,12 +165,14 @@ contract KeystoreTest is Test {
 
     /// @dev Relay a signed lock op (op = 1) authorized by `pk`.
     function _signedLock(uint256 pk, address account, uint16 unlockDelay) internal {
-        keystore.applySignedLockChanges(account, Keystore.LockOp.Lock, unlockDelay, _lockAuth(pk, account, unlockDelay));
+        keystore.applySignedLockChanges(
+            account, Keystore.LockChangeType.Lock, unlockDelay, _lockAuth(pk, account, unlockDelay)
+        );
     }
 
     /// @dev Relay a signed unlock op (op = 2) authorized by `pk`.
     function _signedUnlock(uint256 pk, address account) internal {
-        keystore.applySignedLockChanges(account, Keystore.LockOp.Unlock, 0, _unlockAuth(pk, account));
+        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Unlock, 0, _unlockAuth(pk, account));
     }
 
     // ── Fuzzed key bounding ──

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -27,7 +27,7 @@ contract AccountLockTest is KeystoreTest {
     function _oneAuthorizeChange(bytes32 actorId) internal view returns (Keystore.ActorChange[] memory changes) {
         changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
-            changeType: 0x01,
+            changeType: Keystore.ChangeType.Authorize,
             actorId: actorId,
             data: abi.encode(
                 Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}), bytes("")
@@ -40,7 +40,7 @@ contract AccountLockTest is KeystoreTest {
     function _authorizeK1ActorWithScope(address account, uint256 ownerPk, address newSigner, uint16 scope) internal {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
-            changeType: 0x01,
+            changeType: Keystore.ChangeType.Authorize,
             actorId: bytes32(bytes20(newSigner)),
             data: abi.encode(
                 Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0}), bytes("")
@@ -75,22 +75,43 @@ contract AccountLockTest is KeystoreTest {
 
         bytes memory auth = _lockAuth(scopedPk, account, delay);
         vm.expectRevert(Keystore.UnauthorizedLockChange.selector);
-        keystore.applySignedLockChanges(account, LOCK_OP, delay, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockOp.Lock, delay, auth);
     }
 
-    /// @notice applySignedLockChanges reverts UnknownLockOp for any op other than LOCK_OP / UNLOCK_OP.
-    function test_applySignedLockChanges_revert_unknownOp(uint256 pkSeed, uint8 op, uint16 delay) public {
+    /// @notice applySignedLockChanges reverts UnknownLockOp for LockOp.Invalid (0) — the only unrecognized op value
+    ///         that reaches the handler. Out-of-range wire values (>= 3) never get here; they panic at ABI-decode
+    ///         (see test_applySignedLockChanges_revert_outOfRangeOpPanics).
+    function test_applySignedLockChanges_revert_invalidOp(uint256 pkSeed, uint16 delay) public {
         uint256 pk = _boundK1Pk(pkSeed);
         address account = vm.addr(pk);
         _assumeSafeAccount(account);
-        vm.assume(op != LOCK_OP && op != UNLOCK_OP);
 
         uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeLockChangeDigest(account, block.chainid, op, delay, seq);
+        bytes32 digest = _computeLockChangeDigest(account, block.chainid, uint8(Keystore.LockOp.Invalid), delay, seq);
         bytes memory auth = _buildK1Auth(pk, digest);
 
         vm.expectRevert(Keystore.UnknownLockOp.selector);
-        keystore.applySignedLockChanges(account, op, delay, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockOp.Invalid, delay, auth);
+    }
+
+    /// @notice An out-of-range op wire value (>= 3, not a declared LockOp member) is rejected by the ABI decoder
+    ///         before the handler runs — the enum can only decode to a declared member. This is what makes Invalid (0)
+    ///         the sole reachable "unrecognized" case. Uses a low-level call so the raw wire byte survives to the
+    ///         decoder (the typed entry point cannot express an out-of-range value). Solidity's calldata enum-decode
+    ///         check reverts with empty returndata (distinct from an in-body enum conversion, which panics 0x21).
+    function test_applySignedLockChanges_revert_outOfRangeOp(uint256 pkSeed, uint8 op, uint16 delay) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+        op = uint8(bound(op, 3, type(uint8).max));
+
+        // Decode reverts before the body, so auth is irrelevant. op is ABI-encoded as the enum's uint8 slot.
+        bytes memory cd =
+            abi.encodeWithSelector(Keystore.applySignedLockChanges.selector, account, op, delay, bytes(""));
+        (bool ok, bytes memory ret) = address(keystore).call(cd);
+
+        assertFalse(ok);
+        assertEq(ret.length, 0); // enum decode rejects the out-of-range op with an empty revert
     }
 
     /// @notice A lock op (op = 1) with a zero unlock delay reverts ZeroUnlockDelay.
@@ -102,7 +123,7 @@ contract AccountLockTest is KeystoreTest {
 
         bytes memory auth = _lockAuth(pk, account, 0);
         vm.expectRevert(Keystore.ZeroUnlockDelay.selector);
-        keystore.applySignedLockChanges(account, LOCK_OP, 0, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockOp.Lock, 0, auth);
     }
 
     /// @notice A lock op reverts AccountIsLocked when the account is already hard-locked.
@@ -118,7 +139,7 @@ contract AccountLockTest is KeystoreTest {
 
         bytes memory auth = _lockAuth(pk, account, secondDelay);
         vm.expectRevert(Keystore.AccountIsLocked.selector);
-        keystore.applySignedLockChanges(account, LOCK_OP, secondDelay, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockOp.Lock, secondDelay, auth);
     }
 
     /// @notice An unlock op (op = 2) with a non-zero unlock delay reverts InvalidUnlockDelay.
@@ -134,7 +155,7 @@ contract AccountLockTest is KeystoreTest {
         bytes memory auth = _buildK1Auth(pk, digest);
 
         vm.expectRevert(Keystore.InvalidUnlockDelay.selector);
-        keystore.applySignedLockChanges(account, UNLOCK_OP, delay, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockOp.Unlock, delay, auth);
     }
 
     /// @notice An unlock op reverts NotLocked when the account has never been locked (FLAG_LOCKED clear).
@@ -145,7 +166,7 @@ contract AccountLockTest is KeystoreTest {
 
         bytes memory auth = _unlockAuth(pk, account);
         vm.expectRevert(Keystore.NotLocked.selector);
-        keystore.applySignedLockChanges(account, UNLOCK_OP, 0, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockOp.Unlock, 0, auth);
     }
 
     /// @notice An unlock op reverts NotLocked once an unlock has already been initiated.
@@ -163,7 +184,7 @@ contract AccountLockTest is KeystoreTest {
 
         bytes memory auth = _unlockAuth(pk, account);
         vm.expectRevert(Keystore.NotLocked.selector);
-        keystore.applySignedLockChanges(account, UNLOCK_OP, 0, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockOp.Unlock, 0, auth);
     }
 
     /// @notice A replayed lock auth fails: the local sequence advanced on the first success, so the signed digest no
@@ -175,10 +196,10 @@ contract AccountLockTest is KeystoreTest {
         delay = uint16(bound(delay, 1, type(uint16).max));
 
         bytes memory auth = _lockAuth(pk, account, delay); // signed over sequence 0
-        keystore.applySignedLockChanges(account, LOCK_OP, delay, auth); // sequence 0 -> 1
+        keystore.applySignedLockChanges(account, Keystore.LockOp.Lock, delay, auth); // sequence 0 -> 1
 
         vm.expectRevert();
-        keystore.applySignedLockChanges(account, LOCK_OP, delay, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockOp.Lock, delay, auth);
     }
 
     /// @notice A lock auth signed over a sequence other than the account's current one fails to authenticate.
@@ -196,7 +217,7 @@ contract AccountLockTest is KeystoreTest {
         bytes memory auth = _buildK1Auth(pk, digest);
 
         vm.expectRevert();
-        keystore.applySignedLockChanges(account, LOCK_OP, delay, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockOp.Lock, delay, auth);
     }
 
     /// @notice applySignedActorChanges reverts AccountIsLocked while the target account is hard-locked.
@@ -267,7 +288,7 @@ contract AccountLockTest is KeystoreTest {
         bytes memory auth = _lockAuth(pk, account, delay);
         vm.expectEmit(true, false, false, true, address(keystore));
         emit Keystore.AccountLocked(account, delay);
-        keystore.applySignedLockChanges(account, LOCK_OP, delay, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockOp.Lock, delay, auth);
     }
 
     /// @notice An account can be re-locked after a prior unlock delay has fully elapsed.
@@ -339,7 +360,7 @@ contract AccountLockTest is KeystoreTest {
         bytes memory auth = _unlockAuth(pk, account);
         vm.expectEmit(true, false, false, true, address(keystore));
         emit Keystore.AccountUnlockInitiated(account, uint40(t0 + delay));
-        keystore.applySignedLockChanges(account, UNLOCK_OP, 0, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockOp.Unlock, 0, auth);
     }
 
     /// @notice isLocked is false for an account that has never been locked (FLAG_LOCKED clear).

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -27,7 +27,7 @@ contract AccountLockTest is KeystoreTest {
     function _oneAuthorizeChange(bytes32 actorId) internal view returns (Keystore.ActorChange[] memory changes) {
         changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
-            changeType: Keystore.ChangeType.Authorize,
+            changeType: Keystore.ActorChangeType.Authorize,
             actorId: actorId,
             data: abi.encode(
                 Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}), bytes("")
@@ -40,7 +40,7 @@ contract AccountLockTest is KeystoreTest {
     function _authorizeK1ActorWithScope(address account, uint256 ownerPk, address newSigner, uint16 scope) internal {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
-            changeType: Keystore.ChangeType.Authorize,
+            changeType: Keystore.ActorChangeType.Authorize,
             actorId: bytes32(bytes20(newSigner)),
             data: abi.encode(
                 Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0}), bytes("")
@@ -75,10 +75,10 @@ contract AccountLockTest is KeystoreTest {
 
         bytes memory auth = _lockAuth(scopedPk, account, delay);
         vm.expectRevert(Keystore.UnauthorizedLockChange.selector);
-        keystore.applySignedLockChanges(account, Keystore.LockOp.Lock, delay, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Lock, delay, auth);
     }
 
-    /// @notice applySignedLockChanges reverts UnknownLockOp for LockOp.Invalid (0) — the only unrecognized op value
+    /// @notice applySignedLockChanges reverts UnknownLockChangeType for LockChangeType.Invalid (0) — the only unrecognized op value
     ///         that reaches the handler. Out-of-range wire values (>= 3) never get here; they panic at ABI-decode
     ///         (see test_applySignedLockChanges_revert_outOfRangeOpPanics).
     function test_applySignedLockChanges_revert_invalidOp(uint256 pkSeed, uint16 delay) public {
@@ -87,14 +87,15 @@ contract AccountLockTest is KeystoreTest {
         _assumeSafeAccount(account);
 
         uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeLockChangeDigest(account, block.chainid, uint8(Keystore.LockOp.Invalid), delay, seq);
+        bytes32 digest =
+            _computeLockChangeDigest(account, block.chainid, uint8(Keystore.LockChangeType.Invalid), delay, seq);
         bytes memory auth = _buildK1Auth(pk, digest);
 
-        vm.expectRevert(Keystore.UnknownLockOp.selector);
-        keystore.applySignedLockChanges(account, Keystore.LockOp.Invalid, delay, auth);
+        vm.expectRevert(Keystore.UnknownLockChangeType.selector);
+        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Invalid, delay, auth);
     }
 
-    /// @notice An out-of-range op wire value (>= 3, not a declared LockOp member) is rejected by the ABI decoder
+    /// @notice An out-of-range op wire value (>= 3, not a declared LockChangeType member) is rejected by the ABI decoder
     ///         before the handler runs — the enum can only decode to a declared member. This is what makes Invalid (0)
     ///         the sole reachable "unrecognized" case. Uses a low-level call so the raw wire byte survives to the
     ///         decoder (the typed entry point cannot express an out-of-range value). Solidity's calldata enum-decode
@@ -123,7 +124,7 @@ contract AccountLockTest is KeystoreTest {
 
         bytes memory auth = _lockAuth(pk, account, 0);
         vm.expectRevert(Keystore.ZeroUnlockDelay.selector);
-        keystore.applySignedLockChanges(account, Keystore.LockOp.Lock, 0, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Lock, 0, auth);
     }
 
     /// @notice A lock op reverts AccountIsLocked when the account is already hard-locked.
@@ -139,7 +140,7 @@ contract AccountLockTest is KeystoreTest {
 
         bytes memory auth = _lockAuth(pk, account, secondDelay);
         vm.expectRevert(Keystore.AccountIsLocked.selector);
-        keystore.applySignedLockChanges(account, Keystore.LockOp.Lock, secondDelay, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Lock, secondDelay, auth);
     }
 
     /// @notice An unlock op (op = 2) with a non-zero unlock delay reverts InvalidUnlockDelay.
@@ -155,7 +156,7 @@ contract AccountLockTest is KeystoreTest {
         bytes memory auth = _buildK1Auth(pk, digest);
 
         vm.expectRevert(Keystore.InvalidUnlockDelay.selector);
-        keystore.applySignedLockChanges(account, Keystore.LockOp.Unlock, delay, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Unlock, delay, auth);
     }
 
     /// @notice An unlock op reverts NotLocked when the account has never been locked (FLAG_LOCKED clear).
@@ -166,7 +167,7 @@ contract AccountLockTest is KeystoreTest {
 
         bytes memory auth = _unlockAuth(pk, account);
         vm.expectRevert(Keystore.NotLocked.selector);
-        keystore.applySignedLockChanges(account, Keystore.LockOp.Unlock, 0, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Unlock, 0, auth);
     }
 
     /// @notice An unlock op reverts NotLocked once an unlock has already been initiated.
@@ -184,7 +185,7 @@ contract AccountLockTest is KeystoreTest {
 
         bytes memory auth = _unlockAuth(pk, account);
         vm.expectRevert(Keystore.NotLocked.selector);
-        keystore.applySignedLockChanges(account, Keystore.LockOp.Unlock, 0, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Unlock, 0, auth);
     }
 
     /// @notice A replayed lock auth fails: the local sequence advanced on the first success, so the signed digest no
@@ -196,10 +197,10 @@ contract AccountLockTest is KeystoreTest {
         delay = uint16(bound(delay, 1, type(uint16).max));
 
         bytes memory auth = _lockAuth(pk, account, delay); // signed over sequence 0
-        keystore.applySignedLockChanges(account, Keystore.LockOp.Lock, delay, auth); // sequence 0 -> 1
+        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Lock, delay, auth); // sequence 0 -> 1
 
         vm.expectRevert();
-        keystore.applySignedLockChanges(account, Keystore.LockOp.Lock, delay, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Lock, delay, auth);
     }
 
     /// @notice A lock auth signed over a sequence other than the account's current one fails to authenticate.
@@ -217,7 +218,7 @@ contract AccountLockTest is KeystoreTest {
         bytes memory auth = _buildK1Auth(pk, digest);
 
         vm.expectRevert();
-        keystore.applySignedLockChanges(account, Keystore.LockOp.Lock, delay, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Lock, delay, auth);
     }
 
     /// @notice applySignedActorChanges reverts AccountIsLocked while the target account is hard-locked.
@@ -288,7 +289,7 @@ contract AccountLockTest is KeystoreTest {
         bytes memory auth = _lockAuth(pk, account, delay);
         vm.expectEmit(true, false, false, true, address(keystore));
         emit Keystore.AccountLocked(account, delay);
-        keystore.applySignedLockChanges(account, Keystore.LockOp.Lock, delay, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Lock, delay, auth);
     }
 
     /// @notice An account can be re-locked after a prior unlock delay has fully elapsed.
@@ -360,7 +361,7 @@ contract AccountLockTest is KeystoreTest {
         bytes memory auth = _unlockAuth(pk, account);
         vm.expectEmit(true, false, false, true, address(keystore));
         emit Keystore.AccountUnlockInitiated(account, uint40(t0 + delay));
-        keystore.applySignedLockChanges(account, Keystore.LockOp.Unlock, 0, auth);
+        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Unlock, 0, auth);
     }
 
     /// @notice isLocked is false for an account that has never been locked (FLAG_LOCKED clear).

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -51,7 +51,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         assertTrue(_isActor(account, actorId));
 
         Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](1);
-        ch[0] = Keystore.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
+        ch[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ChangeType.Revoke, data: ""});
         _signApply(account, pk, ch);
 
         assertFalse(_isActor(account, actorId));
@@ -198,7 +198,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
 
         Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](1);
-        ch[0] = Keystore.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
+        ch[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ChangeType.Revoke, data: ""});
         bytes memory auth = _authOver(account, pk, ch);
         vm.expectRevert();
         keystore.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
@@ -400,7 +400,8 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         // Phase 1: in one batch signed by the EOA, add the device key as a full owner and revoke the default EOA.
         Keystore.ActorChange[] memory switchChanges = new Keystore.ActorChange[](2);
         switchChanges[0] = _authorizeChange(deviceActorId, address(k1Authenticator), 0, "")[0];
-        switchChanges[1] = Keystore.ActorChange({actorId: selfActorId, changeType: 0x02, data: ""});
+        switchChanges[1] =
+            Keystore.ActorChange({actorId: selfActorId, changeType: Keystore.ChangeType.Revoke, data: ""});
         _signApply(eoa, eoaPk, switchChanges);
 
         assertFalse(_isActor(eoa, selfActorId));
@@ -431,7 +432,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
 
         Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](2);
         ch[0] = _authorizeChange(newActorId, address(k1Authenticator), 0, "")[0];
-        ch[1] = Keystore.ActorChange({actorId: selfActorId, changeType: 0x02, data: ""});
+        ch[1] = Keystore.ActorChange({actorId: selfActorId, changeType: Keystore.ChangeType.Revoke, data: ""});
         _signApply(eoa, eoaPk, ch);
 
         assertFalse(_isActor(eoa, selfActorId));
@@ -537,15 +538,18 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         keystore.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
     }
 
-    /// @notice A changeType outside {authorize, revoke} reverts with UnknownChangeType (after the scope-0 gate).
-    function test_applySignedActorChanges_revert_unknownChangeType(uint256 pk, uint8 changeType) public {
+    /// @notice An ActorChange carrying ChangeType.Invalid (0) reverts UnknownChangeType (after the scope-0 gate) —
+    ///         the only unrecognized changeType that reaches the handler. Out-of-range wire values (>= 3) are rejected
+    ///         at ABI-decode instead, the same enum-decode guarantee exercised by
+    ///         ApplyAccountChange.test_applySignedLockChanges_revert_outOfRangeOp.
+    function test_applySignedActorChanges_revert_invalidChangeType(uint256 pk) public {
         pk = _boundK1Pk(pk);
-        vm.assume(changeType != 0x01 && changeType != 0x02);
         (address account,) = _createK1Account(pk);
 
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] =
-            Keystore.ActorChange({actorId: bytes32(bytes20(vm.addr(0xBEEF))), changeType: changeType, data: ""});
+        changes[0] = Keystore.ActorChange({
+            actorId: bytes32(bytes20(vm.addr(0xBEEF))), changeType: Keystore.ChangeType.Invalid, data: ""
+        });
 
         bytes memory auth = _authOver(account, pk, changes);
         vm.expectRevert(Keystore.UnknownChangeType.selector);
@@ -654,14 +658,14 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         // [authorize A, revoke A] → A ends not live.
         Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](2);
         ch[0] = _authorizeChange(actorId, address(k1Authenticator), 0, "")[0];
-        ch[1] = Keystore.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
+        ch[1] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ChangeType.Revoke, data: ""});
         _signApply(account, pk, ch);
         assertFalse(_isActor(account, actorId));
 
         // Pre-authorize, then [revoke A, authorize A] → A ends live.
         _authorizeActor(account, pk, actorId, address(k1Authenticator));
         Keystore.ActorChange[] memory ch2 = new Keystore.ActorChange[](2);
-        ch2[0] = Keystore.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
+        ch2[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ChangeType.Revoke, data: ""});
         ch2[1] = _authorizeChange(actorId, address(k1Authenticator), 0, "")[0];
         _signApply(account, pk, ch2);
         assertTrue(_isActor(account, actorId));
@@ -685,7 +689,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         _authorizeActor(account, ownerPk, signerId, address(k1Authenticator));
 
         Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](2);
-        ch[0] = Keystore.ActorChange({actorId: signerId, changeType: 0x02, data: ""});
+        ch[0] = Keystore.ActorChange({actorId: signerId, changeType: Keystore.ChangeType.Revoke, data: ""});
         ch[1] = _authorizeChange(bId, address(k1Authenticator), 0, "")[0];
         _signApply(account, signerPk, ch);
 
@@ -740,7 +744,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         _authorizeActor(account, pk, actorId, address(k1Authenticator));
 
         Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](1);
-        ch[0] = Keystore.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
+        ch[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ChangeType.Revoke, data: ""});
         vm.expectEmit(true, true, false, true, address(keystore));
         emit Keystore.ActorRevoked(account, actorId);
         _signApply(account, pk, ch);
@@ -757,7 +761,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: actorId,
-            changeType: 0x01,
+            changeType: Keystore.ChangeType.Authorize,
             data: abi.encode(Keystore.ActorConfig({authenticator: auth, scope: scope, expiry: 0}), policyData)
         });
     }
@@ -782,7 +786,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: bytes32(bytes20(eoa)),
-            changeType: 0x01,
+            changeType: Keystore.ChangeType.Authorize,
             data: abi.encode(
                 Keystore.ActorConfig({authenticator: keystore.K1_AUTHENTICATOR(), scope: scope, expiry: 0}), bytes("")
             )
@@ -806,7 +810,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: newActorId,
-            changeType: 0x01,
+            changeType: Keystore.ChangeType.Authorize,
             data: abi.encode(Keystore.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes(""))
         });
 
@@ -819,7 +823,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
 
     function _revokeActor(address account, uint256 pk, bytes32 actorId) internal {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
+        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ChangeType.Revoke, data: ""});
 
         uint64 seq = keystore.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
@@ -842,7 +846,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: newActorId,
-            changeType: 0x01,
+            changeType: Keystore.ChangeType.Authorize,
             data: abi.encode(Keystore.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes(""))
         });
 

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -51,7 +51,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         assertTrue(_isActor(account, actorId));
 
         Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](1);
-        ch[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ChangeType.Revoke, data: ""});
+        ch[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
         _signApply(account, pk, ch);
 
         assertFalse(_isActor(account, actorId));
@@ -198,7 +198,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
 
         Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](1);
-        ch[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ChangeType.Revoke, data: ""});
+        ch[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
         bytes memory auth = _authOver(account, pk, ch);
         vm.expectRevert();
         keystore.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
@@ -401,7 +401,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         Keystore.ActorChange[] memory switchChanges = new Keystore.ActorChange[](2);
         switchChanges[0] = _authorizeChange(deviceActorId, address(k1Authenticator), 0, "")[0];
         switchChanges[1] =
-            Keystore.ActorChange({actorId: selfActorId, changeType: Keystore.ChangeType.Revoke, data: ""});
+            Keystore.ActorChange({actorId: selfActorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
         _signApply(eoa, eoaPk, switchChanges);
 
         assertFalse(_isActor(eoa, selfActorId));
@@ -432,7 +432,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
 
         Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](2);
         ch[0] = _authorizeChange(newActorId, address(k1Authenticator), 0, "")[0];
-        ch[1] = Keystore.ActorChange({actorId: selfActorId, changeType: Keystore.ChangeType.Revoke, data: ""});
+        ch[1] = Keystore.ActorChange({actorId: selfActorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
         _signApply(eoa, eoaPk, ch);
 
         assertFalse(_isActor(eoa, selfActorId));
@@ -538,21 +538,21 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         keystore.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
     }
 
-    /// @notice An ActorChange carrying ChangeType.Invalid (0) reverts UnknownChangeType (after the scope-0 gate) —
+    /// @notice An ActorChange carrying ActorChangeType.Invalid (0) reverts UnknownActorChangeType (after the scope-0 gate) —
     ///         the only unrecognized changeType that reaches the handler. Out-of-range wire values (>= 3) are rejected
     ///         at ABI-decode instead, the same enum-decode guarantee exercised by
     ///         ApplyAccountChange.test_applySignedLockChanges_revert_outOfRangeOp.
-    function test_applySignedActorChanges_revert_invalidChangeType(uint256 pk) public {
+    function test_applySignedActorChanges_revert_invalidActorChangeType(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
 
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
-            actorId: bytes32(bytes20(vm.addr(0xBEEF))), changeType: Keystore.ChangeType.Invalid, data: ""
+            actorId: bytes32(bytes20(vm.addr(0xBEEF))), changeType: Keystore.ActorChangeType.Invalid, data: ""
         });
 
         bytes memory auth = _authOver(account, pk, changes);
-        vm.expectRevert(Keystore.UnknownChangeType.selector);
+        vm.expectRevert(Keystore.UnknownActorChangeType.selector);
         keystore.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
     }
 
@@ -658,14 +658,14 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         // [authorize A, revoke A] → A ends not live.
         Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](2);
         ch[0] = _authorizeChange(actorId, address(k1Authenticator), 0, "")[0];
-        ch[1] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ChangeType.Revoke, data: ""});
+        ch[1] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
         _signApply(account, pk, ch);
         assertFalse(_isActor(account, actorId));
 
         // Pre-authorize, then [revoke A, authorize A] → A ends live.
         _authorizeActor(account, pk, actorId, address(k1Authenticator));
         Keystore.ActorChange[] memory ch2 = new Keystore.ActorChange[](2);
-        ch2[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ChangeType.Revoke, data: ""});
+        ch2[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
         ch2[1] = _authorizeChange(actorId, address(k1Authenticator), 0, "")[0];
         _signApply(account, pk, ch2);
         assertTrue(_isActor(account, actorId));
@@ -689,7 +689,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         _authorizeActor(account, ownerPk, signerId, address(k1Authenticator));
 
         Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](2);
-        ch[0] = Keystore.ActorChange({actorId: signerId, changeType: Keystore.ChangeType.Revoke, data: ""});
+        ch[0] = Keystore.ActorChange({actorId: signerId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
         ch[1] = _authorizeChange(bId, address(k1Authenticator), 0, "")[0];
         _signApply(account, signerPk, ch);
 
@@ -744,7 +744,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         _authorizeActor(account, pk, actorId, address(k1Authenticator));
 
         Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](1);
-        ch[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ChangeType.Revoke, data: ""});
+        ch[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
         vm.expectEmit(true, true, false, true, address(keystore));
         emit Keystore.ActorRevoked(account, actorId);
         _signApply(account, pk, ch);
@@ -761,7 +761,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: actorId,
-            changeType: Keystore.ChangeType.Authorize,
+            changeType: Keystore.ActorChangeType.Authorize,
             data: abi.encode(Keystore.ActorConfig({authenticator: auth, scope: scope, expiry: 0}), policyData)
         });
     }
@@ -786,7 +786,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: bytes32(bytes20(eoa)),
-            changeType: Keystore.ChangeType.Authorize,
+            changeType: Keystore.ActorChangeType.Authorize,
             data: abi.encode(
                 Keystore.ActorConfig({authenticator: keystore.K1_AUTHENTICATOR(), scope: scope, expiry: 0}), bytes("")
             )
@@ -810,7 +810,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: newActorId,
-            changeType: Keystore.ChangeType.Authorize,
+            changeType: Keystore.ActorChangeType.Authorize,
             data: abi.encode(Keystore.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes(""))
         });
 
@@ -823,7 +823,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
 
     function _revokeActor(address account, uint256 pk, bytes32 actorId) internal {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ChangeType.Revoke, data: ""});
+        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
 
         uint64 seq = keystore.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
@@ -846,7 +846,7 @@ contract ApplyConfigChangeActorTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: newActorId,
-            changeType: Keystore.ChangeType.Authorize,
+            changeType: Keystore.ActorChangeType.Authorize,
             data: abi.encode(Keystore.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes(""))
         });
 

--- a/test/unit/Keystore/authenticate.t.sol
+++ b/test/unit/Keystore/authenticate.t.sol
@@ -931,7 +931,7 @@ contract AuthenticateTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: newActorId,
-            changeType: 0x01,
+            changeType: Keystore.ChangeType.Authorize,
             data: abi.encode(Keystore.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes(""))
         });
 
@@ -951,7 +951,7 @@ contract AuthenticateTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: newActorId,
-            changeType: 0x01,
+            changeType: Keystore.ChangeType.Authorize,
             data: abi.encode(
                 Keystore.ActorConfig({authenticator: authenticator, scope: 0x00, expiry: expiry}), bytes("")
             )
@@ -970,7 +970,7 @@ contract AuthenticateTest is KeystoreTest {
     /// @dev Revoke `actorId` from `account`, signed by `pk`.
     function _revokeActor(address account, uint256 pk, bytes32 actorId) internal {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: 0x02, data: ""});
+        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ChangeType.Revoke, data: ""});
 
         uint64 seq = keystore.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
@@ -990,7 +990,7 @@ contract AuthenticateTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: newActorId,
-            changeType: 0x01,
+            changeType: Keystore.ChangeType.Authorize,
             data: abi.encode(
                 Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0}),
                 abi.encodePacked(policyManager, commitment)

--- a/test/unit/Keystore/authenticate.t.sol
+++ b/test/unit/Keystore/authenticate.t.sol
@@ -931,7 +931,7 @@ contract AuthenticateTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: newActorId,
-            changeType: Keystore.ChangeType.Authorize,
+            changeType: Keystore.ActorChangeType.Authorize,
             data: abi.encode(Keystore.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes(""))
         });
 
@@ -951,7 +951,7 @@ contract AuthenticateTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: newActorId,
-            changeType: Keystore.ChangeType.Authorize,
+            changeType: Keystore.ActorChangeType.Authorize,
             data: abi.encode(
                 Keystore.ActorConfig({authenticator: authenticator, scope: 0x00, expiry: expiry}), bytes("")
             )
@@ -970,7 +970,7 @@ contract AuthenticateTest is KeystoreTest {
     /// @dev Revoke `actorId` from `account`, signed by `pk`.
     function _revokeActor(address account, uint256 pk, bytes32 actorId) internal {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ChangeType.Revoke, data: ""});
+        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
 
         uint64 seq = keystore.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
@@ -990,7 +990,7 @@ contract AuthenticateTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: newActorId,
-            changeType: Keystore.ChangeType.Authorize,
+            changeType: Keystore.ActorChangeType.Authorize,
             data: abi.encode(
                 Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0}),
                 abi.encodePacked(policyManager, commitment)

--- a/test/unit/Keystore/importAccount.t.sol
+++ b/test/unit/Keystore/importAccount.t.sol
@@ -219,7 +219,7 @@ contract ImportAccountTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: bytes32(bytes20(device)),
-            changeType: Keystore.ChangeType.Authorize,
+            changeType: Keystore.ActorChangeType.Authorize,
             data: abi.encode(
                 Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}), bytes("")
             )

--- a/test/unit/Keystore/importAccount.t.sol
+++ b/test/unit/Keystore/importAccount.t.sol
@@ -57,7 +57,7 @@ contract ImportAccountTest is KeystoreTest {
     bytes32 constant ACTOR_TYPEHASH = keccak256(
         "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
     );
-    bytes32 constant ACTORCONFIG_TYPEHASH = keccak256("ActorConfig(address authenticator,uint48 expiry,uint16 scope)");
+    bytes32 constant ACTOR_CONFIG_TYPEHASH = keccak256("ActorConfig(address authenticator,uint48 expiry,uint16 scope)");
 
     // ── digest helpers ──
 
@@ -79,7 +79,7 @@ contract ImportAccountTest is KeystoreTest {
         for (uint256 i; i < initialActors.length; i++) {
             // Hash the actor's real scope; expiry is always 0 at import. policyData is hashed into the Actor hash.
             bytes32 configHash = keccak256(
-                abi.encode(ACTORCONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), initialActors[i].scope)
+                abi.encode(ACTOR_CONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), initialActors[i].scope)
             );
             actorHashes[i] = keccak256(
                 abi.encode(ACTOR_TYPEHASH, initialActors[i].actorId, configHash, keccak256(initialActors[i].policyData))
@@ -219,7 +219,7 @@ contract ImportAccountTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: bytes32(bytes20(device)),
-            changeType: 0x01,
+            changeType: Keystore.ChangeType.Authorize,
             data: abi.encode(
                 Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}), bytes("")
             )

--- a/test/unit/Keystore/policyAccessors.t.sol
+++ b/test/unit/Keystore/policyAccessors.t.sol
@@ -640,7 +640,7 @@ contract PolicyAccessorsTest is KeystoreTest {
 
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
-            actorId: actorId, changeType: Keystore.ChangeType.Authorize, data: abi.encode(cfg, policyData)
+            actorId: actorId, changeType: Keystore.ActorChangeType.Authorize, data: abi.encode(cfg, policyData)
         });
 
         uint64 seq = keystore.getChangeSequences(account).local;
@@ -665,7 +665,7 @@ contract PolicyAccessorsTest is KeystoreTest {
 
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
-            actorId: selfActorId, changeType: Keystore.ChangeType.Authorize, data: abi.encode(cfg, policyData)
+            actorId: selfActorId, changeType: Keystore.ActorChangeType.Authorize, data: abi.encode(cfg, policyData)
         });
 
         uint64 seq = keystore.getChangeSequences(eoa).local;
@@ -678,7 +678,7 @@ contract PolicyAccessorsTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: newActorId,
-            changeType: Keystore.ChangeType.Authorize,
+            changeType: Keystore.ActorChangeType.Authorize,
             data: abi.encode(Keystore.ActorConfig({authenticator: authenticator, scope: 0x00, expiry: 0}), bytes(""))
         });
         uint64 seq = keystore.getChangeSequences(account).local;
@@ -689,7 +689,7 @@ contract PolicyAccessorsTest is KeystoreTest {
     /// @dev Revoke `actorId` from `account`, signed by `pk`.
     function _revokeActor(address account, uint256 pk, bytes32 actorId) internal {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ChangeType.Revoke, data: ""});
+        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
         uint64 seq = keystore.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
         keystore.applySignedActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));

--- a/test/unit/Keystore/policyAccessors.t.sol
+++ b/test/unit/Keystore/policyAccessors.t.sol
@@ -16,9 +16,6 @@ import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 ///         verbatim, even when a field is zero. Tests bound manager/commitment to non-zero only so the written
 ///         value is distinguishable from the ungated (unwritten, zero) case.
 contract PolicyAccessorsTest is KeystoreTest {
-    uint8 internal constant AUTHORIZE_ACTOR = 0x01;
-    uint8 internal constant REVOKE_ACTOR = 0x02;
-
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // getPolicy — explicit (non-self) actor home  (stored.authenticator != 0)
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -642,8 +639,9 @@ contract PolicyAccessorsTest is KeystoreTest {
         bytes memory policyData = abi.encodePacked(policyManager, commitment);
 
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] =
-            Keystore.ActorChange({actorId: actorId, changeType: AUTHORIZE_ACTOR, data: abi.encode(cfg, policyData)});
+        changes[0] = Keystore.ActorChange({
+            actorId: actorId, changeType: Keystore.ChangeType.Authorize, data: abi.encode(cfg, policyData)
+        });
 
         uint64 seq = keystore.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
@@ -667,7 +665,7 @@ contract PolicyAccessorsTest is KeystoreTest {
 
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
-            actorId: selfActorId, changeType: AUTHORIZE_ACTOR, data: abi.encode(cfg, policyData)
+            actorId: selfActorId, changeType: Keystore.ChangeType.Authorize, data: abi.encode(cfg, policyData)
         });
 
         uint64 seq = keystore.getChangeSequences(eoa).local;
@@ -680,7 +678,7 @@ contract PolicyAccessorsTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: newActorId,
-            changeType: AUTHORIZE_ACTOR,
+            changeType: Keystore.ChangeType.Authorize,
             data: abi.encode(Keystore.ActorConfig({authenticator: authenticator, scope: 0x00, expiry: 0}), bytes(""))
         });
         uint64 seq = keystore.getChangeSequences(account).local;
@@ -691,7 +689,7 @@ contract PolicyAccessorsTest is KeystoreTest {
     /// @dev Revoke `actorId` from `account`, signed by `pk`.
     function _revokeActor(address account, uint256 pk, bytes32 actorId) internal {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: REVOKE_ACTOR, data: ""});
+        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ChangeType.Revoke, data: ""});
         uint64 seq = keystore.getChangeSequences(account).local;
         bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
         keystore.applySignedActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -64,7 +64,7 @@ contract DefaultAccountTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: newActorId,
-            changeType: Keystore.ChangeType.Authorize,
+            changeType: Keystore.ActorChangeType.Authorize,
             data: abi.encode(Keystore.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes(""))
         });
 

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -64,7 +64,7 @@ contract DefaultAccountTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: newActorId,
-            changeType: 0x01,
+            changeType: Keystore.ChangeType.Authorize,
             data: abi.encode(Keystore.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes(""))
         });
 

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -24,7 +24,6 @@ contract DelegateAuthenticatorTest is KeystoreTest {
     uint16 constant SCOPE_NONCE = 0x04;
     uint16 constant SCOPE_SELF_PAYER = 0x08;
     uint16 constant SCOPE_SPONSOR_PAYER = 0x10;
-    uint8 constant AUTHORIZE_ACTOR = 0x01;
 
     // ── Guard 1: require(data.length >= 40) ──
 
@@ -195,7 +194,9 @@ contract DelegateAuthenticatorTest is KeystoreTest {
 
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
-            changeType: AUTHORIZE_ACTOR, actorId: bytes32(bytes20(vm.addr(newPk))), data: abi.encode(config, bytes(""))
+            changeType: Keystore.ChangeType.Authorize,
+            actorId: bytes32(bytes20(vm.addr(newPk))),
+            data: abi.encode(config, bytes(""))
         });
 
         uint64 chainId = uint64(block.chainid);

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -194,7 +194,7 @@ contract DelegateAuthenticatorTest is KeystoreTest {
 
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
-            changeType: Keystore.ChangeType.Authorize,
+            changeType: Keystore.ActorChangeType.Authorize,
             actorId: bytes32(bytes20(vm.addr(newPk))),
             data: abi.encode(config, bytes(""))
         });

--- a/test/unit/policies/ExternalPolicyCaller.t.sol
+++ b/test/unit/policies/ExternalPolicyCaller.t.sol
@@ -342,7 +342,7 @@ contract ExternalPolicyCallerTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: bytes32(bytes20(provider)),
-            changeType: Keystore.ChangeType.Authorize,
+            changeType: Keystore.ActorChangeType.Authorize,
             data: abi.encode(cfg, abi.encodePacked(policyManager, commitment))
         });
         _applyAsRoot(account, changes);
@@ -351,7 +351,7 @@ contract ExternalPolicyCallerTest is KeystoreTest {
     function _revokeProvider(address account) internal {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
-            actorId: bytes32(bytes20(provider)), changeType: Keystore.ChangeType.Revoke, data: ""
+            actorId: bytes32(bytes20(provider)), changeType: Keystore.ActorChangeType.Revoke, data: ""
         });
         _applyAsRoot(account, changes);
     }

--- a/test/unit/policies/ExternalPolicyCaller.t.sol
+++ b/test/unit/policies/ExternalPolicyCaller.t.sol
@@ -40,8 +40,6 @@ contract ExternalPolicyCallerTest is KeystoreTest {
     uint256 internal constant ROOT_PK = 0xA11CE;
     uint8 internal constant SCOPE_SENDER = 0x01;
     uint8 internal constant SCOPE_POLICY = 0x02;
-    uint8 internal constant AUTHORIZE_ACTOR = 0x01;
-    uint8 internal constant REVOKE_ACTOR = 0x02;
 
     bytes4 internal constant TRANSFER = bytes4(keccak256("transfer(address,uint256)"));
     uint40 internal constant MONTH = 30 days;
@@ -344,7 +342,7 @@ contract ExternalPolicyCallerTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: bytes32(bytes20(provider)),
-            changeType: AUTHORIZE_ACTOR,
+            changeType: Keystore.ChangeType.Authorize,
             data: abi.encode(cfg, abi.encodePacked(policyManager, commitment))
         });
         _applyAsRoot(account, changes);
@@ -352,7 +350,9 @@ contract ExternalPolicyCallerTest is KeystoreTest {
 
     function _revokeProvider(address account) internal {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({actorId: bytes32(bytes20(provider)), changeType: REVOKE_ACTOR, data: ""});
+        changes[0] = Keystore.ActorChange({
+            actorId: bytes32(bytes20(provider)), changeType: Keystore.ChangeType.Revoke, data: ""
+        });
         _applyAsRoot(account, changes);
     }
 

--- a/test/unit/policies/PolicyManager.t.sol
+++ b/test/unit/policies/PolicyManager.t.sol
@@ -360,7 +360,7 @@ contract PolicyManagerTest is KeystoreTest {
 
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
-            actorId: actorId, changeType: Keystore.ChangeType.Authorize, data: abi.encode(cfg, policyData)
+            actorId: actorId, changeType: Keystore.ActorChangeType.Authorize, data: abi.encode(cfg, policyData)
         });
 
         uint64 chainId = uint64(block.chainid);
@@ -394,7 +394,7 @@ contract PolicyManagerTest is KeystoreTest {
 
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
-            actorId: actorId, changeType: Keystore.ChangeType.Authorize, data: abi.encode(cfg, policyData)
+            actorId: actorId, changeType: Keystore.ActorChangeType.Authorize, data: abi.encode(cfg, policyData)
         });
 
         uint64 chainId = uint64(block.chainid);
@@ -405,7 +405,7 @@ contract PolicyManagerTest is KeystoreTest {
 
     function _revokePolicyActor(bytes32 actorId) internal {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ChangeType.Revoke, data: ""});
+        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
 
         uint64 chainId = uint64(block.chainid);
         uint64 sequence = keystore.getChangeSequences(account).local;

--- a/test/unit/policies/PolicyManager.t.sol
+++ b/test/unit/policies/PolicyManager.t.sol
@@ -90,8 +90,6 @@ contract PolicyManagerTest is KeystoreTest {
     uint256 internal constant ROOT_PK = 0xA11CE;
 
     uint8 internal constant SCOPE_POLICY = 0x02;
-    uint8 internal constant AUTHORIZE_ACTOR = 0x01;
-    uint8 internal constant REVOKE_ACTOR = 0x02;
 
     function setUp() public override {
         super.setUp();
@@ -361,8 +359,9 @@ contract PolicyManagerTest is KeystoreTest {
         bytes memory policyData = abi.encodePacked(address(manager), commitment);
 
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] =
-            Keystore.ActorChange({actorId: actorId, changeType: AUTHORIZE_ACTOR, data: abi.encode(cfg, policyData)});
+        changes[0] = Keystore.ActorChange({
+            actorId: actorId, changeType: Keystore.ChangeType.Authorize, data: abi.encode(cfg, policyData)
+        });
 
         uint64 chainId = uint64(block.chainid);
         uint64 sequence = keystore.getChangeSequences(account).local;
@@ -394,8 +393,9 @@ contract PolicyManagerTest is KeystoreTest {
         bytes memory policyData = abi.encodePacked(address(manager), commitment);
 
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] =
-            Keystore.ActorChange({actorId: actorId, changeType: AUTHORIZE_ACTOR, data: abi.encode(cfg, policyData)});
+        changes[0] = Keystore.ActorChange({
+            actorId: actorId, changeType: Keystore.ChangeType.Authorize, data: abi.encode(cfg, policyData)
+        });
 
         uint64 chainId = uint64(block.chainid);
         uint64 sequence = keystore.getChangeSequences(target_).local;
@@ -405,7 +405,7 @@ contract PolicyManagerTest is KeystoreTest {
 
     function _revokePolicyActor(bytes32 actorId) internal {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: REVOKE_ACTOR, data: ""});
+        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ChangeType.Revoke, data: ""});
 
         uint64 chainId = uint64(block.chainid);
         uint64 sequence = keystore.getChangeSequences(account).local;

--- a/test/unit/policies/SessionPolicy.t.sol
+++ b/test/unit/policies/SessionPolicy.t.sol
@@ -71,7 +71,6 @@ contract SessionPolicyTest is KeystoreTest {
     uint256 internal constant ROOT_PK = 0xA11CE;
     uint8 internal constant SCOPE_SENDER = 0x01;
     uint8 internal constant SCOPE_POLICY = 0x02;
-    uint8 internal constant AUTHORIZE_ACTOR = 0x01;
 
     bytes4 internal constant TRANSFER = bytes4(keccak256("transfer(address,uint256)"));
     uint40 internal constant WEEK = 7 days;
@@ -751,7 +750,7 @@ contract SessionPolicyTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: actorId,
-            changeType: AUTHORIZE_ACTOR,
+            changeType: Keystore.ChangeType.Authorize,
             data: abi.encode(cfg, abi.encodePacked(address(manager), commitment))
         });
         uint64 chainId = uint64(block.chainid);

--- a/test/unit/policies/SessionPolicy.t.sol
+++ b/test/unit/policies/SessionPolicy.t.sol
@@ -750,7 +750,7 @@ contract SessionPolicyTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: actorId,
-            changeType: Keystore.ChangeType.Authorize,
+            changeType: Keystore.ActorChangeType.Authorize,
             data: abi.encode(cfg, abi.encodePacked(address(manager), commitment))
         });
         uint64 chainId = uint64(block.chainid);

--- a/test/unit/policies/SessionPolicyGas.t.sol
+++ b/test/unit/policies/SessionPolicyGas.t.sol
@@ -373,7 +373,7 @@ contract SessionPolicyGasTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: actorId,
-            changeType: Keystore.ChangeType.Authorize,
+            changeType: Keystore.ActorChangeType.Authorize,
             data: abi.encode(cfg, abi.encodePacked(address(manager), commitment))
         });
         uint64 chainId = uint64(block.chainid);

--- a/test/unit/policies/SessionPolicyGas.t.sol
+++ b/test/unit/policies/SessionPolicyGas.t.sol
@@ -42,7 +42,6 @@ contract SessionPolicyGasTest is KeystoreTest {
 
     uint256 internal constant ROOT_PK = 0xA11CE;
     uint8 internal constant SCOPE_POLICY = 0x02;
-    uint8 internal constant AUTHORIZE_ACTOR = 0x01;
 
     bytes4 internal constant TRANSFER = bytes4(keccak256("transfer(address,uint256)"));
     uint40 internal constant WEEK = 7 days;
@@ -374,7 +373,7 @@ contract SessionPolicyGasTest is KeystoreTest {
         Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
         changes[0] = Keystore.ActorChange({
             actorId: actorId,
-            changeType: AUTHORIZE_ACTOR,
+            changeType: Keystore.ChangeType.Authorize,
             data: abi.encode(cfg, abi.encodePacked(address(manager), commitment))
         });
         uint64 chainId = uint64(block.chainid);


### PR DESCRIPTION
## Summary

Refactor-only cleanup (no wire/ABI changes). Stacked on the merged Scopes-library work.

- **Enums.** `AUTHORIZE_ACTOR` / `REVOKE_ACTOR` → `ChangeType {Invalid, Authorize, Revoke}` and `LOCK_OP` / `UNLOCK_OP` → `LockOp {Invalid, Lock, Unlock}`. Wire values are preserved (Authorize/Lock = `0x01`, Revoke/Unlock = `0x02`) and the typehash strings keep `uint8 changeType` / `uint8 op` (enums ABI-encode as `uint8`), so **digests and the external ABI selectors are unchanged**. `Invalid` (0) is the reachable "unrecognized" case, rejected in-handler with `UnknownChangeType` / `UnknownLockOp`; out-of-range wire values (≥ 3) can never reach the handler — the enum decoder rejects them while ABI-decoding the calldata.
- **Naming.** `ACTORCONFIG_TYPEHASH` → `ACTOR_CONFIG_TYPEHASH`, `ACTORCHANGE_TYPEHASH` → `ACTOR_CHANGE_TYPEHASH`.
- **Policies reframe.** `test/unit/examples` → `test/unit/policies`; dropped the "unaudited example" framing from the policies README (all contracts in this repo are audited).

## Notes

- The two "unknown op / changeType" tests were rewritten: the reachable case now exercises the `Invalid` sentinel, and a new low-level-call test asserts that an out-of-range op is rejected by the ABI decoder (empty revert) before the handler runs.

## Test plan

- [x] `forge build`
- [x] `forge test` — 335 passed, 0 failed
- [x] `forge fmt --check`