### PR TITLE
Widen lockUnion to uint48; getLockStatus reports elapsed unlocks

### DIFF
--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -85,7 +85,7 @@ contract Keystore {
     /// @dev Packed into a single storage slot; the field layout is normative (nodes read the raw slot for mempool
     ///      rate-limit tiering, see the EIP's Account Lock section). Field order and widths match the spec's
     ///      account-state table: multichainSequence, localSequence, flags, lockUnion, defaultEOAExpiry,
-    ///      defaultEOAScope, then 2 reserved bytes that MUST stay zero.
+    ///      defaultEOAScope, then 1 reserved byte that MUST stay zero.
     ///      localSequence > 0 doubles as the account initialized flag.
     ///      `flags` is a bitfield: bit 0 (FLAG_REVOKE_DEFAULT_EOA) disables the k1 self key; bit 1 (FLAG_LOCKED)
     ///      freezes actor configuration; bit 2 (FLAG_UNLOCK_INITIATED) selects how `lockUnion` is interpreted.
@@ -102,10 +102,10 @@ contract Keystore {
         uint64 multichainSequence; // 8 bytes
         uint64 localSequence; // 8 bytes – also serves as initialized flag
         uint8 flags; // 1 byte – bitfield: bit 0 REVOKE_DEFAULT_EOA, bit 1 LOCKED, bit 2 UNLOCK_INITIATED
-        uint40 lockUnion; // 5 bytes – union: unlockDelay while UNLOCK_INITIATED clear, else unlocksAt (timestamp)
+        uint48 lockUnion; // 6 bytes – union: unlockDelay while UNLOCK_INITIATED clear, else unlocksAt (timestamp)
         uint48 defaultEOAExpiry; // 6 bytes – inline self k1 expiry (Unix seconds; 0 = no expiry)
         uint16 defaultEOAScope; // 2 bytes – inline self k1 scope (0 = full owner)
-        // 2 bytes reserved (remaining slot bytes); MUST stay zero.
+        // 1 byte reserved (remaining slot byte); MUST stay zero.
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -250,7 +250,7 @@ contract Keystore {
     ///
     /// @param account The account whose unlock was initiated.
     /// @param unlocksAt The timestamp at which the account will unlock.
-    event AccountUnlockInitiated(address indexed account, uint40 unlocksAt);
+    event AccountUnlockInitiated(address indexed account, uint48 unlocksAt);
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // ERRORS
@@ -591,7 +591,7 @@ contract Keystore {
             if (flags & FLAG_LOCKED == 0 || flags & FLAG_UNLOCK_INITIATED != 0) revert NotLocked();
 
             // Reinterpret the union: it held the stored delay, now it holds the effective unlock timestamp.
-            uint40 unlocksAt = uint40(block.timestamp + uint16(config.lockUnion));
+            uint48 unlocksAt = uint48(block.timestamp + uint16(config.lockUnion));
             config.flags = flags | FLAG_UNLOCK_INITIATED;
             config.lockUnion = unlocksAt;
             emit AccountUnlockInitiated(account, unlocksAt);
@@ -830,12 +830,12 @@ contract Keystore {
     ///
     /// @return locked True if the account is locked at the current block timestamp.
     /// @return hasInitiatedUnlock True if an unlock has been initiated but not yet elapsed.
-    /// @return unlocksAt The timestamp at which the account unlocks (type(uint40).max while hard-locked).
+    /// @return unlocksAt The timestamp at which the account unlocks (type(uint48).max while hard-locked).
     /// @return unlockDelay The configured unlock delay in seconds.
     function getLockStatus(address account)
         external
         view
-        returns (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 unlockDelay)
+        returns (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 unlockDelay)
     {
         AccountState storage config = _accountState[account];
         uint8 flags = config.flags;
@@ -845,11 +845,14 @@ contract Keystore {
         }
         if (flags & FLAG_UNLOCK_INITIATED == 0) {
             // Hard-locked: lockUnion holds the configured delay; synthesize the max sentinel for unlocksAt.
-            return (true, false, type(uint40).max, uint16(config.lockUnion));
+            return (true, false, type(uint48).max, uint16(config.lockUnion));
         }
-        // Unlock initiated: lockUnion holds the effective unlock timestamp; the delay has been consumed.
-        uint40 unlockTime = config.lockUnion;
-        return (block.timestamp < unlockTime, true, unlockTime, 0);
+        // Unlock initiated: lockUnion holds the effective unlock timestamp. Once it has elapsed the account is
+        // effectively unlocked (storage is cleared lazily on the next onlyUnlocked op), so report the clean unlocked
+        // state — matching _checkAndClearLock's post-clear result — instead of surfacing the stale timestamp.
+        uint48 unlockTime = config.lockUnion;
+        if (block.timestamp >= unlockTime) return (false, false, 0, 0);
+        return (true, true, unlockTime, 0);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -271,10 +271,10 @@ contract AccountLockTest is KeystoreTest {
 
         _signedLock(pk, account, delay);
 
-        (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
+        (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
         assertTrue(locked);
         assertFalse(hasInitiatedUnlock);
-        assertEq(unlocksAt, type(uint40).max);
+        assertEq(unlocksAt, type(uint48).max);
         assertEq(storedDelay, delay);
         assertTrue(keystore.isLocked(account));
     }
@@ -319,10 +319,10 @@ contract AccountLockTest is KeystoreTest {
 
         _signedLock(pk, account, secondDelay);
 
-        (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
+        (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
         assertTrue(locked);
         assertFalse(hasInitiatedUnlock);
-        assertEq(unlocksAt, type(uint40).max);
+        assertEq(unlocksAt, type(uint48).max);
         assertEq(storedDelay, secondDelay);
     }
 
@@ -339,10 +339,10 @@ contract AccountLockTest is KeystoreTest {
         vm.warp(t0);
         _signedUnlock(pk, account);
 
-        (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
+        (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
         assertTrue(locked); // block.timestamp (t0) < unlocksAt (t0 + delay)
         assertTrue(hasInitiatedUnlock);
-        assertEq(unlocksAt, uint40(t0 + delay));
+        assertEq(unlocksAt, uint48(t0 + delay));
         assertEq(storedDelay, 0);
         assertTrue(keystore.isLocked(account));
     }
@@ -360,7 +360,7 @@ contract AccountLockTest is KeystoreTest {
 
         bytes memory auth = _unlockAuth(pk, account);
         vm.expectEmit(true, false, false, true, address(keystore));
-        emit Keystore.AccountUnlockInitiated(account, uint40(t0 + delay));
+        emit Keystore.AccountUnlockInitiated(account, uint48(t0 + delay));
         keystore.applySignedLockChanges(account, Keystore.LockChangeType.Unlock, 0, auth);
     }
 
@@ -428,18 +428,19 @@ contract AccountLockTest is KeystoreTest {
 
     /// @notice getLockStatus reports all-clear for a never-locked account: unlocked, not initiated, zeroed fields.
     function test_getLockStatus_success_whenNeverLocked(address account) public view {
-        (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 unlockDelay) = keystore.getLockStatus(account);
+        (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 unlockDelay) = keystore.getLockStatus(account);
         assertFalse(locked);
         assertFalse(hasInitiatedUnlock);
         assertEq(unlocksAt, 0);
         assertEq(unlockDelay, 0);
     }
 
-    /// @notice getLockStatus after the delay elapses (with no intervening onlyUnlocked call) still surfaces the
-    ///         initiated-unlock state: unlocked, but hasInitiatedUnlock true and unlocksAt unchanged.
-    /// @dev getLockStatus is a pure view: it never runs _checkAndClearLock, so the lock flags/union are not cleared and
-    ///      the FLAG_UNLOCK_INITIATED branch reports hasInitiatedUnlock true even though the account is now unlocked.
-    function test_getLockStatus_success_afterUnlockElapsedNotCleared(
+    /// @notice getLockStatus reports a clean unlocked state once an initiated unlock has elapsed, even with no
+    ///         intervening onlyUnlocked call to clear storage.
+    /// @dev getLockStatus never runs _checkAndClearLock, but it applies the elapse itself: once block.timestamp
+    ///      reaches unlocksAt it returns (false, false, 0, 0) — matching _checkAndClearLock's post-clear result —
+    ///      rather than surfacing the stale initiated-unlock fields still sitting in storage.
+    function test_getLockStatus_success_afterUnlockElapsedReportsUnlocked(
         uint256 pkSeed,
         uint16 delay,
         uint256 t0,
@@ -456,12 +457,12 @@ contract AccountLockTest is KeystoreTest {
         vm.warp(t0);
         _signedUnlock(pk, account);
 
-        vm.warp(t0 + delay + extra); // past unlocksAt, but no onlyUnlocked call to clear it
+        vm.warp(t0 + delay + extra); // at or past unlocksAt, but no onlyUnlocked call to clear storage
 
-        (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
+        (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
         assertFalse(locked);
-        assertTrue(hasInitiatedUnlock);
-        assertEq(unlocksAt, uint40(t0 + delay));
+        assertFalse(hasInitiatedUnlock);
+        assertEq(unlocksAt, 0);
         assertEq(storedDelay, 0);
     }
 
@@ -502,7 +503,7 @@ contract AccountLockTest is KeystoreTest {
 
         assertTrue(_isActor(account, newActorId));
         // The onlyUnlocked prelude cleared the stale unlock timestamp back to 0.
-        (,, uint40 unlocksAt,) = keystore.getLockStatus(account);
+        (,, uint48 unlocksAt,) = keystore.getLockStatus(account);
         assertEq(unlocksAt, 0);
     }
 

--- a/test/unit/Keystore/createAccount.t.sol
+++ b/test/unit/Keystore/createAccount.t.sol
@@ -266,7 +266,7 @@ contract CreateAccountTest is KeystoreTest {
         assertEq(keystore.getChangeSequences(account).local, 1);
         assertEq(keystore.getChangeSequences(account).multichain, 0);
 
-        (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 unlockDelay) = keystore.getLockStatus(account);
+        (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 unlockDelay) = keystore.getLockStatus(account);
         assertFalse(locked);
         assertFalse(hasInitiatedUnlock);
         assertEq(unlocksAt, 0);

--- a/test/unit/Keystore/importAccount.t.sol
+++ b/test/unit/Keystore/importAccount.t.sol
@@ -143,7 +143,7 @@ contract ImportAccountTest is KeystoreTest {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     /// @notice Verifies importAccount reverts when the account is hard-locked (onlyUnlocked runs before all else).
-    /// @dev A lock op sets unlocksAt = type(uint40).max, so the account stays locked regardless of warp; any non-zero
+    /// @dev A lock op sets unlocksAt = type(uint48).max, so the account stays locked regardless of warp; any non-zero
     ///      unlock delay locks it. The onlyUnlocked modifier trips before the chainId/sequence/signature checks, so
     ///      the account is a controllable EOA (its inline default-EOA self signs the lock) and the actors/sig are
     ///      never reached.


### PR DESCRIPTION
## Summary
- **Normalize the lock timestamp width with expiry.** `AccountState.lockUnion` goes `uint40 → uint48`, matching `defaultEOAExpiry`/actor `expiry`. The packed state still fits in a single storage slot, so the trailing reserved region shrinks from 2 bytes → 1 byte (struct + normative-layout doc updated). The `AccountUnlockInitiated(address, uint48 unlocksAt)` event, the internal `unlocksAt` cast, and `getLockStatus`'s return type / hard-lock sentinel (`type(uint48).max`) follow.
- **`getLockStatus` now lazily reports elapsed unlocks (view).** Once `block.timestamp` reaches the pending `unlocksAt`, it returns the clean unlocked projection `(false, false, 0, 0)` — matching what `_checkAndClearLock` produces on the next op — instead of surfacing the stale initiated-unlock fields still sitting in storage.

## Details
Before, an initiated unlock that had elapsed but not yet been cleared by a subsequent `onlyUnlocked` op reported `(false, true, staleUnlocksAt, 0)`. The view now reflects the *effective* state, so `getLockStatus` and `isLocked` agree and the projection is fully cleared once the account is effectively unlocked.

## Test plan
- [x] `forge build` clean
- [x] `forge test` — 339 passing (incl. lock suite)
- [x] Rewrote `test_getLockStatus_success_afterUnlockElapsedNotCleared` → `test_getLockStatus_success_afterUnlockElapsedReportsUnlocked` to assert the clean-unlocked projection
- [x] Widened `uint40 → uint48` in all `getLockStatus` destructurings and hard-lock sentinel assertions