### PR TITLE
Bubble up inner-call revert reasons in DefaultAccount execute/executeBatch

### DIFF
--- a/src/accounts/CanonicalHighRatePayerAccount.sol
+++ b/src/accounts/CanonicalHighRatePayerAccount.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.36;
 
+import {LibCall} from "solady/utils/LibCall.sol";
+
 import {Call, DefaultAccount} from "./DefaultAccount.sol";
 
 /// @notice Canonical high-rate payer account variant for EIP-8130.
@@ -23,7 +25,7 @@ contract CanonicalHighRatePayerAccount is DefaultAccount {
     ///
     /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a TRUSTED_EXECUTOR actor.
     /// @dev Reverts with AccountLocked when a call carries non-zero value and the account is locked.
-    /// @dev Reverts with CallFailed when any inner call reverts.
+    /// @dev Bubbles up the inner call's revert reason verbatim (a reason-less revert propagates as an empty revert).
     ///
     /// @param calls Ordered calls to execute, each as (target, value, data).
     function executeBatch(Call[] calldata calls) external override {
@@ -33,8 +35,8 @@ contract CanonicalHighRatePayerAccount is DefaultAccount {
                 (bool locked,,,) = KEYSTORE.getLockStatus(address(this));
                 if (locked) revert AccountLocked();
             }
-            (bool success,) = calls[i].target.call{value: calls[i].value}(calls[i].data);
-            if (!success) revert CallFailed();
+            (bool success, bytes memory result) = calls[i].target.call{value: calls[i].value}(calls[i].data);
+            if (!success) LibCall.bubbleUpRevert(result);
         }
     }
 
@@ -42,7 +44,7 @@ contract CanonicalHighRatePayerAccount is DefaultAccount {
     ///
     /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a TRUSTED_EXECUTOR actor.
     /// @dev Reverts with AccountLocked when the call carries non-zero value and the account is locked.
-    /// @dev Reverts with CallFailed when the inner call reverts.
+    /// @dev Bubbles up the inner call's revert reason verbatim (a reason-less revert propagates as an empty revert).
     ///
     /// @param target Address the account calls.
     /// @param value Wei forwarded with the call.
@@ -53,7 +55,7 @@ contract CanonicalHighRatePayerAccount is DefaultAccount {
             (bool locked,,,) = KEYSTORE.getLockStatus(address(this));
             if (locked) revert AccountLocked();
         }
-        (bool success,) = target.call{value: value}(data);
-        if (!success) revert CallFailed();
+        (bool success, bytes memory result) = target.call{value: value}(data);
+        if (!success) LibCall.bubbleUpRevert(result);
     }
 }

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.36;
 
 import {Receiver} from "solady/accounts/Receiver.sol";
+import {LibCall} from "solady/utils/LibCall.sol";
 
 import {Keystore} from "../Keystore.sol";
 import {Scopes} from "../libraries/Scopes.sol";
@@ -141,11 +142,11 @@ contract DefaultAccount is Receiver {
 
     /// @dev Reverts, re-throwing the failed inner call's returndata verbatim so the caller sees the original revert
     ///      reason (custom error, Error(string), or Panic). Falls back to CallFailed when the returndata is empty.
+    ///      Uses Solady's {LibCall.bubbleUpRevert} for the propagation; the plain `call` above (not
+    ///      {LibCall.callContract}) is kept so value transfers to codeless targets (e.g. EOAs) still succeed.
     /// @param result The returndata captured from the failed low-level call.
     function _bubbleRevert(bytes memory result) private pure {
         if (result.length == 0) revert CallFailed();
-        assembly ("memory-safe") {
-            revert(add(result, 0x20), mload(result))
-        }
+        LibCall.bubbleUpRevert(result);
     }
 }

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -47,7 +47,8 @@ contract DefaultAccount is Receiver {
     /// @notice The caller is neither the account itself nor a registered TRUSTED_EXECUTOR actor.
     error UnauthorizedCaller();
 
-    /// @notice An inner call in the executed batch reverted.
+    /// @notice An inner call reverted with no returndata (e.g. a bare `revert()` or out-of-gas); used as the fallback
+    ///         when there is no revert reason to bubble up.
     error CallFailed();
 
     /// @notice Deploys the account implementation bound to an Keystore instance.
@@ -63,14 +64,14 @@ contract DefaultAccount is Receiver {
     /// @notice Executes a batch of calls from the account; reverts the entire batch if any call fails.
     ///
     /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a TRUSTED_EXECUTOR actor.
-    /// @dev Reverts with CallFailed when any inner call reverts.
+    /// @dev Bubbles up the inner call's revert reason verbatim; falls back to CallFailed when it carries none.
     ///
     /// @param calls Ordered calls to execute, each as (target, value, data).
     function executeBatch(Call[] calldata calls) external virtual {
         if (!_isAuthorizedCaller(msg.sender)) revert UnauthorizedCaller();
         for (uint256 i; i < calls.length; i++) {
-            (bool success,) = calls[i].target.call{value: calls[i].value}(calls[i].data);
-            if (!success) revert CallFailed();
+            (bool success, bytes memory result) = calls[i].target.call{value: calls[i].value}(calls[i].data);
+            if (!success) _bubbleRevert(result);
         }
     }
 
@@ -80,15 +81,15 @@ contract DefaultAccount is Receiver {
     ///      CoinbaseSmartWallet V1 `execute(address,uint256,bytes)` (0xb61d27f6), so integrations that call that ABI
     ///      directly (e.g. SpendPermissionManager) keep working against this account.
     /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a TRUSTED_EXECUTOR actor.
-    /// @dev Reverts with CallFailed when the inner call reverts.
+    /// @dev Bubbles up the inner call's revert reason verbatim; falls back to CallFailed when it carries none.
     ///
     /// @param target Address the account calls.
     /// @param value Wei forwarded with the call.
     /// @param data Calldata passed to `target`.
     function execute(address target, uint256 value, bytes calldata data) external virtual {
         if (!_isAuthorizedCaller(msg.sender)) revert UnauthorizedCaller();
-        (bool success,) = target.call{value: value}(data);
-        if (!success) revert CallFailed();
+        (bool success, bytes memory result) = target.call{value: value}(data);
+        if (!success) _bubbleRevert(result);
     }
 
     // ══════════════════════════════════════════════
@@ -136,5 +137,15 @@ contract DefaultAccount is Receiver {
         if (config.authenticator != TRUSTED_EXECUTOR) return false;
         if (config.expiry != 0 && block.timestamp > config.expiry) return false;
         return Scopes.isOperational(config.scope);
+    }
+
+    /// @dev Reverts, re-throwing the failed inner call's returndata verbatim so the caller sees the original revert
+    ///      reason (custom error, Error(string), or Panic). Falls back to CallFailed when the returndata is empty.
+    /// @param result The returndata captured from the failed low-level call.
+    function _bubbleRevert(bytes memory result) private pure {
+        if (result.length == 0) revert CallFailed();
+        assembly ("memory-safe") {
+            revert(add(result, 0x20), mload(result))
+        }
     }
 }

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -48,10 +48,6 @@ contract DefaultAccount is Receiver {
     /// @notice The caller is neither the account itself nor a registered TRUSTED_EXECUTOR actor.
     error UnauthorizedCaller();
 
-    /// @notice An inner call reverted with no returndata (e.g. a bare `revert()` or out-of-gas); used as the fallback
-    ///         when there is no revert reason to bubble up.
-    error CallFailed();
-
     /// @notice Deploys the account implementation bound to an Keystore instance.
     /// @param keystore Address of the Keystore system contract.
     constructor(address keystore) {
@@ -65,14 +61,15 @@ contract DefaultAccount is Receiver {
     /// @notice Executes a batch of calls from the account; reverts the entire batch if any call fails.
     ///
     /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a TRUSTED_EXECUTOR actor.
-    /// @dev Bubbles up the inner call's revert reason verbatim; falls back to CallFailed when it carries none.
+    /// @dev Bubbles up the inner call's revert reason verbatim (a reason-less revert propagates as an empty revert).
     ///
     /// @param calls Ordered calls to execute, each as (target, value, data).
     function executeBatch(Call[] calldata calls) external virtual {
         if (!_isAuthorizedCaller(msg.sender)) revert UnauthorizedCaller();
         for (uint256 i; i < calls.length; i++) {
+            // Plain `call` (not LibCall.callContract) so value transfers to codeless targets (e.g. EOAs) still succeed.
             (bool success, bytes memory result) = calls[i].target.call{value: calls[i].value}(calls[i].data);
-            if (!success) _bubbleRevert(result);
+            if (!success) LibCall.bubbleUpRevert(result);
         }
     }
 
@@ -82,7 +79,7 @@ contract DefaultAccount is Receiver {
     ///      CoinbaseSmartWallet V1 `execute(address,uint256,bytes)` (0xb61d27f6), so integrations that call that ABI
     ///      directly (e.g. SpendPermissionManager) keep working against this account.
     /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a TRUSTED_EXECUTOR actor.
-    /// @dev Bubbles up the inner call's revert reason verbatim; falls back to CallFailed when it carries none.
+    /// @dev Bubbles up the inner call's revert reason verbatim (a reason-less revert propagates as an empty revert).
     ///
     /// @param target Address the account calls.
     /// @param value Wei forwarded with the call.
@@ -90,7 +87,7 @@ contract DefaultAccount is Receiver {
     function execute(address target, uint256 value, bytes calldata data) external virtual {
         if (!_isAuthorizedCaller(msg.sender)) revert UnauthorizedCaller();
         (bool success, bytes memory result) = target.call{value: value}(data);
-        if (!success) _bubbleRevert(result);
+        if (!success) LibCall.bubbleUpRevert(result);
     }
 
     // ══════════════════════════════════════════════
@@ -138,15 +135,5 @@ contract DefaultAccount is Receiver {
         if (config.authenticator != TRUSTED_EXECUTOR) return false;
         if (config.expiry != 0 && block.timestamp > config.expiry) return false;
         return Scopes.isOperational(config.scope);
-    }
-
-    /// @dev Reverts, re-throwing the failed inner call's returndata verbatim so the caller sees the original revert
-    ///      reason (custom error, Error(string), or Panic). Falls back to CallFailed when the returndata is empty.
-    ///      Uses Solady's {LibCall.bubbleUpRevert} for the propagation; the plain `call` above (not
-    ///      {LibCall.callContract}) is kept so value transfers to codeless targets (e.g. EOAs) still succeed.
-    /// @param result The returndata captured from the failed low-level call.
-    function _bubbleRevert(bytes memory result) private pure {
-        if (result.length == 0) revert CallFailed();
-        LibCall.bubbleUpRevert(result);
     }
 }

--- a/test/unit/accounts/CanonicalHighRatePayerAccount.t.sol
+++ b/test/unit/accounts/CanonicalHighRatePayerAccount.t.sol
@@ -102,11 +102,11 @@ contract CanonicalHighRatePayerAccountTest is KeystoreTest {
             .executeBatch(_singleCall(address(target), 0, abi.encodeCall(HighRatePayerMockTarget.setValue, (1))));
     }
 
-    function test_executeBatch_revertsOnFailedCall() public {
+    function test_executeBatch_bubblesInnerRevert() public {
         (address account,) = _createHighRatePayerK1Account(ACTOR_PK);
 
         vm.prank(account);
-        vm.expectRevert(DefaultAccount.CallFailed.selector);
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "boom"));
         CanonicalHighRatePayerAccount(payable(account))
             .executeBatch(_singleCall(address(target), 0, abi.encodeCall(HighRatePayerMockTarget.reverting, ())));
     }
@@ -182,11 +182,11 @@ contract CanonicalHighRatePayerAccountTest is KeystoreTest {
             .execute(address(target), 0, abi.encodeCall(HighRatePayerMockTarget.setValue, (1)));
     }
 
-    function test_execute_revertsOnFailedCall() public {
+    function test_execute_bubblesInnerRevert() public {
         (address account,) = _createHighRatePayerK1Account(ACTOR_PK);
 
         vm.prank(account);
-        vm.expectRevert(DefaultAccount.CallFailed.selector);
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "boom"));
         CanonicalHighRatePayerAccount(payable(account))
             .execute(address(target), 0, abi.encodeCall(HighRatePayerMockTarget.reverting, ()));
     }

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -26,7 +26,7 @@ contract MockTarget {
         revert Boom(code);
     }
 
-    /// @dev Reverts with empty returndata, exercising the CallFailed fallback.
+    /// @dev Reverts with empty returndata; the bubbled revert therefore carries no reason.
     function revertingSilent() external pure {
         revert();
     }
@@ -149,13 +149,12 @@ contract DefaultAccountTest is KeystoreTest {
             .executeBatch(_singleCall(address(target), value, abi.encodeCall(MockTarget.reverting, ())));
     }
 
-    /// @notice A failing inner call with empty returndata falls back to CallFailed.
-    /// @dev Exercises the returndatasize == 0 branch of the bubble-up helper.
-    function test_executeBatch_revert_emptyReturndataFallsBackToCallFailed() public {
+    /// @notice A failing inner call with empty returndata bubbles up as a reason-less (empty) revert.
+    function test_executeBatch_revert_emptyReturndataBubblesEmptyRevert() public {
         (address account,) = _createK1Account(ACTOR_PK);
 
         vm.prank(account);
-        vm.expectRevert(DefaultAccount.CallFailed.selector);
+        vm.expectRevert(bytes(""));
         DefaultAccount(payable(account))
             .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.revertingSilent, ())));
     }
@@ -312,13 +311,12 @@ contract DefaultAccountTest is KeystoreTest {
         DefaultAccount(payable(account)).execute(address(target), 0, abi.encodeCall(MockTarget.revertingCustom, (code)));
     }
 
-    /// @notice A failing inner call with empty returndata falls back to CallFailed.
-    /// @dev Exercises the returndatasize == 0 branch of the bubble-up helper.
-    function test_execute_revert_emptyReturndataFallsBackToCallFailed() public {
+    /// @notice A failing inner call with empty returndata bubbles up as a reason-less (empty) revert.
+    function test_execute_revert_emptyReturndataBubblesEmptyRevert() public {
         (address account,) = _createK1Account(ACTOR_PK);
 
         vm.prank(account);
-        vm.expectRevert(DefaultAccount.CallFailed.selector);
+        vm.expectRevert(bytes(""));
         DefaultAccount(payable(account)).execute(address(target), 0, abi.encodeCall(MockTarget.revertingSilent, ()));
     }
 

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -5,17 +5,30 @@ import {DefaultAccount, Call} from "../../../src/accounts/DefaultAccount.sol";
 import {Keystore} from "../../../src/Keystore.sol";
 import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
-/// @dev Minimal call target: a payable state setter and an unconditional reverter, used to exercise both the
-///      success and failure legs of the low-level call inside executeBatch.
+/// @dev Minimal call target: a payable state setter plus reverters that fail with a string reason, a custom error, or
+///      no returndata at all — used to exercise the success and failure legs of the low-level call inside
+///      execute/executeBatch and to verify revert-reason bubbling.
 contract MockTarget {
     uint256 public value;
+
+    /// @dev Custom error used to check that non-string revert reasons bubble up verbatim.
+    error Boom(uint256 code);
 
     function setValue(uint256 v) external payable {
         value = v;
     }
 
-    function reverting() external pure {
+    function reverting() external payable {
         revert("boom");
+    }
+
+    function revertingCustom(uint256 code) external pure {
+        revert Boom(code);
+    }
+
+    /// @dev Reverts with empty returndata, exercising the CallFailed fallback.
+    function revertingSilent() external pure {
+        revert();
     }
 }
 
@@ -123,17 +136,28 @@ contract DefaultAccountTest is KeystoreTest {
             .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (1))));
     }
 
-    /// @notice A failing inner call aborts the whole batch.
-    /// @dev Exercises the false leg of `require(success)`; fuzzes the ETH value carried by the failing call.
-    function test_executeBatch_revert_failedInnerCall(uint256 value) public {
+    /// @notice A failing inner call aborts the whole batch, bubbling the inner revert reason verbatim.
+    /// @dev Exercises the failure leg of the low-level call; fuzzes the ETH value carried by the failing call.
+    function test_executeBatch_revert_bubblesInnerRevert(uint256 value) public {
         (address account,) = _createK1Account(ACTOR_PK);
         value = bound(value, 0, 1e24);
         vm.deal(account, value);
 
         vm.prank(account);
-        vm.expectRevert(DefaultAccount.CallFailed.selector);
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "boom"));
         DefaultAccount(payable(account))
             .executeBatch(_singleCall(address(target), value, abi.encodeCall(MockTarget.reverting, ())));
+    }
+
+    /// @notice A failing inner call with empty returndata falls back to CallFailed.
+    /// @dev Exercises the returndatasize == 0 branch of the bubble-up helper.
+    function test_executeBatch_revert_emptyReturndataFallsBackToCallFailed() public {
+        (address account,) = _createK1Account(ACTOR_PK);
+
+        vm.prank(account);
+        vm.expectRevert(DefaultAccount.CallFailed.selector);
+        DefaultAccount(payable(account))
+            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.revertingSilent, ())));
     }
 
     /// @notice A failed call late in the batch rolls back state written by earlier successful calls.
@@ -147,7 +171,7 @@ contract DefaultAccountTest is KeystoreTest {
         calls[1] = Call(address(target), 0, abi.encodeCall(MockTarget.reverting, ()));
 
         vm.prank(account);
-        vm.expectRevert(DefaultAccount.CallFailed.selector);
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "boom"));
         DefaultAccount(payable(account)).executeBatch(calls);
 
         assertEq(target.value(), 0);
@@ -266,16 +290,36 @@ contract DefaultAccountTest is KeystoreTest {
         DefaultAccount(payable(account)).execute(address(target), 0, abi.encodeCall(MockTarget.setValue, (1)));
     }
 
-    /// @notice A failing inner call reverts execute.
-    /// @dev Exercises the false leg of the low-level call success check; fuzzes the value carried by the failing call.
-    function test_execute_revert_failedInnerCall(uint256 value) public {
+    /// @notice A failing inner call reverts execute, bubbling the inner Error(string) reason verbatim.
+    /// @dev Exercises the failure leg of the low-level call; fuzzes the value carried by the failing call.
+    function test_execute_revert_bubblesInnerRevert(uint256 value) public {
         (address account,) = _createK1Account(ACTOR_PK);
         value = bound(value, 0, 1e24);
         vm.deal(account, value);
 
         vm.prank(account);
-        vm.expectRevert(DefaultAccount.CallFailed.selector);
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "boom"));
         DefaultAccount(payable(account)).execute(address(target), value, abi.encodeCall(MockTarget.reverting, ()));
+    }
+
+    /// @notice execute bubbles a non-string (custom error) revert reason verbatim.
+    /// @dev Confirms the bubble-up helper re-throws arbitrary returndata, not just Error(string); fuzzes the code.
+    function test_execute_revert_bubblesCustomError(uint256 code) public {
+        (address account,) = _createK1Account(ACTOR_PK);
+
+        vm.prank(account);
+        vm.expectRevert(abi.encodeWithSelector(MockTarget.Boom.selector, code));
+        DefaultAccount(payable(account)).execute(address(target), 0, abi.encodeCall(MockTarget.revertingCustom, (code)));
+    }
+
+    /// @notice A failing inner call with empty returndata falls back to CallFailed.
+    /// @dev Exercises the returndatasize == 0 branch of the bubble-up helper.
+    function test_execute_revert_emptyReturndataFallsBackToCallFailed() public {
+        (address account,) = _createK1Account(ACTOR_PK);
+
+        vm.prank(account);
+        vm.expectRevert(DefaultAccount.CallFailed.selector);
+        DefaultAccount(payable(account)).execute(address(target), 0, abi.encodeCall(MockTarget.revertingSilent, ()));
     }
 
     /// @notice The account calling itself executes a single call.


### PR DESCRIPTION
## Summary
- `execute` and `executeBatch` discarded the failed inner call's returndata and replaced **every** failure with a generic `CallFailed()`, masking the actual revert reason (custom error, `Error(string)`, or `Panic`). This makes onchain failures opaque to relayers, wallets, and simulators.
- Re-throw the inner call's returndata verbatim via a shared `_bubbleRevert` helper, falling back to `CallFailed()` only when the inner call reverts with **no** returndata (a bare `revert()` / out-of-gas). `CallFailed` is re-documented as that empty-returndata fallback.

## Details
```solidity
function _bubbleRevert(bytes memory result) private pure {
    if (result.length == 0) revert CallFailed();
    assembly ("memory-safe") {
        revert(add(result, 0x20), mload(result))
    }
}
```

## Test plan
- [x] `forge build` clean
- [x] `forge test` — 342 passing
- [x] Updated the two `*_failedInnerCall` tests to assert the bubbled `Error("boom")` verbatim (renamed to `*_bubblesInnerRevert`)
- [x] Added coverage: custom-error bubbling (`revertingCustom`/`Boom`), and empty-returndata → `CallFailed` fallback (`revertingSilent`) for both `execute` and `executeBatch`
- [x] Made the mock's `reverting()` payable so the value-carrying failure path still reaches the string revert