### PR TITLE
feat: EIP-8130 local epoch system for signed config changes

### DIFF
--- a/script/SmokeTest.s.sol
+++ b/script/SmokeTest.s.sol
@@ -18,7 +18,7 @@ contract SmokeTest is Script {
 
     function run(address acctConfig, address k1Authenticator, address defaultImpl) public {
         address signer = vm.addr(SIGNER_PK);
-        bytes32 actorId = bytes32(bytes20(signer));
+        bytes32 actorId = bytes32(uint256(uint160(signer)));
         Keystore config = Keystore(acctConfig);
 
         // 1. Create account

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -337,6 +337,11 @@ contract Keystore {
     ///         BumpLocalEpoch / Unlock).
     error InvalidChangePayload();
 
+    /// @notice Defensive guard for an unhandled ChangeType in the apply loop. Unreachable in practice — out-of-range
+    ///         wire values are rejected by the enum decoder during ABI-decoding — but forces any future ChangeType to
+    ///         be dispatched explicitly instead of silently falling through.
+    error UnknownActorChangeType();
+
     /// @notice The auth blob is shorter than the 20-byte authenticator selector prefix.
     error InvalidAuthLength();
 
@@ -611,10 +616,13 @@ contract Keystore {
                 _applyBumpLocalEpoch(account, isLocal, s.changes[i].payload);
             } else if (t == ChangeType.Lock) {
                 _applyLock(account, s.changes[i].payload);
-            } else {
-                // ChangeType.Unlock (the only remaining member; out-of-range values are rejected by the enum decoder
-                // while ABI-decoding the calldata).
+            } else if (t == ChangeType.Unlock) {
                 _applyUnlock(account, s.changes[i].payload);
+            } else {
+                // Defensive guard: every ChangeType must be dispatched explicitly. Unreachable today — out-of-range
+                // wire values are rejected by the enum decoder while ABI-decoding the calldata — so this forces any
+                // future ChangeType to be wired in here rather than silently falling through.
+                revert UnknownActorChangeType();
             }
         }
     }

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -333,6 +333,17 @@ contract Keystore {
     ///         IncrementLocalEpoch / Unlock).
     error InvalidChangePayload();
 
+    /// @notice A signed batch carried no changes. An empty batch is rejected so it can neither consume a sequence nor
+    ///         initialize a fresh account without altering any configuration.
+    error EmptyChangeSet();
+
+    /// @notice An AuthorizeActor targeted the zero actorId, which is not a usable actor identifier.
+    error InvalidActorId();
+
+    /// @notice A Lock or Unlock appeared in a batch alongside other changes. Lock/unlock must be the sole change in
+    ///         their batch, so a lock transition can never interleave with actor changes in the same signed batch.
+    error LockChangeMustBeStandalone();
+
     /// @notice Defensive guard for an unhandled ChangeType in the apply loop. Unreachable in practice — out-of-range
     ///         wire values are rejected by the enum decoder during ABI-decoding — but forces any future ChangeType to
     ///         be dispatched explicitly instead of silently falling through.
@@ -410,7 +421,7 @@ contract Keystore {
     /// @notice Modifier to check if an account is unlocked.
     /// @dev Reverts with AccountIsLocked when the account is locked.
     modifier onlyUnlocked(address account) {
-        if (_checkAndClearLock(account)) revert AccountIsLocked();
+        if (_isLocked(account)) revert AccountIsLocked();
         _;
     }
 
@@ -543,8 +554,8 @@ contract Keystore {
     ///      Pipeline (in order): (1) split the sequence word; (2) reject a stale local epoch on both channels;
     ///      (3) validate/advance the sequence counter BEFORE apply (reentrancy discipline); (4) compute the digest
     ///      via the relocatable {_changesDigest} seam, authenticate, and reject a non-admin signer; (5) iterate
-    ///      changes enforcing the lock policy (authority ops are rejected while the account is locked). Anyone may
-    ///      relay — authorization comes entirely from the signature.
+    ///      changes enforcing the lock policy (authority ops rejected while the account is locked; Lock/Unlock must be
+    ///      standalone). Anyone may relay — authorization comes entirely from the signature.
     ///
     /// @param account The account whose configuration is changed.
     /// @param s The signed batch (channel, ordered changes, sequence word, signature).
@@ -554,6 +565,10 @@ contract Keystore {
     {
         AccountState storage a = _accountState[account];
         bool isLocal = s.channel == AccountChangeChannel.Local;
+
+        // Reject an empty batch: a no-op signed change would otherwise consume a sequence (or initialize a fresh
+        // account, below) without altering any configuration.
+        if (s.changes.length == 0) revert EmptyChangeSet();
 
         // Epoch / sequence gate. An unsequenced (JIT) batch exists only on the local channel (low half ==
         // UNSEQUENCED) and does not consume a counter; every other batch consumes its channel's counter.
@@ -570,6 +585,14 @@ contract Keystore {
                 // in the same batch overwrites this to 0, but that second write lands on an already-warm slot (~100
                 // gas), so the rare sequenced+increment combo isn't worth special-casing here.
                 a.localSequence = seq + 1;
+            } else if (!_isInitialized(account)) {
+                // First 8130 state change for a never-bootstrapped account (an EOA acting via its inline k1 self):
+                // burn local sequence 0 so the account reads initialized — blocking a later one-time importAccount /
+                // createAccount — and any outstanding sequenced seq==0 signature is invalidated. The unsequenced word
+                // itself commits no counter, so this batch stays replayable. Written before authentication; a revert
+                // rolls it back. (A bootstrapped or epoch-incremented account is already initialized, so this is a
+                // no-op there and never clobbers the live sequence-0 slot of a fresh epoch.)
+                a.localSequence = 1;
             }
         } else {
             // Multichain: a plain monotonic counter, never epoch-bearing or UNSEQUENCED.
@@ -585,20 +608,17 @@ contract Keystore {
         (, uint16 scope) = authenticateActor(account, digest, s.signature);
         if (scope != 0) revert UnauthorizedAccountChange();
 
-        // Lock policy is evaluated against the account's lock state at batch ENTRY (lazily clearing an already-elapsed
-        // unlock). This snapshot — not live state — gates the authority ops: a batch authorized while the account was
-        // locked cannot make actor changes, while a batch authorized while unlocked may, even if the same batch also
-        // contains a Lock (which takes effect only for later batches). Order within the batch is therefore irrelevant
-        // to authority ops. The Lock/Unlock handlers read live storage independently, so an in-batch
-        // [Lock, Unlock, Lock] still resolves consistently against live flags.
-        bool locked = _checkAndClearLock(account);
+        // Lock policy is evaluated against the account's lock state at batch ENTRY: authority ops (authorize/revoke)
+        // are rejected if the account was locked by a PRIOR batch. Lock and Unlock are standalone (enforced below), so
+        // a lock transition never shares a batch with authority ops — the entry state is the batch's whole lock context
+        // and intra-batch ordering is irrelevant.
+        bool locked = _isLocked(a);
 
         uint256 n = s.changes.length;
         for (uint256 i; i < n; i++) {
             ChangeType t = s.changes[i].changeType;
-            // Lock policy: if the account was locked at entry, only environment ops (increment-epoch/lock/unlock) may
-            // run, so the two authority ops gate on the entry snapshot; the environment handlers police their own
-            // preconditions against live state.
+            // Lock policy: if the account was locked at entry, the authority ops are rejected. Lock/Unlock must be the
+            // sole change in their batch (n == 1); IncrementLocalEpoch may ride any batch and is permitted while locked.
             if (t == ChangeType.AuthorizeActor) {
                 if (locked) revert AccountIsLocked();
                 _applyAuthorize(account, s.changes[i].payload);
@@ -609,8 +629,10 @@ contract Keystore {
                 if (!isLocal) revert EpochOpRequiresLocalChannel();
                 _applyIncrementLocalEpoch(account, s.changes[i].payload);
             } else if (t == ChangeType.Lock) {
+                if (n != 1) revert LockChangeMustBeStandalone();
                 _applyLock(account, s.changes[i].payload);
             } else if (t == ChangeType.Unlock) {
+                if (n != 1) revert LockChangeMustBeStandalone();
                 _applyUnlock(account, s.changes[i].payload);
             } else {
                 // Defensive guard: every ChangeType must be dispatched explicitly. Unreachable today — out-of-range
@@ -653,7 +675,7 @@ contract Keystore {
         delete _actorConfig[actorId][account];
         delete _policyCommitment[actorId][account];
         delete _policyManager[actorId][account];
-        if (actorId == bytes32(bytes20(account))) {
+        if (actorId == _selfActorId(account)) {
             _disableInlineSelf(_accountState[account]);
         }
         emit ActorRevoked(account, actorId);
@@ -673,17 +695,11 @@ contract Keystore {
         a.localSequence = 0;
     }
 
-    /// @dev Lock. `payload = abi.encode(uint16 unlockDelay)`. Only from the unlocked state; stores the delay. Gates on
-    ///      LIVE lock state (not the batch-entry snapshot) and its sibling {_applyUnlock} also mutates live storage, so
-    ///      within one batch a later op sees earlier ops' writes — e.g. `[Lock, Unlock, Lock]` correctly reverts on the
-    ///      trailing Lock instead of leaving FLAG_UNLOCK_INITIATED set over a delay-valued union.
-    ///
-    ///      Two facts make the live gate airtight: (a) block.timestamp is constant within a tx, so an unlock initiated
-    ///      earlier in the batch can never elapse mid-batch — once FLAG_UNLOCK_INITIATED is set, {_isLocked} stays true
-    ///      for the remainder of the batch and a following Lock reverts; (b) the entry {_checkAndClearLock} wipes any
-    ///      already-elapsed lock, so a permitted Lock always starts from clean flags. The explicit UNLOCK_INITIATED
-    ///      clear below therefore writes a clean hard-locked flag set (LOCKED set, UNLOCK_INITIATED cleared) so
-    ///      lockUnion unambiguously holds the delay — defense-in-depth given (a)/(b), not a live repair.
+    /// @dev Lock. `payload = abi.encode(uint16 unlockDelay)`. Standalone (its batch carries no other change), so it
+    ///      only ever runs from the account's live lock state. Reverts AccountIsLocked unless currently unlocked, then
+    ///      writes the lock flags unconditionally — `(flags | FLAG_LOCKED) & ~FLAG_UNLOCK_INITIATED` — so it always
+    ///      lands on a clean hard-locked flag set with lockUnion unambiguously holding the delay, regardless of any
+    ///      stale residue left by an elapsed-but-uncleared prior unlock (lock reads are non-clearing).
     function _applyLock(address account, bytes calldata payload) private {
         AccountState storage a = _accountState[account];
         if (_isLocked(a)) revert AccountIsLocked();
@@ -852,7 +868,7 @@ contract Keystore {
             if (_isExpired(config.expiry)) return _emptyActorConfig();
             return config;
         }
-        if (actorId == bytes32(bytes20(account)) && !_isDefaultEoaRevoked(account)) {
+        if (actorId == _selfActorId(account) && !_isDefaultEoaRevoked(account)) {
             AccountState storage st = _accountState[account];
             if (_isExpired(st.defaultEOAExpiry)) return _emptyActorConfig();
             return
@@ -875,7 +891,9 @@ contract Keystore {
     ///      live, so the active gate is read by actorId. Both slots are non-zero only when the actor's scope carries
     ///      Scopes.POLICY (see _authorizeActor / _applyRevoke); either MAY still be zero for an actor deliberately
     ///      gated to a zero manager or a zero (no-params) commitment. On-chain consumers should prefer the
-    ///      single-SLOAD `getPolicyCommitment` / `getPolicyManager` accessors directly.
+    ///      single-SLOAD `getPolicyCommitment` / `getPolicyManager` accessors directly. Like those, this returns the
+    ///      raw slots regardless of actor liveness (expiry clears no slot); expiry is enforced upstream at
+    ///      {authenticateActor}, so cross-check liveness via {getActorConfig} before trusting the values standalone.
     ///
     /// @param account The account to read.
     /// @param actorId The actor identifier to resolve.
@@ -892,6 +910,11 @@ contract Keystore {
     ///      8130 tx path. This slot is non-zero only when the actor's scope carries Scopes.POLICY (see _authorizeActor /
     ///      _applyRevoke), but MAY be zero for a policy-gated actor with a zero (no-params) commitment; gating is
     ///      therefore determined by the Scopes.POLICY bit, not by this slot being non-zero.
+    /// @dev Returns the raw slot regardless of actor LIVENESS: expiry clears no slot (only RevokeActor / re-authorize
+    ///      does), so an expired-but-not-revoked actor still surfaces its stored commitment here. This is sound because
+    ///      expiry is enforced upstream — {authenticateActor} rejects an expired actor, so the enforcement path never
+    ///      reaches a stale gate — but an off-chain reader must cross-check liveness via {getActorConfig}
+    ///      (authenticator != 0) before trusting the value in isolation.
     ///
     /// @param account The account to read.
     /// @param actorId The actor identifier to resolve.
@@ -903,7 +926,9 @@ contract Keystore {
 
     /// @notice Resolves an actor's policy gate target (manager), or address(0) if ungated or no actor.
     ///
-    /// @dev Single SLOAD. Same invariant as getPolicyCommitment.
+    /// @dev Single SLOAD. Same invariant as getPolicyCommitment, including the raw-slot / liveness caveat: an
+    ///      expired-but-not-revoked actor still surfaces its stored manager here; expiry is enforced upstream at
+    ///      {authenticateActor}, and off-chain readers should cross-check liveness via {getActorConfig}.
     ///
     /// @param account The account to read.
     /// @param actorId The actor identifier to resolve.
@@ -959,8 +984,8 @@ contract Keystore {
             return (true, false, type(uint48).max, uint16(config.lockUnion));
         }
         // Unlock initiated: lockUnion holds the effective unlock timestamp. Once it has elapsed the account is
-        // effectively unlocked (storage is cleared lazily on the next onlyUnlocked op), so report the clean unlocked
-        // state — matching _checkAndClearLock's post-clear result — instead of surfacing the stale timestamp.
+        // effectively unlocked, so report the clean unlocked state instead of surfacing the stale timestamp. Storage is
+        // not canonicalized (lock reads are non-clearing); a later Lock overwrites the residue.
         uint48 unlockTime = config.lockUnion;
         if (block.timestamp >= unlockTime) return (false, false, 0, 0);
         return (true, true, unlockTime, 0);
@@ -971,6 +996,12 @@ contract Keystore {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     /// @notice Returns whether the account's configuration is currently frozen, WITHOUT mutating storage.
+    ///
+    /// @dev Read-only by design: an elapsed initiated-unlock reads as unlocked even though FLAG_LOCKED still lingers in
+    ///      storage. Nothing clears it lazily — a later {_applyLock} overwrites lockUnion and clears the flags
+    ///      unconditionally, so the residue never affects relocking, and every liveness read ({isLocked},
+    ///      {getLockStatus}, the entry snapshot) interprets lockUnion against the timestamp anyway. Canonicalizing the
+    ///      storage would therefore buy only cosmetic hygiene, which is not worth the extra SSTOREs.
     function _isLocked(AccountState storage st) private view returns (bool) {
         uint8 flags = st.flags;
         if (flags & FLAG_LOCKED == 0) return false; // not locked
@@ -978,18 +1009,9 @@ contract Keystore {
         return block.timestamp < st.lockUnion; // pending unlock: frozen until the timestamp elapses
     }
 
-    /// @notice Returns true if the account is locked; lazily clears the lock flags/union once an initiated unlock has
-    ///         elapsed (the "cleared by the next op" rule).
-    function _checkAndClearLock(address account) internal returns (bool locked) {
-        AccountState storage st = _accountState[account];
-        if (_isLocked(st)) return true;
-        // Not locked, but FLAG_LOCKED still set means an initiated unlock has now elapsed: clear the lock bits and
-        // union so the account returns to a clean unlocked slot.
-        if (st.flags & FLAG_LOCKED != 0) {
-            st.flags &= ~(FLAG_LOCKED | FLAG_UNLOCK_INITIATED);
-            st.lockUnion = 0;
-        }
-        return false;
+    /// @notice Convenience overload of {_isLocked} keyed by address.
+    function _isLocked(address account) private view returns (bool) {
+        return _isLocked(_accountState[account]);
     }
 
     /// @dev True once the account has been bootstrapped via createAccount or importAccount. Tests the full local word
@@ -1042,6 +1064,12 @@ contract Keystore {
         internal
         nonZeroAccount(account)
     {
+        // Reject the zero actorId: it is not a usable identifier (the tx-context precompile surfaces the zero id as
+        // "no actor"), and every real actorId — derived from keccak(authenticator || salt), or the non-zero self
+        // (bytes32(bytes20(account))) — is non-zero. Bootstrap already rejects it via the strictly-ascending-from-zero
+        // sort; this guards the signed AuthorizeActor path.
+        if (actorId == bytes32(0)) revert InvalidActorId();
+
         // Only reject the zero authenticator (the empty-slot sentinel). A non-zero authenticator with no code is
         // accepted deliberately: authenticators may be counterfactual (deployed later) and some are intentionally
         // codeless sentinels (e.g. EXTERNAL_POLICY_AUTHENTICATOR). A bad authenticator simply fails fail-closed at
@@ -1053,7 +1081,7 @@ contract Keystore {
         // Scopes.POLICY and the account's other capabilities is protocol-side, not enforced here.
         (address manager, bytes32 commitment) = _slicePolicy(config.scope, policyData);
 
-        if (actorId == bytes32(bytes20(account))) {
+        if (actorId == _selfActorId(account)) {
             // Self-actorId is routed by authenticator type and the two homes are mutually exclusive: the k1 self
             // lives inline in AccountState; a non-k1 self lives in _actorConfig. Authorizing one clears the
             // other so a k1 and a non-k1 self are never simultaneously live.
@@ -1147,7 +1175,7 @@ contract Keystore {
         // A populated _actorConfig entry is always live: any non-self actor, or a non-k1 self authenticator.
         if (_actorConfig[actorId][account].authenticator >= K1_AUTHENTICATOR) return true;
         // No _actorConfig entry: the self-actorId's k1 key lives inline in AccountState, live unless the flag is set.
-        if (actorId == bytes32(bytes20(account))) return !_isDefaultEoaRevoked(account);
+        if (actorId == _selfActorId(account)) return !_isDefaultEoaRevoked(account);
         return false;
     }
 
@@ -1310,7 +1338,7 @@ contract Keystore {
             AccountState storage st = _accountState[account];
             if (st.flags & FLAG_REVOKE_DEFAULT_EOA != 0) revert DefaultEoaRevoked();
             if (_isExpired(st.defaultEOAExpiry)) revert ActorExpired();
-            return (bytes32(bytes20(account)), st.defaultEOAScope);
+            return (_selfActorId(account), st.defaultEOAScope);
         }
 
         bytes32 actorId = bytes32(bytes20(recovered));
@@ -1320,6 +1348,12 @@ contract Keystore {
     /// @dev True if the account's default (implicit) EOA has been revoked via the AccountState flag.
     function _isDefaultEoaRevoked(address account) internal view returns (bool) {
         return _accountState[account].flags & FLAG_REVOKE_DEFAULT_EOA != 0;
+    }
+
+    /// @dev The account's implicit self-actorId: the address left-aligned into the high 20 bytes
+    ///      (`bytes32(bytes20(account))`), matching the normative self derivation. Non-zero for any valid account.
+    function _selfActorId(address account) internal pure returns (bytes32) {
+        return bytes32(bytes20(account));
     }
 
     /// @dev True when `expiry` is set (non-zero) and has passed. A zero expiry means no expiry.

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -104,12 +104,15 @@ contract Keystore {
     ///
     /// @dev Packed into a single storage slot; the field layout is normative (nodes read the raw slot for mempool
     ///      rate-limit tiering, see the EIP's Account Lock section). Field order and widths match the spec's
-    ///      account-state table: multichainSequence, localSequence, flags, lockUnion, defaultEOAExpiry,
+    ///      account-state table: multichainSequence, localSequence, localEpoch, flags, lockUnion, defaultEOAExpiry,
     ///      defaultEOAScope, then 1 reserved byte that MUST stay zero.
-    ///      The `localSequence` word is size-neutral but split in two: the high 32 bits are the `localEpoch` and the
-    ///      low 32 bits are the running local sequence counter (see {getLocalEpochAndSequence}). A non-zero combined
-    ///      64-bit word still doubles as the account initialized flag — bootstrap writes low = 1 (epoch 0), and a
-    ///      local-epoch bump writes a non-zero high half, so the word is never zeroed back out for a live account.
+    ///      The local replay counter is stored as two adjacent uint32 fields — `localSequence` (low) then `localEpoch`
+    ///      (high) — which occupy the same 8 bytes as, and read identically to, the single `localEpoch(32)||
+    ///      localSequence(32)` word committed in a signed batch's `sequence` (see {getLocalEpochAndSequence}). Storing
+    ///      them split keeps the layout size-neutral (still one slot) while removing the pack/unpack math from the hot
+    ///      path. `localSequence` non-zero doubles as the account initialized flag — bootstrap writes it to 1 (epoch
+    ///      0), and it is never zeroed for a live account except by a {BumpLocalEpoch}, which simultaneously advances
+    ///      `localEpoch` (keeping the combined value non-zero).
     ///      `flags` is a bitfield: bit 0 (FLAG_REVOKE_DEFAULT_EOA) disables the k1 self key; bit 1 (FLAG_LOCKED)
     ///      freezes actor configuration; bit 2 (FLAG_UNLOCK_INITIATED) selects how `lockUnion` is interpreted.
     ///      `lockUnion` is a union field: while FLAG_UNLOCK_INITIATED is clear it holds the configured unlock delay
@@ -123,7 +126,8 @@ contract Keystore {
     ///      self-actorId); the two homes are mutually exclusive (see _authorizeActor).
     struct AccountState {
         uint64 multichainSequence; // 8 bytes
-        uint64 localSequence; // 8 bytes – also serves as initialized flag
+        uint32 localSequence; // 4 bytes – low half of the signed local word; non-zero also serves as initialized flag
+        uint32 localEpoch; // 4 bytes – high half of the signed local word
         uint8 flags; // 1 byte – bitfield: bit 0 REVOKE_DEFAULT_EOA, bit 1 LOCKED, bit 2 UNLOCK_INITIATED
         uint48 lockUnion; // 6 bytes – union: unlockDelay while UNLOCK_INITIATED clear, else unlocksAt (timestamp)
         uint48 defaultEOAExpiry; // 6 bytes – inline self k1 expiry (Unix seconds; 0 = no expiry)
@@ -244,12 +248,6 @@ contract Keystore {
     /// @param actorId The revoked actor's identifier.
     event ActorRevoked(address indexed account, bytes32 indexed actorId);
 
-    /// @notice Emitted when an expired actor's slot is garbage-collected (permissionlessly reclaimed).
-    ///
-    /// @param account The account whose expired actor slot was collected.
-    /// @param actorId The collected actor's identifier.
-    event ActorCollected(address indexed account, bytes32 indexed actorId);
-
     /// @notice Emitted when a new account is created.
     ///
     /// @param account The created account address.
@@ -325,11 +323,6 @@ contract Keystore {
     /// @notice The local epoch is at its terminal value and cannot be bumped.
     error EpochSaturated();
 
-    /// @notice A batch reduced a landed actor's authority (revoke, shorter expiry, or narrower scope) without also
-    ///         bumping the local epoch in the same batch. Reduction must retire the signatures that granted the
-    ///         authority; on the local channel that requires a BumpLocalEpoch.
-    error ReductionRequiresEpochBump();
-
     /// @notice An authority op (AuthorizeActor / RevokeActor) followed an environment op in the same batch, violating
     ///         the normative op ordering (authority ops first, environment ops last).
     error AuthorityOpAfterEnvOp();
@@ -357,9 +350,6 @@ contract Keystore {
     /// @notice A change payload did not match the shape required by its ChangeType (e.g. a non-empty payload on
     ///         BumpLocalEpoch / Unlock).
     error InvalidChangePayload();
-
-    /// @notice collectActor targeted an actor that is not present, or is present but not yet expired.
-    error CollectLiveActor();
 
     /// @notice The auth blob is shorter than the 20-byte authenticator selector prefix.
     error InvalidAuthLength();
@@ -549,18 +539,20 @@ contract Keystore {
     /// @notice The sole signed-change entry point: applies an ordered, atomic batch of account changes (authorize,
     ///         revoke, bump-local-epoch, lock, unlock) authenticated by `s.signature`.
     ///
-    /// @dev Two axioms govern the whole surface:
-    ///        1. Replay — a signed local change is valid only while it could still be validly applied: the committed
-    ///           local epoch must match, grants self-expire (`cfg.expiry > now`), and the state they commit to must
-    ///           still hold.
-    ///        2. Reduction — removing authority (revoke, shorter expiry, narrower scope) requires retiring the
-    ///           signatures that granted it. On the local channel that means the batch MUST also bump the epoch.
+    /// @dev The governing axiom is Replay: a signed local change is valid only while it could still be validly
+    ///      applied — the committed local epoch must match, grants self-expire (`cfg.expiry > now`), and (on the
+    ///      unsequenced channel) the state they commit to must still hold (extend-by-upsert monotonicity).
+    ///
+    ///      Reduction is NOT contract-enforced. Removing authority durably (revoke, shorter expiry, narrower scope)
+    ///      requires retiring the signatures that granted it, which on the local channel means a {BumpLocalEpoch};
+    ///      the contract lets a bare reduction land, so pairing it with a bump is a wallet responsibility. A bare
+    ///      revoke (or expiry cut) is not durable while a replayable unsequenced grant for that actor is outstanding.
     ///
     ///      Pipeline (in order): (1) split the sequence word; (2) reject a stale local epoch on both channels;
     ///      (3) validate/advance the sequence counter BEFORE apply (reentrancy discipline); (4) compute the digest
     ///      via the relocatable {_changesDigest} seam and authenticate; (5) iterate changes enforcing op ordering,
-    ///      per-op channel/sequencing policy, the lock policy, per-op authorization, and the solo rules; (6) at loop
-    ///      exit enforce the reduction rule. Anyone may relay — authorization comes entirely from the signature.
+    ///      per-op channel/sequencing policy, the lock policy, per-op authorization, and the solo rules. Anyone may
+    ///      relay — authorization comes entirely from the signature.
     ///
     /// @param account The account whose configuration is changed.
     /// @param s The signed batch (channel, ordered changes, sequence word, signature).
@@ -577,15 +569,13 @@ contract Keystore {
         if (isLocal) {
             uint32 epoch = uint32(s.sequence >> 32);
             uint32 seq = uint32(s.sequence);
-            uint32 storedEpoch = uint32(a.localSequence >> 32);
-            uint32 storedSeq = uint32(a.localSequence);
-            if (epoch != storedEpoch) revert StaleEpoch();
+            if (epoch != a.localEpoch) revert StaleEpoch();
             if (seq != UNSEQUENCED) {
                 sequenced = true;
-                if (seq != storedSeq) revert BadSequence();
+                if (seq != a.localSequence) revert BadSequence();
                 if (seq >= UNSEQUENCED - 1) revert SequenceSaturated();
-                // Advance the low half before apply, preserving the epoch in the high half.
-                a.localSequence = (uint64(storedEpoch) << 32) | uint64(seq + 1);
+                // Advance the local sequence before apply (the epoch is untouched by a sequenced batch).
+                a.localSequence = seq + 1;
             }
         } else {
             // Multichain: a plain monotonic counter, always sequenced, never epoch-bearing or UNSEQUENCED.
@@ -603,11 +593,8 @@ contract Keystore {
         // Lock policy is evaluated against the account's lock state at entry (lazily clearing an elapsed unlock).
         bool locked = _checkAndClearLock(account);
 
-        // (5)-(6) Iterate. Track: an environment op having been seen (ordering fence), whether a reduction occurred,
-        // and whether the batch bumped the epoch (satisfies the reduction rule).
+        // (5) Iterate. Track only whether an environment op has been seen, for the ordering fence.
         bool sawEnvOp;
-        bool needsBump;
-        bool hadBump;
         uint256 n = s.changes.length;
         for (uint256 i; i < n; i++) {
             ChangeType t = s.changes[i].changeType;
@@ -635,48 +622,17 @@ contract Keystore {
             if (t == ChangeType.BumpLocalEpoch && !sequenced && n != 1) revert SoloOpNotSolo();
 
             if (t == ChangeType.AuthorizeActor) {
-                needsBump = _applyAuthorize(account, sequenced, isLocal, s.changes[i].payload) || needsBump;
+                _applyAuthorize(account, sequenced, s.changes[i].payload);
             } else if (t == ChangeType.RevokeActor) {
-                needsBump = _applyRevoke(account, isLocal, s.changes[i].payload) || needsBump;
+                _applyRevoke(account, s.changes[i].payload);
             } else if (t == ChangeType.BumpLocalEpoch) {
                 _applyBumpLocalEpoch(account, isLocal, s.changes[i].payload);
-                hadBump = true;
             } else if (t == ChangeType.Lock) {
                 _applyLock(account, locked, s.changes[i].payload);
             } else {
                 // ChangeType.Unlock (the only remaining member; out-of-range values reverted at ABI-decode).
                 _applyUnlock(account, s.changes[i].payload);
             }
-        }
-
-        // Reduction rule: any authority reduction on the local channel must be batched with an epoch bump.
-        if (needsBump && !hadBump) revert ReductionRequiresEpochBump();
-    }
-
-    /// @notice Permissionlessly garbage-collects a single expired actor slot, zeroing it for a gas refund.
-    ///
-    /// @dev A slot may be collected iff it is present and its expiry has passed (`slot.expiry < block.timestamp`,
-    ///      i.e. {_isExpired}). Because expiry is monotone non-decreasing across a slot's life — the unsequenced
-    ///      path only extends it upward and any sequenced decrease is forced to retire outstanding signatures via a
-    ///      mandatory epoch bump — a lapsed slot has no live replayable signature, so collection is unconditional
-    ///      and needs no authorization. Reverts with CollectLiveActor when the slot is absent or not yet expired.
-    ///
-    /// @param account The account to collect from.
-    /// @param actorId The expired actor to collect.
-    function collectActor(address account, bytes32 actorId) public nonZeroAccount(account) {
-        (bool occupied,, uint48 expiry) = _rawSlot(account, actorId);
-        if (!occupied || !_isExpired(expiry)) revert CollectLiveActor();
-        _clearActor(account, actorId);
-        emit ActorCollected(account, actorId);
-    }
-
-    /// @notice Batch variant of {collectActor}: collects each of `actorIds` (all must be present and expired).
-    ///
-    /// @param account The account to collect from.
-    /// @param actorIds The expired actors to collect.
-    function collectActors(address account, bytes32[] calldata actorIds) external {
-        for (uint256 i; i < actorIds.length; i++) {
-            collectActor(account, actorIds[i]);
         }
     }
 
@@ -685,12 +641,14 @@ contract Keystore {
     // ----------------------------------------------------------------------------------------------------------------
 
     /// @dev AuthorizeActor. `payload = abi.encode(bytes32 actorId, ActorConfig cfg, bytes policyData)`; `cfg.expiry`
-    ///      is the granted expiry and the signature self-expires at it. Returns whether the op is a reduction that
-    ///      must be batched with an epoch bump (only ever true on the local channel).
-    function _applyAuthorize(address account, bool sequenced, bool isLocal, bytes calldata payload)
-        private
-        returns (bool needsBump)
-    {
+    ///      is the granted expiry and the signature self-expires at it.
+    ///
+    ///      Note on durability of reductions: a sequenced upsert may freely shorten a slot's expiry or narrow its
+    ///      scope, and the contract does NOT force a batching epoch bump. If an unsequenced (replayable) grant with
+    ///      the older, longer expiry / broader scope is still outstanding, it can be replayed to undo the reduction
+    ///      until the slot lapses or the caller separately bumps the epoch. Durable reduction is a wallet
+    ///      responsibility: batch the reducing op with a {BumpLocalEpoch} (which retires all unlanded local grants).
+    function _applyAuthorize(address account, bool sequenced, bytes calldata payload) private {
         (bytes32 actorId, ActorConfig memory cfg, bytes memory policyData) =
             abi.decode(payload, (bytes32, ActorConfig, bytes));
 
@@ -705,39 +663,32 @@ contract Keystore {
         if (!occupied) {
             // Empty slot: plain install. Both channels, both sequencing modes.
             _authorizeActor(account, actorId, cfg, policyData);
-            return false;
+            return;
         }
 
         // Occupied slot. Authenticator equality is structural: actorId derives from the authenticator, so a different
         // authenticator is a different slot (the empty-slot case above); no explicit check is needed here.
-        // Treat a stored no-expiry (0) as unbounded for monotonicity, so nothing can silently reduce an infinite grant.
-        uint48 effectiveOld = oldExpiry == 0 ? type(uint48).max : oldExpiry;
         if (!sequenced) {
-            // Unsequenced upsert: scope frozen, strictly-monotone-up expiry (extend-by-upsert).
+            // Unsequenced upsert is extend-by-upsert only: scope frozen, expiry strictly monotone up. This is the
+            // Replay defense for the unsequenced channel — re-applying a landed grant (same/lower expiry) must fail.
+            // Treat a stored no-expiry (0) as unbounded so an infinite grant cannot be silently re-applied.
+            uint48 effectiveOld = oldExpiry == 0 ? type(uint48).max : oldExpiry;
             if (cfg.scope != oldScope) revert ScopeChangeRequiresSequencing();
             if (chExpiry <= effectiveOld) revert NonMonotoneExpiry();
-            _authorizeActor(account, actorId, cfg, policyData);
-            return false;
         }
 
-        // Sequenced upsert: any expiry, any scope. A shorter expiry or a narrowed scope (cleared grant bits) is a
-        // reduction that must be batched with a bump — but only on the local channel; the multichain counter alone
-        // retires the prior signature, so it never sets the flag.
-        bool reduction = isLocal && (chExpiry < effectiveOld || (oldScope & ~cfg.scope) != 0);
+        // Sequenced upsert: any expiry, any scope (including a reduction). See the durability note above — the
+        // contract does not force a batching bump; that is left to the caller.
         _authorizeActor(account, actorId, cfg, policyData);
-        return reduction;
     }
 
     /// @dev RevokeActor. `payload = abi.encode(bytes32 actorId)`. Sequenced-only (enforced by the channel policy).
-    ///      Deleting a still-live actor is a reduction (needs a bump on the local channel); revoking an
-    ///      already-lapsed actor is equivalent to garbage collection and skips the flag (gated on the same
-    ///      expiry-vs-now comparison collectActor uses).
-    function _applyRevoke(address account, bool isLocal, bytes calldata payload) private returns (bool needsBump) {
+    ///      Clears the slot unconditionally. Note this alone is not durable against an outstanding replayable
+    ///      unsequenced grant for the same actorId (which would re-install into the emptied slot); to durably revoke,
+    ///      the caller batches a {BumpLocalEpoch}. This is a wallet responsibility, not contract-enforced.
+    function _applyRevoke(address account, bytes calldata payload) private {
         bytes32 actorId = abi.decode(payload, (bytes32));
-        (,, uint48 expiry) = _rawSlot(account, actorId);
-        bool lapsed = _isExpired(expiry);
         _revokeActor(account, actorId);
-        return isLocal && !lapsed;
     }
 
     /// @dev BumpLocalEpoch. Empty payload. Strict increment of the local epoch, resetting the local sequence to 0
@@ -746,11 +697,11 @@ contract Keystore {
         if (payload.length != 0) revert InvalidChangePayload();
         if (!isLocal) revert EpochOpRequiresLocalChannel();
         AccountState storage a = _accountState[account];
-        uint32 epoch = uint32(a.localSequence >> 32);
-        if (epoch >= type(uint32).max - 1) revert EpochSaturated();
+        if (a.localEpoch >= type(uint32).max - 1) revert EpochSaturated();
         unchecked {
-            a.localSequence = uint64(epoch + 1) << 32; // epoch += 1, sequence := 0
+            a.localEpoch += 1;
         }
+        a.localSequence = 0;
     }
 
     /// @dev Lock. `payload = abi.encode(uint16 unlockDelay)`. Only from the unlocked state; stores the delay.
@@ -816,8 +767,8 @@ contract Keystore {
         return (false, 0, 0);
     }
 
-    /// @dev Clears an actor's config and policy slots, disabling the inline k1 self for the self-actorId. Shared by
-    ///      {_revokeActor} (which additionally requires the actor be present) and {collectActor} (GC).
+    /// @dev Clears an actor's config and policy slots, disabling the inline k1 self for the self-actorId. Used by
+    ///      {_revokeActor} (which additionally requires the actor be present).
     function _clearActor(address account, bytes32 actorId) private {
         delete _actorConfig[actorId][account];
         delete _policyCommitment[actorId][account];
@@ -1043,7 +994,9 @@ contract Keystore {
     /// @return The account's ChangeSequences (multichain counter and the raw local epoch||sequence word).
     function getChangeSequences(address account) external view returns (ChangeSequences memory) {
         AccountState storage state = _accountState[account];
-        return ChangeSequences({multichain: state.multichainSequence, local: state.localSequence});
+        // Recompose the split storage fields into the single localEpoch(32, high)||localSequence(32, low) word.
+        uint64 local = (uint64(state.localEpoch) << 32) | uint64(state.localSequence);
+        return ChangeSequences({multichain: state.multichainSequence, local: local});
     }
 
     /// @notice Returns the account's local epoch and local sequence, split from the packed 64-bit word.
@@ -1053,8 +1006,8 @@ contract Keystore {
     /// @return epoch The account's current local epoch (high 32 bits of the local word).
     /// @return sequence The account's current local sequence (low 32 bits of the local word).
     function getLocalEpochAndSequence(address account) external view returns (uint32 epoch, uint32 sequence) {
-        uint64 word = _accountState[account].localSequence;
-        return (uint32(word >> 32), uint32(word));
+        AccountState storage state = _accountState[account];
+        return (state.localEpoch, state.localSequence);
     }
 
     /// @notice Returns whether the account is currently locked (configuration frozen).

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -341,9 +341,6 @@ contract Keystore {
     /// @notice A BumpLocalEpoch was submitted on the Multichain channel. The local epoch is a local-mode concept.
     error EpochOpRequiresLocalChannel();
 
-    /// @notice A solo-only op (Unlock always; BumpLocalEpoch when unsequenced) appeared in a multi-op batch.
-    error SoloOpNotSolo();
-
     /// @notice A change payload did not match the shape required by its ChangeType (e.g. a non-empty payload on
     ///         BumpLocalEpoch / Unlock).
     error InvalidChangePayload();
@@ -556,8 +553,8 @@ contract Keystore {
     ///      Pipeline (in order): (1) split the sequence word; (2) reject a stale local epoch on both channels;
     ///      (3) validate/advance the sequence counter BEFORE apply (reentrancy discipline); (4) compute the digest
     ///      via the relocatable {_changesDigest} seam, authenticate, and reject a non-admin signer; (5) iterate
-    ///      changes enforcing op ordering, the lock policy, and the solo rules. Anyone may relay — authorization
-    ///      comes entirely from the signature.
+    ///      changes enforcing op ordering and the lock policy. Anyone may relay — authorization comes entirely from
+    ///      the signature.
     ///
     /// @param account The account whose configuration is changed.
     /// @param s The signed batch (channel, ordered changes, sequence word, signature).
@@ -615,10 +612,6 @@ contract Keystore {
 
             // Lock policy: while the account is locked, only environment ops (bump/lock/unlock) may run.
             if (locked && !env) revert AccountIsLocked();
-
-            // Solo rules: Unlock is always solo; an unsequenced BumpLocalEpoch is solo.
-            if (t == ChangeType.Unlock && n != 1) revert SoloOpNotSolo();
-            if (t == ChangeType.BumpLocalEpoch && !sequenced && n != 1) revert SoloOpNotSolo();
 
             if (t == ChangeType.AuthorizeActor) {
                 _applyAuthorize(account, sequenced, s.changes[i].payload);
@@ -718,7 +711,7 @@ contract Keystore {
     }
 
     /// @dev Unlock. Empty payload. Only from the hard-locked state with no pending unlock; sets the effective
-    ///      unlock timestamp from the stored delay. Always a solo batch (enforced by the caller).
+    ///      unlock timestamp from the stored delay.
     function _applyUnlock(address account, bytes calldata payload) private {
         if (payload.length != 0) revert InvalidChangePayload();
         AccountState storage a = _accountState[account];

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -88,8 +88,8 @@ contract Keystore {
     /// @dev `changes` are applied in order, all-or-nothing (intersection-strict: any rejected op reverts the whole
     ///      batch). `sequence` is interpreted per `channel`:
     ///        - Local: localEpoch(32, high) || localSequence(32, low). A low half equal to {UNSEQUENCED} marks the
-    ///          batch as unsequenced (JIT) — it does not consume a sequence and only the both-channel ops are
-    ///          permitted; any other low value is a sequenced batch consumed against the account's localSequence.
+    ///          batch as unsequenced (JIT) — it does not consume a sequence (so it stays replayable until the epoch
+    ///          moves); any other low value is a sequenced batch consumed against the account's localSequence.
     ///        - Multichain: a plain uint64 consumed against the account's multichainSequence; never {UNSEQUENCED},
     ///          never carries an epoch.
     ///      `signature` is the standard authenticator(20) || authenticator-data blob authenticating the signer.
@@ -294,8 +294,8 @@ contract Keystore {
     /// @notice The signed chainId is neither 0 (multichain) nor the current chain.
     error InvalidChainId();
 
-    /// @notice The authenticated actor lacks the scope required to change actors.
-    error UnauthorizedActorChange();
+    /// @notice The batch signer is not the account admin (scope 0). Every signed account change is admin-only.
+    error UnauthorizedAccountChange();
 
     /// @notice The importAccount ERC-1271 signature check did not return the magic value.
     error InvalidImportSignature();
@@ -306,9 +306,6 @@ contract Keystore {
     /// @notice An unlock op was requested when the account was not in the hard-locked state (FLAG_LOCKED set,
     ///         FLAG_UNLOCK_INITIATED clear) — i.e. never locked, or an unlock was already initiated.
     error NotLocked();
-
-    /// @notice The authenticated actor lacks the scope required to change the lock state (admin only).
-    error UnauthorizedLockChange();
 
     /// @notice The batch's committed local epoch does not match the account's current local epoch: every unlanded
     ///         local signature at a prior epoch is dead. Applies to both the sequenced and unsequenced channels.
@@ -548,11 +545,15 @@ contract Keystore {
     ///      the contract lets a bare reduction land, so pairing it with a bump is a wallet responsibility. A bare
     ///      revoke (or expiry cut) is not durable while a replayable unsequenced grant for that actor is outstanding.
     ///
+    ///      Authorization is flat: every signed account change is admin-only, so a single up-front scope check
+    ///      (signer scope must be 0) authorizes the whole batch — there is no per-op authorization and no per-op
+    ///      sequencing restriction (any op may ride an unsequenced or sequenced batch).
+    ///
     ///      Pipeline (in order): (1) split the sequence word; (2) reject a stale local epoch on both channels;
     ///      (3) validate/advance the sequence counter BEFORE apply (reentrancy discipline); (4) compute the digest
-    ///      via the relocatable {_changesDigest} seam and authenticate; (5) iterate changes enforcing op ordering,
-    ///      per-op channel/sequencing policy, the lock policy, per-op authorization, and the solo rules. Anyone may
-    ///      relay — authorization comes entirely from the signature.
+    ///      via the relocatable {_changesDigest} seam, authenticate, and reject a non-admin signer; (5) iterate
+    ///      changes enforcing op ordering, the lock policy, and the solo rules. Anyone may relay — authorization
+    ///      comes entirely from the signature.
     ///
     /// @param account The account whose configuration is changed.
     /// @param s The signed batch (channel, ordered changes, sequence word, signature).
@@ -586,9 +587,11 @@ contract Keystore {
             a.multichainSequence = seq + 1;
         }
 
-        // (4) Authenticate over the relocatable digest.
+        // (4) Authenticate over the relocatable digest. Authorization is flat: every signed account change is
+        // admin-only, so a single scope check up front replaces any per-op authorization.
         bytes32 digest = _changesDigest(account, s.channel, s.sequence, s.changes);
         (, uint16 scope) = authenticateActor(account, digest, s.signature);
+        if (scope != 0) revert UnauthorizedAccountChange();
 
         // Lock policy is evaluated against the account's lock state at entry (lazily clearing an elapsed unlock).
         bool locked = _checkAndClearLock(account);
@@ -604,18 +607,8 @@ contract Keystore {
             if (!env && sawEnvOp) revert AuthorityOpAfterEnvOp();
             if (env) sawEnvOp = true;
 
-            // Sequencing (channel) policy: RevokeActor, Lock, Unlock are sequenced-only; AuthorizeActor and
-            // BumpLocalEpoch are permitted on both. (Multichain is always sequenced.)
-            if (!_sequencingAllowed(t, sequenced)) revert BadSequence();
-
             // Lock policy: while the account is locked, only environment ops (bump/lock/unlock) may run.
             if (locked && !env) revert AccountIsLocked();
-
-            // Per-op authorization fence against the recovered signer's scope.
-            if (!_opAuthorized(t, scope)) {
-                if (t == ChangeType.Lock || t == ChangeType.Unlock) revert UnauthorizedLockChange();
-                revert UnauthorizedActorChange();
-            }
 
             // Solo rules: Unlock is always solo; an unsequenced BumpLocalEpoch is solo.
             if (t == ChangeType.Unlock && n != 1) revert SoloOpNotSolo();
@@ -682,10 +675,10 @@ contract Keystore {
         _authorizeActor(account, actorId, cfg, policyData);
     }
 
-    /// @dev RevokeActor. `payload = abi.encode(bytes32 actorId)`. Sequenced-only (enforced by the channel policy).
-    ///      Clears the slot unconditionally. Note this alone is not durable against an outstanding replayable
-    ///      unsequenced grant for the same actorId (which would re-install into the emptied slot); to durably revoke,
-    ///      the caller batches a {BumpLocalEpoch}. This is a wallet responsibility, not contract-enforced.
+    /// @dev RevokeActor. `payload = abi.encode(bytes32 actorId)`. Clears the slot unconditionally. Note this alone is
+    ///      not durable against an outstanding replayable unsequenced grant for the same actorId (which would
+    ///      re-install into the emptied slot); to durably revoke, the caller batches a {BumpLocalEpoch}. This is a
+    ///      wallet responsibility, not contract-enforced.
     function _applyRevoke(address account, bytes calldata payload) private {
         bytes32 actorId = abi.decode(payload, (bytes32));
         _revokeActor(account, actorId);
@@ -735,19 +728,6 @@ contract Keystore {
     /// @dev Enum-ordering-as-classification: an environment op mutates the rules ops are checked against.
     function _isEnvOp(ChangeType t) private pure returns (bool) {
         return t >= ChangeType.BumpLocalEpoch;
-    }
-
-    /// @dev Sequencing (channel) policy: RevokeActor, Lock and Unlock require a sequenced batch; AuthorizeActor and
-    ///      BumpLocalEpoch are permitted on both the sequenced and unsequenced channels.
-    function _sequencingAllowed(ChangeType t, bool sequenced) private pure returns (bool) {
-        if (t == ChangeType.AuthorizeActor || t == ChangeType.BumpLocalEpoch) return true;
-        return sequenced;
-    }
-
-    /// @dev Per-op authorization against the recovered signer's scope. Only the admin (scope 0) may perform any
-    ///      signed change; every scoped (non-zero) actor is rejected for all ops, including Unlock.
-    function _opAuthorized(ChangeType, uint16 scope) private pure returns (bool) {
-        return scope == 0;
     }
 
     /// @dev Reads an actor's raw stored slot IGNORING expiry (structural presence): a populated _actorConfig entry

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.36;
 
+import {ActorId} from "./libraries/ActorId.sol";
 import {IAuthenticator} from "./interfaces/IAuthenticator.sol";
 import {Scopes} from "./libraries/Scopes.sol";
 
@@ -119,7 +120,7 @@ contract Keystore {
     ///      `lockUnion` is a union field: while FLAG_UNLOCK_INITIATED is clear it holds the configured unlock delay
     ///      (seconds, uint16 range); while set it holds unlocksAt (the timestamp at which the unlock takes effect).
     ///      The defaultEOA* fields are the inline home for the account's own secp256k1 ("self") key — the actor whose
-    ///      actorId is bytes32(bytes20(account)). When FLAG_REVOKE_DEFAULT_EOA is unset, a k1 signature recovering to
+    ///      actorId is the account address right-aligned (ActorId.fromAddress). When FLAG_REVOKE_DEFAULT_EOA is unset, a k1 signature recovering to
     ///      the account authenticates with this inline config (all-zero = full owner; non-zero scope/expiry = a
     ///      scoped self key), resolved in a single SLOAD. Policy gating (when scope & Scopes.POLICY != 0) is still keyed
     ///      by actorId in the shared _policyManager/_policyCommitment keyspace. The separate _actorConfig[self][account]
@@ -1066,7 +1067,7 @@ contract Keystore {
     {
         // Reject the zero actorId: it is not a usable identifier (the tx-context precompile surfaces the zero id as
         // "no actor"), and every real actorId — derived from keccak(authenticator || salt), or the non-zero self
-        // (bytes32(bytes20(account))) — is non-zero. Bootstrap already rejects it via the strictly-ascending-from-zero
+        // (the account address right-aligned) — is non-zero. Bootstrap already rejects it via the strictly-ascending-from-zero
         // sort; this guards the signed AuthorizeActor path.
         if (actorId == bytes32(0)) revert InvalidActorId();
 
@@ -1341,7 +1342,7 @@ contract Keystore {
             return (_selfActorId(account), st.defaultEOAScope);
         }
 
-        bytes32 actorId = bytes32(bytes20(recovered));
+        bytes32 actorId = ActorId.fromAddress(recovered);
         return (actorId, _resolveExplicitActor(account, actorId, K1_AUTHENTICATOR));
     }
 
@@ -1350,10 +1351,10 @@ contract Keystore {
         return _accountState[account].flags & FLAG_REVOKE_DEFAULT_EOA != 0;
     }
 
-    /// @dev The account's implicit self-actorId: the address left-aligned into the high 20 bytes
-    ///      (`bytes32(bytes20(account))`), matching the normative self derivation. Non-zero for any valid account.
+    /// @dev The account's implicit self-actorId: the account address right-aligned into a 32-byte word
+    ///      (`ActorId.fromAddress`), matching the normative self derivation. Non-zero for any valid account.
     function _selfActorId(address account) internal pure returns (bytes32) {
-        return bytes32(bytes20(account));
+        return ActorId.fromAddress(account);
     }
 
     /// @dev True when `expiry` is set (non-zero) and has passed. A zero expiry means no expiry.

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -309,8 +309,7 @@ contract Keystore {
     ///         FLAG_UNLOCK_INITIATED clear) — i.e. never locked, or an unlock was already initiated.
     error NotLocked();
 
-    /// @notice The authenticated actor lacks the scope required to change the lock state (admin, or a recovery-class
-    ///         actor for Unlock).
+    /// @notice The authenticated actor lacks the scope required to change the lock state (admin only).
     error UnauthorizedLockChange();
 
     /// @notice The batch's committed local epoch does not match the account's current local epoch: every unlanded
@@ -794,11 +793,10 @@ contract Keystore {
         return sequenced;
     }
 
-    /// @dev Per-op authorization against the recovered signer's scope. Admin (scope 0) may perform every op; a
-    ///      recovery-class actor (Scopes.RECOVERY) may only initiate an Unlock and nothing else (the second fence).
-    function _opAuthorized(ChangeType t, uint16 scope) private pure returns (bool) {
-        if (scope == 0) return true;
-        return t == ChangeType.Unlock && (scope & Scopes.RECOVERY != 0);
+    /// @dev Per-op authorization against the recovered signer's scope. Only the admin (scope 0) may perform any
+    ///      signed change; every scoped (non-zero) actor is rejected for all ops, including Unlock.
+    function _opAuthorized(ChangeType, uint16 scope) private pure returns (bool) {
+        return scope == 0;
     }
 
     /// @dev Reads an actor's raw stored slot IGNORING expiry (structural presence): a populated _actorConfig entry

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -137,12 +137,14 @@ contract Keystore {
     ///      (0x1626ba7e); used both to build the import staticcall and to validate its result.
     bytes4 internal constant ERC1271_SELECTOR = bytes4(keccak256("isValidSignature(bytes32,bytes)"));
 
-    /// @notice Typehash binding an importAccount signature to its salt, chainId, and initial actor set.
+    /// @notice Typehash binding an importAccount signature to its accountId, chainId, and initial actor set.
     ///
-    /// @dev NOT compliant with EIP-712, to mitigate eth_signTypedData phishing. `chainId` is either the current chain
-    ///      or 0 for a multichain import. Initial actors are hashed structurally below.
+    /// @dev NOT compliant with EIP-712, to mitigate eth_signTypedData phishing. `accountId` is the importing account's
+    ///      right-aligned address (`ActorId.fromAddress(account)`), binding the digest to that account so it cannot be
+    ///      replayed against another. `chainId` is either the current chain or 0 for a multichain import. Initial
+    ///      actors are hashed structurally below.
     bytes32 public constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
-        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
+        "ActorInitialization(bytes32 accountId,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
     );
 
     /// @notice Typehash used to structurally hash each Actor within an ActorInitialization import digest.
@@ -1254,8 +1256,9 @@ contract Keystore {
     }
 
     /// @dev Typed digest for the importAccount ERC-1271 signature (a signed message), so signers can reproduce it
-    ///      with standard EIP-712-style struct hashing. `salt` is bound to the account address and the digest is
-    ///      bound to `chainId` (0 = multichain) so its replay domain matches applySignedAccountChanges.
+    ///      with standard EIP-712-style struct hashing. `accountId` is the account's right-aligned address
+    ///      (`ActorId.fromAddress(account)`) and the digest is bound to `chainId` (0 = multichain) so its replay
+    ///      domain matches applySignedAccountChanges.
     function _computeImportDigest(address account, uint256 chainId, InitialActor[] calldata initialActors)
         private
         pure

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -618,7 +618,10 @@ contract Keystore {
         }
 
         // Authority ops use the lock state at batch entry. Local-only changes reject the Multichain channel; Lock and
-        // Unlock are also standalone.
+        // Unlock are also standalone. That standalone rule is what makes this entry snapshot EXACT for the whole batch:
+        // the only ops that mutate lock state (Lock/Unlock) can never share a batch with an authority op, so no op
+        // observes a lock state that a peer changed mid-loop. Relaxing standalone re-opens snapshot staleness — a later
+        // authority op could then run against a lock a Lock earlier in the same batch just set (or a stale-unlocked one).
         bool locked = _isLocked(a);
 
         uint256 n = s.changes.length;
@@ -1274,7 +1277,7 @@ contract Keystore {
         return keccak256(
             abi.encode(
                 ACTOR_INITIALIZATION_TYPEHASH,
-                bytes32(bytes20(account)),
+                ActorId.fromAddress(account),
                 chainId,
                 keccak256(abi.encodePacked(actorHashes))
             )

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -325,7 +325,8 @@ contract Keystore {
     ///         the normative op ordering (authority ops first, environment ops last).
     error AuthorityOpAfterEnvOp();
 
-    /// @notice An AuthorizeActor's granted expiry is not strictly in the future (self-expired on arrival).
+    /// @notice An AuthorizeActor's granted expiry is non-zero and not strictly in the future (self-expired on
+    ///         arrival). A zero expiry is the "no expiry" sentinel and is accepted.
     error ExpiredChange();
 
     /// @notice A BumpLocalEpoch was submitted on the Multichain channel. The local epoch is a local-mode concept.
@@ -528,8 +529,8 @@ contract Keystore {
     ///         revoke, bump-local-epoch, lock, unlock) authenticated by `s.signature`.
     ///
     /// @dev The governing axiom is Replay: a signed local change is valid only while it could still be validly
-    ///      applied — the committed local epoch must match, grants self-expire (`cfg.expiry > now`), and (on the
-    ///      unsequenced channel) the state they commit to must still hold (extend-by-upsert monotonicity).
+    ///      applied — the committed local epoch must match and grants self-expire (`cfg.expiry > now`, unless
+    ///      `cfg.expiry == 0` which is the never-expiring sentinel).
     ///
     ///      Reduction is NOT contract-enforced. Removing authority durably (revoke, shorter expiry, narrower scope)
     ///      requires retiring the signatures that granted it, which on the local channel means a {BumpLocalEpoch};
@@ -623,8 +624,9 @@ contract Keystore {
     // ----------------------------------------------------------------------------------------------------------------
 
     /// @dev AuthorizeActor. `payload = abi.encode(bytes32 actorId, ActorConfig cfg, bytes policyData)`; `cfg.expiry`
-    ///      is the granted expiry and the signature self-expires at it. A plain upsert on both channels and both
-    ///      sequencing modes — the only gate is that the grant be strictly in the future (self-expiring). An
+    ///      is the granted expiry and the signature self-expires at it (or never, if `cfg.expiry == 0`). A plain
+    ///      upsert on both channels and both sequencing modes — the only gate is that a non-zero expiry be in the
+    ///      future. An
     ///      unsequenced grant is replayable (it consumes no counter) and last-write-wins on its slot until the grant
     ///      lapses or the epoch is bumped; durable reduction (revoke, shorter expiry, narrower scope) is therefore a
     ///      wallet responsibility — batch the reducing op with a {BumpLocalEpoch} to retire outstanding grants.
@@ -632,8 +634,9 @@ contract Keystore {
         (bytes32 actorId, ActorConfig memory cfg, bytes memory policyData) =
             abi.decode(payload, (bytes32, ActorConfig, bytes));
 
-        // The grant must be strictly in the future (a zero/past expiry is caught here: 0 <= now).
-        if (cfg.expiry <= block.timestamp) revert ExpiredChange();
+        // A grant must not be already-expired: reject a non-zero expiry that is not strictly in the future. A zero
+        // expiry is the canonical "no expiry" sentinel (unlimited, per {ActorConfig}) and is accepted.
+        if (cfg.expiry != 0 && cfg.expiry <= block.timestamp) revert ExpiredChange();
 
         _authorizeActor(account, actorId, cfg, policyData);
     }

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -20,7 +20,7 @@ contract Keystore {
     struct ChangeSequences {
         uint64 multichain; // chain_id 0 (multichain channel)
         uint32 localEpoch; // local channel epoch; incremented by IncrementLocalEpoch, invalidates unlanded local signatures
-        uint32 localSequence; // local channel counter; starts at 1 once initialized (created/imported), 0 = uninitialized
+        uint32 localSequence; // current local counter; reset to 0 by IncrementLocalEpoch
     }
 
     /// @notice An actor's authorization: authenticator, expiry, and scope. Field order matches the normative
@@ -51,29 +51,25 @@ contract Keystore {
 
     /// @notice The operation an {AccountChange} applies within an {applySignedAccountChanges} batch.
     ///
-    /// @dev ABI-encodes as uint8. Members split into two conceptual classes: *authority ops* (AuthorizeActor,
-    ///      RevokeActor) mutate who can act — the actor set — and are rejected while the account is locked; *environment
-    ///      ops* (IncrementLocalEpoch, Lock, Unlock) mutate the rules ops are checked against — the local epoch or the
-    ///      lock — and remain permitted while locked. This class distinction drives only the per-op lock gate; op order
-    ///      within a batch is otherwise unconstrained (authority and environment ops commute). All five values are
-    ///      reachable and meaningful; out-of-range wire values (>= 5) can never reach the handler — the enum decoder
-    ///      reverts them while ABI-decoding the calldata (no in-handler "unknown" sentinel, unlike the pre-split enums).
+    /// @dev ABI-encodes as uint8. Authority ops (AuthorizeActor, RevokeActor) are rejected while locked. Environment
+    ///      ops enforce their own lock preconditions; Lock and Unlock are Local-only and must each be the batch's only
+    ///      op.
     enum ChangeType {
         // Authority ops (mutate who can act).
         AuthorizeActor, // payload: abi.encode(bytes32 actorId, ActorConfig cfg, bytes policyData); cfg.expiry is the granted expiry
         RevokeActor, // payload: abi.encode(bytes32 actorId)
         // Environment ops (mutate the rules ops are checked against).
-        IncrementLocalEpoch, // payload: empty (length == 0 enforced)
-        Lock, // payload: abi.encode(uint16 unlockDelay)
-        Unlock // payload: empty (length == 0 enforced)
+        IncrementLocalEpoch, // Local only; payload: empty (length == 0 enforced)
+        Lock, // Local only; payload: abi.encode(uint16 unlockDelay)
+        Unlock // Local only; payload: empty (length == 0 enforced)
     }
 
     /// @notice The replay domain a {SignedAccountChanges} batch is bound to.
     ///
     /// @dev Replaces the prior `uint256 chainId` argument. {Local} binds `block.chainid` and carries the full local
     ///      epoch machinery (see {SignedAccountChanges.sequence}); {Multichain} binds chainId 0 and keeps a plain
-    ///      monotonic counter with no epochs and no unsequenced (JIT) mode — its counter alone prevents replay, so
-    ///      it never requires an epoch increment and {IncrementLocalEpoch} is rejected on it.
+    ///      monotonic counter with no epochs and no unsequenced (JIT) mode. {IncrementLocalEpoch}, {Lock}, and
+    ///      {Unlock} are rejected on the Multichain channel.
     enum AccountChangeChannel {
         Local,
         Multichain
@@ -111,24 +107,20 @@ contract Keystore {
     ///      The local replay counter is stored as two adjacent uint32 fields — `localSequence` (low) then `localEpoch`
     ///      (high) — which occupy the same 8 bytes as, and read identically to, the single `localEpoch(32)||
     ///      localSequence(32)` word committed in a signed batch's `sequence` (see {getChangeSequences}). Storing
-    ///      them split keeps the layout size-neutral (still one slot) while removing the pack/unpack math from the hot
-    ///      path. `localSequence` non-zero doubles as the account initialized flag — bootstrap writes it to 1 (epoch
-    ///      0), and it is never zeroed for a live account except by a {IncrementLocalEpoch}, which simultaneously advances
-    ///      `localEpoch` (keeping the combined value non-zero).
-    ///      `flags` is a bitfield: bit 0 (FLAG_REVOKE_DEFAULT_EOA) disables the k1 self key; bit 1 (FLAG_LOCKED)
-    ///      freezes actor configuration; bit 2 (FLAG_UNLOCK_INITIATED) selects how `lockUnion` is interpreted.
-    ///      `lockUnion` is a union field: while FLAG_UNLOCK_INITIATED is clear it holds the configured unlock delay
-    ///      (seconds, uint16 range); while set it holds unlocksAt (the timestamp at which the unlock takes effect).
-    ///      The defaultEOA* fields are the inline home for the account's own secp256k1 ("self") key — the actor whose
-    ///      actorId is the account address right-aligned (ActorId.fromAddress). When FLAG_REVOKE_DEFAULT_EOA is unset, a k1 signature recovering to
-    ///      the account authenticates with this inline config (all-zero = full owner; non-zero scope/expiry = a
+    ///      them split keeps the layout size-neutral (still one slot) while removing pack/unpack math from the hot path.
+    ///      The combined local word marks local initialization; the multichain counter covers global-only activity.
+    ///      {IncrementLocalEpoch} resets the sequence while keeping the combined local word non-zero.
+    ///      See {FLAG_REVOKE_DEFAULT_EOA}, {FLAG_LOCKED}, and {FLAG_UNLOCK_INITIATED} for `flags` and `lockUnion`.
+    ///      The defaultEOA* fields are the inline home for the account's own secp256k1 ("self") key, whose actorId is
+    ///      `ActorId.fromAddress(account)`. When FLAG_REVOKE_DEFAULT_EOA is unset, a k1 signature recovering to the
+    ///      account authenticates with this inline config (all-zero = full owner; non-zero scope/expiry = a
     ///      scoped self key), resolved in a single SLOAD. Policy gating (when scope & Scopes.POLICY != 0) is still keyed
     ///      by actorId in the shared _policyManager/_policyCommitment keyspace. The separate _actorConfig[self][account]
     ///      slot is reserved for a *non-k1* self authenticator (e.g. a post-quantum verifier returning the
     ///      self-actorId); the two homes are mutually exclusive (see _authorizeActor).
     struct AccountState {
         uint64 multichainSequence; // 8 bytes
-        uint32 localSequence; // 4 bytes – low half of the signed local word; non-zero also serves as initialized flag
+        uint32 localSequence; // 4 bytes – low half of the signed local word
         uint32 localEpoch; // 4 bytes – high half of the signed local word
         uint8 flags; // 1 byte – bitfield: bit 0 REVOKE_DEFAULT_EOA, bit 1 LOCKED, bit 2 UNLOCK_INITIATED
         uint48 lockUnion; // 6 bytes – union: unlockDelay while UNLOCK_INITIATED clear, else unlocksAt (timestamp)
@@ -147,9 +139,8 @@ contract Keystore {
 
     /// @notice Typehash binding an importAccount signature to its salt, chainId, and initial actor set.
     ///
-    /// @dev NOT compliant with EIP-712, to mitigate eth_signTypedData phishing. Bound to the current chainId so an
-    ///      import signature cannot be replayed on another chain. Initial actors are hashed structurally via
-    ///      ACTOR_TYPEHASH / ACTOR_CONFIG_TYPEHASH below.
+    /// @dev NOT compliant with EIP-712, to mitigate eth_signTypedData phishing. `chainId` is either the current chain
+    ///      or 0 for a multichain import. Initial actors are hashed structurally below.
     bytes32 public constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
         "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
     );
@@ -179,8 +170,8 @@ contract Keystore {
 
     /// @notice Local-channel sequence low-half sentinel marking an unsequenced (JIT) batch. A {SignedAccountChanges}
     ///         whose low 32 bits equal this value does not consume a sequence, so it stays replayable until the local
-    ///         epoch moves; any op type may ride it (see {applySignedAccountChanges}). Sequenced batches may therefore
-    ///         run up to UNSEQUENCED - 2.
+    ///         epoch moves. Any op may use it, but Lock and Unlock must remain standalone. Sequenced batches may run up
+    ///         to UNSEQUENCED - 2.
     uint32 public constant UNSEQUENCED = type(uint32).max;
 
     // ----------------------------------------------------------------------------------------------------------------
@@ -217,9 +208,8 @@ contract Keystore {
     ///         clears it (re-enabling the inline self, possibly scoped).
     uint8 public constant FLAG_REVOKE_DEFAULT_EOA = 0x01;
 
-    /// @notice AccountState.flags bit (spec `LOCKED`): when set, actor configuration is frozen — only environment
-    ///         ops (IncrementLocalEpoch, Lock, Unlock) are permitted through applySignedAccountChanges; authority ops
-    ///         (AuthorizeActor, RevokeActor) are rejected. Cleared lazily once an initiated unlock elapses.
+    /// @notice AccountState.flags bit (spec `LOCKED`): identifies a lock record. The account is frozen unless an
+    ///         initiated unlock's timestamp has elapsed; expired lock bits remain until a later Lock overwrites them.
     uint8 public constant FLAG_LOCKED = 0x02;
 
     /// @notice AccountState.flags bit (spec `UNLOCK_INITIATED`): selects how the packed `lockUnion` field is read.
@@ -311,7 +301,7 @@ contract Keystore {
     error NotLocked();
 
     /// @notice The batch's committed local epoch does not match the account's current local epoch: every unlanded
-    ///         local signature at a prior epoch is dead. Applies to both the sequenced and unsequenced channels.
+    ///         local signature at a prior epoch is dead. Applies to sequenced and unsequenced Local batches.
     error StaleEpoch();
 
     /// @notice A sequenced batch's sequence did not match the account's current (local or multichain) counter.
@@ -327,8 +317,8 @@ contract Keystore {
     ///         arrival). A zero expiry is the "no expiry" sentinel and is accepted.
     error ExpiredChange();
 
-    /// @notice A IncrementLocalEpoch was submitted on the Multichain channel. The local epoch is a local-mode concept.
-    error EpochOpRequiresLocalChannel();
+    /// @notice A local-only change (IncrementLocalEpoch, Lock, or Unlock) was submitted on the Multichain channel.
+    error ChangeRequiresLocalChannel();
 
     /// @notice A change payload did not match the shape required by its ChangeType (e.g. a non-empty payload on
     ///         IncrementLocalEpoch / Unlock).
@@ -338,7 +328,7 @@ contract Keystore {
     ///         initialize a fresh account without altering any configuration.
     error EmptyChangeSet();
 
-    /// @notice An AuthorizeActor targeted the zero actorId, which is not a usable actor identifier.
+    /// @notice An actor authorization targeted the zero actorId, which is not a usable actor identifier.
     error InvalidActorId();
 
     /// @notice A Lock or Unlock appeared in a batch alongside other changes. Lock/unlock must be the sole change in
@@ -387,9 +377,7 @@ contract Keystore {
     error BytecodeTooLarge();
 
     /// @notice createAccount was called with empty deployment bytecode.
-    /// @dev Zero-length runtime code would leave a Keystore-initialized address with no code. On 8130 chains that
-    ///      looks like an EOA that removed its EIP-7702 delegation, breaking the invariant
-    ///      isEOA = (7702-delegated) || (no code).
+    /// @dev Prevents creating a Keystore-initialized account with no runtime code.
     error EmptyBytecode();
 
     /// @notice CREATE2 did not deploy code at the expected account address (e.g. bytecode too large per EIP-170,
@@ -422,14 +410,18 @@ contract Keystore {
     /// @notice Modifier to check if an account is unlocked.
     /// @dev Reverts with AccountIsLocked when the account is locked.
     modifier onlyUnlocked(address account) {
-        if (_isLocked(account)) revert AccountIsLocked();
+        if (_isLocked(account)) {
+            revert AccountIsLocked();
+        }
         _;
     }
 
     /// @notice Modifier to check if an account is not the zero address.
     /// @dev Reverts with ZeroAccount when the account is the zero address.
     modifier nonZeroAccount(address account) {
-        if (account == address(0)) revert ZeroAccount();
+        if (account == address(0)) {
+            revert ZeroAccount();
+        }
         _;
     }
 
@@ -467,12 +459,12 @@ contract Keystore {
         // Block re-initialization of an already-bootstrapped account. This must be explicit: authorizeActor is now an
         // upsert (no duplicate-actor revert) and the create2 below is intentionally swallowed (pop), so a duplicate
         // createAccount would otherwise silently re-initialize.
-        if (_isInitialized(account)) revert AlreadyInitialized();
+        if (_isInitialized(account)) {
+            revert AlreadyInitialized();
+        }
 
-        // Mark initialized (localSequence = 1) and disable the implicit default-EOA path. A created account has code
-        // at its CREATE2 address, so the recovered==account owner path is unreachable; default it off (canonically
-        // ECDSA-owner-free / quantum-safe), folded into the same slot write. Set *before* initializing actors so a
-        // self-actorId k1 initial actor can re-enable the inline self (parity with import).
+        // Created accounts disable the implicit EOA key. Set this before actor initialization so an explicit k1 self
+        // actor can re-enable it.
         _accountState[account].localSequence = 1;
         _accountState[account].flags = FLAG_REVOKE_DEFAULT_EOA;
 
@@ -480,12 +472,15 @@ contract Keystore {
 
         // Deploy at the derived address. create2 returns address(0) on failure (EIP-170 size, EIP-3541 leading 0xEF,
         // or out of gas); reverting on mismatch unwinds every state write above, so a failed deploy can never leave
-        // an initialized-but-codeless account behind.
+        // an initialized-but-codeless account behind. Assembly is required because Solidity has no high-level
+        // equivalent for CREATE2 over arbitrary prepared initcode.
         address deployed;
         assembly ("memory-safe") {
             deployed := create2(0, add(deploymentCode, 0x20), mload(deploymentCode), effectiveSalt)
         }
-        if (deployed != account) revert AccountDeploymentFailed();
+        if (deployed != account) {
+            revert AccountDeploymentFailed();
+        }
         emit AccountCreated(account, userSalt, keccak256(bytecode));
     }
 
@@ -512,10 +507,14 @@ contract Keystore {
         InitialActor[] calldata initialActors,
         bytes calldata signature
     ) external onlyUnlocked(account) {
-        if (chainId != 0 && chainId != block.chainid) revert InvalidChainId();
+        if (chainId != 0 && chainId != block.chainid) {
+            revert InvalidChainId();
+        }
 
         // Import is a one-time bootstrap for accounts with no 8130 state yet.
-        if (_isInitialized(account)) revert AlreadyInitialized();
+        if (_isInitialized(account)) {
+            revert AlreadyInitialized();
+        }
         _accountState[account].localSequence = 1;
 
         bytes32 digest = _computeImportDigest(account, chainId, initialActors);
@@ -525,11 +524,8 @@ contract Keystore {
             revert InvalidImportSignature();
         }
 
-        // Disable the implicit default-EOA path (parity with createAccount). Set *after* the ERC-1271 check: for an
-        // EIP-7702 delegated EOA its own k1 signature (the implicit full owner) is the only authenticator available
-        // at import time, so it must stay live for that check. An owner who wants to keep using the key can include
-        // the self-actorId as an explicit k1 actor in initialActors (still a full owner, now via its config), or
-        // re-enable it later. Folds into the same slot as localSequence.
+        // Disable the implicit EOA key after ERC-1271 validation so a delegated EOA can use that key to authorize its
+        // import. Including the k1 self in initialActors re-enables it explicitly.
         _accountState[account].flags = FLAG_REVOKE_DEFAULT_EOA;
 
         _initializeAccount(account, initialActors);
@@ -550,13 +546,15 @@ contract Keystore {
     ///
     ///      Authorization is flat: every signed account change is admin-only, so a single up-front scope check
     ///      (signer scope must be 0) authorizes the whole batch — there is no per-op authorization and no per-op
-    ///      sequencing restriction (any op may ride an unsequenced or sequenced batch).
+    ///      sequencing restriction. IncrementLocalEpoch, Lock, and Unlock are Local-only; Lock and Unlock must also be
+    ///      standalone. Other ops may share a non-empty batch.
     ///
-    ///      Pipeline (in order): (1) split the sequence word; (2) reject a stale local epoch on both channels;
+    ///      Pipeline (in order): (1) split the sequence word; (2) reject a stale epoch on Local batches;
     ///      (3) validate/advance the sequence counter BEFORE apply (reentrancy discipline); (4) compute the digest
     ///      via the relocatable {_changesDigest} seam, authenticate, and reject a non-admin signer; (5) iterate
-    ///      changes enforcing the lock policy (authority ops rejected while the account is locked; Lock/Unlock must be
-    ///      standalone). Anyone may relay — authorization comes entirely from the signature.
+    ///      changes enforcing channel and lock policy (local-only changes rejected on Multichain; authority ops
+    ///      rejected while the account is locked; Lock/Unlock must be standalone). Anyone may relay — authorization
+    ///      comes entirely from the signature.
     ///
     /// @param account The account whose configuration is changed.
     /// @param s The signed batch (channel, ordered changes, sequence word, signature).
@@ -569,17 +567,25 @@ contract Keystore {
 
         // Reject an empty batch: a no-op signed change would otherwise consume a sequence (or initialize a fresh
         // account, below) without altering any configuration.
-        if (s.changes.length == 0) revert EmptyChangeSet();
+        if (s.changes.length == 0) {
+            revert EmptyChangeSet();
+        }
 
         // Epoch / sequence gate. An unsequenced (JIT) batch exists only on the local channel (low half ==
         // UNSEQUENCED) and does not consume a counter; every other batch consumes its channel's counter.
         if (isLocal) {
             uint32 epoch = uint32(s.sequence >> 32);
             uint32 seq = uint32(s.sequence);
-            if (epoch != a.localEpoch) revert StaleEpoch();
+            if (epoch != a.localEpoch) {
+                revert StaleEpoch();
+            }
             if (seq != UNSEQUENCED) {
-                if (seq != a.localSequence) revert BadSequence();
-                if (seq >= UNSEQUENCED - 1) revert SequenceSaturated();
+                if (seq != a.localSequence) {
+                    revert BadSequence();
+                }
+                if (seq >= UNSEQUENCED - 1) {
+                    revert SequenceSaturated();
+                }
                 // Advance the local sequence before apply — checks-effects-before-interactions ahead of the
                 // authenticator STATICCALL below. (authenticateActor is `view`, so the authenticator cannot actually
                 // re-enter with a write; this is hardening in case that ever changes.) A trailing IncrementLocalEpoch
@@ -587,19 +593,19 @@ contract Keystore {
                 // gas), so the rare sequenced+increment combo isn't worth special-casing here.
                 a.localSequence = seq + 1;
             } else if (!_isInitialized(account)) {
-                // First 8130 state change for a never-bootstrapped account (an EOA acting via its inline k1 self):
-                // burn local sequence 0 so the account reads initialized — blocking a later one-time importAccount /
-                // createAccount — and any outstanding sequenced seq==0 signature is invalidated. The unsequenced word
-                // itself commits no counter, so this batch stays replayable. Written before authentication; a revert
-                // rolls it back. (A bootstrapped or epoch-incremented account is already initialized, so this is a
-                // no-op there and never clobbers the live sequence-0 slot of a fresh epoch.)
+                // Mark a fresh account initialized and invalidate outstanding sequence-0 signatures. The unsequenced
+                // batch remains replayable; failed authentication rolls this write back.
                 a.localSequence = 1;
             }
         } else {
             // Multichain: a plain monotonic counter, never epoch-bearing or UNSEQUENCED.
             uint64 seq = s.sequence;
-            if (seq != a.multichainSequence) revert BadSequence();
-            if (seq == type(uint64).max) revert SequenceSaturated();
+            if (seq != a.multichainSequence) {
+                revert BadSequence();
+            }
+            if (seq == type(uint64).max) {
+                revert SequenceSaturated();
+            }
             a.multichainSequence = seq + 1;
         }
 
@@ -607,33 +613,47 @@ contract Keystore {
         // admin-only, so a single scope check up front replaces any per-op authorization.
         bytes32 digest = _changesDigest(account, s.channel, s.sequence, s.changes);
         (, uint16 scope) = authenticateActor(account, digest, s.signature);
-        if (scope != 0) revert UnauthorizedAccountChange();
+        if (scope != 0) {
+            revert UnauthorizedAccountChange();
+        }
 
-        // Lock policy is evaluated against the account's lock state at batch ENTRY: authority ops (authorize/revoke)
-        // are rejected if the account was locked by a PRIOR batch. Lock and Unlock are standalone (enforced below), so
-        // a lock transition never shares a batch with authority ops — the entry state is the batch's whole lock context
-        // and intra-batch ordering is irrelevant.
+        // Authority ops use the lock state at batch entry. Local-only changes reject the Multichain channel; Lock and
+        // Unlock are also standalone.
         bool locked = _isLocked(a);
 
         uint256 n = s.changes.length;
         for (uint256 i; i < n; i++) {
             ChangeType t = s.changes[i].changeType;
-            // Lock policy: if the account was locked at entry, the authority ops are rejected. Lock/Unlock must be the
-            // sole change in their batch (n == 1); IncrementLocalEpoch may ride any batch and is permitted while locked.
             if (t == ChangeType.AuthorizeActor) {
-                if (locked) revert AccountIsLocked();
+                if (locked) {
+                    revert AccountIsLocked();
+                }
                 _applyAuthorize(account, s.changes[i].payload);
             } else if (t == ChangeType.RevokeActor) {
-                if (locked) revert AccountIsLocked();
+                if (locked) {
+                    revert AccountIsLocked();
+                }
                 _applyRevoke(account, s.changes[i].payload);
             } else if (t == ChangeType.IncrementLocalEpoch) {
-                if (!isLocal) revert EpochOpRequiresLocalChannel();
+                if (!isLocal) {
+                    revert ChangeRequiresLocalChannel();
+                }
                 _applyIncrementLocalEpoch(account, s.changes[i].payload);
             } else if (t == ChangeType.Lock) {
-                if (n != 1) revert LockChangeMustBeStandalone();
+                if (!isLocal) {
+                    revert ChangeRequiresLocalChannel();
+                }
+                if (n != 1) {
+                    revert LockChangeMustBeStandalone();
+                }
                 _applyLock(account, s.changes[i].payload);
             } else if (t == ChangeType.Unlock) {
-                if (n != 1) revert LockChangeMustBeStandalone();
+                if (!isLocal) {
+                    revert ChangeRequiresLocalChannel();
+                }
+                if (n != 1) {
+                    revert LockChangeMustBeStandalone();
+                }
                 _applyUnlock(account, s.changes[i].payload);
             } else {
                 // Defensive guard: every ChangeType must be dispatched explicitly. Unreachable today — out-of-range
@@ -661,7 +681,9 @@ contract Keystore {
 
         // A grant must not be already-expired: reject a non-zero expiry that is not strictly in the future. A zero
         // expiry is the canonical "no expiry" sentinel (unlimited, per {ActorConfig}) and is accepted.
-        if (cfg.expiry != 0 && cfg.expiry <= block.timestamp) revert ExpiredChange();
+        if (cfg.expiry != 0 && cfg.expiry <= block.timestamp) {
+            revert ExpiredChange();
+        }
 
         _authorizeActor(account, actorId, cfg, policyData);
     }
@@ -672,7 +694,9 @@ contract Keystore {
     ///      actorId (which would re-install into the emptied slot); batch a {IncrementLocalEpoch} for durable teardown.
     function _applyRevoke(address account, bytes calldata payload) private {
         bytes32 actorId = abi.decode(payload, (bytes32));
-        if (!_isAuthorized(account, actorId)) revert UnknownActor();
+        if (!_isAuthorized(account, actorId)) {
+            revert UnknownActor();
+        }
         delete _actorConfig[actorId][account];
         delete _policyCommitment[actorId][account];
         delete _policyManager[actorId][account];
@@ -685,39 +709,46 @@ contract Keystore {
     /// @dev IncrementLocalEpoch. Empty payload. Strict increment of the local epoch, resetting the local sequence to 0
     ///      and thereby invalidating every unlanded local signature (they commit the full 64-bit word). Local-only.
     function _applyIncrementLocalEpoch(address account, bytes calldata payload) private {
-        if (payload.length != 0) revert InvalidChangePayload();
+        if (payload.length != 0) {
+            revert InvalidChangePayload();
+        }
         AccountState storage a = _accountState[account];
         // The epoch half has no reserved sentinel (unlike UNSEQUENCED on the sequence half), so the full uint32 range
         // is usable: only the terminal value itself cannot advance.
-        if (a.localEpoch == type(uint32).max) revert EpochSaturated();
-        unchecked {
-            a.localEpoch += 1;
+        if (a.localEpoch == type(uint32).max) {
+            revert EpochSaturated();
         }
+        a.localEpoch += 1;
         a.localSequence = 0;
     }
 
-    /// @dev Lock. `payload = abi.encode(uint16 unlockDelay)`. Standalone (its batch carries no other change), so it
-    ///      only ever runs from the account's live lock state. Reverts AccountIsLocked unless currently unlocked, then
-    ///      writes the lock flags unconditionally — `(flags | FLAG_LOCKED) & ~FLAG_UNLOCK_INITIATED` — so it always
-    ///      lands on a clean hard-locked flag set with lockUnion unambiguously holding the delay, regardless of any
-    ///      stale residue left by an elapsed-but-uncleared prior unlock (lock reads are non-clearing).
+    /// @dev Lock. Local-only; `payload = abi.encode(uint16 unlockDelay)`. Must be standalone and requires the account
+    ///      to be currently unlocked. Overwrites any residue from an elapsed prior lock.
     function _applyLock(address account, bytes calldata payload) private {
         AccountState storage a = _accountState[account];
-        if (_isLocked(a)) revert AccountIsLocked();
+        if (_isLocked(a)) {
+            revert AccountIsLocked();
+        }
         uint16 unlockDelay = abi.decode(payload, (uint16));
-        if (unlockDelay == 0) revert ZeroUnlockDelay();
+        if (unlockDelay == 0) {
+            revert ZeroUnlockDelay();
+        }
         a.flags = (a.flags | FLAG_LOCKED) & ~FLAG_UNLOCK_INITIATED;
         a.lockUnion = unlockDelay;
         emit AccountLocked(account, unlockDelay);
     }
 
-    /// @dev Unlock. Empty payload. Only from the hard-locked state with no pending unlock; sets the effective
-    ///      unlock timestamp from the stored delay.
+    /// @dev Unlock. Local-only; empty payload. Only from the hard-locked state with no pending unlock; sets the
+    ///      effective unlock timestamp from the stored delay.
     function _applyUnlock(address account, bytes calldata payload) private {
-        if (payload.length != 0) revert InvalidChangePayload();
+        if (payload.length != 0) {
+            revert InvalidChangePayload();
+        }
         AccountState storage a = _accountState[account];
         uint8 flags = a.flags;
-        if (flags & FLAG_LOCKED == 0 || flags & FLAG_UNLOCK_INITIATED != 0) revert NotLocked();
+        if (flags & FLAG_LOCKED == 0 || flags & FLAG_UNLOCK_INITIATED != 0) {
+            revert NotLocked();
+        }
         uint48 unlocksAt = uint48(block.timestamp + uint16(a.lockUnion));
         a.flags = flags | FLAG_UNLOCK_INITIATED;
         a.lockUnion = unlocksAt;
@@ -786,7 +817,7 @@ contract Keystore {
     }
 
     /// @dev EIP-712 domain separator for `account`'s ERC-1271 domain (verifyingContract = account, current chainId).
-    function _accountDomainSeparator(address account) internal view returns (bytes32) {
+    function _accountDomainSeparator(address account) private view returns (bytes32) {
         return keccak256(
             abi.encode(
                 _EIP712_DOMAIN_TYPEHASH, _ACCOUNT_DOMAIN_NAME_HASH, _ACCOUNT_DOMAIN_VERSION_HASH, block.chainid, account
@@ -820,7 +851,9 @@ contract Keystore {
         view
         returns (bytes32 actorId, uint16 scope)
     {
-        if (auth.length < 20) revert InvalidAuthLength();
+        if (auth.length < 20) {
+            revert InvalidAuthLength();
+        }
         return _authenticate(account, hash, address(bytes20(auth[:20])), auth[20:]);
     }
 
@@ -866,12 +899,16 @@ contract Keystore {
         // every stored authenticator is K1_AUTHENTICATOR (0x1) or a contract, so this is equivalent to != address(0).
         if (config.authenticator >= K1_AUTHENTICATOR) {
             // An expired stored actor reports as empty (as if never authorized), never its stale config.
-            if (_isExpired(config.expiry)) return _emptyActorConfig();
+            if (_isExpired(config.expiry)) {
+                return _emptyActorConfig();
+            }
             return config;
         }
         if (actorId == _selfActorId(account) && !_isDefaultEoaRevoked(account)) {
             AccountState storage st = _accountState[account];
-            if (_isExpired(st.defaultEOAExpiry)) return _emptyActorConfig();
+            if (_isExpired(st.defaultEOAExpiry)) {
+                return _emptyActorConfig();
+            }
             return
                 ActorConfig({authenticator: K1_AUTHENTICATOR, scope: st.defaultEOAScope, expiry: st.defaultEOAExpiry});
         }
@@ -883,58 +920,41 @@ contract Keystore {
         return ActorConfig({authenticator: address(0), expiry: 0, scope: 0});
     }
 
-    /// @notice Resolves an actor's policy gate target (manager) and signed commitment.
+    /// @notice Returns an actor's stored policy manager and commitment.
     ///
-    /// @dev Convenience aggregator for off-chain consumers, equivalent to `(getPolicyManager, getPolicyCommitment)`.
-    ///      Enforcement is at execution: this resolves where a policy-gated actor may call and the commitment a
-    ///      target validates presented parameters against. The policy manager/commitment are keyed by actorId, so
-    ///      the inline k1 self and a non-k1 self share that keyspace; mutual exclusion guarantees at most one is
-    ///      live, so the active gate is read by actorId. Both slots are non-zero only when the actor's scope carries
-    ///      Scopes.POLICY (see _authorizeActor / _applyRevoke); either MAY still be zero for an actor deliberately
-    ///      gated to a zero manager or a zero (no-params) commitment. On-chain consumers should prefer the
-    ///      single-SLOAD `getPolicyCommitment` / `getPolicyManager` accessors directly. Like those, this returns the
-    ///      raw slots regardless of actor liveness (expiry clears no slot); expiry is enforced upstream at
-    ///      {authenticateActor}, so cross-check liveness via {getActorConfig} before trusting the values standalone.
+    /// @dev Convenience aggregator for off-chain consumers. Returns raw slots even after actor expiry; authentication
+    ///      enforces expiry, while standalone readers should cross-check {getActorConfig}.
     ///
     /// @param account The account to read.
     /// @param actorId The actor identifier to resolve.
     ///
-    /// @return target The actor's policy gate target (manager), or address(0) if ungated.
-    /// @return commitment The actor's signed policy commitment, or bytes32(0) if ungated.
+    /// @return target The stored policy manager.
+    /// @return commitment The stored policy commitment.
     function getPolicy(address account, bytes32 actorId) external view returns (address target, bytes32 commitment) {
         return (_policyManager[actorId][account], _policyCommitment[actorId][account]);
     }
 
-    /// @notice Resolves an actor's signed policy commitment, or bytes32(0) if ungated / no actor / zero commitment.
+    /// @notice Returns an actor's stored policy commitment.
     ///
-    /// @dev Single SLOAD. Intended for a policy manager's per-tx validation read on the protocol-dispatched
-    ///      8130 tx path. This slot is non-zero only when the actor's scope carries Scopes.POLICY (see _authorizeActor /
-    ///      _applyRevoke), but MAY be zero for a policy-gated actor with a zero (no-params) commitment; gating is
-    ///      therefore determined by the Scopes.POLICY bit, not by this slot being non-zero.
-    /// @dev Returns the raw slot regardless of actor LIVENESS: expiry clears no slot (only RevokeActor / re-authorize
-    ///      does), so an expired-but-not-revoked actor still surfaces its stored commitment here. This is sound because
-    ///      expiry is enforced upstream — {authenticateActor} rejects an expired actor, so the enforcement path never
-    ///      reaches a stale gate — but an off-chain reader must cross-check liveness via {getActorConfig}
-    ///      (authenticator != 0) before trusting the value in isolation.
+    /// @dev Single SLOAD. Gating is determined by Scopes.POLICY, not by a non-zero commitment. Returns the raw slot
+    ///      after expiry; standalone readers should cross-check {getActorConfig}.
     ///
     /// @param account The account to read.
     /// @param actorId The actor identifier to resolve.
     ///
-    /// @return The signed policy commitment, or bytes32(0).
+    /// @return The stored policy commitment.
     function getPolicyCommitment(address account, bytes32 actorId) external view returns (bytes32) {
         return _policyCommitment[actorId][account];
     }
 
-    /// @notice Resolves an actor's policy gate target (manager), or address(0) if ungated or no actor.
+    /// @notice Returns an actor's stored policy manager.
     ///
-    /// @dev Single SLOAD. Same invariant as getPolicyCommitment, including the raw-slot / liveness caveat: an
-    ///      expired-but-not-revoked actor still surfaces its stored manager here; expiry is enforced upstream at
-    ///      {authenticateActor}, and off-chain readers should cross-check liveness via {getActorConfig}.
+    /// @dev Single SLOAD. Returns the raw slot after expiry; standalone readers should cross-check {getActorConfig}.
     ///
     /// @param account The account to read.
     /// @param actorId The actor identifier to resolve.
     ///
-    /// @return The policy gate target (manager), or address(0) if ungated or no actor.
+    /// @return The stored policy manager.
     function getPolicyManager(address account, bytes32 actorId) external view returns (address) {
         return _policyManager[actorId][account];
     }
@@ -988,7 +1008,9 @@ contract Keystore {
         // effectively unlocked, so report the clean unlocked state instead of surfacing the stale timestamp. Storage is
         // not canonicalized (lock reads are non-clearing); a later Lock overwrites the residue.
         uint48 unlockTime = config.lockUnion;
-        if (block.timestamp >= unlockTime) return (false, false, 0, 0);
+        if (block.timestamp >= unlockTime) {
+            return (false, false, 0, 0);
+        }
         return (true, true, unlockTime, 0);
     }
 
@@ -996,31 +1018,26 @@ contract Keystore {
     // INTERNAL FUNCTIONS
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice Returns whether the account's configuration is currently frozen, WITHOUT mutating storage.
-    ///
-    /// @dev Read-only by design: an elapsed initiated-unlock reads as unlocked even though FLAG_LOCKED still lingers in
-    ///      storage. Nothing clears it lazily — a later {_applyLock} overwrites lockUnion and clears the flags
-    ///      unconditionally, so the residue never affects relocking, and every liveness read ({isLocked},
-    ///      {getLockStatus}, the entry snapshot) interprets lockUnion against the timestamp anyway. Canonicalizing the
-    ///      storage would therefore buy only cosmetic hygiene, which is not worth the extra SSTOREs.
+    /// @dev Returns whether the account's configuration is currently frozen without mutating storage.
+    /// @dev An elapsed unlock reads as unlocked; a later {_applyLock} overwrites the stale lock fields.
     function _isLocked(AccountState storage st) private view returns (bool) {
         uint8 flags = st.flags;
-        if (flags & FLAG_LOCKED == 0) return false; // not locked
-        if (flags & FLAG_UNLOCK_INITIATED == 0) return true; // hard-locked
+        if (flags & FLAG_LOCKED == 0) {
+            return false;
+        }
+        if (flags & FLAG_UNLOCK_INITIATED == 0) {
+            return true;
+        }
         return block.timestamp < st.lockUnion; // pending unlock: frozen until the timestamp elapses
     }
 
-    /// @notice Convenience overload of {_isLocked} keyed by address.
+    /// @dev Convenience overload of {_isLocked} keyed by address.
     function _isLocked(address account) private view returns (bool) {
         return _isLocked(_accountState[account]);
     }
 
-    /// @dev True once the account has been bootstrapped via createAccount or importAccount. Tests the full local word
-    ///      (localSequence OR localEpoch), not localSequence alone: bootstrap sets localSequence = 1, but a later
-    ///      {IncrementLocalEpoch} zeroes localSequence while advancing localEpoch, so the combined local word stays
-    ///      non-zero for the account's whole life. Checking only localSequence would let a post-increment local-only
-    ///      account read as uninitialized and re-enter the one-time importAccount/createAccount bootstrap.
-    ///      multichainSequence covers an account that established 8130 state via a global (chainId 0) change.
+    /// @dev True after bootstrap or any successful signed change. The epoch and multichain counter keep initialization
+    ///      observable when the current local sequence is zero.
     function _isInitialized(address account) private view returns (bool) {
         AccountState storage st = _accountState[account];
         return st.localSequence != 0 || st.localEpoch != 0 || st.multichainSequence != 0;
@@ -1036,16 +1053,20 @@ contract Keystore {
     ///      initial actors; scoped-with-expiry keys are added later via applySignedAccountChanges. Reverts with
     ///      NoInitialActors or ActorsNotSortedOrDuplicate.
     function _initializeAccount(address account, InitialActor[] calldata initialActors)
-        internal
+        private
         nonZeroAccount(account)
     {
         // Must have at least one initial actor
-        if (initialActors.length == 0) revert NoInitialActors();
+        if (initialActors.length == 0) {
+            revert NoInitialActors();
+        }
 
         bytes32 previousActorId;
         for (uint256 i; i < initialActors.length; i++) {
             // Enforce sorting with relative comparison of sequential actor ids
-            if (initialActors[i].actorId <= previousActorId) revert ActorsNotSortedOrDuplicate();
+            if (initialActors[i].actorId <= previousActorId) {
+                revert ActorsNotSortedOrDuplicate();
+            }
             previousActorId = initialActors[i].actorId;
 
             // Initial actors carry scope verbatim (0x00 = unrestricted admin) and never an expiry. When
@@ -1060,22 +1081,23 @@ contract Keystore {
     /// @dev Authorizes (upserts) `actorId` with `config` and optional `policyData`, emitting ActorAuthorized. Rejects
     ///      a sub-K1 authenticator. The self-actorId is routed by authenticator type (a k1 self inline in
     ///      AccountState, a non-k1 self in _actorConfig) and the two are kept mutually exclusive; every other actor
-    ///      lives in _actorConfig. Reverts with InvalidAuthenticator or InvalidPolicyData.
+    ///      lives in _actorConfig. Reverts with InvalidActorId, InvalidAuthenticator, or InvalidPolicyData.
     function _authorizeActor(address account, bytes32 actorId, ActorConfig memory config, bytes memory policyData)
-        internal
+        private
         nonZeroAccount(account)
     {
-        // Reject the zero actorId: it is not a usable identifier (the tx-context precompile surfaces the zero id as
-        // "no actor"), and every real actorId — derived from keccak(authenticator || salt), or the non-zero self
-        // (the account address right-aligned) — is non-zero. Bootstrap already rejects it via the strictly-ascending-from-zero
-        // sort; this guards the signed AuthorizeActor path.
-        if (actorId == bytes32(0)) revert InvalidActorId();
+        // Zero is reserved for "no actor." Bootstrap also rejects it through the ascending-order check.
+        if (actorId == bytes32(0)) {
+            revert InvalidActorId();
+        }
 
         // Only reject the zero authenticator (the empty-slot sentinel). A non-zero authenticator with no code is
         // accepted deliberately: authenticators may be counterfactual (deployed later) and some are intentionally
         // codeless sentinels (e.g. EXTERNAL_POLICY_AUTHENTICATOR). A bad authenticator simply fails fail-closed at
         // authentication time, mirroring the reference PolicyManager's treatment of a zero-commitment policy actor.
-        if (config.authenticator < K1_AUTHENTICATOR) revert InvalidAuthenticator();
+        if (config.authenticator < K1_AUTHENTICATOR) {
+            revert InvalidAuthenticator();
+        }
 
         // Slice the signed policy by scope & Scopes.POLICY. The commitment is opaque to the protocol. This contract
         // does not reject scope combinations (e.g. Scopes.POLICY | Scopes.SELF_PAYER) — any use-time exclusivity between
@@ -1114,10 +1136,7 @@ contract Keystore {
         _emitActorAuthorized(account, actorId, config, manager, commitment);
     }
 
-    /// @dev Writes an actor's policy slots verbatim. `_slicePolicy` yields a zero manager/commitment for a non-policy
-    ///      scope, so an ungated actor simply zeroes the slots — a single unconditional write both installs a new gate
-    ///      and clears any stale one when an actor moves policy-gated -> ungated or re-keys to a different manager,
-    ///      preserving the "policy slots are non-zero iff scope & Scopes.POLICY != 0" invariant.
+    /// @dev Writes the current policy values and clears stale values when an actor becomes ungated.
     function _writePolicySlots(bytes32 actorId, address account, address manager, bytes32 commitment) private {
         _policyCommitment[actorId][account] = commitment;
         _policyManager[actorId][account] = manager;
@@ -1153,30 +1172,37 @@ contract Keystore {
     ///      params" and a zero manager gates the actor to address(0). Only a length mismatch reverts. The protocol
     ///      does not interpret the commitment value; self-enforcement is expressed as manager == account.
     function _slicePolicy(uint16 scope, bytes memory policyData)
-        internal
+        private
         pure
         returns (address manager, bytes32 commitment)
     {
         if (scope & Scopes.POLICY == 0) {
-            if (policyData.length != 0) revert InvalidPolicyData();
+            if (policyData.length != 0) {
+                revert InvalidPolicyData();
+            }
             return (address(0), bytes32(0));
         }
-        if (policyData.length != 52) revert InvalidPolicyData();
+        if (policyData.length != 52) {
+            revert InvalidPolicyData();
+        }
+        // The signed format is tightly packed to 52 bytes rather than ABI encoded to 64 bytes, so high-level
+        // abi.decode cannot parse it. This assembly performs the two fixed-offset reads without copying/repacking.
         assembly ("memory-safe") {
             manager := shr(96, mload(add(policyData, 0x20)))
             commitment := mload(add(policyData, 0x34))
         }
     }
 
-    /// @dev Returns whether `actorId` has an authorization entry on `account` (a stored actor config, or the inline
-    ///      k1 self is enabled), IGNORING expiry: an expired-but-not-revoked actor still returns true — intentional,
-    ///      since _applyRevoke relies on it to revoke expired actors and reclaim their slots. Callers that want
-    ///      liveness (expiry-aware) read {getActorConfig} (authenticator != 0) instead.
+    /// @dev Checks authorization presence without expiry so expired actors can still be explicitly revoked.
     function _isAuthorized(address account, bytes32 actorId) private view returns (bool) {
-        // A populated _actorConfig entry is always live: any non-self actor, or a non-k1 self authenticator.
-        if (_actorConfig[actorId][account].authenticator >= K1_AUTHENTICATOR) return true;
+        // A populated entry represents any non-self actor or a non-k1 self authenticator.
+        if (_actorConfig[actorId][account].authenticator >= K1_AUTHENTICATOR) {
+            return true;
+        }
         // No _actorConfig entry: the self-actorId's k1 key lives inline in AccountState, live unless the flag is set.
-        if (actorId == _selfActorId(account)) return !_isDefaultEoaRevoked(account);
+        if (actorId == _selfActorId(account)) {
+            return !_isDefaultEoaRevoked(account);
+        }
         return false;
     }
 
@@ -1199,7 +1225,7 @@ contract Keystore {
     ///      uses a tightly packed encoding that protocol clients can reproduce cheaply across chains:
     ///      effective_salt = keccak256(user_salt || actors_commitment).
     function _computeEffectiveSalt(bytes32 userSalt, InitialActor[] calldata initialActors)
-        internal
+        private
         pure
         returns (bytes32)
     {
@@ -1210,7 +1236,7 @@ contract Keystore {
     ///      actorId (32) || authenticator (20) || scope (2) || policyData, where policyData is empty (POLICY unset)
     ///      or exactly 52 bytes (POLICY set), so the length is unambiguous. Expiry does not participate (always 0
     ///      for initial actors).
-    function _computeActorsCommitment(InitialActor[] calldata initialActors) internal pure returns (bytes32) {
+    function _computeActorsCommitment(InitialActor[] calldata initialActors) private pure returns (bytes32) {
         bytes memory packed;
         for (uint256 i; i < initialActors.length; i++) {
             packed = abi.encodePacked(
@@ -1228,7 +1254,7 @@ contract Keystore {
     ///      with standard EIP-712-style struct hashing. `salt` is bound to the account address and the digest is
     ///      bound to `chainId` (0 = multichain) so its replay domain matches applySignedAccountChanges.
     function _computeImportDigest(address account, uint256 chainId, InitialActor[] calldata initialActors)
-        internal
+        private
         pure
         returns (bytes32)
     {
@@ -1267,7 +1293,7 @@ contract Keystore {
         AccountChangeChannel channel,
         uint64 sequence,
         AccountChange[] calldata changes
-    ) internal view returns (bytes32) {
+    ) private view returns (bytes32) {
         uint256 chainId = channel == AccountChangeChannel.Multichain ? 0 : block.chainid;
         bytes32[] memory changeHashes = new bytes32[](changes.length);
         for (uint256 i; i < changes.length; i++) {
@@ -1291,14 +1317,18 @@ contract Keystore {
     ///      IAuthenticator and requires the resolved actorId to carry a matching, unexpired _actorConfig entry.
     ///      Reverts with AuthenticationFailed, AuthenticatorMismatch, or ActorExpired.
     function _authenticate(address account, bytes32 hash, address authenticator, bytes calldata data)
-        internal
+        private
         view
         returns (bytes32, uint16)
     {
-        if (authenticator == K1_AUTHENTICATOR) return _authenticateK1(account, hash, data);
+        if (authenticator == K1_AUTHENTICATOR) {
+            return _authenticateK1(account, hash, data);
+        }
 
         bytes32 actorId = IAuthenticator(authenticator).authenticate(hash, data);
-        if (actorId == bytes32(0)) revert AuthenticationFailed();
+        if (actorId == bytes32(0)) {
+            revert AuthenticationFailed();
+        }
 
         return (actorId, _resolveExplicitActor(account, actorId, authenticator));
     }
@@ -1312,9 +1342,13 @@ contract Keystore {
         returns (uint16 scope)
     {
         ActorConfig memory config = _actorConfig[actorId][account];
-        if (config.authenticator != expectedAuthenticator) revert AuthenticatorMismatch();
+        if (config.authenticator != expectedAuthenticator) {
+            revert AuthenticatorMismatch();
+        }
         // Expiry is read from the same slot; an expired actor fails authentication. 0 = no expiry.
-        if (_isExpired(config.expiry)) revert ActorExpired();
+        if (_isExpired(config.expiry)) {
+            revert ActorExpired();
+        }
         scope = config.scope;
     }
 
@@ -1326,19 +1360,25 @@ contract Keystore {
     ///        - otherwise the signer's actorId must carry an explicit K1 config in _actorConfig (any other k1 actor).
     ///      Both the common self and other-actor paths cost a single SLOAD.
     function _authenticateK1(address account, bytes32 hash, bytes calldata data)
-        internal
+        private
         view
         returns (bytes32, uint16)
     {
         address recovered = _recoverSigner(hash, data);
-        if (recovered == address(0)) revert InvalidSignature();
+        if (recovered == address(0)) {
+            revert InvalidSignature();
+        }
 
         if (recovered == account) {
             // Inline self: a single SLOAD resolves the whole key. The flag disables it entirely; otherwise the
             // inline scope/expiry govern (all-zero = full owner).
             AccountState storage st = _accountState[account];
-            if (st.flags & FLAG_REVOKE_DEFAULT_EOA != 0) revert DefaultEoaRevoked();
-            if (_isExpired(st.defaultEOAExpiry)) revert ActorExpired();
+            if (st.flags & FLAG_REVOKE_DEFAULT_EOA != 0) {
+                revert DefaultEoaRevoked();
+            }
+            if (_isExpired(st.defaultEOAExpiry)) {
+                revert ActorExpired();
+            }
             return (_selfActorId(account), st.defaultEOAScope);
         }
 
@@ -1347,33 +1387,39 @@ contract Keystore {
     }
 
     /// @dev True if the account's default (implicit) EOA has been revoked via the AccountState flag.
-    function _isDefaultEoaRevoked(address account) internal view returns (bool) {
+    function _isDefaultEoaRevoked(address account) private view returns (bool) {
         return _accountState[account].flags & FLAG_REVOKE_DEFAULT_EOA != 0;
     }
 
     /// @dev The account's implicit self-actorId: the account address right-aligned into a 32-byte word
     ///      (`ActorId.fromAddress`), matching the normative self derivation. Non-zero for any valid account.
-    function _selfActorId(address account) internal pure returns (bytes32) {
+    function _selfActorId(address account) private pure returns (bytes32) {
         return ActorId.fromAddress(account);
     }
 
     /// @dev True when `expiry` is set (non-zero) and has passed. A zero expiry means no expiry.
-    function _isExpired(uint48 expiry) internal view returns (bool) {
+    function _isExpired(uint48 expiry) private view returns (bool) {
         return expiry != 0 && block.timestamp > expiry;
     }
 
     /// @dev Recovers the ECDSA signer from a 65-byte r‖s‖v signature over `hash`, enforcing EIP-2 (low-s only,
     ///      canonical v of 27 or 28). Reverts with InvalidSignature on a bad length or non-canonical encoding; may
     ///      return address(0) if ecrecover fails, which callers treat as a failed authentication.
-    function _recoverSigner(bytes32 hash, bytes calldata data) internal pure returns (address recovered) {
-        if (data.length != 65) revert InvalidSignature();
+    function _recoverSigner(bytes32 hash, bytes calldata data) private pure returns (address recovered) {
+        if (data.length != 65) {
+            revert InvalidSignature();
+        }
         bytes32 r = bytes32(data[:32]);
         bytes32 s = bytes32(data[32:64]);
         uint8 v = uint8(data[64]);
         // EIP-2: reject the malleable high-s half of each signature and non-canonical v to enforce a single
         // canonical encoding per signature.
-        if (uint256(s) > SECP256K1_HALF_ORDER) revert InvalidSignature();
-        if (v != 27 && v != 28) revert InvalidSignature();
+        if (uint256(s) > SECP256K1_HALF_ORDER) {
+            revert InvalidSignature();
+        }
+        if (v != 27 && v != 28) {
+            revert InvalidSignature();
+        }
         return ecrecover(hash, v, r, s);
     }
 
@@ -1381,15 +1427,18 @@ contract Keystore {
     // ACCOUNT CREATION
     // ----------------------------------------------------------------------------------------------------------------
 
-    /// @notice Constructs the deployment code for an account in a manner that doesn't immediately run constructor code.
-    /// @dev Returns a 14-byte EVM loader followed by `bytecode`. Reverts {EmptyBytecode} when `bytecode` is empty.
+    /// @dev Constructs a 14-byte EVM loader followed by `bytecode`. Reverts {EmptyBytecode} when `bytecode` is empty.
     ///      The loader copies the trailing `bytecode` into memory and returns it as the deployed runtime:
     ///        PUSH2 n; PUSH1 0x0e; PUSH1 0x00; CODECOPY   // copy n bytes from code offset 14 to mem 0
     ///        PUSH2 n; PUSH1 0x00; RETURN                 // return mem[0..n]
-    function _buildDeploymentCode(bytes calldata bytecode) internal pure returns (bytes memory) {
+    function _buildDeploymentCode(bytes calldata bytecode) private pure returns (bytes memory) {
         uint256 n = bytecode.length;
-        if (n == 0) revert EmptyBytecode();
-        if (n > 0xFFFF) revert BytecodeTooLarge();
+        if (n == 0) {
+            revert EmptyBytecode();
+        }
+        if (n > 0xFFFF) {
+            revert BytecodeTooLarge();
+        }
         return abi.encodePacked(
             bytes1(0x61), bytes2(uint16(n)), hex"600e600039", bytes1(0x61), bytes2(uint16(n)), hex"6000f3", bytecode
         );

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -18,7 +18,7 @@ contract Keystore {
     /// @notice Per-account replay counters for signed changes.
     struct ChangeSequences {
         uint64 multichain; // chain_id 0 (multichain channel)
-        uint32 localEpoch; // local channel epoch; bumped by BumpLocalEpoch, invalidates unlanded local signatures
+        uint32 localEpoch; // local channel epoch; incremented by IncrementLocalEpoch, invalidates unlanded local signatures
         uint32 localSequence; // local channel counter; starts at 1 once initialized (created/imported), 0 = uninitialized
     }
 
@@ -32,7 +32,7 @@ contract Keystore {
 
     /// @notice Initial actor for account creation and import. Carries its scope and, when scope & Scopes.POLICY is
     ///         set, its policy data; expiry is always 0 for initial actors (scoped-with-expiry keys are added later
-    ///         via applySignedAccountChanges).
+    ///         via applySignedConfigChanges).
     struct InitialActor {
         bytes32 actorId;
         address authenticator;
@@ -48,43 +48,43 @@ contract Keystore {
         bytes policyData;
     }
 
-    /// @notice The operation an {AccountChange} applies within an {applySignedAccountChanges} batch.
+    /// @notice The operation an {ConfigChange} applies within an {applySignedConfigChanges} batch.
     ///
     /// @dev ABI-encodes as uint8. The declaration ORDER is normative and doubles as a classification: every member
-    ///      strictly below {BumpLocalEpoch} is an *authority op* (it mutates who can act — the actor set); every
-    ///      member from {BumpLocalEpoch} onward is an *environment op* (it mutates the rules ops are checked
-    ///      against — the local epoch or the lock). The classification is simply `t >= BumpLocalEpoch`. Future ops MUST be
+    ///      strictly below {IncrementLocalEpoch} is an *authority op* (it mutates who can act — the actor set); every
+    ///      member from {IncrementLocalEpoch} onward is an *environment op* (it mutates the rules ops are checked
+    ///      against — the local epoch or the lock). The classification is simply `t >= IncrementLocalEpoch`. Future ops MUST be
     ///      inserted in the correct class to preserve this predicate. All five values are reachable and meaningful;
     ///      out-of-range wire values (>= 5) can never reach the handler — the enum decoder reverts them while
     ///      ABI-decoding the calldata (no in-handler "unknown" sentinel, unlike the pre-split enums).
     enum ChangeType {
-        // Authority ops (mutate who can act) — MUST stay below BumpLocalEpoch.
+        // Authority ops (mutate who can act) — MUST stay below IncrementLocalEpoch.
         AuthorizeActor, // payload: abi.encode(bytes32 actorId, ActorConfig cfg, bytes policyData); cfg.expiry is the granted expiry
         RevokeActor, // payload: abi.encode(bytes32 actorId)
         // Environment ops (mutate the rules ops are checked against).
-        BumpLocalEpoch, // payload: empty (length == 0 enforced)
+        IncrementLocalEpoch, // payload: empty (length == 0 enforced)
         Lock, // payload: abi.encode(uint16 unlockDelay)
         Unlock // payload: empty (length == 0 enforced)
     }
 
-    /// @notice The replay domain a {SignedAccountChanges} batch is bound to.
+    /// @notice The replay domain a {SignedConfigChanges} batch is bound to.
     ///
     /// @dev Replaces the prior `uint256 chainId` argument. {Local} binds `block.chainid` and carries the full local
-    ///      epoch machinery (see {SignedAccountChanges.sequence}); {Multichain} binds chainId 0 and keeps a plain
+    ///      epoch machinery (see {SignedConfigChanges.sequence}); {Multichain} binds chainId 0 and keeps a plain
     ///      monotonic counter with no epochs and no unsequenced (JIT) mode — its counter alone prevents replay, so
-    ///      it never requires an epoch bump and {BumpLocalEpoch} is rejected on it.
-    enum AccountChangeChannel {
+    ///      it never requires an epoch increment and {IncrementLocalEpoch} is rejected on it.
+    enum ConfigChangeChannel {
         Local,
         Multichain
     }
 
     /// @notice A single operation within a signed batch: its type and an operation-specific ABI-encoded payload.
-    struct AccountChange {
+    struct ConfigChange {
         ChangeType changeType;
         bytes payload;
     }
 
-    /// @notice An ordered, atomic batch of account changes with its replay binding and signature.
+    /// @notice An ordered, atomic batch of config changes with its replay binding and signature.
     ///
     /// @dev `changes` are applied in order, all-or-nothing (intersection-strict: any rejected op reverts the whole
     ///      batch). `sequence` is interpreted per `channel`:
@@ -94,10 +94,10 @@ contract Keystore {
     ///        - Multichain: a plain uint64 consumed against the account's multichainSequence; never {UNSEQUENCED},
     ///          never carries an epoch.
     ///      `signature` is the standard authenticator(20) || authenticator-data blob authenticating the signer.
-    struct SignedAccountChanges {
-        AccountChangeChannel channel;
+    struct SignedConfigChanges {
+        ConfigChangeChannel channel;
         uint64 sequence;
-        AccountChange[] changes;
+        ConfigChange[] changes;
         bytes signature;
     }
 
@@ -112,7 +112,7 @@ contract Keystore {
     ///      localSequence(32)` word committed in a signed batch's `sequence` (see {getChangeSequences}). Storing
     ///      them split keeps the layout size-neutral (still one slot) while removing the pack/unpack math from the hot
     ///      path. `localSequence` non-zero doubles as the account initialized flag — bootstrap writes it to 1 (epoch
-    ///      0), and it is never zeroed for a live account except by a {BumpLocalEpoch}, which simultaneously advances
+    ///      0), and it is never zeroed for a live account except by a {IncrementLocalEpoch}, which simultaneously advances
     ///      `localEpoch` (keeping the combined value non-zero).
     ///      `flags` is a bitfield: bit 0 (FLAG_REVOKE_DEFAULT_EOA) disables the k1 self key; bit 1 (FLAG_LOCKED)
     ///      freezes actor configuration; bit 2 (FLAG_UNLOCK_INITIATED) selects how `lockUnion` is interpreted.
@@ -162,23 +162,23 @@ contract Keystore {
     bytes32 public constant ACTOR_CONFIG_TYPEHASH =
         keccak256("ActorConfig(address authenticator,uint48 expiry,uint16 scope)");
 
-    /// @notice Typehash binding a signed account-change batch to its account, chainId, and sequence.
+    /// @notice Typehash binding a signed config-change batch to its account, chainId, and sequence.
     ///
     /// @dev NOT compliant with EIP-712, to mitigate phishing attacks. `chainId` is the channel's replay domain
-    ///      (0 for {AccountChangeChannel.Multichain}, block.chainid for {AccountChangeChannel.Local}). The digest
+    ///      (0 for {ConfigChangeChannel.Multichain}, block.chainid for {ConfigChangeChannel.Local}). The digest
     ///      scheme is a relocation seam: it lives behind {_changesDigest} so a later hash-relocation workstream can
     ///      move it without touching the pipeline.
-    bytes32 public constant SIGNED_ACCOUNT_CHANGES_TYPEHASH = keccak256(
-        "SignedAccountChanges(address account,uint256 chainId,uint64 sequence,AccountChange[] changes)"
-        "AccountChange(uint8 changeType,bytes payload)"
+    bytes32 public constant SIGNED_CONFIG_CHANGES_TYPEHASH = keccak256(
+        "SignedConfigChanges(address account,uint256 chainId,uint64 sequence,ConfigChange[] changes)"
+        "ConfigChange(uint8 changeType,bytes payload)"
     );
 
-    /// @notice Typehash used to structurally hash each AccountChange within a SignedAccountChanges batch.
-    bytes32 public constant ACCOUNT_CHANGE_TYPEHASH = keccak256("AccountChange(uint8 changeType,bytes payload)");
+    /// @notice Typehash used to structurally hash each ConfigChange within a SignedConfigChanges batch.
+    bytes32 public constant CONFIG_CHANGE_TYPEHASH = keccak256("ConfigChange(uint8 changeType,bytes payload)");
 
-    /// @notice Local-channel sequence low-half sentinel marking an unsequenced (JIT) batch. A {SignedAccountChanges}
+    /// @notice Local-channel sequence low-half sentinel marking an unsequenced (JIT) batch. A {SignedConfigChanges}
     ///         whose low 32 bits equal this value does not consume a sequence, so it stays replayable until the local
-    ///         epoch moves; any op type may ride it (see {applySignedAccountChanges}). Sequenced batches may therefore
+    ///         epoch moves; any op type may ride it (see {applySignedConfigChanges}). Sequenced batches may therefore
     ///         run up to UNSEQUENCED - 2.
     uint32 public constant UNSEQUENCED = type(uint32).max;
 
@@ -217,7 +217,7 @@ contract Keystore {
     uint8 public constant FLAG_REVOKE_DEFAULT_EOA = 0x01;
 
     /// @notice AccountState.flags bit (spec `LOCKED`): when set, actor configuration is frozen — only environment
-    ///         ops (BumpLocalEpoch, Lock, Unlock) are permitted through applySignedAccountChanges; authority ops
+    ///         ops (IncrementLocalEpoch, Lock, Unlock) are permitted through applySignedConfigChanges; authority ops
     ///         (AuthorizeActor, RevokeActor) are rejected. Cleared lazily once an initiated unlock elapses.
     uint8 public constant FLAG_LOCKED = 0x02;
 
@@ -296,8 +296,8 @@ contract Keystore {
     /// @notice The signed chainId is neither 0 (multichain) nor the current chain.
     error InvalidChainId();
 
-    /// @notice The batch signer is not the account admin (scope 0). Every signed account change is admin-only.
-    error UnauthorizedAccountChange();
+    /// @notice The batch signer is not the account admin (scope 0). Every signed config change is admin-only.
+    error UnauthorizedConfigChange();
 
     /// @notice The importAccount ERC-1271 signature check did not return the magic value.
     error InvalidImportSignature();
@@ -319,7 +319,7 @@ contract Keystore {
     /// @notice The channel's sequence counter is at its terminal value and cannot advance.
     error SequenceSaturated();
 
-    /// @notice The local epoch is at its terminal value and cannot be bumped.
+    /// @notice The local epoch is at its terminal value and cannot be incremented.
     error EpochSaturated();
 
     /// @notice An authority op (AuthorizeActor / RevokeActor) followed an environment op in the same batch, violating
@@ -330,17 +330,17 @@ contract Keystore {
     ///         arrival). A zero expiry is the "no expiry" sentinel and is accepted.
     error ExpiredChange();
 
-    /// @notice A BumpLocalEpoch was submitted on the Multichain channel. The local epoch is a local-mode concept.
+    /// @notice A IncrementLocalEpoch was submitted on the Multichain channel. The local epoch is a local-mode concept.
     error EpochOpRequiresLocalChannel();
 
     /// @notice A change payload did not match the shape required by its ChangeType (e.g. a non-empty payload on
-    ///         BumpLocalEpoch / Unlock).
+    ///         IncrementLocalEpoch / Unlock).
     error InvalidChangePayload();
 
     /// @notice Defensive guard for an unhandled ChangeType in the apply loop. Unreachable in practice — out-of-range
     ///         wire values are rejected by the enum decoder during ABI-decoding — but forces any future ChangeType to
     ///         be dispatched explicitly instead of silently falling through.
-    error UnknownActorChangeType();
+    error UnknownChangeType();
 
     /// @notice The auth blob is shorter than the 20-byte authenticator selector prefix.
     error InvalidAuthLength();
@@ -432,7 +432,7 @@ contract Keystore {
     /// @notice Deploys a new account with its initial actors. Each initial actor is registered with its declared
     ///         `scope` and, when `scope & Scopes.POLICY` is set, its `policyData` (an external `manager` is expressible
     ///         at create; `manager = account` is not, as the address is unknown at commitment time). `expiry` is
-    ///         always 0 at create — scoped-with-expiry keys are added afterwards via applySignedAccountChanges. The
+    ///         always 0 at create — scoped-with-expiry keys are added afterwards via applySignedConfigChanges. The
     ///         implicit default-EOA key is disabled on creation.
     ///
     /// @dev Reverts with EmptyBytecode when `bytecode` is empty.
@@ -528,19 +528,19 @@ contract Keystore {
         emit AccountImported(account);
     }
 
-    /// @notice The sole signed-change entry point: applies an ordered, atomic batch of account changes (authorize,
-    ///         revoke, bump-local-epoch, lock, unlock) authenticated by `s.signature`.
+    /// @notice The sole signed-change entry point: applies an ordered, atomic batch of config changes (authorize,
+    ///         revoke, increment-local-epoch, lock, unlock) authenticated by `s.signature`.
     ///
     /// @dev The governing axiom is Replay: a signed local change is valid only while it could still be validly
     ///      applied — the committed local epoch must match and grants self-expire (`cfg.expiry > now`, unless
     ///      `cfg.expiry == 0` which is the never-expiring sentinel).
     ///
     ///      Reduction is NOT contract-enforced. Removing authority durably (revoke, shorter expiry, narrower scope)
-    ///      requires retiring the signatures that granted it, which on the local channel means a {BumpLocalEpoch};
-    ///      the contract lets a bare reduction land, so pairing it with a bump is a wallet responsibility. A bare
+    ///      requires retiring the signatures that granted it, which on the local channel means a {IncrementLocalEpoch};
+    ///      the contract lets a bare reduction land, so pairing it with an increment is a wallet responsibility. A bare
     ///      revoke (or expiry cut) is not durable while a replayable unsequenced grant for that actor is outstanding.
     ///
-    ///      Authorization is flat: every signed account change is admin-only, so a single up-front scope check
+    ///      Authorization is flat: every signed config change is admin-only, so a single up-front scope check
     ///      (signer scope must be 0) authorizes the whole batch — there is no per-op authorization and no per-op
     ///      sequencing restriction (any op may ride an unsequenced or sequenced batch).
     ///
@@ -552,12 +552,12 @@ contract Keystore {
     ///
     /// @param account The account whose configuration is changed.
     /// @param s The signed batch (channel, ordered changes, sequence word, signature).
-    function applySignedAccountChanges(address account, SignedAccountChanges calldata s)
+    function applySignedConfigChanges(address account, SignedConfigChanges calldata s)
         external
         nonZeroAccount(account)
     {
         AccountState storage a = _accountState[account];
-        bool isLocal = s.channel == AccountChangeChannel.Local;
+        bool isLocal = s.channel == ConfigChangeChannel.Local;
 
         // Epoch / sequence gate. An unsequenced (JIT) batch exists only on the local channel (low half ==
         // UNSEQUENCED) and does not consume a counter; every other batch consumes its channel's counter.
@@ -568,7 +568,11 @@ contract Keystore {
             if (seq != UNSEQUENCED) {
                 if (seq != a.localSequence) revert BadSequence();
                 if (seq >= UNSEQUENCED - 1) revert SequenceSaturated();
-                // Advance the local sequence before apply (the epoch is untouched by a sequenced batch).
+                // Advance the local sequence before apply — checks-effects-before-interactions ahead of the
+                // authenticator STATICCALL below. (authenticateActor is `view`, so the authenticator cannot actually
+                // re-enter with a write; this is hardening in case that ever changes.) A trailing IncrementLocalEpoch
+                // in the same batch overwrites this to 0, but that second write lands on an already-warm slot (~100
+                // gas), so the rare sequenced+increment combo isn't worth special-casing here.
                 a.localSequence = seq + 1;
             }
         } else {
@@ -579,11 +583,11 @@ contract Keystore {
             a.multichainSequence = seq + 1;
         }
 
-        // Authenticate over the relocatable digest. Authorization is flat: every signed account change is
+        // Authenticate over the relocatable digest. Authorization is flat: every signed config change is
         // admin-only, so a single scope check up front replaces any per-op authorization.
         bytes32 digest = _changesDigest(account, s.channel, s.sequence, s.changes);
         (, uint16 scope) = authenticateActor(account, digest, s.signature);
-        if (scope != 0) revert UnauthorizedAccountChange();
+        if (scope != 0) revert UnauthorizedConfigChange();
 
         // Lock policy is evaluated against the account's lock state at entry (lazily clearing an elapsed unlock). This
         // snapshot drives ONLY the authority-op gate below; the entry value is sound there because lock state changes
@@ -597,23 +601,23 @@ contract Keystore {
         uint256 n = s.changes.length;
         for (uint256 i; i < n; i++) {
             ChangeType t = s.changes[i].changeType;
-            // Enum-ordering-as-classification: an environment op (BumpLocalEpoch onward) mutates the rules ops are
+            // Enum-ordering-as-classification: an environment op (IncrementLocalEpoch onward) mutates the rules ops are
             // checked against; anything below is an authority op that mutates who can act.
-            bool env = t >= ChangeType.BumpLocalEpoch;
+            bool env = t >= ChangeType.IncrementLocalEpoch;
 
             // Ordering: authority ops may never follow an environment op.
             if (!env && sawEnvOp) revert AuthorityOpAfterEnvOp();
             if (env) sawEnvOp = true;
 
-            // Lock policy: while the account is locked, only environment ops (bump/lock/unlock) may run.
+            // Lock policy: while the account is locked, only environment ops (increment-epoch/lock/unlock) may run.
             if (locked && !env) revert AccountIsLocked();
 
             if (t == ChangeType.AuthorizeActor) {
                 _applyAuthorize(account, s.changes[i].payload);
             } else if (t == ChangeType.RevokeActor) {
                 _applyRevoke(account, s.changes[i].payload);
-            } else if (t == ChangeType.BumpLocalEpoch) {
-                _applyBumpLocalEpoch(account, isLocal, s.changes[i].payload);
+            } else if (t == ChangeType.IncrementLocalEpoch) {
+                _applyIncrementLocalEpoch(account, isLocal, s.changes[i].payload);
             } else if (t == ChangeType.Lock) {
                 _applyLock(account, s.changes[i].payload);
             } else if (t == ChangeType.Unlock) {
@@ -622,7 +626,7 @@ contract Keystore {
                 // Defensive guard: every ChangeType must be dispatched explicitly. Unreachable today — out-of-range
                 // wire values are rejected by the enum decoder while ABI-decoding the calldata — so this forces any
                 // future ChangeType to be wired in here rather than silently falling through.
-                revert UnknownActorChangeType();
+                revert UnknownChangeType();
             }
         }
     }
@@ -635,8 +639,8 @@ contract Keystore {
     ///      is the granted expiry and the signature self-expires at it (or never, if `cfg.expiry == 0`). A plain
     ///      upsert on both channels and both sequencing modes — the only gate is that a non-zero expiry be in the
     ///      future. An unsequenced grant is replayable (it consumes no counter) and last-write-wins on its slot until
-    ///      the grant lapses or the epoch is bumped; durable reduction (revoke, shorter expiry, narrower scope) is
-    ///      therefore a wallet responsibility — batch the reducing op with a {BumpLocalEpoch} to retire outstanding
+    ///      the grant lapses or the epoch is incremented; durable reduction (revoke, shorter expiry, narrower scope) is
+    ///      therefore a wallet responsibility — batch the reducing op with a {IncrementLocalEpoch} to retire outstanding
     ///      grants.
     function _applyAuthorize(address account, bytes calldata payload) private {
         (bytes32 actorId, ActorConfig memory cfg, bytes memory policyData) =
@@ -652,7 +656,7 @@ contract Keystore {
     /// @dev RevokeActor. `payload = abi.encode(bytes32 actorId)`. Clears the actor's config and policy slots (and
     ///      disables the inline k1 self for the self-actorId), emitting ActorRevoked; reverts UnknownActor if the
     ///      actor is not currently live. Not durable against an outstanding replayable unsequenced grant for the same
-    ///      actorId (which would re-install into the emptied slot); batch a {BumpLocalEpoch} for durable teardown.
+    ///      actorId (which would re-install into the emptied slot); batch a {IncrementLocalEpoch} for durable teardown.
     function _applyRevoke(address account, bytes calldata payload) private {
         bytes32 actorId = abi.decode(payload, (bytes32));
         if (!_isAuthorized(account, actorId)) revert UnknownActor();
@@ -665,13 +669,15 @@ contract Keystore {
         emit ActorRevoked(account, actorId);
     }
 
-    /// @dev BumpLocalEpoch. Empty payload. Strict increment of the local epoch, resetting the local sequence to 0
+    /// @dev IncrementLocalEpoch. Empty payload. Strict increment of the local epoch, resetting the local sequence to 0
     ///      and thereby invalidating every unlanded local signature (they commit the full 64-bit word). Local-only.
-    function _applyBumpLocalEpoch(address account, bool isLocal, bytes calldata payload) private {
+    function _applyIncrementLocalEpoch(address account, bool isLocal, bytes calldata payload) private {
         if (payload.length != 0) revert InvalidChangePayload();
         if (!isLocal) revert EpochOpRequiresLocalChannel();
         AccountState storage a = _accountState[account];
-        if (a.localEpoch >= type(uint32).max - 1) revert EpochSaturated();
+        // The epoch half has no reserved sentinel (unlike UNSEQUENCED on the sequence half), so the full uint32 range
+        // is usable: only the terminal value itself cannot advance.
+        if (a.localEpoch == type(uint32).max) revert EpochSaturated();
         unchecked {
             a.localEpoch += 1;
         }
@@ -997,12 +1003,15 @@ contract Keystore {
         return false;
     }
 
-    /// @dev True once the account has been bootstrapped via createAccount or importAccount. localSequence doubles as
-    ///      the initialized flag (set to 1 at bootstrap); multichainSequence covers an account that established 8130
-    ///      state via a global (chainId 0) change.
+    /// @dev True once the account has been bootstrapped via createAccount or importAccount. Tests the full local word
+    ///      (localSequence OR localEpoch), not localSequence alone: bootstrap sets localSequence = 1, but a later
+    ///      {IncrementLocalEpoch} zeroes localSequence while advancing localEpoch, so the combined local word stays
+    ///      non-zero for the account's whole life. Checking only localSequence would let a post-increment local-only
+    ///      account read as uninitialized and re-enter the one-time importAccount/createAccount bootstrap.
+    ///      multichainSequence covers an account that established 8130 state via a global (chainId 0) change.
     function _isInitialized(address account) private view returns (bool) {
         AccountState storage st = _accountState[account];
-        return st.localSequence != 0 || st.multichainSequence != 0;
+        return st.localSequence != 0 || st.localEpoch != 0 || st.multichainSequence != 0;
     }
 
     // ----------------------------------------------------------------------------------------------------------------
@@ -1012,7 +1021,7 @@ contract Keystore {
     /// @dev Registers the bootstrap actor set shared by createAccount and importAccount: requires a non-empty,
     ///      strictly ascending-by-actorId list (rejecting unsorted or duplicate entries) and authorizes each entry
     ///      with its declared scope and (when scope & Scopes.POLICY is set) policyData. Expiry is always 0 for
-    ///      initial actors; scoped-with-expiry keys are added later via applySignedAccountChanges. Reverts with
+    ///      initial actors; scoped-with-expiry keys are added later via applySignedConfigChanges. Reverts with
     ///      NoInitialActors or ActorsNotSortedOrDuplicate.
     function _initializeAccount(address account, InitialActor[] calldata initialActors)
         internal
@@ -1199,7 +1208,7 @@ contract Keystore {
 
     /// @dev Typed digest for the importAccount ERC-1271 signature (a signed message), so signers can reproduce it
     ///      with standard EIP-712-style struct hashing. `salt` is bound to the account address and the digest is
-    ///      bound to `chainId` (0 = multichain) so its replay domain matches applySignedAccountChanges.
+    ///      bound to `chainId` (0 = multichain) so its replay domain matches applySignedConfigChanges.
     function _computeImportDigest(address account, uint256 chainId, InitialActor[] calldata initialActors)
         internal
         pure
@@ -1228,29 +1237,29 @@ contract Keystore {
         );
     }
 
-    /// @dev Computes the digest signed over an applySignedAccountChanges batch: each AccountChange is hashed
+    /// @dev Computes the digest signed over an applySignedConfigChanges batch: each ConfigChange is hashed
     ///      structurally (its variable-length `payload` pre-hashed to a fixed-width layout) and the batch is bound to
     ///      `account`, the channel's replay `chainId` (0 for Multichain, block.chainid for Local), and the raw
-    ///      `sequence` word via SIGNED_ACCOUNT_CHANGES_TYPEHASH.
+    ///      `sequence` word via SIGNED_CONFIG_CHANGES_TYPEHASH.
     ///
     ///      This is the hash-relocation SEAM: the whole scheme is confined here so a later workstream can relocate
-    ///      it without touching the pipeline in {applySignedAccountChanges}.
+    ///      it without touching the pipeline in {applySignedConfigChanges}.
     function _changesDigest(
         address account,
-        AccountChangeChannel channel,
+        ConfigChangeChannel channel,
         uint64 sequence,
-        AccountChange[] calldata changes
+        ConfigChange[] calldata changes
     ) internal view returns (bytes32) {
-        uint256 chainId = channel == AccountChangeChannel.Multichain ? 0 : block.chainid;
+        uint256 chainId = channel == ConfigChangeChannel.Multichain ? 0 : block.chainid;
         bytes32[] memory changeHashes = new bytes32[](changes.length);
         for (uint256 i; i < changes.length; i++) {
             changeHashes[i] = keccak256(
-                abi.encode(ACCOUNT_CHANGE_TYPEHASH, uint8(changes[i].changeType), keccak256(changes[i].payload))
+                abi.encode(CONFIG_CHANGE_TYPEHASH, uint8(changes[i].changeType), keccak256(changes[i].payload))
             );
         }
         return keccak256(
             abi.encode(
-                SIGNED_ACCOUNT_CHANGES_TYPEHASH, account, chainId, sequence, keccak256(abi.encodePacked(changeHashes))
+                SIGNED_CONFIG_CHANGES_TYPEHASH, account, chainId, sequence, keccak256(abi.encodePacked(changeHashes))
             )
         );
     }

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -31,7 +31,7 @@ contract Keystore {
 
     /// @notice Initial actor for account creation and import. Carries its scope and, when scope & Scopes.POLICY is
     ///         set, its policy data; expiry is always 0 for initial actors (scoped-with-expiry keys are added later
-    ///         via applySignedActorChanges).
+    ///         via applySignedAccountChanges).
     struct InitialActor {
         bytes32 actorId;
         address authenticator;
@@ -47,37 +47,57 @@ contract Keystore {
         bytes policyData;
     }
 
-    /// @notice The operation an {ActorChange} applies within an {applySignedActorChanges} batch.
+    /// @notice The operation an {AccountChange} applies within an {applySignedAccountChanges} batch.
     ///
-    /// @dev ABI-encodes as uint8, so the wire values are preserved (Authorize = 0x01, Revoke = 0x02) and the
-    ///      SignedActorChanges typehash keeps `uint8 changeType` — digests and the external ABI selector are
-    ///      unchanged. Invalid (0) is the reachable "unrecognized" case, rejected in-handler with {UnknownActorChangeType};
-    ///      out-of-range wire values (>= 3) can never reach the handler — the enum decoder rejects them (reverts)
-    ///      while ABI-decoding the calldata.
-    enum ActorChangeType {
-        Invalid,
-        Authorize,
-        Revoke
+    /// @dev ABI-encodes as uint8. The declaration ORDER is normative and doubles as a classification: every member
+    ///      strictly below {BumpLocalEpoch} is an *authority op* (it mutates who can act — the actor set); every
+    ///      member from {BumpLocalEpoch} onward is an *environment op* (it mutates the rules ops are checked
+    ///      against — the local epoch or the lock). `_isEnvOp(t) == (t >= BumpLocalEpoch)`. Future ops MUST be
+    ///      inserted in the correct class to preserve this predicate. All five values are reachable and meaningful;
+    ///      out-of-range wire values (>= 5) can never reach the handler — the enum decoder reverts them while
+    ///      ABI-decoding the calldata (no in-handler "unknown" sentinel, unlike the pre-split enums).
+    enum ChangeType {
+        // Authority ops (mutate who can act) — MUST stay below BumpLocalEpoch.
+        AuthorizeActor, // payload: abi.encode(bytes32 actorId, ActorConfig cfg, bytes policyData); cfg.expiry is the granted expiry
+        RevokeActor, // payload: abi.encode(bytes32 actorId)
+        // Environment ops (mutate the rules ops are checked against).
+        BumpLocalEpoch, // payload: empty (length == 0 enforced)
+        Lock, // payload: abi.encode(uint16 unlockDelay)
+        Unlock // payload: empty (length == 0 enforced)
     }
 
-    /// @notice The operation an {applySignedLockChanges} call applies.
+    /// @notice The replay domain a {SignedAccountChanges} batch is bound to.
     ///
-    /// @dev ABI-encodes as uint8, so the wire values are preserved (Lock = 0x01, Unlock = 0x02) and the
-    ///      SignedLockChange typehash keeps `uint8 op` — digests and the external ABI selector are unchanged.
-    ///      Invalid (0) is the reachable "unrecognized" case, rejected in-handler with {UnknownLockChangeType}; out-of-range
-    ///      wire values (>= 3) can never reach the handler — the enum decoder rejects them (reverts) while
-    ///      ABI-decoding the calldata.
-    enum LockChangeType {
-        Invalid,
-        Lock,
-        Unlock
+    /// @dev Replaces the prior `uint256 chainId` argument. {Local} binds `block.chainid` and carries the full local
+    ///      epoch machinery (see {SignedAccountChanges.sequence}); {Multichain} binds chainId 0 and keeps a plain
+    ///      monotonic counter with no epochs and no unsequenced (JIT) mode — its counter alone prevents replay, so
+    ///      it never requires an epoch bump and {BumpLocalEpoch} is rejected on it.
+    enum AccountChangeChannel {
+        Local,
+        Multichain
     }
 
-    /// @notice A single authorize/revoke operation within a signed batch.
-    struct ActorChange {
-        ActorChangeType changeType; // Authorize or Revoke (Invalid rejected in-handler)
-        bytes32 actorId;
-        bytes data; // operation-specific: ActorConfig || policyData for authorize, empty for revoke
+    /// @notice A single operation within a signed batch: its type and an operation-specific ABI-encoded payload.
+    struct AccountChange {
+        ChangeType changeType;
+        bytes payload;
+    }
+
+    /// @notice An ordered, atomic batch of account changes with its replay binding and signature.
+    ///
+    /// @dev `changes` are applied in order, all-or-nothing (intersection-strict: any rejected op reverts the whole
+    ///      batch). `sequence` is interpreted per `channel`:
+    ///        - Local: localEpoch(32, high) || localSequence(32, low). A low half equal to {UNSEQUENCED} marks the
+    ///          batch as unsequenced (JIT) — it does not consume a sequence and only the both-channel ops are
+    ///          permitted; any other low value is a sequenced batch consumed against the account's localSequence.
+    ///        - Multichain: a plain uint64 consumed against the account's multichainSequence; never {UNSEQUENCED},
+    ///          never carries an epoch.
+    ///      `signature` is the standard authenticator(20) || authenticator-data blob authenticating the signer.
+    struct SignedAccountChanges {
+        AccountChangeChannel channel;
+        AccountChange[] changes;
+        uint64 sequence;
+        bytes signature;
     }
 
     /// @notice Per-account packed state: sequences, lock status, and the inline home for the account's k1 self key.
@@ -86,7 +106,10 @@ contract Keystore {
     ///      rate-limit tiering, see the EIP's Account Lock section). Field order and widths match the spec's
     ///      account-state table: multichainSequence, localSequence, flags, lockUnion, defaultEOAExpiry,
     ///      defaultEOAScope, then 1 reserved byte that MUST stay zero.
-    ///      localSequence > 0 doubles as the account initialized flag.
+    ///      The `localSequence` word is size-neutral but split in two: the high 32 bits are the `localEpoch` and the
+    ///      low 32 bits are the running local sequence counter (see {getLocalEpochAndSequence}). A non-zero combined
+    ///      64-bit word still doubles as the account initialized flag — bootstrap writes low = 1 (epoch 0), and a
+    ///      local-epoch bump writes a non-zero high half, so the word is never zeroed back out for a live account.
     ///      `flags` is a bitfield: bit 0 (FLAG_REVOKE_DEFAULT_EOA) disables the k1 self key; bit 1 (FLAG_LOCKED)
     ///      freezes actor configuration; bit 2 (FLAG_UNLOCK_INITIATED) selects how `lockUnion` is interpreted.
     ///      `lockUnion` is a union field: while FLAG_UNLOCK_INITIATED is clear it holds the configured unlock delay
@@ -134,24 +157,24 @@ contract Keystore {
     bytes32 public constant ACTOR_CONFIG_TYPEHASH =
         keccak256("ActorConfig(address authenticator,uint48 expiry,uint16 scope)");
 
-    /// @notice Typehash binding a signed actor-change batch to its account, chainId, and sequence.
+    /// @notice Typehash binding a signed account-change batch to its account, chainId, and sequence.
     ///
-    /// @dev NOT compliant with EIP-712, to mitigate phishing attacks.
-    bytes32 public constant SIGNED_ACTOR_CHANGES_TYPEHASH = keccak256(
-        "SignedActorChanges(address account,uint256 chainId,uint64 sequence,ActorChange[] actorChanges)"
-        "ActorChange(uint8 changeType,bytes32 actorId,bytes data)"
+    /// @dev NOT compliant with EIP-712, to mitigate phishing attacks. `chainId` is the channel's replay domain
+    ///      (0 for {AccountChangeChannel.Multichain}, block.chainid for {AccountChangeChannel.Local}). The digest
+    ///      scheme is a relocation seam: it lives behind {_changesDigest} so a later hash-relocation workstream can
+    ///      move it without touching the pipeline.
+    bytes32 public constant SIGNED_ACCOUNT_CHANGES_TYPEHASH = keccak256(
+        "SignedAccountChanges(address account,uint256 chainId,uint64 sequence,AccountChange[] changes)"
+        "AccountChange(uint8 changeType,bytes payload)"
     );
 
-    /// @notice Typehash used to structurally hash each ActorChange within a SignedActorChanges batch.
-    bytes32 public constant ACTOR_CHANGE_TYPEHASH =
-        keccak256("ActorChange(uint8 changeType,bytes32 actorId,bytes data)");
+    /// @notice Typehash used to structurally hash each AccountChange within a SignedAccountChanges batch.
+    bytes32 public constant ACCOUNT_CHANGE_TYPEHASH = keccak256("AccountChange(uint8 changeType,bytes payload)");
 
-    /// @notice Typehash binding a signed lock-state change to its account, chainId, op, unlock delay, and sequence.
-    ///
-    /// @dev NOT compliant with EIP-712, to mitigate phishing attacks. Lock changes are local-channel only, so the
-    ///      digest always binds the current chainId (there is no multichain lock).
-    bytes32 public constant LOCK_CHANGE_TYPEHASH =
-        keccak256("SignedLockChange(address account,uint256 chainId,uint8 op,uint16 unlockDelay,uint64 sequence)");
+    /// @notice Local-channel sequence low-half sentinel marking an unsequenced (JIT) batch. A {SignedAccountChanges}
+    ///         whose low 32 bits equal this value does not consume a sequence; only both-channel ops are permitted
+    ///         on it (see {applySignedAccountChanges}). Sequenced batches may therefore run up to UNSEQUENCED - 2.
+    uint32 public constant UNSEQUENCED = type(uint32).max;
 
     // ----------------------------------------------------------------------------------------------------------------
     // ACTOR SCOPE
@@ -187,10 +210,9 @@ contract Keystore {
     ///         clears it (re-enabling the inline self, possibly scoped).
     uint8 public constant FLAG_REVOKE_DEFAULT_EOA = 0x01;
 
-    /// @notice AccountState.flags bit (spec `LOCKED`): when set, actor configuration is frozen — all config changes
-    ///         and delegation are rejected on both the account-changes and applySignedActorChanges paths. The only
-    ///         permitted operation while locked is initiating an unlock. Cleared lazily once an initiated unlock
-    ///         elapses (see applySignedLockChanges).
+    /// @notice AccountState.flags bit (spec `LOCKED`): when set, actor configuration is frozen — only environment
+    ///         ops (BumpLocalEpoch, Lock, Unlock) are permitted through applySignedAccountChanges; authority ops
+    ///         (AuthorizeActor, RevokeActor) are rejected. Cleared lazily once an initiated unlock elapses.
     uint8 public constant FLAG_LOCKED = 0x02;
 
     /// @notice AccountState.flags bit (spec `UNLOCK_INITIATED`): selects how the packed `lockUnion` field is read.
@@ -221,6 +243,12 @@ contract Keystore {
     /// @param account The account whose actor was revoked.
     /// @param actorId The revoked actor's identifier.
     event ActorRevoked(address indexed account, bytes32 indexed actorId);
+
+    /// @notice Emitted when an expired actor's slot is garbage-collected (permissionlessly reclaimed).
+    ///
+    /// @param account The account whose expired actor slot was collected.
+    /// @param actorId The collected actor's identifier.
+    event ActorCollected(address indexed account, bytes32 indexed actorId);
 
     /// @notice Emitted when a new account is created.
     ///
@@ -271,27 +299,68 @@ contract Keystore {
     /// @notice The authenticated actor lacks the scope required to change actors.
     error UnauthorizedActorChange();
 
-    /// @notice An ActorChange carried ActorChangeType.Invalid (0). Other unrecognized wire values revert at ABI-decode.
-    error UnknownActorChangeType();
-
     /// @notice The importAccount ERC-1271 signature check did not return the magic value.
     error InvalidImportSignature();
 
-    /// @notice A lock op (op = 1) carried a zero unlock delay.
+    /// @notice A lock op carried a zero unlock delay.
     error ZeroUnlockDelay();
 
-    /// @notice An unlock op (op = 2) was requested when the account was not in the hard-locked state (FLAG_LOCKED set,
+    /// @notice An unlock op was requested when the account was not in the hard-locked state (FLAG_LOCKED set,
     ///         FLAG_UNLOCK_INITIATED clear) — i.e. never locked, or an unlock was already initiated.
     error NotLocked();
 
-    /// @notice applySignedLockChanges carried LockChangeType.Invalid (0). Other unrecognized wire values revert at ABI-decode.
-    error UnknownLockChangeType();
-
-    /// @notice An unlock op (op = 2) carried a non-zero unlock delay (unlock delay is set only by the lock op).
-    error InvalidUnlockDelay();
-
-    /// @notice The authenticated actor lacks the scope required to change the lock state (admin, scope 0, only).
+    /// @notice The authenticated actor lacks the scope required to change the lock state (admin, or a recovery-class
+    ///         actor for Unlock).
     error UnauthorizedLockChange();
+
+    /// @notice The batch's committed local epoch does not match the account's current local epoch: every unlanded
+    ///         local signature at a prior epoch is dead. Applies to both the sequenced and unsequenced channels.
+    error StaleEpoch();
+
+    /// @notice A sequenced batch's sequence did not match the account's current (local or multichain) counter.
+    error BadSequence();
+
+    /// @notice The channel's sequence counter is at its terminal value and cannot advance.
+    error SequenceSaturated();
+
+    /// @notice The local epoch is at its terminal value and cannot be bumped.
+    error EpochSaturated();
+
+    /// @notice A batch reduced a landed actor's authority (revoke, shorter expiry, or narrower scope) without also
+    ///         bumping the local epoch in the same batch. Reduction must retire the signatures that granted the
+    ///         authority; on the local channel that requires a BumpLocalEpoch.
+    error ReductionRequiresEpochBump();
+
+    /// @notice An authority op (AuthorizeActor / RevokeActor) followed an environment op in the same batch, violating
+    ///         the normative op ordering (authority ops first, environment ops last).
+    error AuthorityOpAfterEnvOp();
+
+    /// @notice An AuthorizeActor's granted expiry is not strictly in the future (self-expired on arrival).
+    error ExpiredChange();
+
+    /// @notice An unsequenced AuthorizeActor tried to change an occupied slot's scope. Scope changes are sequenced-only.
+    error ScopeChangeRequiresSequencing();
+
+    /// @notice An unsequenced AuthorizeActor's expiry was not strictly greater than the occupied slot's expiry.
+    ///         Unsequenced grants may only extend expiry monotonically upward.
+    error NonMonotoneExpiry();
+
+    /// @notice An unsequenced AuthorizeActor requested the unbounded (type(uint48).max) expiry. Unbounded grants are
+    ///         sequenced-only.
+    error UnboundedGrantRequiresSequencing();
+
+    /// @notice A BumpLocalEpoch was submitted on the Multichain channel. The local epoch is a local-mode concept.
+    error EpochOpRequiresLocalChannel();
+
+    /// @notice A solo-only op (Unlock always; BumpLocalEpoch when unsequenced) appeared in a multi-op batch.
+    error SoloOpNotSolo();
+
+    /// @notice A change payload did not match the shape required by its ChangeType (e.g. a non-empty payload on
+    ///         BumpLocalEpoch / Unlock).
+    error InvalidChangePayload();
+
+    /// @notice collectActor targeted an actor that is not present, or is present but not yet expired.
+    error CollectLiveActor();
 
     /// @notice The auth blob is shorter than the 20-byte authenticator selector prefix.
     error InvalidAuthLength();
@@ -382,7 +451,7 @@ contract Keystore {
     /// @notice Deploys a new account with its initial actors. Each initial actor is registered with its declared
     ///         `scope` and, when `scope & Scopes.POLICY` is set, its `policyData` (an external `manager` is expressible
     ///         at create; `manager = account` is not, as the address is unknown at commitment time). `expiry` is
-    ///         always 0 at create — scoped-with-expiry keys are added afterwards via applySignedActorChanges. The
+    ///         always 0 at create — scoped-with-expiry keys are added afterwards via applySignedAccountChanges. The
     ///         implicit default-EOA key is disabled on creation.
     ///
     /// @dev Reverts with EmptyBytecode when `bytecode` is empty.
@@ -478,132 +547,285 @@ contract Keystore {
         emit AccountImported(account);
     }
 
-    /// @notice Applies a batch of signed actor changes (authorize/revoke) to an account's configuration.
+    /// @notice The sole signed-change entry point: applies an ordered, atomic batch of account changes (authorize,
+    ///         revoke, bump-local-epoch, lock, unlock) authenticated by `s.signature`.
     ///
-    /// @dev Authenticates `auth` against the account's actors and requires the resolved actor to be unrestricted
-    ///      (scope 0) — there is no elevated scope for changing actors; admin is exactly scope == 0. Replay is
-    ///      bound by `chainId` (0 = multichain, else the current chain) and a monotonic per-account sequence
-    ///      consumed on each call.
-    /// @dev Reverts with AccountIsLocked when the account is locked.
-    /// @dev Reverts with InvalidChainId when `chainId` is neither 0 (multichain) nor the current chain.
-    /// @dev Reverts with InvalidAuthLength, InvalidSignature, AuthenticationFailed, AuthenticatorMismatch,
-    ///      ActorExpired, or DefaultEoaRevoked when `auth` fails to authenticate a live actor.
-    /// @dev Reverts with UnauthorizedActorChange when the authenticated actor is not unrestricted (scope != 0).
-    /// @dev Reverts with UnknownActorChangeType when a change carries an unrecognized changeType.
-    /// @dev Reverts with InvalidAuthenticator or InvalidPolicyData on a malformed authorize.
-    /// @dev Reverts with UnknownActor when revoking an actor that is not authorized.
+    /// @dev Two axioms govern the whole surface:
+    ///        1. Replay — a signed local change is valid only while it could still be validly applied: the committed
+    ///           local epoch must match, grants self-expire (`cfg.expiry > now`), and the state they commit to must
+    ///           still hold.
+    ///        2. Reduction — removing authority (revoke, shorter expiry, narrower scope) requires retiring the
+    ///           signatures that granted it. On the local channel that means the batch MUST also bump the epoch.
+    ///
+    ///      Pipeline (in order): (1) split the sequence word; (2) reject a stale local epoch on both channels;
+    ///      (3) validate/advance the sequence counter BEFORE apply (reentrancy discipline); (4) compute the digest
+    ///      via the relocatable {_changesDigest} seam and authenticate; (5) iterate changes enforcing op ordering,
+    ///      per-op channel/sequencing policy, the lock policy, per-op authorization, and the solo rules; (6) at loop
+    ///      exit enforce the reduction rule. Anyone may relay — authorization comes entirely from the signature.
     ///
     /// @param account The account whose configuration is changed.
-    /// @param chainId Replay domain: 0 = multichain (valid on every chain), otherwise the current chain.
-    /// @param actorChanges Ordered authorize/revoke operations to apply.
-    /// @param auth Authenticator(20) || authenticator-specific data authenticating an unrestricted actor.
-    function applySignedActorChanges(
-        address account,
-        uint256 chainId,
-        ActorChange[] calldata actorChanges,
-        bytes calldata auth
-    ) external onlyUnlocked(account) {
-        if (chainId != 0 && chainId != block.chainid) revert InvalidChainId();
+    /// @param s The signed batch (channel, ordered changes, sequence word, signature).
+    function applySignedAccountChanges(address account, SignedAccountChanges calldata s)
+        external
+        nonZeroAccount(account)
+    {
+        AccountState storage a = _accountState[account];
+        bool isLocal = s.channel == AccountChangeChannel.Local;
 
-        // Increment the corresponding sequence
-        uint64 sequence =
-            chainId == 0 ? _accountState[account].multichainSequence++ : _accountState[account].localSequence++;
-
-        // Compute digest and authenticate
-        bytes32 digest = _computeSignedActorChangesDigest(account, chainId, sequence, actorChanges);
-        (, uint16 scope) = authenticateActor(account, digest, auth);
-
-        // Only an unrestricted actor (scope 0) may change actors; there is no elevated "admin" scope bit.
-        if (scope != 0) revert UnauthorizedActorChange();
-
-        // Apply actorChanges. Out-of-range changeType values revert at ABI-decode, so only ActorChangeType.Invalid reaches
-        // the fall-through revert here.
-        for (uint256 i; i < actorChanges.length; i++) {
-            if (actorChanges[i].changeType == ActorChangeType.Authorize) {
-                (ActorConfig memory newActorConfig, bytes memory policyData) =
-                    abi.decode(actorChanges[i].data, (ActorConfig, bytes));
-                _authorizeActor(account, actorChanges[i].actorId, newActorConfig, policyData);
-            } else if (actorChanges[i].changeType == ActorChangeType.Revoke) {
-                _revokeActor(account, actorChanges[i].actorId);
-            } else {
-                revert UnknownActorChangeType();
+        // (1)-(3) Epoch / sequence gate. A batch is "sequenced" when it consumes a counter; unsequenced (JIT) batches
+        // exist only on the local channel (low half == UNSEQUENCED) and do not consume one.
+        bool sequenced;
+        if (isLocal) {
+            uint32 epoch = uint32(s.sequence >> 32);
+            uint32 seq = uint32(s.sequence);
+            uint32 storedEpoch = uint32(a.localSequence >> 32);
+            uint32 storedSeq = uint32(a.localSequence);
+            if (epoch != storedEpoch) revert StaleEpoch();
+            if (seq != UNSEQUENCED) {
+                sequenced = true;
+                if (seq != storedSeq) revert BadSequence();
+                if (seq >= UNSEQUENCED - 1) revert SequenceSaturated();
+                // Advance the low half before apply, preserving the epoch in the high half.
+                a.localSequence = (uint64(storedEpoch) << 32) | uint64(seq + 1);
             }
+        } else {
+            // Multichain: a plain monotonic counter, always sequenced, never epoch-bearing or UNSEQUENCED.
+            sequenced = true;
+            uint64 seq = s.sequence;
+            if (seq != a.multichainSequence) revert BadSequence();
+            if (seq == type(uint64).max) revert SequenceSaturated();
+            a.multichainSequence = seq + 1;
+        }
+
+        // (4) Authenticate over the relocatable digest.
+        bytes32 digest = _changesDigest(account, s.channel, s.sequence, s.changes);
+        (, uint16 scope) = authenticateActor(account, digest, s.signature);
+
+        // Lock policy is evaluated against the account's lock state at entry (lazily clearing an elapsed unlock).
+        bool locked = _checkAndClearLock(account);
+
+        // (5)-(6) Iterate. Track: an environment op having been seen (ordering fence), whether a reduction occurred,
+        // and whether the batch bumped the epoch (satisfies the reduction rule).
+        bool sawEnvOp;
+        bool needsBump;
+        bool hadBump;
+        uint256 n = s.changes.length;
+        for (uint256 i; i < n; i++) {
+            ChangeType t = s.changes[i].changeType;
+            bool env = _isEnvOp(t);
+
+            // Ordering: authority ops may never follow an environment op.
+            if (!env && sawEnvOp) revert AuthorityOpAfterEnvOp();
+            if (env) sawEnvOp = true;
+
+            // Sequencing (channel) policy: RevokeActor, Lock, Unlock are sequenced-only; AuthorizeActor and
+            // BumpLocalEpoch are permitted on both. (Multichain is always sequenced.)
+            if (!_sequencingAllowed(t, sequenced)) revert BadSequence();
+
+            // Lock policy: while the account is locked, only environment ops (bump/lock/unlock) may run.
+            if (locked && !env) revert AccountIsLocked();
+
+            // Per-op authorization fence against the recovered signer's scope.
+            if (!_opAuthorized(t, scope)) {
+                if (t == ChangeType.Lock || t == ChangeType.Unlock) revert UnauthorizedLockChange();
+                revert UnauthorizedActorChange();
+            }
+
+            // Solo rules: Unlock is always solo; an unsequenced BumpLocalEpoch is solo.
+            if (t == ChangeType.Unlock && n != 1) revert SoloOpNotSolo();
+            if (t == ChangeType.BumpLocalEpoch && !sequenced && n != 1) revert SoloOpNotSolo();
+
+            if (t == ChangeType.AuthorizeActor) {
+                needsBump = _applyAuthorize(account, sequenced, isLocal, s.changes[i].payload) || needsBump;
+            } else if (t == ChangeType.RevokeActor) {
+                needsBump = _applyRevoke(account, isLocal, s.changes[i].payload) || needsBump;
+            } else if (t == ChangeType.BumpLocalEpoch) {
+                _applyBumpLocalEpoch(account, isLocal, s.changes[i].payload);
+                hadBump = true;
+            } else if (t == ChangeType.Lock) {
+                _applyLock(account, locked, s.changes[i].payload);
+            } else {
+                // ChangeType.Unlock (the only remaining member; out-of-range values reverted at ABI-decode).
+                _applyUnlock(account, s.changes[i].payload);
+            }
+        }
+
+        // Reduction rule: any authority reduction on the local channel must be batched with an epoch bump.
+        if (needsBump && !hadBump) revert ReductionRequiresEpochBump();
+    }
+
+    /// @notice Permissionlessly garbage-collects a single expired actor slot, zeroing it for a gas refund.
+    ///
+    /// @dev A slot may be collected iff it is present and its expiry has passed (`slot.expiry < block.timestamp`,
+    ///      i.e. {_isExpired}). Because expiry is monotone non-decreasing across a slot's life — the unsequenced
+    ///      path only extends it upward and any sequenced decrease is forced to retire outstanding signatures via a
+    ///      mandatory epoch bump — a lapsed slot has no live replayable signature, so collection is unconditional
+    ///      and needs no authorization. Reverts with CollectLiveActor when the slot is absent or not yet expired.
+    ///
+    /// @param account The account to collect from.
+    /// @param actorId The expired actor to collect.
+    function collectActor(address account, bytes32 actorId) public nonZeroAccount(account) {
+        (bool occupied,, uint48 expiry) = _rawSlot(account, actorId);
+        if (!occupied || !_isExpired(expiry)) revert CollectLiveActor();
+        _clearActor(account, actorId);
+        emit ActorCollected(account, actorId);
+    }
+
+    /// @notice Batch variant of {collectActor}: collects each of `actorIds` (all must be present and expired).
+    ///
+    /// @param account The account to collect from.
+    /// @param actorIds The expired actors to collect.
+    function collectActors(address account, bytes32[] calldata actorIds) external {
+        for (uint256 i; i < actorIds.length; i++) {
+            collectActor(account, actorIds[i]);
         }
     }
 
     // ----------------------------------------------------------------------------------------------------------------
-    // ACCOUNT LOCKS
+    // SIGNED-CHANGE OP HANDLERS
     // ----------------------------------------------------------------------------------------------------------------
 
-    /// @notice Applies a signed lock-state change (hard-lock or initiate-unlock) to an account.
-    ///
-    /// @dev Lock state changes ONLY through this signed EVM entry point. Authorization comes entirely from the
-    ///      signature, so anyone may relay the call; the digest is authenticated against the account's actors and
-    ///      the resolved actor must be unrestricted (scope 0, admin) — there is no elevated scope for changing the
-    ///      lock. Lock changes are local-channel only: the digest binds `block.chainid` and a monotonic per-account
-    ///      `localSequence` consumed on each call (mirroring applySignedActorChanges so both signed entry points
-    ///      stay coherent on the same counter). Because both entry points share this counter, a pre-signed local
-    ///      actor change and a lock op contend for the same sequence: whichever is relayed first consumes it and
-    ///      invalidates the other until it is re-signed at the next sequence.
-    /// @dev op = LockChangeType.Lock (1): only from the unlocked state (reverts AccountIsLocked if currently locked). Sets
-    ///      FLAG_LOCKED and stores `unlockDelay` in `lockUnion`. Emits AccountLocked.
-    /// @dev op = LockChangeType.Unlock (2): only from the hard-locked state with no pending unlock (reverts NotLocked
-    ///      otherwise); `unlockDelay` MUST be 0. Sets FLAG_UNLOCK_INITIATED and overwrites `lockUnion` with
-    ///      unlocksAt = block.timestamp + storedDelay. Emits AccountUnlockInitiated.
-    /// @dev Reverts with InvalidAuthLength, InvalidSignature, AuthenticationFailed, AuthenticatorMismatch,
-    ///      ActorExpired, or DefaultEoaRevoked when `auth` fails to authenticate a live actor.
-    /// @dev Reverts with UnauthorizedLockChange when the authenticated actor is not unrestricted (scope != 0).
-    /// @dev Reverts with ZeroUnlockDelay when a lock op carries a zero unlock delay.
-    /// @dev Reverts with AccountIsLocked when a lock op targets an already-locked account.
-    /// @dev Reverts with InvalidUnlockDelay when an unlock op carries a non-zero unlock delay.
-    /// @dev Reverts with NotLocked when an unlock op targets an account that is not hard-locked.
-    /// @dev Reverts with UnknownLockChangeType when `op` is LockChangeType.Invalid.
-    ///
-    /// @param account The account whose lock state is changed.
-    /// @param op The lock operation: LockChangeType.Lock (1) to hard-lock, LockChangeType.Unlock (2) to initiate an unlock.
-    /// @param unlockDelay Delay in seconds before the account unlocks after an unlock is initiated (lock op only,
-    ///        max uint16, ~18 hours); MUST be 0 for the unlock op.
-    /// @param auth Authenticator(20) || authenticator-specific data authenticating an unrestricted actor.
-    function applySignedLockChanges(address account, LockChangeType op, uint16 unlockDelay, bytes calldata auth)
-        external
+    /// @dev AuthorizeActor. `payload = abi.encode(bytes32 actorId, ActorConfig cfg, bytes policyData)`; `cfg.expiry`
+    ///      is the granted expiry and the signature self-expires at it. Returns whether the op is a reduction that
+    ///      must be batched with an epoch bump (only ever true on the local channel).
+    function _applyAuthorize(address account, bool sequenced, bool isLocal, bytes calldata payload)
+        private
+        returns (bool needsBump)
     {
-        // Local channel only: bind the digest to the current chain and consume the local sequence (post-increment,
-        // hashing the pre-increment value — identical to applySignedActorChanges so both paths share one counter).
-        uint64 sequence = _accountState[account].localSequence++;
+        (bytes32 actorId, ActorConfig memory cfg, bytes memory policyData) =
+            abi.decode(payload, (bytes32, ActorConfig, bytes));
 
-        bytes32 digest = _computeSignedLockChangesDigest(account, block.chainid, op, unlockDelay, sequence);
-        (, uint16 scope) = authenticateActor(account, digest, auth);
+        // The grant must be strictly in the future (a zero/no-expiry grant is caught here: 0 <= now). Unsequenced
+        // grants additionally cannot be unbounded — that is sequenced-only.
+        uint48 chExpiry = cfg.expiry;
+        if (chExpiry <= block.timestamp) revert ExpiredChange();
+        if (!sequenced && chExpiry == type(uint48).max) revert UnboundedGrantRequiresSequencing();
 
-        // Only an unrestricted actor (scope 0) may change the lock; there is no elevated "admin" scope bit.
-        if (scope != 0) revert UnauthorizedLockChange();
+        (bool occupied, uint16 oldScope, uint48 oldExpiry) = _rawSlot(account, actorId);
 
-        AccountState storage config = _accountState[account];
+        if (!occupied) {
+            // Empty slot: plain install. Both channels, both sequencing modes.
+            _authorizeActor(account, actorId, cfg, policyData);
+            return false;
+        }
 
-        // Out-of-range op values revert at ABI-decode, so only LockChangeType.Invalid reaches the fall-through revert below.
-        if (op == LockChangeType.Lock) {
-            // Lock only from the unlocked state; lazily clear any elapsed unlock (also clears LOCKED) first.
-            if (_checkAndClearLock(account)) revert AccountIsLocked();
-            // Require non-zero unlock delay.
-            if (unlockDelay == 0) revert ZeroUnlockDelay();
+        // Occupied slot. Authenticator equality is structural: actorId derives from the authenticator, so a different
+        // authenticator is a different slot (the empty-slot case above); no explicit check is needed here.
+        // Treat a stored no-expiry (0) as unbounded for monotonicity, so nothing can silently reduce an infinite grant.
+        uint48 effectiveOld = oldExpiry == 0 ? type(uint48).max : oldExpiry;
+        if (!sequenced) {
+            // Unsequenced upsert: scope frozen, strictly-monotone-up expiry (extend-by-upsert).
+            if (cfg.scope != oldScope) revert ScopeChangeRequiresSequencing();
+            if (chExpiry <= effectiveOld) revert NonMonotoneExpiry();
+            _authorizeActor(account, actorId, cfg, policyData);
+            return false;
+        }
 
-            // Post-clear the lock bits are clear, so set FLAG_LOCKED and stash the delay in the union.
-            config.flags |= FLAG_LOCKED;
-            config.lockUnion = unlockDelay;
-            emit AccountLocked(account, unlockDelay);
-        } else if (op == LockChangeType.Unlock) {
-            // The unlock op never sets the delay; it consumes the delay stored by the lock op.
-            if (unlockDelay != 0) revert InvalidUnlockDelay();
-            // Require the account is hard-locked (LOCKED set) with no unlock already initiated (UNLOCK_INITIATED clear).
-            uint8 flags = config.flags;
-            if (flags & FLAG_LOCKED == 0 || flags & FLAG_UNLOCK_INITIATED != 0) revert NotLocked();
+        // Sequenced upsert: any expiry, any scope. A shorter expiry or a narrowed scope (cleared grant bits) is a
+        // reduction that must be batched with a bump — but only on the local channel; the multichain counter alone
+        // retires the prior signature, so it never sets the flag.
+        bool reduction = isLocal && (chExpiry < effectiveOld || (oldScope & ~cfg.scope) != 0);
+        _authorizeActor(account, actorId, cfg, policyData);
+        return reduction;
+    }
 
-            // Reinterpret the union: it held the stored delay, now it holds the effective unlock timestamp.
-            uint48 unlocksAt = uint48(block.timestamp + uint16(config.lockUnion));
-            config.flags = flags | FLAG_UNLOCK_INITIATED;
-            config.lockUnion = unlocksAt;
-            emit AccountUnlockInitiated(account, unlocksAt);
-        } else {
-            revert UnknownLockChangeType();
+    /// @dev RevokeActor. `payload = abi.encode(bytes32 actorId)`. Sequenced-only (enforced by the channel policy).
+    ///      Deleting a still-live actor is a reduction (needs a bump on the local channel); revoking an
+    ///      already-lapsed actor is equivalent to garbage collection and skips the flag (gated on the same
+    ///      expiry-vs-now comparison collectActor uses).
+    function _applyRevoke(address account, bool isLocal, bytes calldata payload) private returns (bool needsBump) {
+        bytes32 actorId = abi.decode(payload, (bytes32));
+        (,, uint48 expiry) = _rawSlot(account, actorId);
+        bool lapsed = _isExpired(expiry);
+        _revokeActor(account, actorId);
+        return isLocal && !lapsed;
+    }
+
+    /// @dev BumpLocalEpoch. Empty payload. Strict increment of the local epoch, resetting the local sequence to 0
+    ///      and thereby invalidating every unlanded local signature (they commit the full 64-bit word). Local-only.
+    function _applyBumpLocalEpoch(address account, bool isLocal, bytes calldata payload) private {
+        if (payload.length != 0) revert InvalidChangePayload();
+        if (!isLocal) revert EpochOpRequiresLocalChannel();
+        AccountState storage a = _accountState[account];
+        uint32 epoch = uint32(a.localSequence >> 32);
+        if (epoch >= type(uint32).max - 1) revert EpochSaturated();
+        unchecked {
+            a.localSequence = uint64(epoch + 1) << 32; // epoch += 1, sequence := 0
+        }
+    }
+
+    /// @dev Lock. `payload = abi.encode(uint16 unlockDelay)`. Only from the unlocked state; stores the delay.
+    function _applyLock(address account, bool locked, bytes calldata payload) private {
+        if (locked) revert AccountIsLocked();
+        uint16 unlockDelay = abi.decode(payload, (uint16));
+        if (unlockDelay == 0) revert ZeroUnlockDelay();
+        AccountState storage a = _accountState[account];
+        a.flags |= FLAG_LOCKED;
+        a.lockUnion = unlockDelay;
+        emit AccountLocked(account, unlockDelay);
+    }
+
+    /// @dev Unlock. Empty payload. Only from the hard-locked state with no pending unlock; sets the effective
+    ///      unlock timestamp from the stored delay. Always a solo batch (enforced by the caller).
+    function _applyUnlock(address account, bytes calldata payload) private {
+        if (payload.length != 0) revert InvalidChangePayload();
+        AccountState storage a = _accountState[account];
+        uint8 flags = a.flags;
+        if (flags & FLAG_LOCKED == 0 || flags & FLAG_UNLOCK_INITIATED != 0) revert NotLocked();
+        uint48 unlocksAt = uint48(block.timestamp + uint16(a.lockUnion));
+        a.flags = flags | FLAG_UNLOCK_INITIATED;
+        a.lockUnion = unlocksAt;
+        emit AccountUnlockInitiated(account, unlocksAt);
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // SIGNED-CHANGE POLICY PREDICATES
+    // ----------------------------------------------------------------------------------------------------------------
+
+    /// @dev Enum-ordering-as-classification: an environment op mutates the rules ops are checked against.
+    function _isEnvOp(ChangeType t) private pure returns (bool) {
+        return t >= ChangeType.BumpLocalEpoch;
+    }
+
+    /// @dev Sequencing (channel) policy: RevokeActor, Lock and Unlock require a sequenced batch; AuthorizeActor and
+    ///      BumpLocalEpoch are permitted on both the sequenced and unsequenced channels.
+    function _sequencingAllowed(ChangeType t, bool sequenced) private pure returns (bool) {
+        if (t == ChangeType.AuthorizeActor || t == ChangeType.BumpLocalEpoch) return true;
+        return sequenced;
+    }
+
+    /// @dev Per-op authorization against the recovered signer's scope. Admin (scope 0) may perform every op; a
+    ///      recovery-class actor (Scopes.RECOVERY) may only initiate an Unlock and nothing else (the second fence).
+    function _opAuthorized(ChangeType t, uint16 scope) private pure returns (bool) {
+        if (scope == 0) return true;
+        return t == ChangeType.Unlock && (scope & Scopes.RECOVERY != 0);
+    }
+
+    /// @dev Reads an actor's raw stored slot IGNORING expiry (structural presence): a populated _actorConfig entry
+    ///      for any non-self actor or a non-k1 self, or the inline k1 self when enabled. Returns whether the slot is
+    ///      occupied plus its scope and expiry. Mirrors {getActorConfig}'s resolution minus the expiry masking.
+    function _rawSlot(address account, bytes32 actorId)
+        private
+        view
+        returns (bool occupied, uint16 scope, uint48 expiry)
+    {
+        ActorConfig storage c = _actorConfig[actorId][account];
+        if (c.authenticator >= K1_AUTHENTICATOR) return (true, c.scope, c.expiry);
+        if (actorId == bytes32(bytes20(account)) && !_isDefaultEoaRevoked(account)) {
+            AccountState storage st = _accountState[account];
+            return (true, st.defaultEOAScope, st.defaultEOAExpiry);
+        }
+        return (false, 0, 0);
+    }
+
+    /// @dev Clears an actor's config and policy slots, disabling the inline k1 self for the self-actorId. Shared by
+    ///      {_revokeActor} (which additionally requires the actor be present) and {collectActor} (GC).
+    function _clearActor(address account, bytes32 actorId) private {
+        delete _actorConfig[actorId][account];
+        delete _policyCommitment[actorId][account];
+        delete _policyManager[actorId][account];
+        if (actorId == bytes32(bytes20(account))) {
+            _disableInlineSelf(_accountState[account]);
         }
     }
 
@@ -815,12 +1037,26 @@ contract Keystore {
 
     /// @notice Returns the account's multichain and local change sequences (replay counters).
     ///
+    /// @dev The `local` field is the raw 64-bit word: localEpoch(32, high) || localSequence(32, low). Use
+    ///      {getLocalEpochAndSequence} to read the two halves split out.
+    ///
     /// @param account The account to read.
     ///
-    /// @return The account's ChangeSequences (multichain and local counters).
+    /// @return The account's ChangeSequences (multichain counter and the raw local epoch||sequence word).
     function getChangeSequences(address account) external view returns (ChangeSequences memory) {
         AccountState storage state = _accountState[account];
         return ChangeSequences({multichain: state.multichainSequence, local: state.localSequence});
+    }
+
+    /// @notice Returns the account's local epoch and local sequence, split from the packed 64-bit word.
+    ///
+    /// @param account The account to read.
+    ///
+    /// @return epoch The account's current local epoch (high 32 bits of the local word).
+    /// @return sequence The account's current local sequence (low 32 bits of the local word).
+    function getLocalEpochAndSequence(address account) external view returns (uint32 epoch, uint32 sequence) {
+        uint64 word = _accountState[account].localSequence;
+        return (uint32(word >> 32), uint32(word));
     }
 
     /// @notice Returns whether the account is currently locked (configuration frozen).
@@ -904,7 +1140,7 @@ contract Keystore {
     /// @dev Registers the bootstrap actor set shared by createAccount and importAccount: requires a non-empty,
     ///      strictly ascending-by-actorId list (rejecting unsorted or duplicate entries) and authorizes each entry
     ///      with its declared scope and (when scope & Scopes.POLICY is set) policyData. Expiry is always 0 for
-    ///      initial actors; scoped-with-expiry keys are added later via applySignedActorChanges. Reverts with
+    ///      initial actors; scoped-with-expiry keys are added later via applySignedAccountChanges. Reverts with
     ///      NoInitialActors or ActorsNotSortedOrDuplicate.
     function _initializeAccount(address account, InitialActor[] calldata initialActors)
         internal
@@ -1050,15 +1286,9 @@ contract Keystore {
     ///      fields). Reverts with UnknownActor when the actor is not currently live.
     function _revokeActor(address account, bytes32 actorId) internal nonZeroAccount(account) {
         if (!_isAuthorized(account, actorId)) revert UnknownActor();
-        delete _actorConfig[actorId][account];
-        // Policy state is keyed by (account, actorId) and cleared exactly on revoke.
-        delete _policyCommitment[actorId][account];
-        delete _policyManager[actorId][account];
-        // For the self-actorId, disable the k1 self: set the flag (so the inline full-owner path stays off) and
-        // clear the inline config. Covers both homes — a non-k1 self was deleted above. Never auto-resurrected.
-        if (actorId == bytes32(bytes20(account))) {
-            _disableInlineSelf(_accountState[account]);
-        }
+        // Clears the config and policy slots, and disables the inline k1 self for the self-actorId (covers both
+        // homes; never auto-resurrected).
+        _clearActor(account, actorId);
         emit ActorRevoked(account, actorId);
     }
 
@@ -1108,7 +1338,7 @@ contract Keystore {
 
     /// @dev Typed digest for the importAccount ERC-1271 signature (a signed message), so signers can reproduce it
     ///      with standard EIP-712-style struct hashing. `salt` is bound to the account address and the digest is
-    ///      bound to `chainId` (0 = multichain) so its replay domain matches applySignedActorChanges.
+    ///      bound to `chainId` (0 = multichain) so its replay domain matches applySignedAccountChanges.
     function _computeImportDigest(address account, uint256 chainId, InitialActor[] calldata initialActors)
         internal
         pure
@@ -1137,52 +1367,31 @@ contract Keystore {
         );
     }
 
-    /// @dev Computes the digest signed over an applySignedActorChanges batch: each ActorChange is hashed structurally
-    ///      (its variable-length `data` pre-hashed to a fixed-width layout) and the batch is bound to `account`,
-    ///      `chainId`, and `sequence` via SIGNED_ACTOR_CHANGES_TYPEHASH.
-    function _computeSignedActorChangesDigest(
+    /// @dev Computes the digest signed over an applySignedAccountChanges batch: each AccountChange is hashed
+    ///      structurally (its variable-length `payload` pre-hashed to a fixed-width layout) and the batch is bound to
+    ///      `account`, the channel's replay `chainId` (0 for Multichain, block.chainid for Local), and the raw
+    ///      `sequence` word via SIGNED_ACCOUNT_CHANGES_TYPEHASH.
+    ///
+    ///      This is the hash-relocation SEAM: the whole scheme is confined here so a later workstream can relocate
+    ///      it without touching the pipeline in {applySignedAccountChanges}.
+    function _changesDigest(
         address account,
-        uint256 chainId,
+        AccountChangeChannel channel,
         uint64 sequence,
-        ActorChange[] calldata actorChanges
-    ) internal pure returns (bytes32) {
-        // Hash each actor change structurally: the variable-length `data` is hashed before encoding so the
-        // digest commits to a fixed-width layout (matches the ActorChange sub-type in SIGNED_ACTOR_CHANGES_TYPEHASH).
-        bytes32[] memory actorChangeHashes = new bytes32[](actorChanges.length);
-        for (uint256 i; i < actorChanges.length; i++) {
-            actorChangeHashes[i] = keccak256(
-                abi.encode(
-                    ACTOR_CHANGE_TYPEHASH,
-                    actorChanges[i].changeType,
-                    actorChanges[i].actorId,
-                    keccak256(actorChanges[i].data)
-                )
+        AccountChange[] calldata changes
+    ) internal view returns (bytes32) {
+        uint256 chainId = channel == AccountChangeChannel.Multichain ? 0 : block.chainid;
+        bytes32[] memory changeHashes = new bytes32[](changes.length);
+        for (uint256 i; i < changes.length; i++) {
+            changeHashes[i] = keccak256(
+                abi.encode(ACCOUNT_CHANGE_TYPEHASH, uint8(changes[i].changeType), keccak256(changes[i].payload))
             );
         }
-
-        // Hash the batch of actor changes
         return keccak256(
             abi.encode(
-                SIGNED_ACTOR_CHANGES_TYPEHASH,
-                account,
-                chainId,
-                sequence,
-                keccak256(abi.encodePacked(actorChangeHashes))
+                SIGNED_ACCOUNT_CHANGES_TYPEHASH, account, chainId, sequence, keccak256(abi.encodePacked(changeHashes))
             )
         );
-    }
-
-    /// @dev Computes the digest signed over an applySignedLockChanges call, binding the lock op and its unlock delay
-    ///      to `account`, `chainId`, and `sequence` via LOCK_CHANGE_TYPEHASH. Lock changes are local-channel only,
-    ///      so callers always pass the current chainId.
-    function _computeSignedLockChangesDigest(
-        address account,
-        uint256 chainId,
-        LockChangeType op,
-        uint16 unlockDelay,
-        uint64 sequence
-    ) internal pure returns (bytes32) {
-        return keccak256(abi.encode(LOCK_CHANGE_TYPEHASH, account, chainId, op, unlockDelay, sequence));
     }
 
     // ----------------------------------------------------------------------------------------------------------------

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -32,7 +32,7 @@ contract Keystore {
 
     /// @notice Initial actor for account creation and import. Carries its scope and, when scope & Scopes.POLICY is
     ///         set, its policy data; expiry is always 0 for initial actors (scoped-with-expiry keys are added later
-    ///         via applySignedConfigChanges).
+    ///         via applySignedAccountChanges).
     struct InitialActor {
         bytes32 actorId;
         address authenticator;
@@ -48,7 +48,7 @@ contract Keystore {
         bytes policyData;
     }
 
-    /// @notice The operation an {ConfigChange} applies within an {applySignedConfigChanges} batch.
+    /// @notice The operation an {AccountChange} applies within an {applySignedAccountChanges} batch.
     ///
     /// @dev ABI-encodes as uint8. The declaration ORDER is normative and doubles as a classification: every member
     ///      strictly below {IncrementLocalEpoch} is an *authority op* (it mutates who can act — the actor set); every
@@ -67,24 +67,24 @@ contract Keystore {
         Unlock // payload: empty (length == 0 enforced)
     }
 
-    /// @notice The replay domain a {SignedConfigChanges} batch is bound to.
+    /// @notice The replay domain a {SignedAccountChanges} batch is bound to.
     ///
     /// @dev Replaces the prior `uint256 chainId` argument. {Local} binds `block.chainid` and carries the full local
-    ///      epoch machinery (see {SignedConfigChanges.sequence}); {Multichain} binds chainId 0 and keeps a plain
+    ///      epoch machinery (see {SignedAccountChanges.sequence}); {Multichain} binds chainId 0 and keeps a plain
     ///      monotonic counter with no epochs and no unsequenced (JIT) mode — its counter alone prevents replay, so
     ///      it never requires an epoch increment and {IncrementLocalEpoch} is rejected on it.
-    enum ConfigChangeChannel {
+    enum AccountChangeChannel {
         Local,
         Multichain
     }
 
     /// @notice A single operation within a signed batch: its type and an operation-specific ABI-encoded payload.
-    struct ConfigChange {
+    struct AccountChange {
         ChangeType changeType;
         bytes payload;
     }
 
-    /// @notice An ordered, atomic batch of config changes with its replay binding and signature.
+    /// @notice An ordered, atomic batch of account changes with its replay binding and signature.
     ///
     /// @dev `changes` are applied in order, all-or-nothing (intersection-strict: any rejected op reverts the whole
     ///      batch). `sequence` is interpreted per `channel`:
@@ -94,10 +94,10 @@ contract Keystore {
     ///        - Multichain: a plain uint64 consumed against the account's multichainSequence; never {UNSEQUENCED},
     ///          never carries an epoch.
     ///      `signature` is the standard authenticator(20) || authenticator-data blob authenticating the signer.
-    struct SignedConfigChanges {
-        ConfigChangeChannel channel;
+    struct SignedAccountChanges {
+        AccountChangeChannel channel;
         uint64 sequence;
-        ConfigChange[] changes;
+        AccountChange[] changes;
         bytes signature;
     }
 
@@ -162,23 +162,23 @@ contract Keystore {
     bytes32 public constant ACTOR_CONFIG_TYPEHASH =
         keccak256("ActorConfig(address authenticator,uint48 expiry,uint16 scope)");
 
-    /// @notice Typehash binding a signed config-change batch to its account, chainId, and sequence.
+    /// @notice Typehash binding a signed account-change batch to its account, chainId, and sequence.
     ///
     /// @dev NOT compliant with EIP-712, to mitigate phishing attacks. `chainId` is the channel's replay domain
-    ///      (0 for {ConfigChangeChannel.Multichain}, block.chainid for {ConfigChangeChannel.Local}). The digest
+    ///      (0 for {AccountChangeChannel.Multichain}, block.chainid for {AccountChangeChannel.Local}). The digest
     ///      scheme is a relocation seam: it lives behind {_changesDigest} so a later hash-relocation workstream can
     ///      move it without touching the pipeline.
-    bytes32 public constant SIGNED_CONFIG_CHANGES_TYPEHASH = keccak256(
-        "SignedConfigChanges(address account,uint256 chainId,uint64 sequence,ConfigChange[] changes)"
-        "ConfigChange(uint8 changeType,bytes payload)"
+    bytes32 public constant SIGNED_ACCOUNT_CHANGES_TYPEHASH = keccak256(
+        "SignedAccountChanges(address account,uint256 chainId,uint64 sequence,AccountChange[] changes)"
+        "AccountChange(uint8 changeType,bytes payload)"
     );
 
-    /// @notice Typehash used to structurally hash each ConfigChange within a SignedConfigChanges batch.
-    bytes32 public constant CONFIG_CHANGE_TYPEHASH = keccak256("ConfigChange(uint8 changeType,bytes payload)");
+    /// @notice Typehash used to structurally hash each AccountChange within a SignedAccountChanges batch.
+    bytes32 public constant ACCOUNT_CHANGE_TYPEHASH = keccak256("AccountChange(uint8 changeType,bytes payload)");
 
-    /// @notice Local-channel sequence low-half sentinel marking an unsequenced (JIT) batch. A {SignedConfigChanges}
+    /// @notice Local-channel sequence low-half sentinel marking an unsequenced (JIT) batch. A {SignedAccountChanges}
     ///         whose low 32 bits equal this value does not consume a sequence, so it stays replayable until the local
-    ///         epoch moves; any op type may ride it (see {applySignedConfigChanges}). Sequenced batches may therefore
+    ///         epoch moves; any op type may ride it (see {applySignedAccountChanges}). Sequenced batches may therefore
     ///         run up to UNSEQUENCED - 2.
     uint32 public constant UNSEQUENCED = type(uint32).max;
 
@@ -217,7 +217,7 @@ contract Keystore {
     uint8 public constant FLAG_REVOKE_DEFAULT_EOA = 0x01;
 
     /// @notice AccountState.flags bit (spec `LOCKED`): when set, actor configuration is frozen — only environment
-    ///         ops (IncrementLocalEpoch, Lock, Unlock) are permitted through applySignedConfigChanges; authority ops
+    ///         ops (IncrementLocalEpoch, Lock, Unlock) are permitted through applySignedAccountChanges; authority ops
     ///         (AuthorizeActor, RevokeActor) are rejected. Cleared lazily once an initiated unlock elapses.
     uint8 public constant FLAG_LOCKED = 0x02;
 
@@ -296,8 +296,8 @@ contract Keystore {
     /// @notice The signed chainId is neither 0 (multichain) nor the current chain.
     error InvalidChainId();
 
-    /// @notice The batch signer is not the account admin (scope 0). Every signed config change is admin-only.
-    error UnauthorizedConfigChange();
+    /// @notice The batch signer is not the account admin (scope 0). Every signed account change is admin-only.
+    error UnauthorizedAccountChange();
 
     /// @notice The importAccount ERC-1271 signature check did not return the magic value.
     error InvalidImportSignature();
@@ -432,7 +432,7 @@ contract Keystore {
     /// @notice Deploys a new account with its initial actors. Each initial actor is registered with its declared
     ///         `scope` and, when `scope & Scopes.POLICY` is set, its `policyData` (an external `manager` is expressible
     ///         at create; `manager = account` is not, as the address is unknown at commitment time). `expiry` is
-    ///         always 0 at create — scoped-with-expiry keys are added afterwards via applySignedConfigChanges. The
+    ///         always 0 at create — scoped-with-expiry keys are added afterwards via applySignedAccountChanges. The
     ///         implicit default-EOA key is disabled on creation.
     ///
     /// @dev Reverts with EmptyBytecode when `bytecode` is empty.
@@ -528,7 +528,7 @@ contract Keystore {
         emit AccountImported(account);
     }
 
-    /// @notice The sole signed-change entry point: applies an ordered, atomic batch of config changes (authorize,
+    /// @notice The sole signed-change entry point: applies an ordered, atomic batch of account changes (authorize,
     ///         revoke, increment-local-epoch, lock, unlock) authenticated by `s.signature`.
     ///
     /// @dev The governing axiom is Replay: a signed local change is valid only while it could still be validly
@@ -540,7 +540,7 @@ contract Keystore {
     ///      the contract lets a bare reduction land, so pairing it with an increment is a wallet responsibility. A bare
     ///      revoke (or expiry cut) is not durable while a replayable unsequenced grant for that actor is outstanding.
     ///
-    ///      Authorization is flat: every signed config change is admin-only, so a single up-front scope check
+    ///      Authorization is flat: every signed account change is admin-only, so a single up-front scope check
     ///      (signer scope must be 0) authorizes the whole batch — there is no per-op authorization and no per-op
     ///      sequencing restriction (any op may ride an unsequenced or sequenced batch).
     ///
@@ -552,12 +552,12 @@ contract Keystore {
     ///
     /// @param account The account whose configuration is changed.
     /// @param s The signed batch (channel, ordered changes, sequence word, signature).
-    function applySignedConfigChanges(address account, SignedConfigChanges calldata s)
+    function applySignedAccountChanges(address account, SignedAccountChanges calldata s)
         external
         nonZeroAccount(account)
     {
         AccountState storage a = _accountState[account];
-        bool isLocal = s.channel == ConfigChangeChannel.Local;
+        bool isLocal = s.channel == AccountChangeChannel.Local;
 
         // Epoch / sequence gate. An unsequenced (JIT) batch exists only on the local channel (low half ==
         // UNSEQUENCED) and does not consume a counter; every other batch consumes its channel's counter.
@@ -583,11 +583,11 @@ contract Keystore {
             a.multichainSequence = seq + 1;
         }
 
-        // Authenticate over the relocatable digest. Authorization is flat: every signed config change is
+        // Authenticate over the relocatable digest. Authorization is flat: every signed account change is
         // admin-only, so a single scope check up front replaces any per-op authorization.
         bytes32 digest = _changesDigest(account, s.channel, s.sequence, s.changes);
         (, uint16 scope) = authenticateActor(account, digest, s.signature);
-        if (scope != 0) revert UnauthorizedConfigChange();
+        if (scope != 0) revert UnauthorizedAccountChange();
 
         // Lock policy is evaluated against the account's lock state at entry (lazily clearing an elapsed unlock). This
         // snapshot drives ONLY the authority-op gate below; the entry value is sound there because lock state changes
@@ -1021,7 +1021,7 @@ contract Keystore {
     /// @dev Registers the bootstrap actor set shared by createAccount and importAccount: requires a non-empty,
     ///      strictly ascending-by-actorId list (rejecting unsorted or duplicate entries) and authorizes each entry
     ///      with its declared scope and (when scope & Scopes.POLICY is set) policyData. Expiry is always 0 for
-    ///      initial actors; scoped-with-expiry keys are added later via applySignedConfigChanges. Reverts with
+    ///      initial actors; scoped-with-expiry keys are added later via applySignedAccountChanges. Reverts with
     ///      NoInitialActors or ActorsNotSortedOrDuplicate.
     function _initializeAccount(address account, InitialActor[] calldata initialActors)
         internal
@@ -1208,7 +1208,7 @@ contract Keystore {
 
     /// @dev Typed digest for the importAccount ERC-1271 signature (a signed message), so signers can reproduce it
     ///      with standard EIP-712-style struct hashing. `salt` is bound to the account address and the digest is
-    ///      bound to `chainId` (0 = multichain) so its replay domain matches applySignedConfigChanges.
+    ///      bound to `chainId` (0 = multichain) so its replay domain matches applySignedAccountChanges.
     function _computeImportDigest(address account, uint256 chainId, InitialActor[] calldata initialActors)
         internal
         pure
@@ -1237,29 +1237,29 @@ contract Keystore {
         );
     }
 
-    /// @dev Computes the digest signed over an applySignedConfigChanges batch: each ConfigChange is hashed
+    /// @dev Computes the digest signed over an applySignedAccountChanges batch: each AccountChange is hashed
     ///      structurally (its variable-length `payload` pre-hashed to a fixed-width layout) and the batch is bound to
     ///      `account`, the channel's replay `chainId` (0 for Multichain, block.chainid for Local), and the raw
-    ///      `sequence` word via SIGNED_CONFIG_CHANGES_TYPEHASH.
+    ///      `sequence` word via SIGNED_ACCOUNT_CHANGES_TYPEHASH.
     ///
     ///      This is the hash-relocation SEAM: the whole scheme is confined here so a later workstream can relocate
-    ///      it without touching the pipeline in {applySignedConfigChanges}.
+    ///      it without touching the pipeline in {applySignedAccountChanges}.
     function _changesDigest(
         address account,
-        ConfigChangeChannel channel,
+        AccountChangeChannel channel,
         uint64 sequence,
-        ConfigChange[] calldata changes
+        AccountChange[] calldata changes
     ) internal view returns (bytes32) {
-        uint256 chainId = channel == ConfigChangeChannel.Multichain ? 0 : block.chainid;
+        uint256 chainId = channel == AccountChangeChannel.Multichain ? 0 : block.chainid;
         bytes32[] memory changeHashes = new bytes32[](changes.length);
         for (uint256 i; i < changes.length; i++) {
             changeHashes[i] = keccak256(
-                abi.encode(CONFIG_CHANGE_TYPEHASH, uint8(changes[i].changeType), keccak256(changes[i].payload))
+                abi.encode(ACCOUNT_CHANGE_TYPEHASH, uint8(changes[i].changeType), keccak256(changes[i].payload))
             );
         }
         return keccak256(
             abi.encode(
-                SIGNED_CONFIG_CHANGES_TYPEHASH, account, chainId, sequence, keccak256(abi.encodePacked(changeHashes))
+                SIGNED_ACCOUNT_CHANGES_TYPEHASH, account, chainId, sequence, keccak256(abi.encodePacked(changeHashes))
             )
         );
     }

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -587,11 +587,9 @@ contract Keystore {
                 if (seq >= UNSEQUENCED - 1) {
                     revert SequenceSaturated();
                 }
-                // Advance the local sequence before apply — checks-effects-before-interactions ahead of the
-                // authenticator STATICCALL below. (authenticateActor is `view`, so the authenticator cannot actually
-                // re-enter with a write; this is hardening in case that ever changes.) A trailing IncrementLocalEpoch
-                // in the same batch overwrites this to 0, but that second write lands on an already-warm slot (~100
-                // gas), so the rare sequenced+increment combo isn't worth special-casing here.
+                // Advance the local sequence before apply. A trailing IncrementLocalEpoch in the same batch
+                // overwrites this to 0, but that second write lands on an already-warm slot (~100 gas), so the
+                // combo isn't worth special-casing here.
                 a.localSequence = seq + 1;
             } else if (!_isInitialized(account)) {
                 // Mark a fresh account initialized and invalidate outstanding sequence-0 signatures. The unsequenced

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -95,8 +95,8 @@ contract Keystore {
     ///      `signature` is the standard authenticator(20) || authenticator-data blob authenticating the signer.
     struct SignedAccountChanges {
         AccountChangeChannel channel;
-        AccountChange[] changes;
         uint64 sequence;
+        AccountChange[] changes;
         bytes signature;
     }
 

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -52,7 +52,7 @@ contract Keystore {
     /// @dev ABI-encodes as uint8. The declaration ORDER is normative and doubles as a classification: every member
     ///      strictly below {BumpLocalEpoch} is an *authority op* (it mutates who can act — the actor set); every
     ///      member from {BumpLocalEpoch} onward is an *environment op* (it mutates the rules ops are checked
-    ///      against — the local epoch or the lock). `_isEnvOp(t) == (t >= BumpLocalEpoch)`. Future ops MUST be
+    ///      against — the local epoch or the lock). The classification is simply `t >= BumpLocalEpoch`. Future ops MUST be
     ///      inserted in the correct class to preserve this predicate. All five values are reachable and meaningful;
     ///      out-of-range wire values (>= 5) can never reach the handler — the enum decoder reverts them while
     ///      ABI-decoding the calldata (no in-handler "unknown" sentinel, unlike the pre-split enums).
@@ -348,6 +348,10 @@ contract Keystore {
     ///         BumpLocalEpoch / Unlock).
     error InvalidChangePayload();
 
+    /// @notice Defensive guard for an unhandled ChangeType in the apply loop. Unreachable in practice — out-of-range
+    ///         wire values are rejected by the enum decoder during ABI-decoding.
+    error UnknownActorChangeType();
+
     /// @notice The auth blob is shorter than the 20-byte authenticator selector prefix.
     error InvalidAuthLength();
 
@@ -601,7 +605,9 @@ contract Keystore {
         uint256 n = s.changes.length;
         for (uint256 i; i < n; i++) {
             ChangeType t = s.changes[i].changeType;
-            bool env = _isEnvOp(t);
+            // Enum-ordering-as-classification: an environment op (BumpLocalEpoch onward) mutates the rules ops are
+            // checked against; anything below is an authority op that mutates who can act.
+            bool env = t >= ChangeType.BumpLocalEpoch;
 
             // Ordering: authority ops may never follow an environment op.
             if (!env && sawEnvOp) revert AuthorityOpAfterEnvOp();
@@ -622,9 +628,12 @@ contract Keystore {
                 _applyBumpLocalEpoch(account, isLocal, s.changes[i].payload);
             } else if (t == ChangeType.Lock) {
                 _applyLock(account, locked, s.changes[i].payload);
-            } else {
-                // ChangeType.Unlock (the only remaining member; out-of-range values reverted at ABI-decode).
+            } else if (t == ChangeType.Unlock) {
                 _applyUnlock(account, s.changes[i].payload);
+            } else {
+                // Unreachable: out-of-range wire values are rejected by the enum decoder while ABI-decoding the
+                // calldata. Kept as a defensive guard so any future ChangeType must be wired in explicitly.
+                revert UnknownActorChangeType();
             }
         }
     }
@@ -722,13 +731,8 @@ contract Keystore {
     }
 
     // ----------------------------------------------------------------------------------------------------------------
-    // SIGNED-CHANGE POLICY PREDICATES
+    // SIGNED-CHANGE HELPERS
     // ----------------------------------------------------------------------------------------------------------------
-
-    /// @dev Enum-ordering-as-classification: an environment op mutates the rules ops are checked against.
-    function _isEnvOp(ChangeType t) private pure returns (bool) {
-        return t >= ChangeType.BumpLocalEpoch;
-    }
 
     /// @dev Reads an actor's raw stored slot IGNORING expiry (structural presence): a populated _actorConfig entry
     ///      for any non-self actor or a non-k1 self, or the inline k1 self when enabled. Returns whether the slot is

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -50,15 +50,15 @@ contract Keystore {
 
     /// @notice The operation an {AccountChange} applies within an {applySignedAccountChanges} batch.
     ///
-    /// @dev ABI-encodes as uint8. The declaration ORDER is normative and doubles as a classification: every member
-    ///      strictly below {IncrementLocalEpoch} is an *authority op* (it mutates who can act — the actor set); every
-    ///      member from {IncrementLocalEpoch} onward is an *environment op* (it mutates the rules ops are checked
-    ///      against — the local epoch or the lock). The classification is simply `t >= IncrementLocalEpoch`. Future ops MUST be
-    ///      inserted in the correct class to preserve this predicate. All five values are reachable and meaningful;
-    ///      out-of-range wire values (>= 5) can never reach the handler — the enum decoder reverts them while
-    ///      ABI-decoding the calldata (no in-handler "unknown" sentinel, unlike the pre-split enums).
+    /// @dev ABI-encodes as uint8. Members split into two conceptual classes: *authority ops* (AuthorizeActor,
+    ///      RevokeActor) mutate who can act — the actor set — and are rejected while the account is locked; *environment
+    ///      ops* (IncrementLocalEpoch, Lock, Unlock) mutate the rules ops are checked against — the local epoch or the
+    ///      lock — and remain permitted while locked. This class distinction drives only the per-op lock gate; op order
+    ///      within a batch is otherwise unconstrained (authority and environment ops commute). All five values are
+    ///      reachable and meaningful; out-of-range wire values (>= 5) can never reach the handler — the enum decoder
+    ///      reverts them while ABI-decoding the calldata (no in-handler "unknown" sentinel, unlike the pre-split enums).
     enum ChangeType {
-        // Authority ops (mutate who can act) — MUST stay below IncrementLocalEpoch.
+        // Authority ops (mutate who can act).
         AuthorizeActor, // payload: abi.encode(bytes32 actorId, ActorConfig cfg, bytes policyData); cfg.expiry is the granted expiry
         RevokeActor, // payload: abi.encode(bytes32 actorId)
         // Environment ops (mutate the rules ops are checked against).
@@ -322,10 +322,6 @@ contract Keystore {
     /// @notice The local epoch is at its terminal value and cannot be incremented.
     error EpochSaturated();
 
-    /// @notice An authority op (AuthorizeActor / RevokeActor) followed an environment op in the same batch, violating
-    ///         the normative op ordering (authority ops first, environment ops last).
-    error AuthorityOpAfterEnvOp();
-
     /// @notice An AuthorizeActor's granted expiry is non-zero and not strictly in the future (self-expired on
     ///         arrival). A zero expiry is the "no expiry" sentinel and is accepted.
     error ExpiredChange();
@@ -547,8 +543,8 @@ contract Keystore {
     ///      Pipeline (in order): (1) split the sequence word; (2) reject a stale local epoch on both channels;
     ///      (3) validate/advance the sequence counter BEFORE apply (reentrancy discipline); (4) compute the digest
     ///      via the relocatable {_changesDigest} seam, authenticate, and reject a non-admin signer; (5) iterate
-    ///      changes enforcing op ordering and the lock policy. Anyone may relay — authorization comes entirely from
-    ///      the signature.
+    ///      changes enforcing the lock policy (authority ops are rejected while the account is locked). Anyone may
+    ///      relay — authorization comes entirely from the signature.
     ///
     /// @param account The account whose configuration is changed.
     /// @param s The signed batch (channel, ordered changes, sequence word, signature).
@@ -589,35 +585,29 @@ contract Keystore {
         (, uint16 scope) = authenticateActor(account, digest, s.signature);
         if (scope != 0) revert UnauthorizedAccountChange();
 
-        // Lock policy is evaluated against the account's lock state at entry (lazily clearing an elapsed unlock). This
-        // snapshot drives ONLY the authority-op gate below; the entry value is sound there because lock state changes
-        // only via environment ops, and the ordering fence (AuthorityOpAfterEnvOp) forces every authority op before
-        // the first environment op — so throughout the authority prefix the snapshot still equals live state.
-        // The Lock/Unlock handlers themselves read live storage, so they never rely on this snapshot.
+        // Lock policy is evaluated against the account's lock state at batch ENTRY (lazily clearing an already-elapsed
+        // unlock). This snapshot — not live state — gates the authority ops: a batch authorized while the account was
+        // locked cannot make actor changes, while a batch authorized while unlocked may, even if the same batch also
+        // contains a Lock (which takes effect only for later batches). Order within the batch is therefore irrelevant
+        // to authority ops. The Lock/Unlock handlers read live storage independently, so an in-batch
+        // [Lock, Unlock, Lock] still resolves consistently against live flags.
         bool locked = _checkAndClearLock(account);
 
-        // Iterate. Track only whether an environment op has been seen, for the ordering fence.
-        bool sawEnvOp;
         uint256 n = s.changes.length;
         for (uint256 i; i < n; i++) {
             ChangeType t = s.changes[i].changeType;
-            // Enum-ordering-as-classification: an environment op (IncrementLocalEpoch onward) mutates the rules ops are
-            // checked against; anything below is an authority op that mutates who can act.
-            bool env = t >= ChangeType.IncrementLocalEpoch;
-
-            // Ordering: authority ops may never follow an environment op.
-            if (!env && sawEnvOp) revert AuthorityOpAfterEnvOp();
-            if (env) sawEnvOp = true;
-
-            // Lock policy: while the account is locked, only environment ops (increment-epoch/lock/unlock) may run.
-            if (locked && !env) revert AccountIsLocked();
-
+            // Lock policy: if the account was locked at entry, only environment ops (increment-epoch/lock/unlock) may
+            // run, so the two authority ops gate on the entry snapshot; the environment handlers police their own
+            // preconditions against live state.
             if (t == ChangeType.AuthorizeActor) {
+                if (locked) revert AccountIsLocked();
                 _applyAuthorize(account, s.changes[i].payload);
             } else if (t == ChangeType.RevokeActor) {
+                if (locked) revert AccountIsLocked();
                 _applyRevoke(account, s.changes[i].payload);
             } else if (t == ChangeType.IncrementLocalEpoch) {
-                _applyIncrementLocalEpoch(account, isLocal, s.changes[i].payload);
+                if (!isLocal) revert EpochOpRequiresLocalChannel();
+                _applyIncrementLocalEpoch(account, s.changes[i].payload);
             } else if (t == ChangeType.Lock) {
                 _applyLock(account, s.changes[i].payload);
             } else if (t == ChangeType.Unlock) {
@@ -671,9 +661,8 @@ contract Keystore {
 
     /// @dev IncrementLocalEpoch. Empty payload. Strict increment of the local epoch, resetting the local sequence to 0
     ///      and thereby invalidating every unlanded local signature (they commit the full 64-bit word). Local-only.
-    function _applyIncrementLocalEpoch(address account, bool isLocal, bytes calldata payload) private {
+    function _applyIncrementLocalEpoch(address account, bytes calldata payload) private {
         if (payload.length != 0) revert InvalidChangePayload();
-        if (!isLocal) revert EpochOpRequiresLocalChannel();
         AccountState storage a = _accountState[account];
         // The epoch half has no reserved sentinel (unlike UNSEQUENCED on the sequence half), so the full uint32 range
         // is usable: only the terminal value itself cannot advance.

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -17,8 +17,9 @@ contract Keystore {
 
     /// @notice Per-account replay counters for signed changes.
     struct ChangeSequences {
-        uint64 multichain; // chain_id 0
-        uint64 local; // chain_id == block.chainid; starts at 1 once initialized (created/imported), 0 = uninitialized
+        uint64 multichain; // chain_id 0 (multichain channel)
+        uint32 localEpoch; // local channel epoch; bumped by BumpLocalEpoch, invalidates unlanded local signatures
+        uint32 localSequence; // local channel counter; starts at 1 once initialized (created/imported), 0 = uninitialized
     }
 
     /// @notice An actor's authorization: authenticator, expiry, and scope. Field order matches the normative
@@ -108,7 +109,7 @@ contract Keystore {
     ///      defaultEOAScope, then 1 reserved byte that MUST stay zero.
     ///      The local replay counter is stored as two adjacent uint32 fields — `localSequence` (low) then `localEpoch`
     ///      (high) — which occupy the same 8 bytes as, and read identically to, the single `localEpoch(32)||
-    ///      localSequence(32)` word committed in a signed batch's `sequence` (see {getLocalEpochAndSequence}). Storing
+    ///      localSequence(32)` word committed in a signed batch's `sequence` (see {getChangeSequences}). Storing
     ///      them split keeps the layout size-neutral (still one slot) while removing the pack/unpack math from the hot
     ///      path. `localSequence` non-zero doubles as the account initialized flag — bootstrap writes it to 1 (epoch
     ///      0), and it is never zeroed for a live account except by a {BumpLocalEpoch}, which simultaneously advances
@@ -326,17 +327,6 @@ contract Keystore {
 
     /// @notice An AuthorizeActor's granted expiry is not strictly in the future (self-expired on arrival).
     error ExpiredChange();
-
-    /// @notice An unsequenced AuthorizeActor tried to change an occupied slot's scope. Scope changes are sequenced-only.
-    error ScopeChangeRequiresSequencing();
-
-    /// @notice An unsequenced AuthorizeActor's expiry was not strictly greater than the occupied slot's expiry.
-    ///         Unsequenced grants may only extend expiry monotonically upward.
-    error NonMonotoneExpiry();
-
-    /// @notice An unsequenced AuthorizeActor requested the unbounded (type(uint48).max) expiry. Unbounded grants are
-    ///         sequenced-only.
-    error UnboundedGrantRequiresSequencing();
 
     /// @notice A BumpLocalEpoch was submitted on the Multichain channel. The local epoch is a local-mode concept.
     error EpochOpRequiresLocalChannel();
@@ -565,30 +555,27 @@ contract Keystore {
         AccountState storage a = _accountState[account];
         bool isLocal = s.channel == AccountChangeChannel.Local;
 
-        // (1)-(3) Epoch / sequence gate. A batch is "sequenced" when it consumes a counter; unsequenced (JIT) batches
-        // exist only on the local channel (low half == UNSEQUENCED) and do not consume one.
-        bool sequenced;
+        // Epoch / sequence gate. An unsequenced (JIT) batch exists only on the local channel (low half ==
+        // UNSEQUENCED) and does not consume a counter; every other batch consumes its channel's counter.
         if (isLocal) {
             uint32 epoch = uint32(s.sequence >> 32);
             uint32 seq = uint32(s.sequence);
             if (epoch != a.localEpoch) revert StaleEpoch();
             if (seq != UNSEQUENCED) {
-                sequenced = true;
                 if (seq != a.localSequence) revert BadSequence();
                 if (seq >= UNSEQUENCED - 1) revert SequenceSaturated();
                 // Advance the local sequence before apply (the epoch is untouched by a sequenced batch).
                 a.localSequence = seq + 1;
             }
         } else {
-            // Multichain: a plain monotonic counter, always sequenced, never epoch-bearing or UNSEQUENCED.
-            sequenced = true;
+            // Multichain: a plain monotonic counter, never epoch-bearing or UNSEQUENCED.
             uint64 seq = s.sequence;
             if (seq != a.multichainSequence) revert BadSequence();
             if (seq == type(uint64).max) revert SequenceSaturated();
             a.multichainSequence = seq + 1;
         }
 
-        // (4) Authenticate over the relocatable digest. Authorization is flat: every signed account change is
+        // Authenticate over the relocatable digest. Authorization is flat: every signed account change is
         // admin-only, so a single scope check up front replaces any per-op authorization.
         bytes32 digest = _changesDigest(account, s.channel, s.sequence, s.changes);
         (, uint16 scope) = authenticateActor(account, digest, s.signature);
@@ -597,7 +584,7 @@ contract Keystore {
         // Lock policy is evaluated against the account's lock state at entry (lazily clearing an elapsed unlock).
         bool locked = _checkAndClearLock(account);
 
-        // (5) Iterate. Track only whether an environment op has been seen, for the ordering fence.
+        // Iterate. Track only whether an environment op has been seen, for the ordering fence.
         bool sawEnvOp;
         uint256 n = s.changes.length;
         for (uint256 i; i < n; i++) {
@@ -614,7 +601,7 @@ contract Keystore {
             if (locked && !env) revert AccountIsLocked();
 
             if (t == ChangeType.AuthorizeActor) {
-                _applyAuthorize(account, sequenced, s.changes[i].payload);
+                _applyAuthorize(account, s.changes[i].payload);
             } else if (t == ChangeType.RevokeActor) {
                 _applyRevoke(account, s.changes[i].payload);
             } else if (t == ChangeType.BumpLocalEpoch) {
@@ -636,54 +623,35 @@ contract Keystore {
     // ----------------------------------------------------------------------------------------------------------------
 
     /// @dev AuthorizeActor. `payload = abi.encode(bytes32 actorId, ActorConfig cfg, bytes policyData)`; `cfg.expiry`
-    ///      is the granted expiry and the signature self-expires at it.
-    ///
-    ///      Note on durability of reductions: a sequenced upsert may freely shorten a slot's expiry or narrow its
-    ///      scope, and the contract does NOT force a batching epoch bump. If an unsequenced (replayable) grant with
-    ///      the older, longer expiry / broader scope is still outstanding, it can be replayed to undo the reduction
-    ///      until the slot lapses or the caller separately bumps the epoch. Durable reduction is a wallet
-    ///      responsibility: batch the reducing op with a {BumpLocalEpoch} (which retires all unlanded local grants).
-    function _applyAuthorize(address account, bool sequenced, bytes calldata payload) private {
+    ///      is the granted expiry and the signature self-expires at it. A plain upsert on both channels and both
+    ///      sequencing modes — the only gate is that the grant be strictly in the future (self-expiring). An
+    ///      unsequenced grant is replayable (it consumes no counter) and last-write-wins on its slot until the grant
+    ///      lapses or the epoch is bumped; durable reduction (revoke, shorter expiry, narrower scope) is therefore a
+    ///      wallet responsibility — batch the reducing op with a {BumpLocalEpoch} to retire outstanding grants.
+    function _applyAuthorize(address account, bytes calldata payload) private {
         (bytes32 actorId, ActorConfig memory cfg, bytes memory policyData) =
             abi.decode(payload, (bytes32, ActorConfig, bytes));
 
-        // The grant must be strictly in the future (a zero/no-expiry grant is caught here: 0 <= now). Unsequenced
-        // grants additionally cannot be unbounded — that is sequenced-only.
-        uint48 chExpiry = cfg.expiry;
-        if (chExpiry <= block.timestamp) revert ExpiredChange();
-        if (!sequenced && chExpiry == type(uint48).max) revert UnboundedGrantRequiresSequencing();
+        // The grant must be strictly in the future (a zero/past expiry is caught here: 0 <= now).
+        if (cfg.expiry <= block.timestamp) revert ExpiredChange();
 
-        (bool occupied, uint16 oldScope, uint48 oldExpiry) = _rawSlot(account, actorId);
-
-        if (!occupied) {
-            // Empty slot: plain install. Both channels, both sequencing modes.
-            _authorizeActor(account, actorId, cfg, policyData);
-            return;
-        }
-
-        // Occupied slot. Authenticator equality is structural: actorId derives from the authenticator, so a different
-        // authenticator is a different slot (the empty-slot case above); no explicit check is needed here.
-        if (!sequenced) {
-            // Unsequenced upsert is extend-by-upsert only: scope frozen, expiry strictly monotone up. This is the
-            // Replay defense for the unsequenced channel — re-applying a landed grant (same/lower expiry) must fail.
-            // Treat a stored no-expiry (0) as unbounded so an infinite grant cannot be silently re-applied.
-            uint48 effectiveOld = oldExpiry == 0 ? type(uint48).max : oldExpiry;
-            if (cfg.scope != oldScope) revert ScopeChangeRequiresSequencing();
-            if (chExpiry <= effectiveOld) revert NonMonotoneExpiry();
-        }
-
-        // Sequenced upsert: any expiry, any scope (including a reduction). See the durability note above — the
-        // contract does not force a batching bump; that is left to the caller.
         _authorizeActor(account, actorId, cfg, policyData);
     }
 
-    /// @dev RevokeActor. `payload = abi.encode(bytes32 actorId)`. Clears the slot unconditionally. Note this alone is
-    ///      not durable against an outstanding replayable unsequenced grant for the same actorId (which would
-    ///      re-install into the emptied slot); to durably revoke, the caller batches a {BumpLocalEpoch}. This is a
-    ///      wallet responsibility, not contract-enforced.
+    /// @dev RevokeActor. `payload = abi.encode(bytes32 actorId)`. Clears the actor's config and policy slots (and
+    ///      disables the inline k1 self for the self-actorId), emitting ActorRevoked; reverts UnknownActor if the
+    ///      actor is not currently live. Not durable against an outstanding replayable unsequenced grant for the same
+    ///      actorId (which would re-install into the emptied slot); batch a {BumpLocalEpoch} for durable teardown.
     function _applyRevoke(address account, bytes calldata payload) private {
         bytes32 actorId = abi.decode(payload, (bytes32));
-        _revokeActor(account, actorId);
+        if (!_isAuthorized(account, actorId)) revert UnknownActor();
+        delete _actorConfig[actorId][account];
+        delete _policyCommitment[actorId][account];
+        delete _policyManager[actorId][account];
+        if (actorId == bytes32(bytes20(account))) {
+            _disableInlineSelf(_accountState[account]);
+        }
+        emit ActorRevoked(account, actorId);
     }
 
     /// @dev BumpLocalEpoch. Empty payload. Strict increment of the local epoch, resetting the local sequence to 0
@@ -742,17 +710,6 @@ contract Keystore {
             return (true, st.defaultEOAScope, st.defaultEOAExpiry);
         }
         return (false, 0, 0);
-    }
-
-    /// @dev Clears an actor's config and policy slots, disabling the inline k1 self for the self-actorId. Used by
-    ///      {_revokeActor} (which additionally requires the actor be present).
-    function _clearActor(address account, bytes32 actorId) private {
-        delete _actorConfig[actorId][account];
-        delete _policyCommitment[actorId][account];
-        delete _policyManager[actorId][account];
-        if (actorId == bytes32(bytes20(account))) {
-            _disableInlineSelf(_accountState[account]);
-        }
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -921,7 +878,7 @@ contract Keystore {
     ///      target validates presented parameters against. The policy manager/commitment are keyed by actorId, so
     ///      the inline k1 self and a non-k1 self share that keyspace; mutual exclusion guarantees at most one is
     ///      live, so the active gate is read by actorId. Both slots are non-zero only when the actor's scope carries
-    ///      Scopes.POLICY (see _authorizeActor / _revokeActor); either MAY still be zero for an actor deliberately
+    ///      Scopes.POLICY (see _authorizeActor / _applyRevoke); either MAY still be zero for an actor deliberately
     ///      gated to a zero manager or a zero (no-params) commitment. On-chain consumers should prefer the
     ///      single-SLOAD `getPolicyCommitment` / `getPolicyManager` accessors directly.
     ///
@@ -938,7 +895,7 @@ contract Keystore {
     ///
     /// @dev Single SLOAD. Intended for a policy manager's per-tx validation read on the protocol-dispatched
     ///      8130 tx path. This slot is non-zero only when the actor's scope carries Scopes.POLICY (see _authorizeActor /
-    ///      _revokeActor), but MAY be zero for a policy-gated actor with a zero (no-params) commitment; gating is
+    ///      _applyRevoke), but MAY be zero for a policy-gated actor with a zero (no-params) commitment; gating is
     ///      therefore determined by the Scopes.POLICY bit, not by this slot being non-zero.
     ///
     /// @param account The account to read.
@@ -961,30 +918,17 @@ contract Keystore {
         return _policyManager[actorId][account];
     }
 
-    /// @notice Returns the account's multichain and local change sequences (replay counters).
-    ///
-    /// @dev The `local` field is the raw 64-bit word: localEpoch(32, high) || localSequence(32, low). Use
-    ///      {getLocalEpochAndSequence} to read the two halves split out.
+    /// @notice Returns the account's replay counters: the multichain counter and the local channel's epoch and
+    ///         sequence.
     ///
     /// @param account The account to read.
     ///
-    /// @return The account's ChangeSequences (multichain counter and the raw local epoch||sequence word).
+    /// @return The account's ChangeSequences (multichain counter, local epoch, local sequence).
     function getChangeSequences(address account) external view returns (ChangeSequences memory) {
         AccountState storage state = _accountState[account];
-        // Recompose the split storage fields into the single localEpoch(32, high)||localSequence(32, low) word.
-        uint64 local = (uint64(state.localEpoch) << 32) | uint64(state.localSequence);
-        return ChangeSequences({multichain: state.multichainSequence, local: local});
-    }
-
-    /// @notice Returns the account's local epoch and local sequence, split from the packed 64-bit word.
-    ///
-    /// @param account The account to read.
-    ///
-    /// @return epoch The account's current local epoch (high 32 bits of the local word).
-    /// @return sequence The account's current local sequence (low 32 bits of the local word).
-    function getLocalEpochAndSequence(address account) external view returns (uint32 epoch, uint32 sequence) {
-        AccountState storage state = _accountState[account];
-        return (state.localEpoch, state.localSequence);
+        return ChangeSequences({
+            multichain: state.multichainSequence, localEpoch: state.localEpoch, localSequence: state.localSequence
+        });
     }
 
     /// @notice Returns whether the account is currently locked (configuration frozen).
@@ -1199,7 +1143,7 @@ contract Keystore {
 
     /// @dev Returns whether `actorId` has an authorization entry on `account` (a stored actor config, or the inline
     ///      k1 self is enabled), IGNORING expiry: an expired-but-not-revoked actor still returns true — intentional,
-    ///      since _revokeActor relies on it to revoke expired actors and reclaim their slots. Callers that want
+    ///      since _applyRevoke relies on it to revoke expired actors and reclaim their slots. Callers that want
     ///      liveness (expiry-aware) read {getActorConfig} (authenticator != 0) instead.
     function _isAuthorized(address account, bytes32 actorId) private view returns (bool) {
         // A populated _actorConfig entry is always live: any non-self actor, or a non-k1 self authenticator.
@@ -1207,17 +1151,6 @@ contract Keystore {
         // No _actorConfig entry: the self-actorId's k1 key lives inline in AccountState, live unless the flag is set.
         if (actorId == bytes32(bytes20(account))) return !_isDefaultEoaRevoked(account);
         return false;
-    }
-
-    /// @dev Revokes `actorId` from `account`, clearing its config and policy slots and emitting ActorRevoked. For the
-    ///      self-actorId it also disables the inline k1 self (sets FLAG_REVOKE_DEFAULT_EOA and zeroes the inline
-    ///      fields). Reverts with UnknownActor when the actor is not currently live.
-    function _revokeActor(address account, bytes32 actorId) internal nonZeroAccount(account) {
-        if (!_isAuthorized(account, actorId)) revert UnknownActor();
-        // Clears the config and policy slots, and disables the inline k1 self for the self-actorId (covers both
-        // homes; never auto-resurrected).
-        _clearActor(account, actorId);
-        emit ActorRevoked(account, actorId);
     }
 
     /// @dev Derives the CREATE2 inputs once for both {createAccount} and {computeAddress}: the effective salt, the

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -177,8 +177,9 @@ contract Keystore {
     bytes32 public constant ACCOUNT_CHANGE_TYPEHASH = keccak256("AccountChange(uint8 changeType,bytes payload)");
 
     /// @notice Local-channel sequence low-half sentinel marking an unsequenced (JIT) batch. A {SignedAccountChanges}
-    ///         whose low 32 bits equal this value does not consume a sequence; only both-channel ops are permitted
-    ///         on it (see {applySignedAccountChanges}). Sequenced batches may therefore run up to UNSEQUENCED - 2.
+    ///         whose low 32 bits equal this value does not consume a sequence, so it stays replayable until the local
+    ///         epoch moves; any op type may ride it (see {applySignedAccountChanges}). Sequenced batches may therefore
+    ///         run up to UNSEQUENCED - 2.
     uint32 public constant UNSEQUENCED = type(uint32).max;
 
     // ----------------------------------------------------------------------------------------------------------------
@@ -336,10 +337,6 @@ contract Keystore {
     ///         BumpLocalEpoch / Unlock).
     error InvalidChangePayload();
 
-    /// @notice Defensive guard for an unhandled ChangeType in the apply loop. Unreachable in practice — out-of-range
-    ///         wire values are rejected by the enum decoder during ABI-decoding.
-    error UnknownActorChangeType();
-
     /// @notice The auth blob is shorter than the 20-byte authenticator selector prefix.
     error InvalidAuthLength();
 
@@ -351,6 +348,7 @@ contract Keystore {
 
     /// @notice An actor config named an authenticator below the K1 sentinel (i.e. address(0)).
     error InvalidAuthenticator();
+
     /// @notice The policyData length did not match `scope & Scopes.POLICY` (52 bytes when set, empty when unset).
     error InvalidPolicyData();
 
@@ -582,7 +580,11 @@ contract Keystore {
         (, uint16 scope) = authenticateActor(account, digest, s.signature);
         if (scope != 0) revert UnauthorizedAccountChange();
 
-        // Lock policy is evaluated against the account's lock state at entry (lazily clearing an elapsed unlock).
+        // Lock policy is evaluated against the account's lock state at entry (lazily clearing an elapsed unlock). This
+        // snapshot drives ONLY the authority-op gate below; the entry value is sound there because lock state changes
+        // only via environment ops, and the ordering fence (AuthorityOpAfterEnvOp) forces every authority op before
+        // the first environment op — so throughout the authority prefix the snapshot still equals live state.
+        // The Lock/Unlock handlers themselves read live storage, so they never rely on this snapshot.
         bool locked = _checkAndClearLock(account);
 
         // Iterate. Track only whether an environment op has been seen, for the ordering fence.
@@ -608,13 +610,11 @@ contract Keystore {
             } else if (t == ChangeType.BumpLocalEpoch) {
                 _applyBumpLocalEpoch(account, isLocal, s.changes[i].payload);
             } else if (t == ChangeType.Lock) {
-                _applyLock(account, locked, s.changes[i].payload);
-            } else if (t == ChangeType.Unlock) {
-                _applyUnlock(account, s.changes[i].payload);
+                _applyLock(account, s.changes[i].payload);
             } else {
-                // Unreachable: out-of-range wire values are rejected by the enum decoder while ABI-decoding the
-                // calldata. Kept as a defensive guard so any future ChangeType must be wired in explicitly.
-                revert UnknownActorChangeType();
+                // ChangeType.Unlock (the only remaining member; out-of-range values are rejected by the enum decoder
+                // while ABI-decoding the calldata).
+                _applyUnlock(account, s.changes[i].payload);
             }
         }
     }
@@ -626,10 +626,10 @@ contract Keystore {
     /// @dev AuthorizeActor. `payload = abi.encode(bytes32 actorId, ActorConfig cfg, bytes policyData)`; `cfg.expiry`
     ///      is the granted expiry and the signature self-expires at it (or never, if `cfg.expiry == 0`). A plain
     ///      upsert on both channels and both sequencing modes — the only gate is that a non-zero expiry be in the
-    ///      future. An
-    ///      unsequenced grant is replayable (it consumes no counter) and last-write-wins on its slot until the grant
-    ///      lapses or the epoch is bumped; durable reduction (revoke, shorter expiry, narrower scope) is therefore a
-    ///      wallet responsibility — batch the reducing op with a {BumpLocalEpoch} to retire outstanding grants.
+    ///      future. An unsequenced grant is replayable (it consumes no counter) and last-write-wins on its slot until
+    ///      the grant lapses or the epoch is bumped; durable reduction (revoke, shorter expiry, narrower scope) is
+    ///      therefore a wallet responsibility — batch the reducing op with a {BumpLocalEpoch} to retire outstanding
+    ///      grants.
     function _applyAuthorize(address account, bytes calldata payload) private {
         (bytes32 actorId, ActorConfig memory cfg, bytes memory policyData) =
             abi.decode(payload, (bytes32, ActorConfig, bytes));
@@ -670,13 +670,23 @@ contract Keystore {
         a.localSequence = 0;
     }
 
-    /// @dev Lock. `payload = abi.encode(uint16 unlockDelay)`. Only from the unlocked state; stores the delay.
-    function _applyLock(address account, bool locked, bytes calldata payload) private {
-        if (locked) revert AccountIsLocked();
+    /// @dev Lock. `payload = abi.encode(uint16 unlockDelay)`. Only from the unlocked state; stores the delay. Gates on
+    ///      LIVE lock state (not the batch-entry snapshot) and its sibling {_applyUnlock} also mutates live storage, so
+    ///      within one batch a later op sees earlier ops' writes — e.g. `[Lock, Unlock, Lock]` correctly reverts on the
+    ///      trailing Lock instead of leaving FLAG_UNLOCK_INITIATED set over a delay-valued union.
+    ///
+    ///      Two facts make the live gate airtight: (a) block.timestamp is constant within a tx, so an unlock initiated
+    ///      earlier in the batch can never elapse mid-batch — once FLAG_UNLOCK_INITIATED is set, {_isLocked} stays true
+    ///      for the remainder of the batch and a following Lock reverts; (b) the entry {_checkAndClearLock} wipes any
+    ///      already-elapsed lock, so a permitted Lock always starts from clean flags. The explicit UNLOCK_INITIATED
+    ///      clear below therefore writes a clean hard-locked flag set (LOCKED set, UNLOCK_INITIATED cleared) so
+    ///      lockUnion unambiguously holds the delay — defense-in-depth given (a)/(b), not a live repair.
+    function _applyLock(address account, bytes calldata payload) private {
+        AccountState storage a = _accountState[account];
+        if (_isLocked(a)) revert AccountIsLocked();
         uint16 unlockDelay = abi.decode(payload, (uint16));
         if (unlockDelay == 0) revert ZeroUnlockDelay();
-        AccountState storage a = _accountState[account];
-        a.flags |= FLAG_LOCKED;
+        a.flags = (a.flags | FLAG_LOCKED) & ~FLAG_UNLOCK_INITIATED;
         a.lockUnion = unlockDelay;
         emit AccountLocked(account, unlockDelay);
     }
@@ -692,27 +702,6 @@ contract Keystore {
         a.flags = flags | FLAG_UNLOCK_INITIATED;
         a.lockUnion = unlocksAt;
         emit AccountUnlockInitiated(account, unlocksAt);
-    }
-
-    // ----------------------------------------------------------------------------------------------------------------
-    // SIGNED-CHANGE HELPERS
-    // ----------------------------------------------------------------------------------------------------------------
-
-    /// @dev Reads an actor's raw stored slot IGNORING expiry (structural presence): a populated _actorConfig entry
-    ///      for any non-self actor or a non-k1 self, or the inline k1 self when enabled. Returns whether the slot is
-    ///      occupied plus its scope and expiry. Mirrors {getActorConfig}'s resolution minus the expiry masking.
-    function _rawSlot(address account, bytes32 actorId)
-        private
-        view
-        returns (bool occupied, uint16 scope, uint48 expiry)
-    {
-        ActorConfig storage c = _actorConfig[actorId][account];
-        if (c.authenticator >= K1_AUTHENTICATOR) return (true, c.scope, c.expiry);
-        if (actorId == bytes32(bytes20(account)) && !_isDefaultEoaRevoked(account)) {
-            AccountState storage st = _accountState[account];
-            return (true, st.defaultEOAScope, st.defaultEOAExpiry);
-        }
-        return (false, 0, 0);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -140,9 +140,9 @@ contract Keystore {
     /// @notice Typehash binding an importAccount signature to its accountId, chainId, and initial actor set.
     ///
     /// @dev NOT compliant with EIP-712, to mitigate eth_signTypedData phishing. `accountId` is the importing account's
-    ///      right-aligned address (`ActorId.fromAddress(account)`), binding the digest to that account so it cannot be
-    ///      replayed against another. `chainId` is either the current chain or 0 for a multichain import. Initial
-    ///      actors are hashed structurally below.
+    ///      actorId (`ActorId.fromAddress(account)`), binding the digest to that account so it cannot be replayed
+    ///      against another. `chainId` is either the current chain or 0 for a multichain import. Initial actors are
+    ///      hashed structurally below.
     bytes32 public constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
         "ActorInitialization(bytes32 accountId,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
     );
@@ -160,8 +160,7 @@ contract Keystore {
     ///
     /// @dev NOT compliant with EIP-712, to mitigate phishing attacks. `chainId` is the channel's replay domain
     ///      (0 for {AccountChangeChannel.Multichain}, block.chainid for {AccountChangeChannel.Local}). The digest
-    ///      scheme is a relocation seam: it lives behind {_changesDigest} so a later hash-relocation workstream can
-    ///      move it without touching the pipeline.
+    ///      scheme is confined to {_changesDigest}, keeping it independent of the apply pipeline.
     bytes32 public constant SIGNED_ACCOUNT_CHANGES_TYPEHASH = keccak256(
         "SignedAccountChanges(address account,uint256 chainId,uint64 sequence,AccountChange[] changes)"
         "AccountChange(uint8 changeType,bytes payload)"
@@ -458,9 +457,9 @@ contract Keystore {
         bytes memory deploymentCode;
         (account, effectiveSalt, deploymentCode) = _prepareDeployment(userSalt, bytecode, initialActors);
 
-        // Block re-initialization of an already-bootstrapped account. This must be explicit: authorizeActor is now an
-        // upsert (no duplicate-actor revert) and the create2 below is intentionally swallowed (pop), so a duplicate
-        // createAccount would otherwise silently re-initialize.
+        // Block re-initialization of an already-bootstrapped account. This must be explicit: authorizeActor is an
+        // upsert (no duplicate-actor revert), so without this guard a duplicate createAccount would re-run
+        // initialization over the existing actor set.
         if (_isInitialized(account)) {
             revert AlreadyInitialized();
         }
@@ -553,7 +552,7 @@ contract Keystore {
     ///
     ///      Pipeline (in order): (1) split the sequence word; (2) reject a stale epoch on Local batches;
     ///      (3) validate/advance the sequence counter BEFORE apply (reentrancy discipline); (4) compute the digest
-    ///      via the relocatable {_changesDigest} seam, authenticate, and reject a non-admin signer; (5) iterate
+    ///      via {_changesDigest}, authenticate, and reject a non-admin signer; (5) iterate
     ///      changes enforcing channel and lock policy (local-only changes rejected on Multichain; authority ops
     ///      rejected while the account is locked; Lock/Unlock must be standalone). Anyone may relay — authorization
     ///      comes entirely from the signature.
@@ -611,7 +610,7 @@ contract Keystore {
             a.multichainSequence = seq + 1;
         }
 
-        // Authenticate over the relocatable digest. Authorization is flat: every signed account change is
+        // Authenticate over the digest. Authorization is flat: every signed account change is
         // admin-only, so a single scope check up front replaces any per-op authorization.
         bytes32 digest = _changesDigest(account, s.channel, s.sequence, s.changes);
         (, uint16 scope) = authenticateActor(account, digest, s.signature);
@@ -783,12 +782,10 @@ contract Keystore {
     {
         // Authenticate against the account-scoped digest (see {replaySafeHash}), not the raw hash.
         try this.authenticateActor(account, replaySafeHash(account, hash), signature) returns (bytes32, uint16 scope) {
-            // ERC-1271 signing is authorized for any operational actor: the admin (scope == 0x00), or a SENDER actor
-            // that is not gated by a policy (Scopes.SENDER set AND Scopes.POLICY unset). Signing is an encoding of
-            // authority a SENDER actor already holds via calls, not a separate grant, so it needs no dedicated scope
-            // bit. A POLICY-bearing actor is not operational and cannot sign: a signature acts outside its policy
-            // gate, so honoring one would let it act off its gate.
-            return scope == 0 || ((scope & Scopes.SENDER != 0) && (scope & Scopes.POLICY == 0));
+            // ERC-1271 signing is authorized for any operational actor (see {Scopes.isOperator}): signing encodes
+            // authority a SENDER actor already holds via calls, so it needs no dedicated grant, while a POLICY-gated
+            // actor is not operational because a signature would act outside its policy gate.
+            return Scopes.isOperator(scope);
         } catch {
             return false;
         }
@@ -1256,7 +1253,7 @@ contract Keystore {
     }
 
     /// @dev Typed digest for the importAccount ERC-1271 signature (a signed message), so signers can reproduce it
-    ///      with standard EIP-712-style struct hashing. `accountId` is the account's right-aligned address
+    ///      with standard EIP-712-style struct hashing. `accountId` is the account's actorId
     ///      (`ActorId.fromAddress(account)`) and the digest is bound to `chainId` (0 = multichain) so its replay
     ///      domain matches applySignedAccountChanges.
     function _computeImportDigest(address account, uint256 chainId, InitialActor[] calldata initialActors)
@@ -1266,9 +1263,9 @@ contract Keystore {
     {
         bytes32[] memory actorHashes = new bytes32[](initialActors.length);
         for (uint256 i; i < initialActors.length; i++) {
-            // Hash the actor's real scope. Expiry is always 0 at import — an actor-provided expiry is never
-            // accepted here. policyData is hashed via keccak256 into the Actor struct hash. The typehash structure
-            // matches the importAccount signature payload in EIP-8130.
+            // Expiry is forced to 0 at import — an actor-provided expiry is never accepted here. policyData is
+            // hashed via keccak256 into the Actor struct hash. The typehash structure matches the importAccount
+            // signature payload in EIP-8130.
             bytes32 configHash = keccak256(
                 abi.encode(ACTOR_CONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), initialActors[i].scope)
             );
@@ -1290,10 +1287,8 @@ contract Keystore {
     /// @dev Computes the digest signed over an applySignedAccountChanges batch: each AccountChange is hashed
     ///      structurally (its variable-length `payload` pre-hashed to a fixed-width layout) and the batch is bound to
     ///      `account`, the channel's replay `chainId` (0 for Multichain, block.chainid for Local), and the raw
-    ///      `sequence` word via SIGNED_ACCOUNT_CHANGES_TYPEHASH.
-    ///
-    ///      This is the hash-relocation SEAM: the whole scheme is confined here so a later workstream can relocate
-    ///      it without touching the pipeline in {applySignedAccountChanges}.
+    ///      `sequence` word via SIGNED_ACCOUNT_CHANGES_TYPEHASH. The entire digest scheme is confined to this function
+    ///      so {applySignedAccountChanges} depends only on its output.
     function _changesDigest(
         address account,
         AccountChangeChannel channel,
@@ -1397,8 +1392,8 @@ contract Keystore {
         return _accountState[account].flags & FLAG_REVOKE_DEFAULT_EOA != 0;
     }
 
-    /// @dev The account's implicit self-actorId: the account address right-aligned into a 32-byte word
-    ///      (`ActorId.fromAddress`), matching the normative self derivation. Non-zero for any valid account.
+    /// @dev The account's implicit self-actorId (`ActorId.fromAddress`), matching the normative self derivation.
+    ///      Non-zero for any valid account.
     function _selfActorId(address account) private pure returns (bytes32) {
         return ActorId.fromAddress(account);
     }

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.36;
 import {Receiver} from "solady/accounts/Receiver.sol";
 
 import {Keystore} from "../Keystore.sol";
+import {ActorId} from "../libraries/ActorId.sol";
 import {Scopes} from "../libraries/Scopes.sol";
 
 /// @notice A single call in an execution batch.
@@ -132,7 +133,7 @@ contract DefaultAccount is Receiver {
     ///      signing (ERC-1271) authorization surfaces aligned.
     function _isAuthorizedCaller(address caller) internal view virtual returns (bool) {
         if (caller == address(this)) return true;
-        Keystore.ActorConfig memory config = KEYSTORE.getActorConfig(address(this), bytes32(bytes20(caller)));
+        Keystore.ActorConfig memory config = KEYSTORE.getActorConfig(address(this), ActorId.fromAddress(caller));
         if (config.authenticator != TRUSTED_EXECUTOR) return false;
         if (config.expiry != 0 && block.timestamp > config.expiry) return false;
         return Scopes.isOperator(config.scope);

--- a/src/authenticators/DelegateAuthenticator.sol
+++ b/src/authenticators/DelegateAuthenticator.sol
@@ -55,11 +55,10 @@ contract DelegateAuthenticator is IAuthenticator {
         address nestedAuthenticator = address(bytes20(nestedAuth[:20]));
         if (nestedAuthenticator == address(this)) revert RecursiveDelegation();
 
-        // The nested actor MUST be the admin (scope == 0x00) of the delegate account. This is enforced
-        // independently of verifySignature, which is now operational (signing is not admin-only, but a delegate
-        // vouch requires admin to preserve non-escalation): an operational SENDER key can sign for its own account,
-        // yet it must NOT be able to vouch as a delegate here. authenticateActor reverts on any auth failure and
-        // otherwise returns the resolved scope, so we require scope == 0x00 explicitly.
+        // The nested actor MUST be the admin (scope == 0x00) of the delegate account. Signing is not admin-only, but
+        // a delegate vouch requires admin to preserve non-escalation: an operational SENDER key can sign for its own
+        // account, yet it must NOT be able to vouch as a delegate here. authenticateActor reverts on any auth failure
+        // and otherwise returns the resolved scope, so we require scope == 0x00 explicitly.
         try KEYSTORE.authenticateActor(delegate, hash, nestedAuth) returns (bytes32, uint16 nestedScope) {
             if (nestedScope != 0) revert InvalidNestedSignature();
         } catch {

--- a/src/authenticators/DelegateAuthenticator.sol
+++ b/src/authenticators/DelegateAuthenticator.sol
@@ -3,9 +3,10 @@ pragma solidity 0.8.36;
 
 import {Keystore} from "../Keystore.sol";
 import {IAuthenticator} from "../interfaces/IAuthenticator.sol";
+import {ActorId} from "../libraries/ActorId.sol";
 
 /// @notice Delegates authentication to another account's actor configuration; a single hop only.
-///         actorId = bytes32(bytes20(delegate_address))
+///         actorId = ActorId.fromAddress(delegate_address)
 ///
 ///         This contract exists for non-8130 chains where verifySignature() runs in normal EVM.
 ///         On 8130 chains, the protocol handles DELEGATE directly at the protocol level.
@@ -42,13 +43,13 @@ contract DelegateAuthenticator is IAuthenticator {
     /// @param hash The digest being authenticated.
     /// @param data delegate address (20) then the nested auth blob (nested authenticator address then its data).
     ///
-    /// @return actorId The delegate's actorId, bytes32(bytes20(delegate)), when the nested signature is valid.
+    /// @return actorId The delegate's actorId, ActorId.fromAddress(delegate), when the nested signature is valid.
     function authenticate(bytes32 hash, bytes calldata data) external view returns (bytes32 actorId) {
         if (data.length < 40) revert InvalidDataLength();
         address delegate = address(bytes20(data[:20]));
         bytes calldata nestedAuth = data[20:];
 
-        actorId = bytes32(bytes20(delegate));
+        actorId = ActorId.fromAddress(delegate);
 
         // Prevent recursive delegation (only 1 hop permitted)
         address nestedAuthenticator = address(bytes20(nestedAuth[:20]));

--- a/src/libraries/ActorId.sol
+++ b/src/libraries/ActorId.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @notice Canonical derivation of an actorId from an address-based identity.
+///
+/// @dev Address-derived actors — an ECDSA/k1 recovered signer, a delegate, an external policy caller, and the
+///      implicit self — carry their raw address as the actorId (no hashing, no salt). The address is placed
+///      RIGHT-ALIGNED in the 32-byte word, i.e. the ABI `address` layout `bytes32(uint256(uint160(addr)))` (high 12
+///      bytes zero). This matches `abi.encode(address)`, an indexed `address` event topic, and the standard
+///      `address(uint160(uint256(id)))` round-trip, so off-chain tooling and indexers can correlate an actorId with
+///      the address it represents without a bespoke (left-aligned) decode. Defined once here so the self and
+///      recovered-signer derivations — which must always agree for the inline k1 self to authenticate — can never
+///      drift.
+library ActorId {
+    /// @dev The actorId for an address-derived actor: `addr` right-aligned into a 32-byte word.
+    function fromAddress(address addr) internal pure returns (bytes32) {
+        return bytes32(uint256(uint160(addr)));
+    }
+}

--- a/src/libraries/ActorId.sol
+++ b/src/libraries/ActorId.sol
@@ -1,16 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-/// @notice Canonical derivation of an actorId from an address-based identity.
-///
-/// @dev Address-derived actors — an ECDSA/k1 recovered signer, a delegate, an external policy caller, and the
-///      implicit self — carry their raw address as the actorId (no hashing, no salt). The address is placed
-///      RIGHT-ALIGNED in the 32-byte word, i.e. the ABI `address` layout `bytes32(uint256(uint160(addr)))` (high 12
-///      bytes zero). This matches `abi.encode(address)`, an indexed `address` event topic, and the standard
-///      `address(uint160(uint256(id)))` round-trip, so off-chain tooling and indexers can correlate an actorId with
-///      the address it represents without a bespoke (left-aligned) decode. Defined once here so the self and
-///      recovered-signer derivations — which must always agree for the inline k1 self to authenticate — can never
-///      drift.
+/// @notice Utilities for deriving actor IDs.
 library ActorId {
     /// @dev The actorId for an address-derived actor: `addr` right-aligned into a 32-byte word.
     function fromAddress(address addr) internal pure returns (bytes32) {

--- a/src/libraries/Scopes.sol
+++ b/src/libraries/Scopes.sol
@@ -1,26 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.36;
 
-/// @notice Canonical EIP-8130 actor scope grants: the named bits of the `uint16` scope bitmask carried in an
-///         actor's config.
-///
-/// @dev Reference vocabulary, not enforcement. Keystore is deliberately scope-agnostic: it treats `scope == 0` as
-///      the admin predicate and interprets only {POLICY} (to slice/store policy data). Every other bit's *meaning*
-///      is enforced by whoever reads it — protocol nodes for the transaction paths, account contracts for ERC-1271,
-///      policy managers for gating. This library only gives those consumers a shared set of names so the same value
-///      is not re-declared as a magic number at each site.
-///
-///      Delegation for agent fleets is expressed via the external-policy pattern (an account authorizes a hub as a
-///      single POLICY-gated external actor that drives it through a policy manager), so no dedicated delegate grant
-///      is defined here.
-///
-///      The assignment is append-only: a value once given a name keeps it, and new grants take the next free bit.
-///      That is safe against the immutable Keystore deployment because unknown bits grant nothing and are stored
-///      verbatim (see the EIP's Actor Scope section), so adding a bit here can never change how an already-deployed
-///      config behaves. Admin is intentionally absent — it is the *absence* of grants (`scope == 0`), a predicate
-///      rather than a pure grant.
-///
-/// @author Coinbase
+/// @notice Canonical EIP-8130 actor scope grants.
+/// @dev Scope assignments are append-only; unknown bits are stored verbatim and grant no authority.
+///      Keystore treats `scope == 0` as admin and interprets only {POLICY}; consumers enforce all other grants.
 library Scopes {
     /// @notice Ungated initiation (`sender_auth`): may originate transactions to any `call.to`.
     uint16 internal constant SENDER = 0x0001;

--- a/src/libraries/Scopes.sol
+++ b/src/libraries/Scopes.sol
@@ -38,7 +38,14 @@ library Scopes {
     /// @notice Sponsor gas: authorizes acting as `payer_auth` for a different sender (`payer != sender`).
     uint16 internal constant SPONSOR_PAYER = 0x0010;
 
-    // 0x0020..0x8000 (bits 5–15) are spare, reserved for future pure grants.
+    /// @notice Recovery class: a break-glass authenticator that may only initiate an account Unlock (never authorize,
+    ///         revoke, bump the local epoch, or lock). This is the sole grant besides admin (`scope == 0`) that
+    ///         {Keystore.applySignedAccountChanges} treats specially — it passes the Unlock authorization fence and
+    ///         nothing else. A recovery key is deliberately non-admin: it cannot mutate the actor set, so it can free
+    ///         a hard-locked account without being able to seize control of it.
+    uint16 internal constant RECOVERY = 0x0020;
+
+    // 0x0040..0x8000 (bits 6–15) are spare, reserved for future pure grants.
 
     /// @notice Whether `scope` grants operational authority — the authority to drive execution and to sign
     ///         (ERC-1271) as the account.

--- a/src/libraries/Scopes.sol
+++ b/src/libraries/Scopes.sol
@@ -38,14 +38,7 @@ library Scopes {
     /// @notice Sponsor gas: authorizes acting as `payer_auth` for a different sender (`payer != sender`).
     uint16 internal constant SPONSOR_PAYER = 0x0010;
 
-    /// @notice Recovery class: a break-glass authenticator that may only initiate an account Unlock (never authorize,
-    ///         revoke, bump the local epoch, or lock). This is the sole grant besides admin (`scope == 0`) that
-    ///         {Keystore.applySignedAccountChanges} treats specially — it passes the Unlock authorization fence and
-    ///         nothing else. A recovery key is deliberately non-admin: it cannot mutate the actor set, so it can free
-    ///         a hard-locked account without being able to seize control of it.
-    uint16 internal constant RECOVERY = 0x0020;
-
-    // 0x0040..0x8000 (bits 6–15) are spare, reserved for future pure grants.
+    // 0x0020..0x8000 (bits 5–15) are spare, reserved for future pure grants.
 
     /// @notice Whether `scope` grants operational authority — the authority to drive execution and to sign
     ///         (ERC-1271) as the account.

--- a/src/policies/PolicyManager.sol
+++ b/src/policies/PolicyManager.sol
@@ -6,6 +6,7 @@ import {ReentrancyGuard} from "openzeppelin/utils/ReentrancyGuard.sol";
 
 import {Keystore} from "../Keystore.sol";
 import {ITransactionContext, TX_CONTEXT_ADDRESS} from "../interfaces/ITransactionContext.sol";
+import {ActorId} from "../libraries/ActorId.sol";
 import {Policy} from "./Policy.sol";
 
 /// @dev Required `authenticator` for an actor that represents an *external caller* governed by a policy (e.g. a
@@ -16,7 +17,7 @@ import {Policy} from "./Policy.sol";
 ///      call into empty code and fail). `executeFor` / `executeForMany` require the acting actor's stored
 ///      authenticator to equal this sentinel: that restricts the external path to actors the account explicitly
 ///      provisioned as external-pull, so a native signing key gated to the same manager cannot be driven through the
-///      auth-less external path. Authorization then also requires `actorId == bytes20(msg.sender)`,
+///      auth-less external path. Authorization then also requires `actorId == ActorId.fromAddress(msg.sender)`,
 ///      `policy_manager == this`, and a matching binding commitment.
 address constant EXTERNAL_POLICY_AUTHENTICATOR = address(uint160(uint256(keccak256("externalPolicyCaller"))));
 
@@ -41,7 +42,7 @@ address constant EXTERNAL_POLICY_AUTHENTICATOR = address(uint160(uint256(keccak2
 ///        the account. The acting identity is read from the transaction-context precompile and `account == msg.sender`.
 ///      - {executeFor} / {executeForMany}: an *external caller* acts on behalf of one or more accounts that authorized
 ///        it (e.g. a subscription provider pulling from many accounts in one transaction). Identity is the caller
-///        itself (`actorId == bytes20(msg.sender)`) and `account` comes from the supplied binding.
+///        itself (`actorId == ActorId.fromAddress(msg.sender)`) and `account` comes from the supplied binding.
 ///
 ///      Commitment binding: the account authorizes a {PolicyBinding}; its `keccak256` is the `commitment`. When the
 ///      account authorizes the session-key actor it stores `scope & Scopes.POLICY != 0`, `policy_manager =
@@ -156,7 +157,7 @@ contract PolicyManager is ReentrancyGuard {
     ///         for it. Used when the actor is not a key *on* the account but a separate party (e.g. a subscription
     ///         provider) the account opted into.
     ///
-    /// @dev The acting identity is the caller itself — `actorId == bytes20(msg.sender)` — and `account` is
+    /// @dev The acting identity is the caller itself — `actorId == ActorId.fromAddress(msg.sender)` — and `account` is
     ///      `binding.account`. There is no protocol routing on this path, so unlike {execute} this re-verifies that
     ///      the caller is a live external-pull actor (authenticator == {EXTERNAL_POLICY_AUTHENTICATOR}) and that the
     ///      account gated *this* manager for it.
@@ -164,7 +165,7 @@ contract PolicyManager is ReentrancyGuard {
     /// @param binding       Full account-authorized binding (config + window + salt).
     /// @param executionData Per-use action parameters interpreted by the policy.
     function executeFor(PolicyBinding calldata binding, bytes calldata executionData) external nonReentrant {
-        _enforceExternal(binding, bytes32(bytes20(msg.sender)), executionData, msg.sender);
+        _enforceExternal(binding, ActorId.fromAddress(msg.sender), executionData, msg.sender);
     }
 
     /// @notice Best-effort cross-account batch of {executeFor}: one external caller, many bindings, one transaction.
@@ -182,7 +183,7 @@ contract PolicyManager is ReentrancyGuard {
         returns (bool[] memory results)
     {
         if (bindings.length != executionData.length) revert LengthMismatch();
-        bytes32 actorId = bytes32(bytes20(msg.sender));
+        bytes32 actorId = ActorId.fromAddress(msg.sender);
         address caller = msg.sender;
         results = new bool[](bindings.length);
         for (uint256 i; i < bindings.length; i++) {

--- a/src/policies/README.md
+++ b/src/policies/README.md
@@ -116,7 +116,7 @@ caller, not the protocol.
 
 `executeFor(binding, executionData)` is the external-caller entrypoint:
 
-- **Identity is the caller:** `actorId = bytes20(msg.sender)`, and `account` is an explicit argument. The caller
+- **Identity is the caller:** `actorId = ActorId.fromAddress(msg.sender)` (the address right-aligned in a 32-byte word), and `account` is an explicit argument. The caller
   can't forge the identity because it's derived from `msg.sender`.
 - **No protocol routing, so the manager re-checks itself:** it re-adds the `policy_manager(account, actorId) ==
   address(this)` check that the account-acting `execute` omits (the 8130 gate guarantees routing only on the
@@ -131,7 +131,7 @@ then `executeFor` — so the account never needs to send a transaction. The acco
 *policy-only* actor — it has no authority of its own, it only carries a binding the manager enforces:
 
 ```solidity
-// actorId = bytes20(provider). The provider never signs an 8130 tx; it acts by being msg.sender.
+// actorId = ActorId.fromAddress(provider). The provider never signs an 8130 tx; it acts by being msg.sender.
 Keystore.ActorConfig({
     authenticator: EXTERNAL_POLICY_AUTHENTICATOR, // recognized actor; NO direct executeBatch; not 8130-usable
     scope:         0x02,                          // Scopes.POLICY — gated initiation only (MAY also OR Scopes.SELF_PAYER

--- a/test/lib/KeystoreTest.sol
+++ b/test/lib/KeystoreTest.sol
@@ -268,11 +268,8 @@ contract KeystoreTest is Test {
     }
 
     function _revokeActor(address account, uint256 pk, bytes32 actorId) internal {
-        // A live revoke is a reduction; batch it with a bump so it lands without ReductionRequiresEpochBump.
-        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
-        ch[0] = _revokeChange(actorId);
-        ch[1] = _bumpChange();
-        _applyLocal(pk, account, ch);
+        // A bare (sequenced) revoke lands on its own; durable teardown against outstanding grants is a separate bump.
+        _applyLocal(pk, account, _one(_revokeChange(actorId)));
     }
 
     // Implicit-EOA variants are identical here (the same k1 signer path); kept as named aliases for readability.

--- a/test/lib/KeystoreTest.sol
+++ b/test/lib/KeystoreTest.sol
@@ -30,12 +30,12 @@ contract KeystoreTest is Test {
 
     // SECP256K1_ORDER (curve order n) is inherited from forge-std; _boundK1Pk bounds fuzzed keys to [1, n-1].
 
-    bytes32 constant SIGNED_ACCOUNT_CHANGES_TYPEHASH = keccak256(
-        "SignedAccountChanges(address account,uint256 chainId,uint64 sequence,AccountChange[] changes)"
-        "AccountChange(uint8 changeType,bytes payload)"
+    bytes32 constant SIGNED_CONFIG_CHANGES_TYPEHASH = keccak256(
+        "SignedConfigChanges(address account,uint256 chainId,uint64 sequence,ConfigChange[] changes)"
+        "ConfigChange(uint8 changeType,bytes payload)"
     );
 
-    bytes32 constant ACCOUNT_CHANGE_TYPEHASH = keccak256("AccountChange(uint8 changeType,bytes payload)");
+    bytes32 constant CONFIG_CHANGE_TYPEHASH = keccak256("ConfigChange(uint8 changeType,bytes payload)");
 
     /// @dev Unbounded expiry sentinel: an unbounded (never-expiring) grant is expressed as this value and is only
     ///      permitted on a sequenced batch. Convenience helpers that stand in for the old "no expiry" actors grant
@@ -135,9 +135,9 @@ contract KeystoreTest is Test {
     function _authorizeChange(bytes32 actorId, address auth, uint16 scope, uint48 expiry, bytes memory policyData)
         internal
         pure
-        returns (Keystore.AccountChange memory)
+        returns (Keystore.ConfigChange memory)
     {
-        return Keystore.AccountChange({
+        return Keystore.ConfigChange({
             changeType: Keystore.ChangeType.AuthorizeActor,
             payload: abi.encode(
                 actorId, Keystore.ActorConfig({authenticator: auth, scope: scope, expiry: expiry}), policyData
@@ -145,25 +145,25 @@ contract KeystoreTest is Test {
         });
     }
 
-    function _revokeChange(bytes32 actorId) internal pure returns (Keystore.AccountChange memory) {
-        return Keystore.AccountChange({changeType: Keystore.ChangeType.RevokeActor, payload: abi.encode(actorId)});
+    function _revokeChange(bytes32 actorId) internal pure returns (Keystore.ConfigChange memory) {
+        return Keystore.ConfigChange({changeType: Keystore.ChangeType.RevokeActor, payload: abi.encode(actorId)});
     }
 
-    function _bumpChange() internal pure returns (Keystore.AccountChange memory) {
-        return Keystore.AccountChange({changeType: Keystore.ChangeType.BumpLocalEpoch, payload: ""});
+    function _bumpChange() internal pure returns (Keystore.ConfigChange memory) {
+        return Keystore.ConfigChange({changeType: Keystore.ChangeType.IncrementLocalEpoch, payload: ""});
     }
 
-    function _lockChange(uint16 unlockDelay) internal pure returns (Keystore.AccountChange memory) {
-        return Keystore.AccountChange({changeType: Keystore.ChangeType.Lock, payload: abi.encode(unlockDelay)});
+    function _lockChange(uint16 unlockDelay) internal pure returns (Keystore.ConfigChange memory) {
+        return Keystore.ConfigChange({changeType: Keystore.ChangeType.Lock, payload: abi.encode(unlockDelay)});
     }
 
-    function _unlockChange() internal pure returns (Keystore.AccountChange memory) {
-        return Keystore.AccountChange({changeType: Keystore.ChangeType.Unlock, payload: ""});
+    function _unlockChange() internal pure returns (Keystore.ConfigChange memory) {
+        return Keystore.ConfigChange({changeType: Keystore.ChangeType.Unlock, payload: ""});
     }
 
     /// @dev Wrap a single change into a one-element array.
-    function _one(Keystore.AccountChange memory c) internal pure returns (Keystore.AccountChange[] memory arr) {
-        arr = new Keystore.AccountChange[](1);
+    function _one(Keystore.ConfigChange memory c) internal pure returns (Keystore.ConfigChange[] memory arr) {
+        arr = new Keystore.ConfigChange[](1);
         arr[0] = c;
     }
 
@@ -171,20 +171,20 @@ contract KeystoreTest is Test {
 
     function _changesDigest(
         address account,
-        Keystore.AccountChangeChannel channel,
+        Keystore.ConfigChangeChannel channel,
         uint64 sequence,
-        Keystore.AccountChange[] memory changes
+        Keystore.ConfigChange[] memory changes
     ) internal view returns (bytes32) {
-        uint256 chainId = channel == Keystore.AccountChangeChannel.Multichain ? 0 : block.chainid;
+        uint256 chainId = channel == Keystore.ConfigChangeChannel.Multichain ? 0 : block.chainid;
         bytes32[] memory changeHashes = new bytes32[](changes.length);
         for (uint256 i; i < changes.length; i++) {
             changeHashes[i] = keccak256(
-                abi.encode(ACCOUNT_CHANGE_TYPEHASH, uint8(changes[i].changeType), keccak256(changes[i].payload))
+                abi.encode(CONFIG_CHANGE_TYPEHASH, uint8(changes[i].changeType), keccak256(changes[i].payload))
             );
         }
         return keccak256(
             abi.encode(
-                SIGNED_ACCOUNT_CHANGES_TYPEHASH, account, chainId, sequence, keccak256(abi.encodePacked(changeHashes))
+                SIGNED_CONFIG_CHANGES_TYPEHASH, account, chainId, sequence, keccak256(abi.encodePacked(changeHashes))
             )
         );
     }
@@ -195,34 +195,34 @@ contract KeystoreTest is Test {
     function _signBatch(
         uint256 pk,
         address account,
-        Keystore.AccountChangeChannel channel,
+        Keystore.ConfigChangeChannel channel,
         uint64 sequence,
-        Keystore.AccountChange[] memory changes
-    ) internal view returns (Keystore.SignedAccountChanges memory) {
+        Keystore.ConfigChange[] memory changes
+    ) internal view returns (Keystore.SignedConfigChanges memory) {
         bytes32 digest = _changesDigest(account, channel, sequence, changes);
-        return Keystore.SignedAccountChanges({
+        return Keystore.SignedConfigChanges({
             channel: channel, sequence: sequence, changes: changes, signature: _buildK1Auth(pk, digest)
         });
     }
 
     /// @dev Build + relay a sequenced local batch at the account's current sequence word, K1-signed by `pk`.
-    function _applyLocal(uint256 pk, address account, Keystore.AccountChange[] memory changes) internal {
-        keystore.applySignedAccountChanges(
-            account, _signBatch(pk, account, Keystore.AccountChangeChannel.Local, _localSeqWord(account), changes)
+    function _applyLocal(uint256 pk, address account, Keystore.ConfigChange[] memory changes) internal {
+        keystore.applySignedConfigChanges(
+            account, _signBatch(pk, account, Keystore.ConfigChangeChannel.Local, _localSeqWord(account), changes)
         );
     }
 
     /// @dev Build + relay an unsequenced (JIT) local batch at the account's current epoch, K1-signed by `pk`.
-    function _applyUnsequenced(uint256 pk, address account, Keystore.AccountChange[] memory changes) internal {
-        keystore.applySignedAccountChanges(
-            account, _signBatch(pk, account, Keystore.AccountChangeChannel.Local, _unseqWord(account), changes)
+    function _applyUnsequenced(uint256 pk, address account, Keystore.ConfigChange[] memory changes) internal {
+        keystore.applySignedConfigChanges(
+            account, _signBatch(pk, account, Keystore.ConfigChangeChannel.Local, _unseqWord(account), changes)
         );
     }
 
     /// @dev Build + relay a multichain batch at the account's current multichain sequence, K1-signed by `pk`.
-    function _applyMultichain(uint256 pk, address account, Keystore.AccountChange[] memory changes) internal {
-        keystore.applySignedAccountChanges(
-            account, _signBatch(pk, account, Keystore.AccountChangeChannel.Multichain, _multichainSeq(account), changes)
+    function _applyMultichain(uint256 pk, address account, Keystore.ConfigChange[] memory changes) internal {
+        keystore.applySignedConfigChanges(
+            account, _signBatch(pk, account, Keystore.ConfigChangeChannel.Multichain, _multichainSeq(account), changes)
         );
     }
 
@@ -231,33 +231,33 @@ contract KeystoreTest is Test {
     // These build the fully-signed batch WITHOUT relaying it, so revert tests can construct the batch (which reads
     // the current sequence word via a view staticcall) BEFORE `vm.expectRevert`, then relay it as the single
     // expected-reverting external call. Foundry's strict expectRevert binds to the very next external call, so the
-    // sequence-word staticcall must not sit between expectRevert and applySignedAccountChanges.
+    // sequence-word staticcall must not sit between expectRevert and applySignedConfigChanges.
 
-    function _localBatch(uint256 pk, address account, Keystore.AccountChange[] memory changes)
+    function _localBatch(uint256 pk, address account, Keystore.ConfigChange[] memory changes)
         internal
         view
-        returns (Keystore.SignedAccountChanges memory)
+        returns (Keystore.SignedConfigChanges memory)
     {
-        return _signBatch(pk, account, Keystore.AccountChangeChannel.Local, _localSeqWord(account), changes);
+        return _signBatch(pk, account, Keystore.ConfigChangeChannel.Local, _localSeqWord(account), changes);
     }
 
-    function _unseqBatch(uint256 pk, address account, Keystore.AccountChange[] memory changes)
+    function _unseqBatch(uint256 pk, address account, Keystore.ConfigChange[] memory changes)
         internal
         view
-        returns (Keystore.SignedAccountChanges memory)
+        returns (Keystore.SignedConfigChanges memory)
     {
-        return _signBatch(pk, account, Keystore.AccountChangeChannel.Local, _unseqWord(account), changes);
+        return _signBatch(pk, account, Keystore.ConfigChangeChannel.Local, _unseqWord(account), changes);
     }
 
-    function _multichainBatch(uint256 pk, address account, Keystore.AccountChange[] memory changes)
+    function _multichainBatch(uint256 pk, address account, Keystore.ConfigChange[] memory changes)
         internal
         view
-        returns (Keystore.SignedAccountChanges memory)
+        returns (Keystore.SignedConfigChanges memory)
     {
-        return _signBatch(pk, account, Keystore.AccountChangeChannel.Multichain, _multichainSeq(account), changes);
+        return _signBatch(pk, account, Keystore.ConfigChangeChannel.Multichain, _multichainSeq(account), changes);
     }
 
-    // ── Back-compat actor helpers (re-implemented on applySignedAccountChanges) ──
+    // ── Back-compat actor helpers (re-implemented on applySignedConfigChanges) ──
     //
     // These preserve the pre-split helper names used across the suite. A signed grant always self-expires, so where
     // the old model used a no-expiry (0) actor these grant UNBOUNDED (type(uint48).max) on a sequenced batch — the

--- a/test/lib/KeystoreTest.sol
+++ b/test/lib/KeystoreTest.sol
@@ -294,7 +294,7 @@ contract KeystoreTest is Test {
         _applyLocal(pk, account, _one(_lockChange(unlockDelay)));
     }
 
-    /// @dev Relay a signed (solo) Unlock authorized by `pk` on the local channel.
+    /// @dev Relay a signed Unlock authorized by `pk` on the local channel.
     function _signedUnlock(uint256 pk, address account) internal {
         _applyLocal(pk, account, _one(_unlockChange()));
     }

--- a/test/lib/KeystoreTest.sol
+++ b/test/lib/KeystoreTest.sol
@@ -30,20 +30,17 @@ contract KeystoreTest is Test {
 
     // SECP256K1_ORDER (curve order n) is inherited from forge-std; _boundK1Pk bounds fuzzed keys to [1, n-1].
 
-    bytes32 constant SIGNED_ACTOR_CHANGES_TYPEHASH = keccak256(
-        "SignedActorChanges(address account,uint256 chainId,uint64 sequence,ActorChange[] actorChanges)"
-        "ActorChange(uint8 changeType,bytes32 actorId,bytes data)"
+    bytes32 constant SIGNED_ACCOUNT_CHANGES_TYPEHASH = keccak256(
+        "SignedAccountChanges(address account,uint256 chainId,uint64 sequence,AccountChange[] changes)"
+        "AccountChange(uint8 changeType,bytes payload)"
     );
 
-    bytes32 constant ACTOR_CHANGE_TYPEHASH = keccak256("ActorChange(uint8 changeType,bytes32 actorId,bytes data)");
+    bytes32 constant ACCOUNT_CHANGE_TYPEHASH = keccak256("AccountChange(uint8 changeType,bytes payload)");
 
-    bytes32 constant LOCK_CHANGE_TYPEHASH =
-        keccak256("SignedLockChange(address account,uint256 chainId,uint8 op,uint16 unlockDelay,uint64 sequence)");
-
-    // Wire values for the LockChangeType enum (which ABI-encodes as uint8). Used to compute the signed digest, whose typehash
-    // binds `uint8 op`; the applySignedLockChanges call itself takes the typed Keystore.LockChangeType.
-    uint8 constant LOCK_OP = uint8(Keystore.LockChangeType.Lock);
-    uint8 constant UNLOCK_OP = uint8(Keystore.LockChangeType.Unlock);
+    /// @dev Unbounded expiry sentinel: an unbounded (never-expiring) grant is expressed as this value and is only
+    ///      permitted on a sequenced batch. Convenience helpers that stand in for the old "no expiry" actors grant
+    ///      this so they never trip the ExpiredChange fence (a signed grant always self-expires).
+    uint48 constant UNBOUNDED = type(uint48).max;
 
     function setUp() public virtual {
         keystore = new Keystore();
@@ -109,70 +106,237 @@ contract KeystoreTest is Test {
         return abi.encodePacked(k1Authenticator, sig);
     }
 
-    // ── Canonical digest computation ──
+    // ── Sequence-word helpers ──
 
-    function _computeActorChangeBatchDigest(
+    /// @dev The account's current local sequence WORD (localEpoch(32) || localSequence(32)) for a sequenced batch.
+    function _localSeqWord(address account) internal view returns (uint64) {
+        return keystore.getChangeSequences(account).local;
+    }
+
+    /// @dev An unsequenced (JIT) local sequence word at the account's current epoch: epoch || UNSEQUENCED.
+    function _unseqWord(address account) internal view returns (uint64) {
+        (uint32 epoch,) = keystore.getLocalEpochAndSequence(account);
+        return (uint64(epoch) << 32) | uint64(keystore.UNSEQUENCED());
+    }
+
+    /// @dev The account's current multichain sequence.
+    function _multichainSeq(address account) internal view returns (uint64) {
+        return keystore.getChangeSequences(account).multichain;
+    }
+
+    // ── Change builders ──
+
+    function _authorizeChange(bytes32 actorId, address auth, uint16 scope, uint48 expiry, bytes memory policyData)
+        internal
+        pure
+        returns (Keystore.AccountChange memory)
+    {
+        return Keystore.AccountChange({
+            changeType: Keystore.ChangeType.AuthorizeActor,
+            payload: abi.encode(
+                actorId, Keystore.ActorConfig({authenticator: auth, scope: scope, expiry: expiry}), policyData
+            )
+        });
+    }
+
+    function _revokeChange(bytes32 actorId) internal pure returns (Keystore.AccountChange memory) {
+        return Keystore.AccountChange({changeType: Keystore.ChangeType.RevokeActor, payload: abi.encode(actorId)});
+    }
+
+    function _bumpChange() internal pure returns (Keystore.AccountChange memory) {
+        return Keystore.AccountChange({changeType: Keystore.ChangeType.BumpLocalEpoch, payload: ""});
+    }
+
+    function _lockChange(uint16 unlockDelay) internal pure returns (Keystore.AccountChange memory) {
+        return Keystore.AccountChange({changeType: Keystore.ChangeType.Lock, payload: abi.encode(unlockDelay)});
+    }
+
+    function _unlockChange() internal pure returns (Keystore.AccountChange memory) {
+        return Keystore.AccountChange({changeType: Keystore.ChangeType.Unlock, payload: ""});
+    }
+
+    /// @dev Wrap a single change into a one-element array.
+    function _one(Keystore.AccountChange memory c) internal pure returns (Keystore.AccountChange[] memory arr) {
+        arr = new Keystore.AccountChange[](1);
+        arr[0] = c;
+    }
+
+    // ── Canonical digest computation (mirrors Keystore._changesDigest) ──
+
+    function _changesDigest(
         address account,
-        uint256 chainId,
+        Keystore.AccountChangeChannel channel,
         uint64 sequence,
-        Keystore.ActorChange[] memory actorChanges
-    ) internal pure returns (bytes32) {
-        bytes32[] memory actorChangeHash = new bytes32[](actorChanges.length);
-        for (uint256 i; i < actorChanges.length; i++) {
-            actorChangeHash[i] = keccak256(
-                abi.encode(
-                    ACTOR_CHANGE_TYPEHASH,
-                    actorChanges[i].changeType,
-                    actorChanges[i].actorId,
-                    keccak256(actorChanges[i].data)
-                )
+        Keystore.AccountChange[] memory changes
+    ) internal view returns (bytes32) {
+        uint256 chainId = channel == Keystore.AccountChangeChannel.Multichain ? 0 : block.chainid;
+        bytes32[] memory changeHashes = new bytes32[](changes.length);
+        for (uint256 i; i < changes.length; i++) {
+            changeHashes[i] = keccak256(
+                abi.encode(ACCOUNT_CHANGE_TYPEHASH, uint8(changes[i].changeType), keccak256(changes[i].payload))
             );
         }
         return keccak256(
             abi.encode(
-                SIGNED_ACTOR_CHANGES_TYPEHASH, account, chainId, sequence, keccak256(abi.encodePacked(actorChangeHash))
+                SIGNED_ACCOUNT_CHANGES_TYPEHASH, account, chainId, sequence, keccak256(abi.encodePacked(changeHashes))
             )
         );
     }
 
-    // ── Signed lock-change helpers ──
-    //
-    // Lock state changes go through applySignedLockChanges: a relayable, admin-authorized (scope 0) signed call.
-    // These helpers drive it for an account controlled by `pk` — either the account's inline default-EOA self (an
-    // uninitialized EOA at vm.addr(pk)) or a k1 admin actor whose actorId is bytes32(bytes20(vm.addr(pk))).
+    // ── Signed batch construction (K1) ──
 
-    function _computeLockChangeDigest(address account, uint256 chainId, uint8 op, uint16 unlockDelay, uint64 sequence)
-        internal
-        pure
-        returns (bytes32)
-    {
-        return keccak256(abi.encode(LOCK_CHANGE_TYPEHASH, account, chainId, op, unlockDelay, sequence));
+    /// @dev Build a fully-signed batch for `channel`/`sequence`, K1-signed by `pk`.
+    function _signBatch(
+        uint256 pk,
+        address account,
+        Keystore.AccountChangeChannel channel,
+        uint64 sequence,
+        Keystore.AccountChange[] memory changes
+    ) internal view returns (Keystore.SignedAccountChanges memory) {
+        bytes32 digest = _changesDigest(account, channel, sequence, changes);
+        return Keystore.SignedAccountChanges({
+            channel: channel, changes: changes, sequence: sequence, signature: _buildK1Auth(pk, digest)
+        });
     }
 
-    /// @dev Admin auth blob for a lock op (op = 1) at the account's current local sequence.
-    function _lockAuth(uint256 pk, address account, uint16 unlockDelay) internal view returns (bytes memory) {
-        uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeLockChangeDigest(account, block.chainid, LOCK_OP, unlockDelay, seq);
-        return _buildK1Auth(pk, digest);
-    }
-
-    /// @dev Admin auth blob for an unlock op (op = 2) at the account's current local sequence.
-    function _unlockAuth(uint256 pk, address account) internal view returns (bytes memory) {
-        uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeLockChangeDigest(account, block.chainid, UNLOCK_OP, 0, seq);
-        return _buildK1Auth(pk, digest);
-    }
-
-    /// @dev Relay a signed lock op (op = 1) authorized by `pk`.
-    function _signedLock(uint256 pk, address account, uint16 unlockDelay) internal {
-        keystore.applySignedLockChanges(
-            account, Keystore.LockChangeType.Lock, unlockDelay, _lockAuth(pk, account, unlockDelay)
+    /// @dev Build + relay a sequenced local batch at the account's current sequence word, K1-signed by `pk`.
+    function _applyLocal(uint256 pk, address account, Keystore.AccountChange[] memory changes) internal {
+        keystore.applySignedAccountChanges(
+            account, _signBatch(pk, account, Keystore.AccountChangeChannel.Local, _localSeqWord(account), changes)
         );
     }
 
-    /// @dev Relay a signed unlock op (op = 2) authorized by `pk`.
+    /// @dev Build + relay an unsequenced (JIT) local batch at the account's current epoch, K1-signed by `pk`.
+    function _applyUnsequenced(uint256 pk, address account, Keystore.AccountChange[] memory changes) internal {
+        keystore.applySignedAccountChanges(
+            account, _signBatch(pk, account, Keystore.AccountChangeChannel.Local, _unseqWord(account), changes)
+        );
+    }
+
+    /// @dev Build + relay a multichain batch at the account's current multichain sequence, K1-signed by `pk`.
+    function _applyMultichain(uint256 pk, address account, Keystore.AccountChange[] memory changes) internal {
+        keystore.applySignedAccountChanges(
+            account, _signBatch(pk, account, Keystore.AccountChangeChannel.Multichain, _multichainSeq(account), changes)
+        );
+    }
+
+    // ── Pre-built (unrelayed) batches ──
+    //
+    // These build the fully-signed batch WITHOUT relaying it, so revert tests can construct the batch (which reads
+    // the current sequence word via a view staticcall) BEFORE `vm.expectRevert`, then relay it as the single
+    // expected-reverting external call. Foundry's strict expectRevert binds to the very next external call, so the
+    // sequence-word staticcall must not sit between expectRevert and applySignedAccountChanges.
+
+    function _localBatch(uint256 pk, address account, Keystore.AccountChange[] memory changes)
+        internal
+        view
+        returns (Keystore.SignedAccountChanges memory)
+    {
+        return _signBatch(pk, account, Keystore.AccountChangeChannel.Local, _localSeqWord(account), changes);
+    }
+
+    function _unseqBatch(uint256 pk, address account, Keystore.AccountChange[] memory changes)
+        internal
+        view
+        returns (Keystore.SignedAccountChanges memory)
+    {
+        return _signBatch(pk, account, Keystore.AccountChangeChannel.Local, _unseqWord(account), changes);
+    }
+
+    function _multichainBatch(uint256 pk, address account, Keystore.AccountChange[] memory changes)
+        internal
+        view
+        returns (Keystore.SignedAccountChanges memory)
+    {
+        return _signBatch(pk, account, Keystore.AccountChangeChannel.Multichain, _multichainSeq(account), changes);
+    }
+
+    // ── Back-compat actor helpers (re-implemented on applySignedAccountChanges) ──
+    //
+    // These preserve the pre-split helper names used across the suite. A signed grant always self-expires, so where
+    // the old model used a no-expiry (0) actor these grant UNBOUNDED (type(uint48).max) on a sequenced batch — the
+    // same never-expiring behavior, expressed the new way.
+
+    function _authorizeActor(address account, uint256 pk, bytes32 actorId, address authenticator) internal {
+        _authorizeActorWithScope(account, pk, actorId, authenticator, 0);
+    }
+
+    function _authorizeActorWithScope(address account, uint256 pk, bytes32 actorId, address authenticator, uint16 scope)
+        internal
+    {
+        _applyLocal(pk, account, _one(_authorizeChange(actorId, authenticator, scope, UNBOUNDED, "")));
+    }
+
+    function _revokeActor(address account, uint256 pk, bytes32 actorId) internal {
+        // A live revoke is a reduction; batch it with a bump so it lands without ReductionRequiresEpochBump.
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        ch[0] = _revokeChange(actorId);
+        ch[1] = _bumpChange();
+        _applyLocal(pk, account, ch);
+    }
+
+    // Implicit-EOA variants are identical here (the same k1 signer path); kept as named aliases for readability.
+    function _implicitAuthorizeActor(address account, uint256 pk, bytes32 actorId, address authenticator) internal {
+        _authorizeActor(account, pk, actorId, authenticator);
+    }
+
+    function _implicitAuthorizeActorWithScope(
+        address account,
+        uint256 pk,
+        bytes32 actorId,
+        address authenticator,
+        uint16 scope
+    ) internal {
+        _authorizeActorWithScope(account, pk, actorId, authenticator, scope);
+    }
+
+    // ── Signed lock helpers (re-implemented as environment-op batches) ──
+
+    /// @dev Relay a signed Lock (unlockDelay) authorized by `pk` on the local channel.
+    function _signedLock(uint256 pk, address account, uint16 unlockDelay) internal {
+        _applyLocal(pk, account, _one(_lockChange(unlockDelay)));
+    }
+
+    /// @dev Relay a signed (solo) Unlock authorized by `pk` on the local channel.
     function _signedUnlock(uint256 pk, address account) internal {
-        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Unlock, 0, _unlockAuth(pk, account));
+        _applyLocal(pk, account, _one(_unlockChange()));
+    }
+
+    /// @dev Hard-lock `account` via the signed lock path, authorized by its admin owner key `pk`.
+    function _lockAccount(uint256 pk, address account) internal {
+        _signedLock(pk, account, 1 hours);
+    }
+
+    // ── Direct AccountState storage pokes (for saturation edge cases) ──
+    //
+    // AccountState packs into one slot at base-slot 3 (declaration order: _actorConfig, _policyCommitment,
+    // _policyManager, _accountState). multichainSequence occupies bytes[0:8] and localSequence bytes[8:16] of that
+    // slot; localSequence's high 32 bits are the epoch, its low 32 bits the sequence.
+
+    function _accountStateSlot(address account) internal pure returns (bytes32) {
+        return keccak256(abi.encode(account, uint256(3)));
+    }
+
+    /// @dev Overwrite the packed localSequence word (epoch<<32 | seq), preserving every other field in the slot.
+    function _forceLocalWord(address account, uint64 word) internal {
+        bytes32 slot = _accountStateSlot(account);
+        uint256 cur = uint256(vm.load(address(keystore), slot));
+        // Clear bytes[8:16] (bits 64..127) and write the new word there.
+        uint256 mask = ~(uint256(type(uint64).max) << 64);
+        uint256 updated = (cur & mask) | (uint256(word) << 64);
+        vm.store(address(keystore), slot, bytes32(updated));
+    }
+
+    /// @dev Force the account's local epoch (high 32 bits), keeping the current low sequence.
+    function _forceLocalEpoch(address account, uint32 epoch) internal {
+        (, uint32 seq) = keystore.getLocalEpochAndSequence(account);
+        _forceLocalWord(account, (uint64(epoch) << 32) | uint64(seq));
+    }
+
+    /// @dev Force the account's local sequence (low 32 bits), keeping the current epoch.
+    function _forceLocalSequence(address account, uint32 seq) internal {
+        (uint32 epoch,) = keystore.getLocalEpochAndSequence(account);
+        _forceLocalWord(account, (uint64(epoch) << 32) | uint64(seq));
     }
 
     // ── Fuzzed key bounding ──

--- a/test/lib/KeystoreTest.sol
+++ b/test/lib/KeystoreTest.sol
@@ -69,7 +69,7 @@ contract KeystoreTest is Test {
 
     function _createK1Account(uint256 pk) internal returns (address account, bytes32 actorId) {
         address signer = vm.addr(pk);
-        actorId = bytes32(bytes20(signer));
+        actorId = bytes32(uint256(uint160(signer)));
 
         Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](1);
         actors[0] = Keystore.InitialActor({
@@ -82,7 +82,7 @@ contract KeystoreTest is Test {
 
     function _createK1AccountWithSalt(uint256 pk, bytes32 salt) internal returns (address account, bytes32 actorId) {
         address signer = vm.addr(pk);
-        actorId = bytes32(bytes20(signer));
+        actorId = bytes32(uint256(uint160(signer)));
 
         Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](1);
         actors[0] = Keystore.InitialActor({

--- a/test/lib/KeystoreTest.sol
+++ b/test/lib/KeystoreTest.sol
@@ -30,12 +30,12 @@ contract KeystoreTest is Test {
 
     // SECP256K1_ORDER (curve order n) is inherited from forge-std; _boundK1Pk bounds fuzzed keys to [1, n-1].
 
-    bytes32 constant SIGNED_CONFIG_CHANGES_TYPEHASH = keccak256(
-        "SignedConfigChanges(address account,uint256 chainId,uint64 sequence,ConfigChange[] changes)"
-        "ConfigChange(uint8 changeType,bytes payload)"
+    bytes32 constant SIGNED_ACCOUNT_CHANGES_TYPEHASH = keccak256(
+        "SignedAccountChanges(address account,uint256 chainId,uint64 sequence,AccountChange[] changes)"
+        "AccountChange(uint8 changeType,bytes payload)"
     );
 
-    bytes32 constant CONFIG_CHANGE_TYPEHASH = keccak256("ConfigChange(uint8 changeType,bytes payload)");
+    bytes32 constant ACCOUNT_CHANGE_TYPEHASH = keccak256("AccountChange(uint8 changeType,bytes payload)");
 
     /// @dev Unbounded expiry sentinel: an unbounded (never-expiring) grant is expressed as this value and is only
     ///      permitted on a sequenced batch. Convenience helpers that stand in for the old "no expiry" actors grant
@@ -135,9 +135,9 @@ contract KeystoreTest is Test {
     function _authorizeChange(bytes32 actorId, address auth, uint16 scope, uint48 expiry, bytes memory policyData)
         internal
         pure
-        returns (Keystore.ConfigChange memory)
+        returns (Keystore.AccountChange memory)
     {
-        return Keystore.ConfigChange({
+        return Keystore.AccountChange({
             changeType: Keystore.ChangeType.AuthorizeActor,
             payload: abi.encode(
                 actorId, Keystore.ActorConfig({authenticator: auth, scope: scope, expiry: expiry}), policyData
@@ -145,25 +145,25 @@ contract KeystoreTest is Test {
         });
     }
 
-    function _revokeChange(bytes32 actorId) internal pure returns (Keystore.ConfigChange memory) {
-        return Keystore.ConfigChange({changeType: Keystore.ChangeType.RevokeActor, payload: abi.encode(actorId)});
+    function _revokeChange(bytes32 actorId) internal pure returns (Keystore.AccountChange memory) {
+        return Keystore.AccountChange({changeType: Keystore.ChangeType.RevokeActor, payload: abi.encode(actorId)});
     }
 
-    function _bumpChange() internal pure returns (Keystore.ConfigChange memory) {
-        return Keystore.ConfigChange({changeType: Keystore.ChangeType.IncrementLocalEpoch, payload: ""});
+    function _bumpChange() internal pure returns (Keystore.AccountChange memory) {
+        return Keystore.AccountChange({changeType: Keystore.ChangeType.IncrementLocalEpoch, payload: ""});
     }
 
-    function _lockChange(uint16 unlockDelay) internal pure returns (Keystore.ConfigChange memory) {
-        return Keystore.ConfigChange({changeType: Keystore.ChangeType.Lock, payload: abi.encode(unlockDelay)});
+    function _lockChange(uint16 unlockDelay) internal pure returns (Keystore.AccountChange memory) {
+        return Keystore.AccountChange({changeType: Keystore.ChangeType.Lock, payload: abi.encode(unlockDelay)});
     }
 
-    function _unlockChange() internal pure returns (Keystore.ConfigChange memory) {
-        return Keystore.ConfigChange({changeType: Keystore.ChangeType.Unlock, payload: ""});
+    function _unlockChange() internal pure returns (Keystore.AccountChange memory) {
+        return Keystore.AccountChange({changeType: Keystore.ChangeType.Unlock, payload: ""});
     }
 
     /// @dev Wrap a single change into a one-element array.
-    function _one(Keystore.ConfigChange memory c) internal pure returns (Keystore.ConfigChange[] memory arr) {
-        arr = new Keystore.ConfigChange[](1);
+    function _one(Keystore.AccountChange memory c) internal pure returns (Keystore.AccountChange[] memory arr) {
+        arr = new Keystore.AccountChange[](1);
         arr[0] = c;
     }
 
@@ -171,20 +171,20 @@ contract KeystoreTest is Test {
 
     function _changesDigest(
         address account,
-        Keystore.ConfigChangeChannel channel,
+        Keystore.AccountChangeChannel channel,
         uint64 sequence,
-        Keystore.ConfigChange[] memory changes
+        Keystore.AccountChange[] memory changes
     ) internal view returns (bytes32) {
-        uint256 chainId = channel == Keystore.ConfigChangeChannel.Multichain ? 0 : block.chainid;
+        uint256 chainId = channel == Keystore.AccountChangeChannel.Multichain ? 0 : block.chainid;
         bytes32[] memory changeHashes = new bytes32[](changes.length);
         for (uint256 i; i < changes.length; i++) {
             changeHashes[i] = keccak256(
-                abi.encode(CONFIG_CHANGE_TYPEHASH, uint8(changes[i].changeType), keccak256(changes[i].payload))
+                abi.encode(ACCOUNT_CHANGE_TYPEHASH, uint8(changes[i].changeType), keccak256(changes[i].payload))
             );
         }
         return keccak256(
             abi.encode(
-                SIGNED_CONFIG_CHANGES_TYPEHASH, account, chainId, sequence, keccak256(abi.encodePacked(changeHashes))
+                SIGNED_ACCOUNT_CHANGES_TYPEHASH, account, chainId, sequence, keccak256(abi.encodePacked(changeHashes))
             )
         );
     }
@@ -195,34 +195,34 @@ contract KeystoreTest is Test {
     function _signBatch(
         uint256 pk,
         address account,
-        Keystore.ConfigChangeChannel channel,
+        Keystore.AccountChangeChannel channel,
         uint64 sequence,
-        Keystore.ConfigChange[] memory changes
-    ) internal view returns (Keystore.SignedConfigChanges memory) {
+        Keystore.AccountChange[] memory changes
+    ) internal view returns (Keystore.SignedAccountChanges memory) {
         bytes32 digest = _changesDigest(account, channel, sequence, changes);
-        return Keystore.SignedConfigChanges({
+        return Keystore.SignedAccountChanges({
             channel: channel, sequence: sequence, changes: changes, signature: _buildK1Auth(pk, digest)
         });
     }
 
     /// @dev Build + relay a sequenced local batch at the account's current sequence word, K1-signed by `pk`.
-    function _applyLocal(uint256 pk, address account, Keystore.ConfigChange[] memory changes) internal {
-        keystore.applySignedConfigChanges(
-            account, _signBatch(pk, account, Keystore.ConfigChangeChannel.Local, _localSeqWord(account), changes)
+    function _applyLocal(uint256 pk, address account, Keystore.AccountChange[] memory changes) internal {
+        keystore.applySignedAccountChanges(
+            account, _signBatch(pk, account, Keystore.AccountChangeChannel.Local, _localSeqWord(account), changes)
         );
     }
 
     /// @dev Build + relay an unsequenced (JIT) local batch at the account's current epoch, K1-signed by `pk`.
-    function _applyUnsequenced(uint256 pk, address account, Keystore.ConfigChange[] memory changes) internal {
-        keystore.applySignedConfigChanges(
-            account, _signBatch(pk, account, Keystore.ConfigChangeChannel.Local, _unseqWord(account), changes)
+    function _applyUnsequenced(uint256 pk, address account, Keystore.AccountChange[] memory changes) internal {
+        keystore.applySignedAccountChanges(
+            account, _signBatch(pk, account, Keystore.AccountChangeChannel.Local, _unseqWord(account), changes)
         );
     }
 
     /// @dev Build + relay a multichain batch at the account's current multichain sequence, K1-signed by `pk`.
-    function _applyMultichain(uint256 pk, address account, Keystore.ConfigChange[] memory changes) internal {
-        keystore.applySignedConfigChanges(
-            account, _signBatch(pk, account, Keystore.ConfigChangeChannel.Multichain, _multichainSeq(account), changes)
+    function _applyMultichain(uint256 pk, address account, Keystore.AccountChange[] memory changes) internal {
+        keystore.applySignedAccountChanges(
+            account, _signBatch(pk, account, Keystore.AccountChangeChannel.Multichain, _multichainSeq(account), changes)
         );
     }
 
@@ -231,33 +231,33 @@ contract KeystoreTest is Test {
     // These build the fully-signed batch WITHOUT relaying it, so revert tests can construct the batch (which reads
     // the current sequence word via a view staticcall) BEFORE `vm.expectRevert`, then relay it as the single
     // expected-reverting external call. Foundry's strict expectRevert binds to the very next external call, so the
-    // sequence-word staticcall must not sit between expectRevert and applySignedConfigChanges.
+    // sequence-word staticcall must not sit between expectRevert and applySignedAccountChanges.
 
-    function _localBatch(uint256 pk, address account, Keystore.ConfigChange[] memory changes)
+    function _localBatch(uint256 pk, address account, Keystore.AccountChange[] memory changes)
         internal
         view
-        returns (Keystore.SignedConfigChanges memory)
+        returns (Keystore.SignedAccountChanges memory)
     {
-        return _signBatch(pk, account, Keystore.ConfigChangeChannel.Local, _localSeqWord(account), changes);
+        return _signBatch(pk, account, Keystore.AccountChangeChannel.Local, _localSeqWord(account), changes);
     }
 
-    function _unseqBatch(uint256 pk, address account, Keystore.ConfigChange[] memory changes)
+    function _unseqBatch(uint256 pk, address account, Keystore.AccountChange[] memory changes)
         internal
         view
-        returns (Keystore.SignedConfigChanges memory)
+        returns (Keystore.SignedAccountChanges memory)
     {
-        return _signBatch(pk, account, Keystore.ConfigChangeChannel.Local, _unseqWord(account), changes);
+        return _signBatch(pk, account, Keystore.AccountChangeChannel.Local, _unseqWord(account), changes);
     }
 
-    function _multichainBatch(uint256 pk, address account, Keystore.ConfigChange[] memory changes)
+    function _multichainBatch(uint256 pk, address account, Keystore.AccountChange[] memory changes)
         internal
         view
-        returns (Keystore.SignedConfigChanges memory)
+        returns (Keystore.SignedAccountChanges memory)
     {
-        return _signBatch(pk, account, Keystore.ConfigChangeChannel.Multichain, _multichainSeq(account), changes);
+        return _signBatch(pk, account, Keystore.AccountChangeChannel.Multichain, _multichainSeq(account), changes);
     }
 
-    // ── Back-compat actor helpers (re-implemented on applySignedConfigChanges) ──
+    // ── Back-compat actor helpers (re-implemented on applySignedAccountChanges) ──
     //
     // These preserve the pre-split helper names used across the suite. A signed grant always self-expires, so where
     // the old model used a no-expiry (0) actor these grant UNBOUNDED (type(uint48).max) on a sequenced batch — the

--- a/test/lib/KeystoreTest.sol
+++ b/test/lib/KeystoreTest.sol
@@ -195,7 +195,7 @@ contract KeystoreTest is Test {
     ) internal view returns (Keystore.SignedAccountChanges memory) {
         bytes32 digest = _changesDigest(account, channel, sequence, changes);
         return Keystore.SignedAccountChanges({
-            channel: channel, changes: changes, sequence: sequence, signature: _buildK1Auth(pk, digest)
+            channel: channel, sequence: sequence, changes: changes, signature: _buildK1Auth(pk, digest)
         });
     }
 

--- a/test/lib/KeystoreTest.sol
+++ b/test/lib/KeystoreTest.sol
@@ -110,18 +110,24 @@ contract KeystoreTest is Test {
 
     /// @dev The account's current local sequence WORD (localEpoch(32) || localSequence(32)) for a sequenced batch.
     function _localSeqWord(address account) internal view returns (uint64) {
-        return keystore.getChangeSequences(account).local;
+        Keystore.ChangeSequences memory cs = keystore.getChangeSequences(account);
+        return (uint64(cs.localEpoch) << 32) | uint64(cs.localSequence);
     }
 
     /// @dev An unsequenced (JIT) local sequence word at the account's current epoch: epoch || UNSEQUENCED.
     function _unseqWord(address account) internal view returns (uint64) {
-        (uint32 epoch,) = keystore.getLocalEpochAndSequence(account);
-        return (uint64(epoch) << 32) | uint64(keystore.UNSEQUENCED());
+        return (uint64(keystore.getChangeSequences(account).localEpoch) << 32) | uint64(keystore.UNSEQUENCED());
     }
 
     /// @dev The account's current multichain sequence.
     function _multichainSeq(address account) internal view returns (uint64) {
         return keystore.getChangeSequences(account).multichain;
+    }
+
+    /// @dev The account's current local epoch and local sequence (split), for terse test assertions.
+    function _localEpochSeq(address account) internal view returns (uint32 epoch, uint32 sequence) {
+        Keystore.ChangeSequences memory cs = keystore.getChangeSequences(account);
+        return (cs.localEpoch, cs.localSequence);
     }
 
     // ── Change builders ──
@@ -326,13 +332,13 @@ contract KeystoreTest is Test {
 
     /// @dev Force the account's local epoch (high 32 bits), keeping the current low sequence.
     function _forceLocalEpoch(address account, uint32 epoch) internal {
-        (, uint32 seq) = keystore.getLocalEpochAndSequence(account);
+        uint32 seq = keystore.getChangeSequences(account).localSequence;
         _forceLocalWord(account, (uint64(epoch) << 32) | uint64(seq));
     }
 
     /// @dev Force the account's local sequence (low 32 bits), keeping the current epoch.
     function _forceLocalSequence(address account, uint32 seq) internal {
-        (uint32 epoch,) = keystore.getLocalEpochAndSequence(account);
+        uint32 epoch = keystore.getChangeSequences(account).localEpoch;
         _forceLocalWord(account, (uint64(epoch) << 32) | uint64(seq));
     }
 

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -88,10 +88,9 @@ contract AccountEnvironmentTest is KeystoreTest {
         keystore.applySignedAccountChanges(account, s);
     }
 
-    /// @notice Regression: `[Lock, Unlock, Lock]` in a single batch from the unlocked state must revert on the
-    ///         trailing Lock. _applyLock gates on LIVE lock state, so it sees the mid-batch Unlock rather than the
-    ///         stale batch-entry snapshot; otherwise the final Lock would corrupt the union (FLAG_UNLOCK_INITIATED
-    ///         set over a delay-valued lockUnion, making the account read instantly unlockable).
+    /// @notice `[Lock, Unlock, Lock]` reverts LockChangeMustBeStandalone: the standalone rule rejects the multi-op
+    ///         batch on its first (Lock) change, so the earlier lock/unlock desync scenario is now structurally
+    ///         impossible (a lock transition can never interleave with another change in one batch).
     function test_lock_revert_lockUnlockLockSameBatch(uint256 pkSeed, uint16 d1, uint16 d2) public {
         uint256 pk = _boundK1Pk(pkSeed);
         address account = vm.addr(pk);
@@ -105,7 +104,7 @@ contract AccountEnvironmentTest is KeystoreTest {
         ch[2] = _lockChange(d2);
 
         Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
-        vm.expectRevert(Keystore.AccountIsLocked.selector);
+        vm.expectRevert(Keystore.LockChangeMustBeStandalone.selector);
         keystore.applySignedAccountChanges(account, s);
     }
 
@@ -326,6 +325,59 @@ contract AccountEnvironmentTest is KeystoreTest {
 
         // importAccount must still reject the account as already initialized. The check fires before the ERC-1271
         // staticcall, so the empty signature is never reached.
+        Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](1);
+        actors[0] = Keystore.InitialActor({
+            actorId: bytes32(bytes20(account)), authenticator: address(1), scope: 0, policyData: ""
+        });
+        vm.expectRevert(Keystore.AlreadyInitialized.selector);
+        keystore.importAccount(account, 0, actors, "");
+    }
+
+    /// @notice An empty sequenced batch is rejected (EmptyChangeSet) so it cannot consume a sequence doing nothing.
+    function test_apply_revert_emptyBatchSequenced(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, new Keystore.AccountChange[](0));
+        vm.expectRevert(Keystore.EmptyChangeSet.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    /// @notice An empty unsequenced batch is rejected (EmptyChangeSet) so it cannot initialize a fresh account without
+    ///         altering any configuration.
+    function test_apply_revert_emptyBatchUnsequenced(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+
+        Keystore.SignedAccountChanges memory s = _unseqBatch(pk, account, new Keystore.AccountChange[](0));
+        vm.expectRevert(Keystore.EmptyChangeSet.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    /// @notice A never-bootstrapped EOA acting via its inline k1 self on its first unsequenced batch is marked
+    ///         initialized: the batch burns local sequence 0 (0 -> 1), closing the one-time importAccount bootstrap and
+    ///         invalidating any outstanding sequenced seq==0 signature. The batch itself remains replayable.
+    function test_regression_unsequencedInitBlocksImport(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+
+        // Uninitialized: both local counters are zero.
+        (uint32 epoch0, uint32 seq0) = _localEpochSeq(account);
+        assertEq(epoch0, 0);
+        assertEq(seq0, 0);
+
+        _applyUnsequenced(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
+
+        // Sequence 0 burned -> reads initialized; the actor landed.
+        (uint32 epoch1, uint32 seq1) = _localEpochSeq(account);
+        assertEq(epoch1, 0);
+        assertEq(seq1, 1);
+        assertTrue(_isActor(account, ACTOR_A));
+
+        // importAccount must now reject the account as already initialized.
         Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](1);
         actors[0] = Keystore.InitialActor({
             actorId: bytes32(bytes20(account)), authenticator: address(1), scope: 0, policyData: ""

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -6,14 +6,13 @@ import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
 /// @notice §10 test matrix for the account-environment surface driven through {applySignedAccountChanges}: the lock
-///         / unlock ops, the recovery-class "second fence" (Unlock-only) authorization, garbage collection, the
-///         Multichain channel (no epochs, no unsequenced mode), and the split-layout regression checks.
+///         / unlock ops (admin-authorized), garbage collection, the Multichain channel (no epochs, no unsequenced
+///         mode), and the split-layout regression checks.
 contract AccountEnvironmentTest is KeystoreTest {
     bytes32 constant ACTOR_A = bytes32(uint256(0xA1));
     bytes32 constant ACTOR_B = bytes32(uint256(0xB2));
 
     uint16 constant SENDER = Scopes.SENDER;
-    uint16 constant RECOVERY = Scopes.RECOVERY;
 
     function setUp() public override {
         super.setUp();
@@ -198,48 +197,24 @@ contract AccountEnvironmentTest is KeystoreTest {
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // RECOVERY-CLASS SECOND FENCE
+    // ADMIN-ONLY LOCK CHANGES
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice A recovery-class (scope RECOVERY) key may initiate a solo Unlock on a hard-locked account.
-    function test_recovery_success_unlockSolo(uint256 ownerSeed, uint256 recSeed) public {
+    /// @notice A scoped (non-admin) actor cannot initiate an Unlock — lock changes are admin-only
+    ///         (UnauthorizedLockChange).
+    function test_lock_revert_scopedActorCannotUnlock(uint256 ownerSeed, uint256 scopedSeed) public {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
-        uint256 recPk = _boundK1Pk(recSeed);
-        vm.assume(vm.addr(ownerPk) != vm.addr(recPk));
+        uint256 scopedPk = _boundK1Pk(scopedSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(scopedPk));
         (address account,) = _createK1Account(ownerPk);
-        bytes32 recId = bytes32(bytes20(vm.addr(recPk)));
+        bytes32 scopedId = bytes32(bytes20(vm.addr(scopedPk)));
 
-        _applyLocal(ownerPk, account, _one(_authorizeChange(recId, address(k1Authenticator), RECOVERY, UNBOUNDED, "")));
+        _applyLocal(ownerPk, account, _one(_authorizeChange(scopedId, address(k1Authenticator), SENDER, UNBOUNDED, "")));
         _signedLock(ownerPk, account, 1 hours);
         assertTrue(keystore.isLocked(account));
 
-        // Recovery key signs a solo unlock.
-        _applyLocal(recPk, account, _one(_unlockChange()));
-
-        (, bool init,,) = keystore.getLockStatus(account);
-        assertTrue(init);
-    }
-
-    /// @notice A recovery-class key signing a RevokeActor batch fails the per-op authorization fence
-    ///         (UnauthorizedActorChange) — it may unlock and nothing else.
-    function test_recovery_revert_revokeUnauthorized(uint256 ownerSeed, uint256 recSeed) public {
-        uint256 ownerPk = _boundK1Pk(ownerSeed);
-        uint256 recPk = _boundK1Pk(recSeed);
-        vm.assume(vm.addr(ownerPk) != vm.addr(recPk));
-        (address account,) = _createK1Account(ownerPk);
-        bytes32 recId = bytes32(bytes20(vm.addr(recPk)));
-
-        _applyLocal(
-            ownerPk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
-        );
-        _applyLocal(ownerPk, account, _one(_authorizeChange(recId, address(k1Authenticator), RECOVERY, UNBOUNDED, "")));
-
-        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
-        ch[0] = _revokeChange(ACTOR_A);
-        ch[1] = _bumpChange();
-
-        Keystore.SignedAccountChanges memory s = _localBatch(recPk, account, ch);
-        vm.expectRevert(Keystore.UnauthorizedActorChange.selector);
+        Keystore.SignedAccountChanges memory s = _localBatch(scopedPk, account, _one(_unlockChange()));
+        vm.expectRevert(Keystore.UnauthorizedLockChange.selector);
         keystore.applySignedAccountChanges(account, s);
     }
 

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -88,6 +88,27 @@ contract AccountEnvironmentTest is KeystoreTest {
         keystore.applySignedAccountChanges(account, s);
     }
 
+    /// @notice Regression: `[Lock, Unlock, Lock]` in a single batch from the unlocked state must revert on the
+    ///         trailing Lock. _applyLock gates on LIVE lock state, so it sees the mid-batch Unlock rather than the
+    ///         stale batch-entry snapshot; otherwise the final Lock would corrupt the union (FLAG_UNLOCK_INITIATED
+    ///         set over a delay-valued lockUnion, making the account read instantly unlockable).
+    function test_lock_revert_lockUnlockLockSameBatch(uint256 pkSeed, uint16 d1, uint16 d2) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+        d1 = uint16(bound(d1, 1, type(uint16).max));
+        d2 = uint16(bound(d2, 1, type(uint16).max));
+
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](3);
+        ch[0] = _lockChange(d1);
+        ch[1] = _unlockChange();
+        ch[2] = _lockChange(d2);
+
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
+        vm.expectRevert(Keystore.AccountIsLocked.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
     /// @notice An unlock on a never-locked account reverts NotLocked.
     function test_unlock_revert_whenNeverLocked(uint256 pkSeed) public {
         uint256 pk = _boundK1Pk(pkSeed);

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -227,7 +227,7 @@ contract AccountEnvironmentTest is KeystoreTest {
         uint256 scopedPk = _boundK1Pk(scopedSeed);
         vm.assume(vm.addr(ownerPk) != vm.addr(scopedPk));
         (address account,) = _createK1Account(ownerPk);
-        bytes32 scopedId = bytes32(bytes20(vm.addr(scopedPk)));
+        bytes32 scopedId = bytes32(uint256(uint160(vm.addr(scopedPk))));
 
         _applyLocal(ownerPk, account, _one(_authorizeChange(scopedId, address(k1Authenticator), SENDER, UNBOUNDED, "")));
         _signedLock(ownerPk, account, 1 hours);
@@ -327,7 +327,7 @@ contract AccountEnvironmentTest is KeystoreTest {
         // staticcall, so the empty signature is never reached.
         Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](1);
         actors[0] = Keystore.InitialActor({
-            actorId: bytes32(bytes20(account)), authenticator: address(1), scope: 0, policyData: ""
+            actorId: bytes32(uint256(uint160(account))), authenticator: address(1), scope: 0, policyData: ""
         });
         vm.expectRevert(Keystore.AlreadyInitialized.selector);
         keystore.importAccount(account, 0, actors, "");
@@ -380,7 +380,7 @@ contract AccountEnvironmentTest is KeystoreTest {
         // importAccount must now reject the account as already initialized.
         Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](1);
         actors[0] = Keystore.InitialActor({
-            actorId: bytes32(bytes20(account)), authenticator: address(1), scope: 0, policyData: ""
+            actorId: bytes32(uint256(uint160(account))), authenticator: address(1), scope: 0, policyData: ""
         });
         vm.expectRevert(Keystore.AlreadyInitialized.selector);
         keystore.importAccount(account, 0, actors, "");

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -168,7 +168,7 @@ contract AccountEnvironmentTest is KeystoreTest {
 
         // Bump under lock: allowed.
         _applyLocal(pk, account, _one(_bumpChange()));
-        (uint32 epoch,) = keystore.getLocalEpochAndSequence(account);
+        (uint32 epoch,) = _localEpochSeq(account);
         assertEq(epoch, 1);
 
         // Authorize under lock: rejected.
@@ -258,10 +258,10 @@ contract AccountEnvironmentTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
 
-        (uint32 epoch, uint32 seq) = keystore.getLocalEpochAndSequence(account);
+        (uint32 epoch, uint32 seq) = _localEpochSeq(account);
         assertEq(epoch, 0);
         assertEq(seq, 1);
-        assertEq(keystore.getChangeSequences(account).local, 1);
+        assertEq(keystore.getChangeSequences(account).localSequence, 1);
         assertEq(keystore.getChangeSequences(account).multichain, 0);
     }
 

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -5,7 +5,7 @@ import {Keystore} from "../../../src/Keystore.sol";
 import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
-/// @notice §10 test matrix for the account-environment surface driven through {applySignedConfigChanges}: the lock
+/// @notice §10 test matrix for the account-environment surface driven through {applySignedAccountChanges}: the lock
 ///         / unlock ops (admin-authorized), the Multichain channel (no epochs, no unsequenced mode), and the
 ///         split-layout regression checks.
 contract AccountEnvironmentTest is KeystoreTest {
@@ -69,9 +69,9 @@ contract AccountEnvironmentTest is KeystoreTest {
         address account = vm.addr(pk);
         _assumeSafeAccount(account);
 
-        Keystore.SignedConfigChanges memory s = _localBatch(pk, account, _one(_lockChange(0)));
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_lockChange(0)));
         vm.expectRevert(Keystore.ZeroUnlockDelay.selector);
-        keystore.applySignedConfigChanges(account, s);
+        keystore.applySignedAccountChanges(account, s);
     }
 
     /// @notice A second lock while already hard-locked reverts AccountIsLocked.
@@ -83,9 +83,9 @@ contract AccountEnvironmentTest is KeystoreTest {
         d2 = uint16(bound(d2, 1, type(uint16).max));
 
         _signedLock(pk, account, d1);
-        Keystore.SignedConfigChanges memory s = _localBatch(pk, account, _one(_lockChange(d2)));
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_lockChange(d2)));
         vm.expectRevert(Keystore.AccountIsLocked.selector);
-        keystore.applySignedConfigChanges(account, s);
+        keystore.applySignedAccountChanges(account, s);
     }
 
     /// @notice Regression: `[Lock, Unlock, Lock]` in a single batch from the unlocked state must revert on the
@@ -99,14 +99,14 @@ contract AccountEnvironmentTest is KeystoreTest {
         d1 = uint16(bound(d1, 1, type(uint16).max));
         d2 = uint16(bound(d2, 1, type(uint16).max));
 
-        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](3);
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](3);
         ch[0] = _lockChange(d1);
         ch[1] = _unlockChange();
         ch[2] = _lockChange(d2);
 
-        Keystore.SignedConfigChanges memory s = _localBatch(pk, account, ch);
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
         vm.expectRevert(Keystore.AccountIsLocked.selector);
-        keystore.applySignedConfigChanges(account, s);
+        keystore.applySignedAccountChanges(account, s);
     }
 
     /// @notice An unlock on a never-locked account reverts NotLocked.
@@ -115,9 +115,9 @@ contract AccountEnvironmentTest is KeystoreTest {
         address account = vm.addr(pk);
         _assumeSafeAccount(account);
 
-        Keystore.SignedConfigChanges memory s = _localBatch(pk, account, _one(_unlockChange()));
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_unlockChange()));
         vm.expectRevert(Keystore.NotLocked.selector);
-        keystore.applySignedConfigChanges(account, s);
+        keystore.applySignedAccountChanges(account, s);
     }
 
     /// @notice An unlock op sets unlocksAt = now + delay, zeroes the stored delay, emits AccountUnlockInitiated.
@@ -154,9 +154,9 @@ contract AccountEnvironmentTest is KeystoreTest {
         vm.warp(t0);
         _signedUnlock(pk, account);
 
-        Keystore.SignedConfigChanges memory s = _localBatch(pk, account, _one(_unlockChange()));
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_unlockChange()));
         vm.expectRevert(Keystore.NotLocked.selector);
-        keystore.applySignedConfigChanges(account, s);
+        keystore.applySignedAccountChanges(account, s);
     }
 
     /// @notice An account can be re-locked once a prior unlock delay has fully elapsed.
@@ -193,11 +193,11 @@ contract AccountEnvironmentTest is KeystoreTest {
         assertEq(epoch, 1);
 
         // Authorize under lock: rejected.
-        Keystore.SignedConfigChanges memory s = _localBatch(
+        Keystore.SignedAccountChanges memory s = _localBatch(
             pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
         );
         vm.expectRevert(Keystore.AccountIsLocked.selector);
-        keystore.applySignedConfigChanges(account, s);
+        keystore.applySignedAccountChanges(account, s);
     }
 
     /// @notice After a full unlock cycle elapses, an authority op is accepted again (lazy lock clear).
@@ -222,7 +222,7 @@ contract AccountEnvironmentTest is KeystoreTest {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     /// @notice A scoped (non-admin) actor cannot initiate an Unlock — every signed change is admin-only
-    ///         (UnauthorizedConfigChange).
+    ///         (UnauthorizedAccountChange).
     function test_lock_revert_scopedActorCannotUnlock(uint256 ownerSeed, uint256 scopedSeed) public {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
         uint256 scopedPk = _boundK1Pk(scopedSeed);
@@ -234,9 +234,9 @@ contract AccountEnvironmentTest is KeystoreTest {
         _signedLock(ownerPk, account, 1 hours);
         assertTrue(keystore.isLocked(account));
 
-        Keystore.SignedConfigChanges memory s = _localBatch(scopedPk, account, _one(_unlockChange()));
-        vm.expectRevert(Keystore.UnauthorizedConfigChange.selector);
-        keystore.applySignedConfigChanges(account, s);
+        Keystore.SignedAccountChanges memory s = _localBatch(scopedPk, account, _one(_unlockChange()));
+        vm.expectRevert(Keystore.UnauthorizedAccountChange.selector);
+        keystore.applySignedAccountChanges(account, s);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -264,9 +264,9 @@ contract AccountEnvironmentTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
 
-        Keystore.SignedConfigChanges memory s = _multichainBatch(pk, account, _one(_bumpChange()));
+        Keystore.SignedAccountChanges memory s = _multichainBatch(pk, account, _one(_bumpChange()));
         vm.expectRevert(Keystore.EpochOpRequiresLocalChannel.selector);
-        keystore.applySignedConfigChanges(account, s);
+        keystore.applySignedAccountChanges(account, s);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -200,8 +200,8 @@ contract AccountEnvironmentTest is KeystoreTest {
     // ADMIN-ONLY LOCK CHANGES
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice A scoped (non-admin) actor cannot initiate an Unlock — lock changes are admin-only
-    ///         (UnauthorizedLockChange).
+    /// @notice A scoped (non-admin) actor cannot initiate an Unlock — every signed change is admin-only
+    ///         (UnauthorizedAccountChange).
     function test_lock_revert_scopedActorCannotUnlock(uint256 ownerSeed, uint256 scopedSeed) public {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
         uint256 scopedPk = _boundK1Pk(scopedSeed);
@@ -214,7 +214,7 @@ contract AccountEnvironmentTest is KeystoreTest {
         assertTrue(keystore.isLocked(account));
 
         Keystore.SignedAccountChanges memory s = _localBatch(scopedPk, account, _one(_unlockChange()));
-        vm.expectRevert(Keystore.UnauthorizedLockChange.selector);
+        vm.expectRevert(Keystore.UnauthorizedAccountChange.selector);
         keystore.applySignedAccountChanges(account, s);
     }
 

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -258,13 +258,34 @@ contract AccountEnvironmentTest is KeystoreTest {
         assertEq(_multichainSeq(account), mcBefore + 1);
     }
 
-    /// @notice An IncrementLocalEpoch on the Multichain channel reverts EpochOpRequiresLocalChannel.
+    /// @notice An IncrementLocalEpoch on the Multichain channel reverts ChangeRequiresLocalChannel.
     function test_multichain_revert_bumpRejected(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
 
         Keystore.SignedAccountChanges memory s = _multichainBatch(pk, account, _one(_bumpChange()));
-        vm.expectRevert(Keystore.EpochOpRequiresLocalChannel.selector);
+        vm.expectRevert(Keystore.ChangeRequiresLocalChannel.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    /// @notice A Lock on the Multichain channel reverts ChangeRequiresLocalChannel.
+    function test_multichain_revert_lockRejected(uint256 pk, uint16 delay) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+
+        Keystore.SignedAccountChanges memory s = _multichainBatch(pk, account, _one(_lockChange(delay)));
+        vm.expectRevert(Keystore.ChangeRequiresLocalChannel.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    /// @notice an Unlock on the Multichain channel reverts ChangeRequiresLocalChannel.
+    function test_multichain_revert_unlockRejected(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+
+        Keystore.SignedAccountChanges memory s = _multichainBatch(pk, account, _one(_unlockChange()));
+        vm.expectRevert(Keystore.ChangeRequiresLocalChannel.selector);
         keystore.applySignedAccountChanges(account, s);
     }
 

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -5,17 +5,25 @@ import {Keystore} from "../../../src/Keystore.sol";
 import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
-/// @notice Branch-complete, fuzz-by-default suite for the account lock surface: applySignedLockChanges (op = lock /
-///         unlock), isLocked, getLockStatus, the onlyUnlocked modifier and _checkAndClearLock. Lock state changes
-///         ONLY through applySignedLockChanges — a relayable, admin-authorized (scope 0) signed call — so lock-side
-///         tests use a controllable key: an uninitialized EOA at vm.addr(pk) signs with its inline default-EOA self
-///         (scope 0 admin), and anyone (here the test) relays. Tests that must drive an onlyUnlocked-guarded config
-///         path (applySignedActorChanges) create a real k1 account so the authenticated actor can change actors.
-contract AccountLockTest is KeystoreTest {
-    // ── Local fuzz-bound helpers ──
+/// @notice §10 test matrix for the account-environment surface driven through {applySignedAccountChanges}: the lock
+///         / unlock ops, the recovery-class "second fence" (Unlock-only) authorization, garbage collection, the
+///         Multichain channel (no epochs, no unsequenced mode), and the split-layout regression checks.
+contract AccountEnvironmentTest is KeystoreTest {
+    bytes32 constant ACTOR_A = bytes32(uint256(0xA1));
+    bytes32 constant ACTOR_B = bytes32(uint256(0xB2));
 
-    /// @dev Keep a fuzzed account out of the zero address, the system contract, and the forge-std cheatcode /
-    ///      console addresses so it acts as a clean, code-free account.
+    uint16 constant SENDER = Scopes.SENDER;
+    uint16 constant RECOVERY = Scopes.RECOVERY;
+
+    function setUp() public override {
+        super.setUp();
+        vm.warp(1_000_000);
+    }
+
+    function _future(uint48 delta) internal view returns (uint48) {
+        return uint48(block.timestamp + delta);
+    }
+
     function _assumeSafeAccount(address account) internal view {
         vm.assume(account != address(0));
         vm.assume(account != address(keystore));
@@ -23,227 +31,12 @@ contract AccountLockTest is KeystoreTest {
         vm.assume(account != CONSOLE);
     }
 
-    /// @dev A single authorize-actor change granting an unrestricted k1 owner (scope 0, no expiry, no policy).
-    function _oneAuthorizeChange(bytes32 actorId) internal view returns (Keystore.ActorChange[] memory changes) {
-        changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            changeType: Keystore.ActorChangeType.Authorize,
-            actorId: actorId,
-            data: abi.encode(
-                Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}), bytes("")
-            )
-        });
-    }
-
-    /// @dev Authorize a k1 actor (actorId = bytes32(bytes20(newSigner))) with `scope` on `account`, signed by the
-    ///      account's admin owner `ownerPk`.
-    function _authorizeK1ActorWithScope(address account, uint256 ownerPk, address newSigner, uint16 scope) internal {
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            changeType: Keystore.ActorChangeType.Authorize,
-            actorId: bytes32(bytes20(newSigner)),
-            data: abi.encode(
-                Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0}), bytes("")
-            )
-        });
-        uint64 chainId = uint64(block.chainid);
-        uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, chainId, seq, changes);
-        bytes memory auth = _buildK1Auth(ownerPk, digest);
-        keystore.applySignedActorChanges(account, chainId, changes, auth);
-    }
-
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // REVERTS (source order: authorization -> lock op -> unlock op -> onlyUnlocked on other functions)
+    // LOCK / UNLOCK
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice applySignedLockChanges reverts UnauthorizedLockChange when the signer is a scoped (non-admin) actor.
-    /// @dev The owner authorizes a SCOPE_SENDER k1 actor, which then signs a lock op; scope != 0 is rejected after
-    ///      authentication, before any lock-state work.
-    function test_applySignedLockChanges_revert_whenSignerNotAdmin(uint256 ownerSeed, uint256 scopedSeed, uint16 delay)
-        public
-    {
-        uint256 ownerPk = _boundK1Pk(ownerSeed);
-        uint256 scopedPk = _boundK1Pk(scopedSeed);
-        vm.assume(vm.addr(ownerPk) != vm.addr(scopedPk));
-        delay = uint16(bound(delay, 1, type(uint16).max));
-        (address account,) = _createK1Account(ownerPk);
-        address scopedSigner = vm.addr(scopedPk);
-        vm.assume(scopedSigner != account);
-
-        _authorizeK1ActorWithScope(account, ownerPk, scopedSigner, Scopes.SENDER);
-
-        bytes memory auth = _lockAuth(scopedPk, account, delay);
-        vm.expectRevert(Keystore.UnauthorizedLockChange.selector);
-        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Lock, delay, auth);
-    }
-
-    /// @notice applySignedLockChanges reverts UnknownLockChangeType for LockChangeType.Invalid (0) — the only unrecognized op value
-    ///         that reaches the handler. Out-of-range wire values (>= 3) never get here; they panic at ABI-decode
-    ///         (see test_applySignedLockChanges_revert_outOfRangeOpPanics).
-    function test_applySignedLockChanges_revert_invalidOp(uint256 pkSeed, uint16 delay) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-
-        uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest =
-            _computeLockChangeDigest(account, block.chainid, uint8(Keystore.LockChangeType.Invalid), delay, seq);
-        bytes memory auth = _buildK1Auth(pk, digest);
-
-        vm.expectRevert(Keystore.UnknownLockChangeType.selector);
-        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Invalid, delay, auth);
-    }
-
-    /// @notice An out-of-range op wire value (>= 3, not a declared LockChangeType member) is rejected by the ABI decoder
-    ///         before the handler runs — the enum can only decode to a declared member. This is what makes Invalid (0)
-    ///         the sole reachable "unrecognized" case. Uses a low-level call so the raw wire byte survives to the
-    ///         decoder (the typed entry point cannot express an out-of-range value). Solidity's calldata enum-decode
-    ///         check reverts with empty returndata (distinct from an in-body enum conversion, which panics 0x21).
-    function test_applySignedLockChanges_revert_outOfRangeOp(uint256 pkSeed, uint8 op, uint16 delay) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        op = uint8(bound(op, 3, type(uint8).max));
-
-        // Decode reverts before the body, so auth is irrelevant. op is ABI-encoded as the enum's uint8 slot.
-        bytes memory cd =
-            abi.encodeWithSelector(Keystore.applySignedLockChanges.selector, account, op, delay, bytes(""));
-        (bool ok, bytes memory ret) = address(keystore).call(cd);
-
-        assertFalse(ok);
-        assertEq(ret.length, 0); // enum decode rejects the out-of-range op with an empty revert
-    }
-
-    /// @notice A lock op (op = 1) with a zero unlock delay reverts ZeroUnlockDelay.
-    /// @dev Exercises the `unlockDelay == 0` guard on the lock branch; the unlocked-state check passes (fresh account).
-    function test_lock_revert_zeroUnlockDelay(uint256 pkSeed) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-
-        bytes memory auth = _lockAuth(pk, account, 0);
-        vm.expectRevert(Keystore.ZeroUnlockDelay.selector);
-        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Lock, 0, auth);
-    }
-
-    /// @notice A lock op reverts AccountIsLocked when the account is already hard-locked.
-    /// @dev Second lock hits _checkAndClearLock with FLAG_LOCKED set and FLAG_UNLOCK_INITIATED clear (hard-locked branch).
-    function test_lock_revert_whenAlreadyHardLocked(uint256 pkSeed, uint16 firstDelay, uint16 secondDelay) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        firstDelay = uint16(bound(firstDelay, 1, type(uint16).max));
-        secondDelay = uint16(bound(secondDelay, 1, type(uint16).max));
-
-        _signedLock(pk, account, firstDelay);
-
-        bytes memory auth = _lockAuth(pk, account, secondDelay);
-        vm.expectRevert(Keystore.AccountIsLocked.selector);
-        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Lock, secondDelay, auth);
-    }
-
-    /// @notice An unlock op (op = 2) with a non-zero unlock delay reverts InvalidUnlockDelay.
-    /// @dev The delay guard fires before the hard-locked-state check, so it trips even on a fresh account.
-    function test_unlock_revert_nonZeroUnlockDelay(uint256 pkSeed, uint16 delay) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        delay = uint16(bound(delay, 1, type(uint16).max));
-
-        uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeLockChangeDigest(account, block.chainid, UNLOCK_OP, delay, seq);
-        bytes memory auth = _buildK1Auth(pk, digest);
-
-        vm.expectRevert(Keystore.InvalidUnlockDelay.selector);
-        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Unlock, delay, auth);
-    }
-
-    /// @notice An unlock op reverts NotLocked when the account has never been locked (FLAG_LOCKED clear).
-    function test_initiateUnlock_revert_whenNeverLocked(uint256 pkSeed) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-
-        bytes memory auth = _unlockAuth(pk, account);
-        vm.expectRevert(Keystore.NotLocked.selector);
-        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Unlock, 0, auth);
-    }
-
-    /// @notice An unlock op reverts NotLocked once an unlock has already been initiated.
-    /// @dev After the first unlock, FLAG_UNLOCK_INITIATED is set, so a second unlock reverts.
-    function test_initiateUnlock_revert_whenUnlockAlreadyInitiated(uint256 pkSeed, uint16 delay, uint256 t0) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        delay = uint16(bound(delay, 1, type(uint16).max));
-        t0 = bound(t0, 1, 1e9);
-
-        _signedLock(pk, account, delay);
-        vm.warp(t0);
-        _signedUnlock(pk, account);
-
-        bytes memory auth = _unlockAuth(pk, account);
-        vm.expectRevert(Keystore.NotLocked.selector);
-        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Unlock, 0, auth);
-    }
-
-    /// @notice A replayed lock auth fails: the local sequence advanced on the first success, so the signed digest no
-    ///         longer matches and authentication fails.
-    function test_applySignedLockChanges_revert_whenAuthReplayed(uint256 pkSeed, uint16 delay) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        delay = uint16(bound(delay, 1, type(uint16).max));
-
-        bytes memory auth = _lockAuth(pk, account, delay); // signed over sequence 0
-        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Lock, delay, auth); // sequence 0 -> 1
-
-        vm.expectRevert();
-        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Lock, delay, auth);
-    }
-
-    /// @notice A lock auth signed over a sequence other than the account's current one fails to authenticate.
-    function test_applySignedLockChanges_revert_whenSequenceWrong(uint256 pkSeed, uint16 delay, uint64 seqOffset)
-        public
-    {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        delay = uint16(bound(delay, 1, type(uint16).max));
-        seqOffset = uint64(bound(seqOffset, 1, type(uint64).max - 1));
-
-        uint64 wrongSeq = keystore.getChangeSequences(account).local + seqOffset;
-        bytes32 digest = _computeLockChangeDigest(account, block.chainid, LOCK_OP, delay, wrongSeq);
-        bytes memory auth = _buildK1Auth(pk, digest);
-
-        vm.expectRevert();
-        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Lock, delay, auth);
-    }
-
-    /// @notice applySignedActorChanges reverts AccountIsLocked while the target account is hard-locked.
-    /// @dev Exercises the onlyUnlocked modifier on a config-mutating path; the guard fires before any auth work.
-    function test_applySignedActorChanges_revert_whenLocked(uint256 pkSeed, uint16 delay) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        delay = uint16(bound(delay, 1, type(uint16).max));
-        (address account,) = _createK1Account(pk);
-
-        _signedLock(pk, account, delay);
-
-        Keystore.ActorChange[] memory changes = _oneAuthorizeChange(bytes32(bytes20(vm.addr(pk))));
-        uint64 chainId = uint64(block.chainid);
-        uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, chainId, seq, changes);
-        bytes memory auth = _buildK1Auth(pk, digest);
-
-        vm.expectRevert(Keystore.AccountIsLocked.selector);
-        keystore.applySignedActorChanges(account, chainId, changes, auth);
-    }
-
-    /// @notice importAccount reverts AccountIsLocked while the target account is hard-locked.
-    /// @dev The onlyUnlocked(account) modifier runs before the import body, so the lock guard is asserted in
-    ///      isolation on a second, distinct function (empty initialActors never reached).
-    function test_importAccount_revert_whenLocked(uint256 pkSeed, uint16 delay) public {
+    /// @notice A lock op hard-locks the account (delay stored, isLocked true, max-sentinel unlocksAt).
+    function test_lock_success_setsHardLock(uint256 pkSeed, uint16 delay) public {
         uint256 pk = _boundK1Pk(pkSeed);
         address account = vm.addr(pk);
         _assumeSafeAccount(account);
@@ -251,289 +44,331 @@ contract AccountLockTest is KeystoreTest {
 
         _signedLock(pk, account, delay);
 
-        Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](0);
-        vm.expectRevert(Keystore.AccountIsLocked.selector);
-        keystore.importAccount(account, block.chainid, actors, "");
-    }
-
-    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // HAPPY PATHS / BRANCH COVERAGE
-    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-
-    /// @notice A lock op hard-locks the account: FLAG_LOCKED set, delay stored in lockUnion.
-    /// @dev getLockStatus reports locked, not-yet-initiated, the synthesized max sentinel for unlocksAt and the stored
-    ///      delay; isLocked true.
-    function test_lock_success_setsHardLockStatus(uint256 pkSeed, uint16 delay) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        delay = uint16(bound(delay, 1, type(uint16).max));
-
-        _signedLock(pk, account, delay);
-
-        (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
+        (bool locked, bool init, uint48 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
         assertTrue(locked);
-        assertFalse(hasInitiatedUnlock);
+        assertFalse(init);
         assertEq(unlocksAt, type(uint48).max);
         assertEq(storedDelay, delay);
         assertTrue(keystore.isLocked(account));
     }
 
-    /// @notice A lock op emits AccountLocked(account, unlockDelay) exactly once. Sole assertion of this event.
+    /// @notice A lock op emits AccountLocked(account, delay).
     function test_lock_success_emitsAccountLocked(uint256 pkSeed, uint16 delay) public {
         uint256 pk = _boundK1Pk(pkSeed);
         address account = vm.addr(pk);
         _assumeSafeAccount(account);
         delay = uint16(bound(delay, 1, type(uint16).max));
 
-        bytes memory auth = _lockAuth(pk, account, delay);
         vm.expectEmit(true, false, false, true, address(keystore));
         emit Keystore.AccountLocked(account, delay);
-        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Lock, delay, auth);
+        _signedLock(pk, account, delay);
     }
 
-    /// @notice An account can be re-locked after a prior unlock delay has fully elapsed.
-    /// @dev Drives _checkAndClearLock through its lazy-clear branch (UNLOCK_INITIATED set, block.timestamp >= stored unlocksAt):
-    ///      the stale timestamp is cleared to 0 and the fresh lock succeeds, hard-locking again with the new delay.
-    function test_lock_success_relockAfterUnlockExpired(
-        uint256 pkSeed,
-        uint16 firstDelay,
-        uint16 secondDelay,
-        uint256 t0,
-        uint256 extra
-    ) public {
+    /// @notice A lock op with a zero unlock delay reverts ZeroUnlockDelay.
+    function test_lock_revert_zeroDelay(uint256 pkSeed) public {
         uint256 pk = _boundK1Pk(pkSeed);
         address account = vm.addr(pk);
         _assumeSafeAccount(account);
-        firstDelay = uint16(bound(firstDelay, 1, type(uint16).max));
-        secondDelay = uint16(bound(secondDelay, 1, type(uint16).max));
-        t0 = bound(t0, 1, 1e9);
-        extra = bound(extra, 0, 1e9);
 
-        _signedLock(pk, account, firstDelay);
-        vm.warp(t0);
-        _signedUnlock(pk, account);
-
-        vm.warp(t0 + firstDelay + extra); // at or past unlocksAt: account is unlocked
-        assertFalse(keystore.isLocked(account));
-
-        _signedLock(pk, account, secondDelay);
-
-        (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
-        assertTrue(locked);
-        assertFalse(hasInitiatedUnlock);
-        assertEq(unlocksAt, type(uint48).max);
-        assertEq(storedDelay, secondDelay);
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_lockChange(0)));
+        vm.expectRevert(Keystore.ZeroUnlockDelay.selector);
+        keystore.applySignedAccountChanges(account, s);
     }
 
-    /// @notice An unlock op sets unlocksAt = block.timestamp + delay and zeroes the stored delay.
-    /// @dev Before the delay elapses the account is still locked but now reports hasInitiatedUnlock; unlockDelay is 0.
-    function test_initiateUnlock_success_setsUnlocksAtAndClearsDelay(uint256 pkSeed, uint16 delay, uint256 t0) public {
+    /// @notice A second lock while already hard-locked reverts AccountIsLocked.
+    function test_lock_revert_whenAlreadyLocked(uint256 pkSeed, uint16 d1, uint16 d2) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+        d1 = uint16(bound(d1, 1, type(uint16).max));
+        d2 = uint16(bound(d2, 1, type(uint16).max));
+
+        _signedLock(pk, account, d1);
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_lockChange(d2)));
+        vm.expectRevert(Keystore.AccountIsLocked.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    /// @notice An unlock on a never-locked account reverts NotLocked.
+    function test_unlock_revert_whenNeverLocked(uint256 pkSeed) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_unlockChange()));
+        vm.expectRevert(Keystore.NotLocked.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    /// @notice An unlock op sets unlocksAt = now + delay, zeroes the stored delay, emits AccountUnlockInitiated.
+    function test_unlock_success_initiates(uint256 pkSeed, uint16 delay, uint256 t0) public {
         uint256 pk = _boundK1Pk(pkSeed);
         address account = vm.addr(pk);
         _assumeSafeAccount(account);
         delay = uint16(bound(delay, 1, type(uint16).max));
-        t0 = bound(t0, 1, 1e9);
-
-        _signedLock(pk, account, delay);
-        vm.warp(t0);
-        _signedUnlock(pk, account);
-
-        (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
-        assertTrue(locked); // block.timestamp (t0) < unlocksAt (t0 + delay)
-        assertTrue(hasInitiatedUnlock);
-        assertEq(unlocksAt, uint48(t0 + delay));
-        assertEq(storedDelay, 0);
-        assertTrue(keystore.isLocked(account));
-    }
-
-    /// @notice An unlock op emits AccountUnlockInitiated(account, unlocksAt) exactly once. Sole assertion.
-    function test_initiateUnlock_success_emitsAccountUnlockInitiated(uint256 pkSeed, uint16 delay, uint256 t0) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        delay = uint16(bound(delay, 1, type(uint16).max));
-        t0 = bound(t0, 1, 1e9);
+        t0 = bound(t0, block.timestamp, 1e12);
 
         _signedLock(pk, account, delay);
         vm.warp(t0);
 
-        bytes memory auth = _unlockAuth(pk, account);
         vm.expectEmit(true, false, false, true, address(keystore));
         emit Keystore.AccountUnlockInitiated(account, uint48(t0 + delay));
-        keystore.applySignedLockChanges(account, Keystore.LockChangeType.Unlock, 0, auth);
-    }
-
-    /// @notice isLocked is false for an account that has never been locked (FLAG_LOCKED clear).
-    function test_isLocked_success_falseWhenNeverLocked(address account, uint256 ts) public {
-        _assumeSafeAccount(account);
-        vm.warp(bound(ts, 1, 1e12));
-        assertFalse(keystore.isLocked(account));
-    }
-
-    /// @notice isLocked stays true for a hard-locked account at any timestamp (FLAG_LOCKED set, no pending unlock —
-    ///         hard-lock is timestamp-independent).
-    function test_isLocked_success_trueWhileHardLocked(uint256 pkSeed, uint16 delay, uint256 ts) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        delay = uint16(bound(delay, 1, type(uint16).max));
-
-        _signedLock(pk, account, delay);
-
-        vm.warp(bound(ts, 1, 1e12)); // hard-lock ignores the clock: FLAG_LOCKED set with no pending unlock
-        assertTrue(keystore.isLocked(account));
-    }
-
-    /// @notice isLocked remains true after an unlock is initiated while block.timestamp is strictly before unlocksAt.
-    function test_isLocked_success_trueBeforeUnlockDelayElapses(
-        uint256 pkSeed,
-        uint16 delay,
-        uint256 t0,
-        uint256 within
-    ) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        delay = uint16(bound(delay, 1, type(uint16).max));
-        t0 = bound(t0, 1, 1e9);
-
-        _signedLock(pk, account, delay);
-        vm.warp(t0);
         _signedUnlock(pk, account);
 
-        vm.warp(bound(within, t0, t0 + delay - 1)); // strictly before unlocksAt == t0 + delay
-        assertTrue(keystore.isLocked(account));
-    }
-
-    /// @notice isLocked flips to false once block.timestamp reaches or passes unlocksAt after an initiated unlock.
-    /// @dev Includes the exact boundary (extra == 0): isLocked is `block.timestamp < unlocksAt`, so == is unlocked.
-    function test_isLocked_success_falseAfterUnlockDelayElapses(uint256 pkSeed, uint16 delay, uint256 t0, uint256 extra)
-        public
-    {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        delay = uint16(bound(delay, 1, type(uint16).max));
-        t0 = bound(t0, 1, 1e9);
-        extra = bound(extra, 0, 1e9);
-
-        _signedLock(pk, account, delay);
-        vm.warp(t0);
-        _signedUnlock(pk, account);
-
-        vm.warp(t0 + delay + extra); // at or past unlocksAt
-        assertFalse(keystore.isLocked(account));
-    }
-
-    /// @notice getLockStatus reports all-clear for a never-locked account: unlocked, not initiated, zeroed fields.
-    function test_getLockStatus_success_whenNeverLocked(address account) public view {
-        (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 unlockDelay) = keystore.getLockStatus(account);
-        assertFalse(locked);
-        assertFalse(hasInitiatedUnlock);
-        assertEq(unlocksAt, 0);
-        assertEq(unlockDelay, 0);
-    }
-
-    /// @notice getLockStatus reports a clean unlocked state once an initiated unlock has elapsed, even with no
-    ///         intervening onlyUnlocked call to clear storage.
-    /// @dev getLockStatus never runs _checkAndClearLock, but it applies the elapse itself: once block.timestamp
-    ///      reaches unlocksAt it returns (false, false, 0, 0) — matching _checkAndClearLock's post-clear result —
-    ///      rather than surfacing the stale initiated-unlock fields still sitting in storage.
-    function test_getLockStatus_success_afterUnlockElapsedReportsUnlocked(
-        uint256 pkSeed,
-        uint16 delay,
-        uint256 t0,
-        uint256 extra
-    ) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        delay = uint16(bound(delay, 1, type(uint16).max));
-        t0 = bound(t0, 1, 1e9);
-        extra = bound(extra, 0, 1e9);
-
-        _signedLock(pk, account, delay);
-        vm.warp(t0);
-        _signedUnlock(pk, account);
-
-        vm.warp(t0 + delay + extra); // at or past unlocksAt, but no onlyUnlocked call to clear storage
-
-        (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
-        assertFalse(locked);
-        assertFalse(hasInitiatedUnlock);
-        assertEq(unlocksAt, 0);
+        (bool locked, bool init, uint48 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
+        assertTrue(locked);
+        assertTrue(init);
+        assertEq(unlocksAt, uint48(t0 + delay));
         assertEq(storedDelay, 0);
     }
 
-    /// @notice Full lock -> initiate-unlock -> warp-past -> config change cycle: once the delay elapses,
-    ///         _checkAndClearLock lets an onlyUnlocked config change through and the new actor is authorized.
-    /// @dev Drives the expiry-clear branch of _checkAndClearLock on the real applySignedActorChanges path.
-    function test_applySignedActorChanges_success_afterFullUnlockCycle(
-        uint256 pkSeed,
-        uint256 newActorSeed,
-        uint16 delay,
-        uint256 t0,
-        uint256 extra
-    ) public {
+    /// @notice A second unlock after one was already initiated reverts NotLocked.
+    function test_unlock_revert_whenAlreadyInitiated(uint256 pkSeed, uint16 delay, uint256 t0) public {
         uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
         delay = uint16(bound(delay, 1, type(uint16).max));
-        t0 = bound(t0, 1, 1e9);
-        extra = bound(extra, 0, 1e9);
-        (address account,) = _createK1Account(pk);
-
-        address newActor = address(uint160(bound(newActorSeed, 1, type(uint160).max)));
-        vm.assume(newActor != account);
-        vm.assume(newActor != vm.addr(pk));
-        bytes32 newActorId = bytes32(bytes20(newActor));
+        t0 = bound(t0, block.timestamp, 1e9);
 
         _signedLock(pk, account, delay);
         vm.warp(t0);
         _signedUnlock(pk, account);
-        vm.warp(t0 + delay + extra); // at or past unlocksAt: unlocked
-        assertFalse(keystore.isLocked(account));
 
-        Keystore.ActorChange[] memory changes = _oneAuthorizeChange(newActorId);
-        uint64 chainId = uint64(block.chainid);
-        uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, chainId, seq, changes);
-        bytes memory auth = _buildK1Auth(pk, digest);
-
-        keystore.applySignedActorChanges(account, chainId, changes, auth);
-
-        assertTrue(_isActor(account, newActorId));
-        // The onlyUnlocked prelude cleared the stale unlock timestamp back to 0.
-        (,, uint48 unlocksAt,) = keystore.getLockStatus(account);
-        assertEq(unlocksAt, 0);
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_unlockChange()));
+        vm.expectRevert(Keystore.NotLocked.selector);
+        keystore.applySignedAccountChanges(account, s);
     }
 
-    /// @notice applySignedActorChanges still reverts AccountIsLocked after an unlock is initiated but before its delay
-    ///         elapses: config stays frozen for the whole notice window, not just while hard-locked.
-    /// @dev Drives the pending-unlock branch of _checkAndClearLock (FLAG_UNLOCK_INITIATED set, block.timestamp <
-    ///      stored unlocksAt) on the real onlyUnlocked-guarded config path — distinct from the hard-locked branch.
-    function test_applySignedActorChanges_revert_whileUnlockPending(
-        uint256 pkSeed,
-        uint16 delay,
-        uint256 t0,
-        uint256 within
-    ) public {
+    /// @notice An account can be re-locked once a prior unlock delay has fully elapsed.
+    function test_lock_success_relockAfterUnlockElapsed(uint256 pkSeed, uint16 d1, uint16 d2, uint256 t0) public {
         uint256 pk = _boundK1Pk(pkSeed);
-        delay = uint16(bound(delay, 1, type(uint16).max));
-        t0 = bound(t0, 1, 1e9);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+        d1 = uint16(bound(d1, 1, type(uint16).max));
+        d2 = uint16(bound(d2, 1, type(uint16).max));
+        t0 = bound(t0, block.timestamp, 1e9);
+
+        _signedLock(pk, account, d1);
+        vm.warp(t0);
+        _signedUnlock(pk, account);
+        vm.warp(t0 + d1); // at unlocksAt: unlocked
+        assertFalse(keystore.isLocked(account));
+
+        _signedLock(pk, account, d2);
+        assertTrue(keystore.isLocked(account));
+    }
+
+    /// @notice While locked, an authority op (authorize) reverts AccountIsLocked but an environment op (bump)
+    ///         succeeds — the lock freezes the actor set, not the epoch.
+    function test_lock_bumpSucceedsAuthorizeFails(uint256 pkSeed) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+
+        _signedLock(pk, account, 1 hours);
+
+        // Bump under lock: allowed.
+        _applyLocal(pk, account, _one(_bumpChange()));
+        (uint32 epoch,) = keystore.getLocalEpochAndSequence(account);
+        assertEq(epoch, 1);
+
+        // Authorize under lock: rejected.
+        Keystore.SignedAccountChanges memory s = _localBatch(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
+        vm.expectRevert(Keystore.AccountIsLocked.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    /// @notice After a full unlock cycle elapses, an authority op is accepted again (lazy lock clear).
+    function test_lock_success_authorizeAfterFullUnlockCycle(uint256 pkSeed, uint16 delay, uint256 t0) public {
+        uint256 pk = _boundK1Pk(pkSeed);
         (address account,) = _createK1Account(pk);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+        t0 = bound(t0, block.timestamp, 1e9);
 
         _signedLock(pk, account, delay);
         vm.warp(t0);
         _signedUnlock(pk, account);
-        vm.warp(bound(within, t0, t0 + delay - 1)); // strictly before unlocksAt == t0 + delay: still frozen
+        vm.warp(t0 + delay); // unlocked
+        assertFalse(keystore.isLocked(account));
 
-        Keystore.ActorChange[] memory changes = _oneAuthorizeChange(bytes32(bytes20(vm.addr(pk))));
-        uint64 chainId = uint64(block.chainid);
-        uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, chainId, seq, changes);
-        bytes memory auth = _buildK1Auth(pk, digest);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        assertTrue(_isActor(account, ACTOR_A));
+    }
 
-        vm.expectRevert(Keystore.AccountIsLocked.selector);
-        keystore.applySignedActorChanges(account, chainId, changes, auth);
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // RECOVERY-CLASS SECOND FENCE
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice A recovery-class (scope RECOVERY) key may initiate a solo Unlock on a hard-locked account.
+    function test_recovery_success_unlockSolo(uint256 ownerSeed, uint256 recSeed) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 recPk = _boundK1Pk(recSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(recPk));
+        (address account,) = _createK1Account(ownerPk);
+        bytes32 recId = bytes32(bytes20(vm.addr(recPk)));
+
+        _applyLocal(ownerPk, account, _one(_authorizeChange(recId, address(k1Authenticator), RECOVERY, UNBOUNDED, "")));
+        _signedLock(ownerPk, account, 1 hours);
+        assertTrue(keystore.isLocked(account));
+
+        // Recovery key signs a solo unlock.
+        _applyLocal(recPk, account, _one(_unlockChange()));
+
+        (, bool init,,) = keystore.getLockStatus(account);
+        assertTrue(init);
+    }
+
+    /// @notice A recovery-class key signing a RevokeActor batch fails the per-op authorization fence
+    ///         (UnauthorizedActorChange) — it may unlock and nothing else.
+    function test_recovery_revert_revokeUnauthorized(uint256 ownerSeed, uint256 recSeed) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 recPk = _boundK1Pk(recSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(recPk));
+        (address account,) = _createK1Account(ownerPk);
+        bytes32 recId = bytes32(bytes20(vm.addr(recPk)));
+
+        _applyLocal(
+            ownerPk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
+        _applyLocal(ownerPk, account, _one(_authorizeChange(recId, address(k1Authenticator), RECOVERY, UNBOUNDED, "")));
+
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        ch[0] = _revokeChange(ACTOR_A);
+        ch[1] = _bumpChange();
+
+        Keystore.SignedAccountChanges memory s = _localBatch(recPk, account, ch);
+        vm.expectRevert(Keystore.UnauthorizedActorChange.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // GARBAGE COLLECTION
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice Collecting a live actor reverts CollectLiveActor.
+    function test_collect_revert_liveActor(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+
+        vm.expectRevert(Keystore.CollectLiveActor.selector);
+        keystore.collectActor(account, ACTOR_A);
+    }
+
+    /// @notice Collecting an absent actor reverts CollectLiveActor.
+    function test_collect_revert_absentActor(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+
+        vm.expectRevert(Keystore.CollectLiveActor.selector);
+        keystore.collectActor(account, ACTOR_A);
+    }
+
+    /// @notice Collecting a lapsed actor clears the slot and emits ActorCollected; a fresh authorize then succeeds.
+    function test_collect_success_lapsedThenFreshAuthorize(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        uint48 e = _future(1 days);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, e, "")));
+
+        vm.warp(uint256(e) + 1);
+        vm.expectEmit(true, true, false, true, address(keystore));
+        emit Keystore.ActorCollected(account, ACTOR_A);
+        keystore.collectActor(account, ACTOR_A);
+        assertFalse(_isActor(account, ACTOR_A));
+
+        // Fresh authorize into the emptied slot succeeds (empty-slot install).
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        assertTrue(_isActor(account, ACTOR_A));
+    }
+
+    /// @notice The batch collector reclaims several lapsed actors at once.
+    function test_collectActors_success_batch(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        uint48 e = _future(1 days);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, e, "")));
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_B, address(k1Authenticator), SENDER, e, "")));
+
+        vm.warp(uint256(e) + 1);
+        bytes32[] memory ids = new bytes32[](2);
+        ids[0] = ACTOR_A;
+        ids[1] = ACTOR_B;
+        keystore.collectActors(account, ids);
+
+        assertFalse(_isActor(account, ACTOR_A));
+        assertFalse(_isActor(account, ACTOR_B));
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // MULTICHAIN CHANNEL
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice A Multichain authorize consumes only the multichain counter and leaves the local word untouched.
+    function test_multichain_success_authorize(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        uint64 localBefore = _localSeqWord(account);
+        uint64 mcBefore = _multichainSeq(account);
+
+        _applyMultichain(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
+
+        assertTrue(_isActor(account, ACTOR_A));
+        assertEq(_localSeqWord(account), localBefore); // local channel untouched
+        assertEq(_multichainSeq(account), mcBefore + 1);
+    }
+
+    /// @notice A BumpLocalEpoch on the Multichain channel reverts EpochOpRequiresLocalChannel.
+    function test_multichain_revert_bumpRejected(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+
+        Keystore.SignedAccountChanges memory s = _multichainBatch(pk, account, _one(_bumpChange()));
+        vm.expectRevert(Keystore.EpochOpRequiresLocalChannel.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // REGRESSION (split layout / deleted entry points)
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice A freshly created account starts at epoch 0, sequence 1 (the non-zero initialized flag) with a zero
+    ///         multichain counter.
+    function test_regression_initFlagUnderSplitLayout(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+
+        (uint32 epoch, uint32 seq) = keystore.getLocalEpochAndSequence(account);
+        assertEq(epoch, 0);
+        assertEq(seq, 1);
+        assertEq(keystore.getChangeSequences(account).local, 1);
+        assertEq(keystore.getChangeSequences(account).multichain, 0);
+    }
+
+    /// @notice The deleted entry points (applySignedActorChanges / applySignedLockChanges) are absent from the ABI —
+    ///         a call to their old selector finds no function and reverts.
+    function test_regression_deletedEntryPointsAbsent(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+
+        (bool ok1,) = address(keystore)
+            .call(
+                abi.encodeWithSignature(
+                    "applySignedLockChanges(address,uint8,uint16,bytes)", account, uint8(1), uint16(3600), bytes("")
+                )
+            );
+        assertFalse(ok1);
+
+        (bool ok2,) = address(keystore)
+            .call(
+                abi.encodeWithSignature(
+                    "applySignedActorChanges(address,uint64,bytes,bytes)", account, uint64(0), bytes(""), bytes("")
+                )
+            );
+        assertFalse(ok2);
     }
 }

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -216,6 +216,40 @@ contract AccountEnvironmentTest is KeystoreTest {
         assertTrue(_isActor(account, ACTOR_A));
     }
 
+    /// @notice Lock-residue overwrite. A full lock -> initiate-unlock -> elapse cycle leaves FLAG_UNLOCK_INITIATED set
+    ///         and a now-elapsed unlocksAt in storage (lock reads never clear them). A fresh Lock over that residue must
+    ///         land a CLEAN hard-lock: FLAG_LOCKED set, FLAG_UNLOCK_INITIATED clear (init == false), and lockUnion
+    ///         holding the NEW delay rather than the stale timestamp. This pins the load-bearing `& ~FLAG_UNLOCK_INITIATED`
+    ///         clear in _applyLock: dropping it would leave a delay-valued union under a set INITIATED flag (the
+    ///         union-corruption bug).
+    function test_lock_success_overwritesElapsedUnlockResidue(uint256 pkSeed, uint16 d1, uint16 d2, uint256 t0) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+        d1 = uint16(bound(d1, 1, type(uint16).max));
+        d2 = uint16(bound(d2, 1, type(uint16).max));
+        t0 = bound(t0, block.timestamp, 1e9);
+
+        // Lock, initiate unlock, and let the delay fully elapse. Storage residue now reads unlocked but still carries
+        // FLAG_LOCKED | FLAG_UNLOCK_INITIATED with an elapsed timestamp in lockUnion.
+        _signedLock(pk, account, d1);
+        vm.warp(t0);
+        _signedUnlock(pk, account);
+        vm.warp(t0 + d1);
+        assertFalse(keystore.isLocked(account));
+
+        // Re-lock over the residue.
+        _signedLock(pk, account, d2);
+
+        // Clean hard-lock: INITIATED cleared and the union holds the new delay (surfaced as storedDelay), not the
+        // stale timestamp.
+        (bool locked, bool init, uint48 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
+        assertTrue(locked);
+        assertFalse(init);
+        assertEq(unlocksAt, type(uint48).max);
+        assertEq(storedDelay, d2);
+    }
+
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // ADMIN-ONLY LOCK CHANGES
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -405,5 +439,64 @@ contract AccountEnvironmentTest is KeystoreTest {
         });
         vm.expectRevert(Keystore.AlreadyInitialized.selector);
         keystore.importAccount(account, 0, actors, "");
+    }
+
+    /// @notice Init asymmetry (fresh-account branch): a never-bootstrapped EOA's first LOCAL unsequenced batch burns
+    ///         local sequence 0 -> 1, so any sequenced-at-0 signature it had already produced is now dead (BadSequence).
+    ///         This is the side of the asymmetry that the unsequenced-init write creates.
+    function test_init_unsequencedFirstBatchKillsSequenceZero(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+
+        // A sequenced local batch at seq 0, captured while the account is still fresh (epoch 0, seq 0).
+        Keystore.SignedAccountChanges memory seqZero = _localBatch(
+            pk, account, _one(_authorizeChange(ACTOR_B, address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
+
+        // First act is an unsequenced batch: burns local sequence 0 -> 1 (marks initialized).
+        _applyUnsequenced(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
+        (, uint32 seq1) = _localEpochSeq(account);
+        assertEq(seq1, 1);
+
+        // The pre-signed sequenced-at-0 batch no longer matches the advanced counter.
+        vm.expectRevert(Keystore.BadSequence.selector);
+        keystore.applySignedAccountChanges(account, seqZero);
+    }
+
+    /// @notice Init asymmetry (multichain-active branch): once an EOA has bootstrapped via the Multichain channel it
+    ///         already reads initialized, so a later first LOCAL unsequenced batch does NOT burn local sequence 0. The
+    ///         local sequenced-at-0 slot stays live and a sequenced-at-0 batch still lands — the opposite of a fresh
+    ///         account, pinned deliberately.
+    function test_init_multichainActiveKeepsLocalSequenceZero(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+
+        // Bootstrap via multichain: multichain counter 0 -> 1, local word stays 0/0 (initialized via the multichain
+        // term of _isInitialized).
+        _applyMultichain(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
+        (uint32 epoch0, uint32 seq0) = _localEpochSeq(account);
+        assertEq(epoch0, 0);
+        assertEq(seq0, 0);
+
+        // A local unsequenced batch: the unsequenced-init write is skipped (already initialized), so localSequence
+        // stays 0.
+        _applyUnsequenced(
+            pk, account, _one(_authorizeChange(ACTOR_B, address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
+        (, uint32 seq1) = _localEpochSeq(account);
+        assertEq(seq1, 0);
+
+        // A local sequenced batch at seq 0 therefore still lands (seq 0 == localSequence 0), consuming 0 -> 1.
+        bytes32 idC = bytes32(uint256(0xC3));
+        _applyLocal(pk, account, _one(_authorizeChange(idC, address(k1Authenticator), SENDER, _future(1 days), "")));
+        assertTrue(_isActor(account, idC));
+        (, uint32 seq2) = _localEpochSeq(account);
+        assertEq(seq2, 1);
     }
 }

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -6,8 +6,8 @@ import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
 /// @notice §10 test matrix for the account-environment surface driven through {applySignedAccountChanges}: the lock
-///         / unlock ops (admin-authorized), garbage collection, the Multichain channel (no epochs, no unsequenced
-///         mode), and the split-layout regression checks.
+///         / unlock ops (admin-authorized), the Multichain channel (no epochs, no unsequenced mode), and the
+///         split-layout regression checks.
 contract AccountEnvironmentTest is KeystoreTest {
     bytes32 constant ACTOR_A = bytes32(uint256(0xA1));
     bytes32 constant ACTOR_B = bytes32(uint256(0xB2));
@@ -216,65 +216,6 @@ contract AccountEnvironmentTest is KeystoreTest {
         Keystore.SignedAccountChanges memory s = _localBatch(scopedPk, account, _one(_unlockChange()));
         vm.expectRevert(Keystore.UnauthorizedLockChange.selector);
         keystore.applySignedAccountChanges(account, s);
-    }
-
-    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // GARBAGE COLLECTION
-    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-
-    /// @notice Collecting a live actor reverts CollectLiveActor.
-    function test_collect_revert_liveActor(uint256 pk) public {
-        pk = _boundK1Pk(pk);
-        (address account,) = _createK1Account(pk);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
-
-        vm.expectRevert(Keystore.CollectLiveActor.selector);
-        keystore.collectActor(account, ACTOR_A);
-    }
-
-    /// @notice Collecting an absent actor reverts CollectLiveActor.
-    function test_collect_revert_absentActor(uint256 pk) public {
-        pk = _boundK1Pk(pk);
-        (address account,) = _createK1Account(pk);
-
-        vm.expectRevert(Keystore.CollectLiveActor.selector);
-        keystore.collectActor(account, ACTOR_A);
-    }
-
-    /// @notice Collecting a lapsed actor clears the slot and emits ActorCollected; a fresh authorize then succeeds.
-    function test_collect_success_lapsedThenFreshAuthorize(uint256 pk) public {
-        pk = _boundK1Pk(pk);
-        (address account,) = _createK1Account(pk);
-        uint48 e = _future(1 days);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, e, "")));
-
-        vm.warp(uint256(e) + 1);
-        vm.expectEmit(true, true, false, true, address(keystore));
-        emit Keystore.ActorCollected(account, ACTOR_A);
-        keystore.collectActor(account, ACTOR_A);
-        assertFalse(_isActor(account, ACTOR_A));
-
-        // Fresh authorize into the emptied slot succeeds (empty-slot install).
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
-        assertTrue(_isActor(account, ACTOR_A));
-    }
-
-    /// @notice The batch collector reclaims several lapsed actors at once.
-    function test_collectActors_success_batch(uint256 pk) public {
-        pk = _boundK1Pk(pk);
-        (address account,) = _createK1Account(pk);
-        uint48 e = _future(1 days);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, e, "")));
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_B, address(k1Authenticator), SENDER, e, "")));
-
-        vm.warp(uint256(e) + 1);
-        bytes32[] memory ids = new bytes32[](2);
-        ids[0] = ACTOR_A;
-        ids[1] = ACTOR_B;
-        keystore.collectActors(account, ids);
-
-        assertFalse(_isActor(account, ACTOR_A));
-        assertFalse(_isActor(account, ACTOR_B));
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -5,7 +5,7 @@ import {Keystore} from "../../../src/Keystore.sol";
 import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
-/// @notice §10 test matrix for the account-environment surface driven through {applySignedAccountChanges}: the lock
+/// @notice §10 test matrix for the account-environment surface driven through {applySignedConfigChanges}: the lock
 ///         / unlock ops (admin-authorized), the Multichain channel (no epochs, no unsequenced mode), and the
 ///         split-layout regression checks.
 contract AccountEnvironmentTest is KeystoreTest {
@@ -69,9 +69,9 @@ contract AccountEnvironmentTest is KeystoreTest {
         address account = vm.addr(pk);
         _assumeSafeAccount(account);
 
-        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_lockChange(0)));
+        Keystore.SignedConfigChanges memory s = _localBatch(pk, account, _one(_lockChange(0)));
         vm.expectRevert(Keystore.ZeroUnlockDelay.selector);
-        keystore.applySignedAccountChanges(account, s);
+        keystore.applySignedConfigChanges(account, s);
     }
 
     /// @notice A second lock while already hard-locked reverts AccountIsLocked.
@@ -83,9 +83,9 @@ contract AccountEnvironmentTest is KeystoreTest {
         d2 = uint16(bound(d2, 1, type(uint16).max));
 
         _signedLock(pk, account, d1);
-        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_lockChange(d2)));
+        Keystore.SignedConfigChanges memory s = _localBatch(pk, account, _one(_lockChange(d2)));
         vm.expectRevert(Keystore.AccountIsLocked.selector);
-        keystore.applySignedAccountChanges(account, s);
+        keystore.applySignedConfigChanges(account, s);
     }
 
     /// @notice Regression: `[Lock, Unlock, Lock]` in a single batch from the unlocked state must revert on the
@@ -99,14 +99,14 @@ contract AccountEnvironmentTest is KeystoreTest {
         d1 = uint16(bound(d1, 1, type(uint16).max));
         d2 = uint16(bound(d2, 1, type(uint16).max));
 
-        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](3);
+        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](3);
         ch[0] = _lockChange(d1);
         ch[1] = _unlockChange();
         ch[2] = _lockChange(d2);
 
-        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
+        Keystore.SignedConfigChanges memory s = _localBatch(pk, account, ch);
         vm.expectRevert(Keystore.AccountIsLocked.selector);
-        keystore.applySignedAccountChanges(account, s);
+        keystore.applySignedConfigChanges(account, s);
     }
 
     /// @notice An unlock on a never-locked account reverts NotLocked.
@@ -115,9 +115,9 @@ contract AccountEnvironmentTest is KeystoreTest {
         address account = vm.addr(pk);
         _assumeSafeAccount(account);
 
-        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_unlockChange()));
+        Keystore.SignedConfigChanges memory s = _localBatch(pk, account, _one(_unlockChange()));
         vm.expectRevert(Keystore.NotLocked.selector);
-        keystore.applySignedAccountChanges(account, s);
+        keystore.applySignedConfigChanges(account, s);
     }
 
     /// @notice An unlock op sets unlocksAt = now + delay, zeroes the stored delay, emits AccountUnlockInitiated.
@@ -154,9 +154,9 @@ contract AccountEnvironmentTest is KeystoreTest {
         vm.warp(t0);
         _signedUnlock(pk, account);
 
-        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_unlockChange()));
+        Keystore.SignedConfigChanges memory s = _localBatch(pk, account, _one(_unlockChange()));
         vm.expectRevert(Keystore.NotLocked.selector);
-        keystore.applySignedAccountChanges(account, s);
+        keystore.applySignedConfigChanges(account, s);
     }
 
     /// @notice An account can be re-locked once a prior unlock delay has fully elapsed.
@@ -193,11 +193,11 @@ contract AccountEnvironmentTest is KeystoreTest {
         assertEq(epoch, 1);
 
         // Authorize under lock: rejected.
-        Keystore.SignedAccountChanges memory s = _localBatch(
+        Keystore.SignedConfigChanges memory s = _localBatch(
             pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
         );
         vm.expectRevert(Keystore.AccountIsLocked.selector);
-        keystore.applySignedAccountChanges(account, s);
+        keystore.applySignedConfigChanges(account, s);
     }
 
     /// @notice After a full unlock cycle elapses, an authority op is accepted again (lazy lock clear).
@@ -222,7 +222,7 @@ contract AccountEnvironmentTest is KeystoreTest {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     /// @notice A scoped (non-admin) actor cannot initiate an Unlock — every signed change is admin-only
-    ///         (UnauthorizedAccountChange).
+    ///         (UnauthorizedConfigChange).
     function test_lock_revert_scopedActorCannotUnlock(uint256 ownerSeed, uint256 scopedSeed) public {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
         uint256 scopedPk = _boundK1Pk(scopedSeed);
@@ -234,9 +234,9 @@ contract AccountEnvironmentTest is KeystoreTest {
         _signedLock(ownerPk, account, 1 hours);
         assertTrue(keystore.isLocked(account));
 
-        Keystore.SignedAccountChanges memory s = _localBatch(scopedPk, account, _one(_unlockChange()));
-        vm.expectRevert(Keystore.UnauthorizedAccountChange.selector);
-        keystore.applySignedAccountChanges(account, s);
+        Keystore.SignedConfigChanges memory s = _localBatch(scopedPk, account, _one(_unlockChange()));
+        vm.expectRevert(Keystore.UnauthorizedConfigChange.selector);
+        keystore.applySignedConfigChanges(account, s);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -259,14 +259,14 @@ contract AccountEnvironmentTest is KeystoreTest {
         assertEq(_multichainSeq(account), mcBefore + 1);
     }
 
-    /// @notice A BumpLocalEpoch on the Multichain channel reverts EpochOpRequiresLocalChannel.
+    /// @notice An IncrementLocalEpoch on the Multichain channel reverts EpochOpRequiresLocalChannel.
     function test_multichain_revert_bumpRejected(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
 
-        Keystore.SignedAccountChanges memory s = _multichainBatch(pk, account, _one(_bumpChange()));
+        Keystore.SignedConfigChanges memory s = _multichainBatch(pk, account, _one(_bumpChange()));
         vm.expectRevert(Keystore.EpochOpRequiresLocalChannel.selector);
-        keystore.applySignedAccountChanges(account, s);
+        keystore.applySignedConfigChanges(account, s);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -307,5 +307,30 @@ contract AccountEnvironmentTest is KeystoreTest {
                 )
             );
         assertFalse(ok2);
+    }
+
+    /// @notice Regression: an IncrementLocalEpoch zeroes localSequence, but the account must still read as
+    ///         initialized (localEpoch is now non-zero) so the one-time importAccount bootstrap stays closed. Prior
+    ///         to the fix, _isInitialized checked localSequence alone, so a post-increment local-only account looked
+    ///         uninitialized and importAccount would re-bootstrap on top of the live actor set.
+    function test_regression_importBlockedAfterEpochIncrement(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+
+        // Increment the epoch: localSequence -> 0, localEpoch -> 1 (both counters no longer trivially non-zero on the
+        // sequence half).
+        _applyLocal(pk, account, _one(_bumpChange()));
+        (uint32 epoch, uint32 seq) = _localEpochSeq(account);
+        assertEq(epoch, 1);
+        assertEq(seq, 0);
+
+        // importAccount must still reject the account as already initialized. The check fires before the ERC-1271
+        // staticcall, so the empty signature is never reached.
+        Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](1);
+        actors[0] = Keystore.InitialActor({
+            actorId: bytes32(bytes20(account)), authenticator: address(1), scope: 0, policyData: ""
+        });
+        vm.expectRevert(Keystore.AlreadyInitialized.selector);
+        keystore.importAccount(account, 0, actors, "");
     }
 }

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -49,21 +49,25 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         assertEq(_localSeqWord(account), seqBefore);
     }
 
-    /// @notice Replaying an unsequenced grant after it landed reverts NonMonotoneExpiry (same expiry, occupied slot).
-    function test_authorizeUnsequenced_revert_replayAfterLanding(uint256 pk) public {
+    /// @notice Replaying an unsequenced grant that is still in the future is idempotent — it re-lands the same config
+    ///         (no monotonicity gate; a grant is valid while its own expiry has not passed).
+    function test_authorizeUnsequenced_success_replayIdempotent(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
+        uint48 expiry = _future(1 days);
         Keystore.SignedAccountChanges memory s = _signBatch(
             pk,
             account,
             Keystore.AccountChangeChannel.Local,
             _unseqWord(account),
-            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, expiry, ""))
         );
         keystore.applySignedAccountChanges(account, s);
-
-        vm.expectRevert(Keystore.NonMonotoneExpiry.selector);
         keystore.applySignedAccountChanges(account, s);
+
+        Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, ACTOR_A);
+        assertEq(cfg.scope, SENDER);
+        assertEq(cfg.expiry, expiry);
     }
 
     /// @notice Replaying an unsequenced grant after its granted expiry has passed reverts ExpiredChange (the fixed
@@ -117,53 +121,47 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         keystore.applySignedAccountChanges(account, s);
     }
 
-    /// @notice An unsequenced grant may not request the unbounded (max) expiry — that is sequenced-only.
-    function test_authorizeUnsequenced_revert_unboundedExpiry(uint256 pk) public {
+    /// @notice An unsequenced grant may request the unbounded (max) expiry.
+    function test_authorizeUnsequenced_success_unboundedExpiry(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
 
-        Keystore.SignedAccountChanges memory s =
-            _unseqBatch(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, UNBOUNDED, "")));
-        vm.expectRevert(Keystore.UnboundedGrantRequiresSequencing.selector);
-        keystore.applySignedAccountChanges(account, s);
+        _applyUnsequenced(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, UNBOUNDED, "")));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, UNBOUNDED);
     }
 
-    /// @notice An unsequenced upsert may not change an occupied slot's scope.
-    function test_authorizeUnsequenced_revert_scopeChangeOnOccupied(uint256 pk) public {
+    /// @notice An unsequenced upsert may change an occupied slot's scope (last-write-wins, no sequencing gate).
+    function test_authorizeUnsequenced_success_scopeChangeOnOccupied(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         _applyUnsequenced(
             pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
         );
 
-        Keystore.SignedAccountChanges memory s = _unseqBatch(
+        _applyUnsequenced(
             pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), NONCE, _future(2 days), ""))
         );
-        vm.expectRevert(Keystore.ScopeChangeRequiresSequencing.selector);
-        keystore.applySignedAccountChanges(account, s);
+        assertEq(keystore.getActorConfig(account, ACTOR_A).scope, NONCE);
+        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, _future(2 days));
     }
 
-    /// @notice Extend-by-upsert is order-independent: applying two grants (T1 < T2) in either order settles at the
-    ///         max expiry (the lower one either lands-then-is-overwritten or reverts NonMonotoneExpiry).
-    function test_authorizeUnsequenced_extendByUpsert_bothOrdersSettleAtMax(uint256 pk) public {
+    /// @notice Unsequenced upserts are last-write-wins: the final applied grant's expiry stands, regardless of order.
+    function test_authorizeUnsequenced_lastWriteWins(uint256 pk) public {
         pk = _boundK1Pk(pk);
         uint48 t1 = _future(1 days);
         uint48 t2 = _future(2 days);
 
-        // Order (T1, T2): both land, expiry ends at T2.
+        // Order (T1, T2): ends at T2.
         (address accA,) = _createK1Account(pk);
         _applyUnsequenced(pk, accA, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, t1, "")));
         _applyUnsequenced(pk, accA, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, t2, "")));
         assertEq(keystore.getActorConfig(accA, ACTOR_A).expiry, t2);
 
-        // Order (T2, T1): T2 lands, T1 reverts NonMonotoneExpiry, expiry still at T2.
+        // Order (T2, T1): ends at T1 (last write wins; a shorter expiry is allowed).
         (address accB,) = _createK1AccountWithSalt(pk, bytes32(uint256(1)));
         _applyUnsequenced(pk, accB, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, t2, "")));
-        Keystore.SignedAccountChanges memory low =
-            _unseqBatch(pk, accB, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, t1, "")));
-        vm.expectRevert(Keystore.NonMonotoneExpiry.selector);
-        keystore.applySignedAccountChanges(accB, low);
-        assertEq(keystore.getActorConfig(accB, ACTOR_A).expiry, t2);
+        _applyUnsequenced(pk, accB, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, t1, "")));
+        assertEq(keystore.getActorConfig(accB, ACTOR_A).expiry, t1);
     }
 
     /// @notice A different authenticator under the same actorId is not possible (id derives from the authenticator);
@@ -191,11 +189,11 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
     function test_authorizeSequenced_success_consumesSequence(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        (uint32 epoch0, uint32 seq0) = keystore.getLocalEpochAndSequence(account);
+        (uint32 epoch0, uint32 seq0) = _localEpochSeq(account);
 
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
 
-        (uint32 epoch1, uint32 seq1) = keystore.getLocalEpochAndSequence(account);
+        (uint32 epoch1, uint32 seq1) = _localEpochSeq(account);
         assertEq(epoch1, epoch0);
         assertEq(seq1, seq0 + 1);
     }
@@ -273,7 +271,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         _applyLocal(pk, account, ch);
 
         assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, lower);
-        (uint32 epoch,) = keystore.getLocalEpochAndSequence(account);
+        (uint32 epoch,) = _localEpochSeq(account);
         assertEq(epoch, 1);
     }
 
@@ -365,11 +363,11 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
         // Consume a sequence first so we can observe the reset.
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
-        (uint32 epoch0,) = keystore.getLocalEpochAndSequence(account);
+        (uint32 epoch0,) = _localEpochSeq(account);
 
         _applyUnsequenced(pk, account, _one(_bumpChange()));
 
-        (uint32 epoch1, uint32 seq1) = keystore.getLocalEpochAndSequence(account);
+        (uint32 epoch1, uint32 seq1) = _localEpochSeq(account);
         assertEq(epoch1, epoch0 + 1);
         assertEq(seq1, 0);
     }
@@ -385,7 +383,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         _applyUnsequenced(pk, account, ch);
 
         assertTrue(_isActor(account, ACTOR_A));
-        (uint32 epoch, uint32 seq) = keystore.getLocalEpochAndSequence(account);
+        (uint32 epoch, uint32 seq) = _localEpochSeq(account);
         assertEq(epoch, 1);
         assertEq(seq, 0);
     }
@@ -492,7 +490,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
 
         assertFalse(_isActor(account, ACTOR_A));
         assertTrue(keystore.isLocked(account));
-        (uint32 epoch,) = keystore.getLocalEpochAndSequence(account);
+        (uint32 epoch,) = _localEpochSeq(account);
         assertEq(epoch, 1);
     }
 
@@ -511,7 +509,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
 
         (, bool init,,) = keystore.getLockStatus(account);
         assertTrue(init);
-        (uint32 epoch,) = keystore.getLocalEpochAndSequence(account);
+        (uint32 epoch,) = _localEpochSeq(account);
         assertEq(epoch, 1);
     }
 

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -593,6 +593,34 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
     }
 
+    /// @notice Right-aligned actorId round-trip. An address-derived actor's id is the address right-aligned
+    ///         (ActorId.fromAddress: bytes32(uint256(uint160(addr))), high 12 bytes zero). The emitted ActorAuthorized
+    ///         indexed topic therefore decodes back to the address via the standard address(uint160(uint256(id)))
+    ///         round-trip that off-chain indexers rely on, and the on-chain k1 derivation resolves the very same id.
+    function test_authorize_success_rightAlignedActorIdRoundTrip(uint256 pk, uint256 actorSeed) public {
+        pk = _boundK1Pk(pk);
+        uint256 actorPk = _boundK1Pk(actorSeed);
+        (address account,) = _createK1Account(pk);
+        address actorAddr = vm.addr(actorPk);
+        vm.assume(actorAddr != account);
+
+        bytes32 actorId = bytes32(uint256(uint160(actorAddr))); // right-aligned, high 12 bytes zero
+
+        // The indexed topic equals the right-aligned id.
+        vm.expectEmit(true, true, false, false, address(keystore));
+        emit Keystore.ActorAuthorized(account, actorId, "");
+        _applyLocal(pk, account, _one(_authorizeChange(actorId, address(k1Authenticator), 0x00, UNBOUNDED, "")));
+
+        // Round-trip: the id decodes back to the address and carries no high bytes.
+        assertEq(address(uint160(uint256(actorId))), actorAddr);
+        assertEq(uint256(actorId) >> 160, 0);
+
+        // The on-chain k1 derivation (recovered signer -> actorId) agrees with the wallet-side derivation.
+        bytes32 hash = keccak256("round-trip");
+        (bytes32 resolvedId,) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
+        assertEq(resolvedId, actorId);
+    }
+
     /// @notice A `[revoke, bump]` batch emits ActorRevoked(account, actorId).
     function test_revoke_success_emitsActorRevoked(uint256 pk) public {
         pk = _boundK1Pk(pk);

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -6,7 +6,7 @@ import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
 /// @notice §10 test matrix for the authority / environment ops driven through {applySignedAccountChanges}:
-///         AuthorizeActor (sequenced + unsequenced), RevokeActor, BumpLocalEpoch, the op-ordering / solo fences,
+///         AuthorizeActor (sequenced + unsequenced), RevokeActor, BumpLocalEpoch, the op-ordering fence,
 ///         and the sequenced-channel replay/saturation edges. Lock/unlock (admin-only),
 ///         and multichain regression live in applyAccountChange.t.sol.
 contract ApplySignedAccountChangesTest is KeystoreTest {
@@ -374,17 +374,20 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         assertEq(seq1, 0);
     }
 
-    /// @notice A non-solo unsequenced bump reverts SoloOpNotSolo.
-    function test_bump_revert_unsequencedNonSolo(uint256 pk) public {
+    /// @notice An unsequenced bump may be batched with other ops (no solo rule): `[authorize, bump]` lands.
+    function test_bump_success_unsequencedNonSolo(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "");
         ch[1] = _bumpChange();
 
-        Keystore.SignedAccountChanges memory s = _unseqBatch(pk, account, ch);
-        vm.expectRevert(Keystore.SoloOpNotSolo.selector);
-        keystore.applySignedAccountChanges(account, s);
+        _applyUnsequenced(pk, account, ch);
+
+        assertTrue(_isActor(account, ACTOR_A));
+        (uint32 epoch, uint32 seq) = keystore.getLocalEpochAndSequence(account);
+        assertEq(epoch, 1);
+        assertEq(seq, 0);
     }
 
     /// @notice Two independently signed unsequenced bumps at the same epoch: the first lands, the second dies on
@@ -493,18 +496,23 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         assertEq(epoch, 1);
     }
 
-    /// @notice `[unlock, <anything>]` reverts SoloOpNotSolo — unlock must be the sole op.
-    function test_solo_revert_unlockNotSolo(uint256 pk) public {
+    /// @notice Unlock may be batched with other ops (no solo rule): on a locked account `[unlock, bump]` initiates
+    ///         the unlock and bumps the epoch.
+    function test_unlock_success_batchedWithBump(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
+        _signedLock(pk, account, 1 hours);
+        assertTrue(keystore.isLocked(account));
 
         Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _unlockChange();
         ch[1] = _bumpChange();
+        _applyLocal(pk, account, ch);
 
-        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
-        vm.expectRevert(Keystore.SoloOpNotSolo.selector);
-        keystore.applySignedAccountChanges(account, s);
+        (, bool init,,) = keystore.getLockStatus(account);
+        assertTrue(init);
+        (uint32 epoch,) = keystore.getLocalEpochAndSequence(account);
+        assertEq(epoch, 1);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -195,6 +195,19 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         assertEq(keystore.getActorConfig(account, ACTOR_B).authenticator, address(p256Authenticator));
     }
 
+    /// @notice AuthorizeActor targeting the zero actorId reverts InvalidActorId: bytes32(0) is not a usable actor
+    ///         identifier (every real id is a non-zero hash, or the non-zero self).
+    function test_authorize_revert_zeroActorId(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+
+        Keystore.SignedAccountChanges memory s = _localBatch(
+            pk, account, _one(_authorizeChange(bytes32(0), address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
+        vm.expectRevert(Keystore.InvalidActorId.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // AUTHORIZE — SEQUENCED
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -483,10 +496,8 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
     // ORDERING / BATCHING
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice `[lock, revoke]` on an account that was UNLOCKED at entry succeeds: the authority-op gate reads the
-    ///         batch-entry snapshot, so a Lock earlier in the same batch does not block the following revoke (the lock
-    ///         takes effect only for later batches). Order within the batch is irrelevant to the authority op.
-    function test_ordering_success_lockThenRevoke(uint256 pk) public {
+    /// @notice `[lock, revoke]` reverts LockChangeMustBeStandalone: a Lock may not share a batch with any other change.
+    function test_ordering_revert_lockNotStandalone(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
@@ -494,47 +505,43 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _lockChange(1 hours);
         ch[1] = _revokeChange(ACTOR_A);
-        _applyLocal(pk, account, ch);
 
-        assertFalse(_isActor(account, ACTOR_A));
-        assertTrue(keystore.isLocked(account));
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
+        vm.expectRevert(Keystore.LockChangeMustBeStandalone.selector);
+        keystore.applySignedAccountChanges(account, s);
     }
 
-    /// @notice `[revoke, bump, lock]` succeeds: authority op first, environment ops after, reduction retired by bump.
-    function test_ordering_success_revokeBumpLock(uint256 pk) public {
+    /// @notice `[revoke, bump]` succeeds: an authority op and an environment op (epoch increment) still freely share a
+    ///         batch — only Lock/Unlock are standalone — and the revoke is retired durably by the bump.
+    function test_ordering_success_revokeThenBump(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
 
-        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](3);
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _revokeChange(ACTOR_A);
         ch[1] = _bumpChange();
-        ch[2] = _lockChange(1 hours);
         _applyLocal(pk, account, ch);
 
         assertFalse(_isActor(account, ACTOR_A));
-        assertTrue(keystore.isLocked(account));
         (uint32 epoch,) = _localEpochSeq(account);
         assertEq(epoch, 1);
     }
 
-    /// @notice Unlock may be batched with other ops (no solo rule): on a locked account `[unlock, bump]` initiates
-    ///         the unlock and bumps the epoch.
-    function test_unlock_success_batchedWithBump(uint256 pk) public {
+    /// @notice `[unlock, bump]` reverts LockChangeMustBeStandalone: an Unlock may not share a batch with any other
+    ///         change, even an environment op. Unlocking then bumping requires two separate signed batches.
+    function test_unlock_revert_notStandalone(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         _signedLock(pk, account, 1 hours);
-        assertTrue(keystore.isLocked(account));
 
         Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _unlockChange();
         ch[1] = _bumpChange();
-        _applyLocal(pk, account, ch);
 
-        (, bool init,,) = keystore.getLockStatus(account);
-        assertTrue(init);
-        (uint32 epoch,) = _localEpochSeq(account);
-        assertEq(epoch, 1);
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
+        vm.expectRevert(Keystore.LockChangeMustBeStandalone.selector);
+        keystore.applySignedAccountChanges(account, s);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -2,863 +2,551 @@
 pragma solidity ^0.8.30;
 
 import {Keystore} from "../../../src/Keystore.sol";
+import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
-contract ApplyConfigChangeActorTest is KeystoreTest {
-    uint16 constant SCOPE_SENDER = 0x01;
-    uint16 constant SCOPE_POLICY = 0x02;
-    uint16 constant SCOPE_NONCE = 0x04;
-    uint16 constant SCOPE_SELF_PAYER = 0x08;
-    uint16 constant SCOPE_SPONSOR_PAYER = 0x10;
+/// @notice §10 test matrix for the authority / environment ops driven through {applySignedAccountChanges}:
+///         AuthorizeActor (sequenced + unsequenced), RevokeActor, BumpLocalEpoch, the op-ordering / solo fences,
+///         the reduction rule, and the sequenced-channel replay/saturation edges. Lock/unlock, recovery-key
+///         authorization, garbage collection, and multichain regression live in applyAccountChange.t.sol.
+contract ApplySignedAccountChangesTest is KeystoreTest {
+    // Non-self, non-owner actor ids (low right-aligned constants never collide with a bytes20-left-aligned address).
+    bytes32 constant ACTOR_A = bytes32(uint256(0xA1));
+    bytes32 constant ACTOR_B = bytes32(uint256(0xB2));
 
-    /// @notice Authorizing a non-self actor registers it with the given authenticator and unrestricted scope.
-    function test_authorizeActor_success_unrestricted(uint256 pk, bytes32 actorId) public {
-        pk = _boundK1Pk(pk);
-        (address account, bytes32 ownerId) = _createK1Account(pk);
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+    uint16 constant SENDER = Scopes.SENDER;
+    uint16 constant NONCE = Scopes.NONCE;
 
-        Keystore.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), 0, "");
-        _signApply(account, pk, ch);
-
-        Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, actorId);
-        assertEq(cfg.authenticator, address(k1Authenticator));
-        assertEq(cfg.scope, 0x00);
+    function setUp() public override {
+        super.setUp();
+        // A non-zero base timestamp so `expiry <= block.timestamp` comparisons are meaningful.
+        vm.warp(1_000_000);
     }
 
-    /// @notice Authorizing an actor stores the requested non-zero scope verbatim.
-    /// @dev SCOPE_POLICY is masked out because a policy-bearing scope requires policyData (covered elsewhere).
-    function test_authorizeActor_success_withScope(uint256 pk, bytes32 actorId, uint16 scope) public {
-        pk = _boundK1Pk(pk);
-        (address account, bytes32 ownerId) = _createK1Account(pk);
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
-        scope = uint16(bound(uint256(scope), 1, 255)) & ~SCOPE_POLICY;
-        vm.assume(scope != 0);
-
-        Keystore.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), scope, "");
-        _signApply(account, pk, ch);
-
-        Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, actorId);
-        assertEq(cfg.authenticator, address(k1Authenticator));
-        assertEq(cfg.scope, scope);
+    function _future(uint48 delta) internal view returns (uint48) {
+        return uint48(block.timestamp + delta);
     }
 
-    /// @notice Revoking a live non-self actor removes it from the account.
-    function test_revokeActor_success_removesActor(uint256 pk, bytes32 actorId) public {
-        pk = _boundK1Pk(pk);
-        (address account, bytes32 ownerId) = _createK1Account(pk);
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
-        _authorizeActor(account, pk, actorId, address(k1Authenticator));
-        assertTrue(_isActor(account, actorId));
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // AUTHORIZE — UNSEQUENCED (JIT)
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-        Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](1);
-        ch[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
-        _signApply(account, pk, ch);
-
-        assertFalse(_isActor(account, actorId));
-    }
-
-    /// @notice A batch of multiple authorize operations applies every element.
-    function test_applySignedActorChanges_success_multipleOperations(uint256 pk, bytes32 idA, bytes32 idB) public {
-        pk = _boundK1Pk(pk);
-        (address account, bytes32 ownerId) = _createK1Account(pk);
-        vm.assume(idA != ownerId && idA != bytes32(bytes20(account)));
-        vm.assume(idB != ownerId && idB != bytes32(bytes20(account)));
-        vm.assume(idA != idB);
-
-        Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](2);
-        ch[0] = _authorizeChange(idA, address(k1Authenticator), 0, "")[0];
-        ch[1] = _authorizeChange(idB, address(k1Authenticator), 0, "")[0];
-        _signApply(account, pk, ch);
-
-        assertTrue(_isActor(account, idA));
-        assertTrue(_isActor(account, idB));
-    }
-
-    /// @notice Each applied batch increments the account's local change sequence by one.
-    /// @dev createAccount initializes localSequence to 1 (the initialized flag), so the local channel starts at 1.
-    function test_applySignedActorChanges_success_sequenceIncrements(uint256 pk, bytes32 idA, bytes32 idB) public {
-        pk = _boundK1Pk(pk);
-        (address account, bytes32 ownerId) = _createK1Account(pk);
-        vm.assume(idA != ownerId && idA != bytes32(bytes20(account)));
-        vm.assume(idB != ownerId && idB != bytes32(bytes20(account)));
-        vm.assume(idA != idB);
-
-        assertEq(keystore.getChangeSequences(account).local, 1);
-
-        _authorizeActor(account, pk, idA, address(k1Authenticator));
-        assertEq(keystore.getChangeSequences(account).local, 2);
-
-        _authorizeActor(account, pk, idB, address(k1Authenticator));
-        assertEq(keystore.getChangeSequences(account).local, 3);
-    }
-
-    /// @notice A hard-locked account rejects actor changes.
-    /// @dev The onlyUnlocked modifier fires before any authentication work.
-    function test_applySignedActorChanges_revert_whenLocked(uint256 pk, bytes32 actorId) public {
-        pk = _boundK1Pk(pk);
-        (address account, bytes32 ownerId) = _createK1Account(pk);
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
-        _lockAccount(pk, account);
-
-        Keystore.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), 0, "");
-        bytes memory auth = _authOver(account, pk, ch);
-        vm.expectRevert(Keystore.AccountIsLocked.selector);
-        keystore.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
-    }
-
-    /// @notice Any authorized unrestricted actor, not only the owner, may authorize further actors.
-    function test_applySignedActorChanges_success_anyUnrestrictedActorAuthorizes(
-        uint256 ownerPk,
-        uint256 actorPk,
-        bytes32 targetId
-    ) public {
-        ownerPk = _boundK1Pk(ownerPk);
-        actorPk = _boundK1Pk(actorPk);
-        vm.assume(ownerPk != actorPk);
-        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
-        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
-        vm.assume(targetId != ownerId && targetId != actorId && targetId != bytes32(bytes20(account)));
-
-        _authorizeActor(account, ownerPk, actorId, address(k1Authenticator));
-
-        Keystore.ActorChange[] memory ch = _authorizeChange(targetId, address(k1Authenticator), 0, "");
-        _signApply(account, actorPk, ch);
-        assertTrue(_isActor(account, targetId));
-    }
-
-    /// @notice Any scoped (non-zero) actor cannot authorize actors; admin is exactly scope == 0.
-    /// @dev Reverts with UnauthorizedActorChange at the scope-0 gate.
-    function test_applySignedActorChanges_revert_scopedActorCannotAuthorize(
-        uint256 ownerPk,
-        uint256 actorPk,
-        uint16 scope,
-        bytes32 targetId
-    ) public {
-        ownerPk = _boundK1Pk(ownerPk);
-        actorPk = _boundK1Pk(actorPk);
-        vm.assume(ownerPk != actorPk);
-        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
-        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
-        vm.assume(targetId != ownerId && targetId != actorId && targetId != bytes32(bytes20(account)));
-        scope = uint16(bound(uint256(scope), 1, 255)) & ~SCOPE_POLICY;
-        vm.assume(scope != 0);
-
-        _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), scope);
-
-        Keystore.ActorChange[] memory ch = _authorizeChange(targetId, address(k1Authenticator), 0, "");
-        bytes memory auth = _authOver(account, actorPk, ch);
-        vm.expectRevert(Keystore.UnauthorizedActorChange.selector);
-        keystore.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
-    }
-
-    /// @notice Re-authorizing an already-configured non-self actor upserts its config in place.
-    /// @dev The owner actor is re-scoped from unrestricted to a scoped key rather than reverting.
-    function test_authorizeActor_success_reauthorizeUpsertsInPlace(uint256 pk) public {
-        pk = _boundK1Pk(pk);
-        (address account, bytes32 ownerId) = _createK1Account(pk);
-
-        uint16 newScope = SCOPE_SENDER;
-        Keystore.ActorChange[] memory ch = _authorizeChange(ownerId, address(k1Authenticator), newScope, "");
-        _signApply(account, pk, ch);
-
-        Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, ownerId);
-        assertEq(cfg.scope, newScope);
-        assertEq(cfg.authenticator, address(k1Authenticator));
-    }
-
-    /// @notice Re-authorizing a live inline k1 self is an in-place upsert with no prior revoke.
-    /// @dev Even a non-trivially-scoped live self can be re-scoped directly.
-    function test_selfActorId_success_reauthorizeLiveSelfRescopes(uint256 eoaPk) public {
-        eoaPk = _boundK1Pk(eoaPk);
-        address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
-
-        // First rescope keeps self at admin scope (0) so the same key retains authority to sign the second change;
-        // this materializes an explicit live self config over the implicit default-EOA.
-        uint8 firstScope = 0;
-        _rescopeSelf(eoa, eoaPk, firstScope);
-        assertEq(keystore.getActorConfig(eoa, selfActorId).scope, firstScope);
-
-        // Second admin-signed change rescopes the live self actor in place to a non-admin scope.
-        uint16 newScope = SCOPE_SENDER | SCOPE_SELF_PAYER;
-        _rescopeSelf(eoa, eoaPk, newScope);
-
-        Keystore.ActorConfig memory cfg = keystore.getActorConfig(eoa, selfActorId);
-        assertEq(cfg.scope, newScope);
-        assertEq(cfg.authenticator, keystore.K1_AUTHENTICATOR());
-        assertTrue(_isActor(eoa, selfActorId));
-    }
-
-    /// @notice Revoking an actor that was never authorized reverts.
-    function test_revokeActor_revert_nonExistentActor(uint256 pk, bytes32 actorId) public {
-        pk = _boundK1Pk(pk);
-        (address account, bytes32 ownerId) = _createK1Account(pk);
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
-
-        Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](1);
-        ch[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
-        bytes memory auth = _authOver(account, pk, ch);
-        vm.expectRevert();
-        keystore.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
-    }
-
-    /// @notice A batch signed by a key that is not an actor on the account reverts.
-    function test_applySignedActorChanges_revert_invalidSignature(uint256 pk, uint256 wrongPk, bytes32 actorId) public {
-        pk = _boundK1Pk(pk);
-        wrongPk = _boundK1Pk(wrongPk);
-        vm.assume(vm.addr(pk) != vm.addr(wrongPk));
-        (address account, bytes32 ownerId) = _createK1Account(pk);
-        vm.assume(vm.addr(wrongPk) != account);
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
-
-        Keystore.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), 0, "");
-        bytes memory badAuth = _authOver(account, wrongPk, ch);
-        vm.expectRevert();
-        keystore.applySignedActorChanges(account, uint64(block.chainid), ch, badAuth);
-    }
-
-    // ── Implicit EOA (registered by default) ──
-    //
-    // Every account has an implicit self-actorId bytes32(bytes20(account))
-    // that is authorized with unrestricted scope when the config slot
-    // is empty. No createAccount/importAccount needed.
-
-    /// @notice A never-created EOA can sign actor changes via its implicit self key.
-    function test_applySignedActorChanges_success_implicitEoaSigner(uint256 eoaPk, bytes32 actorId) public {
-        eoaPk = _boundK1Pk(eoaPk);
-        address eoa = vm.addr(eoaPk);
-        vm.assume(actorId != bytes32(bytes20(eoa)));
-
-        _signApply(eoa, eoaPk, _authorizeChange(actorId, address(k1Authenticator), 0, ""));
-        assertTrue(_isActor(eoa, actorId));
-    }
-
-    /// @notice The implicit EOA self key can be revoked via the default-EOA flag using another key.
-    /// @dev A revoked default EOA reports an all-zero config.
-    function test_selfActorId_success_implicitEoaRevokesSelfViaFlag(uint256 eoaPk, uint256 newPk) public {
-        eoaPk = _boundK1Pk(eoaPk);
-        newPk = _boundK1Pk(newPk);
-        vm.assume(eoaPk != newPk);
-        address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
-        bytes32 newActorId = bytes32(bytes20(vm.addr(newPk)));
-        vm.assume(newActorId != selfActorId);
-        assertTrue(_isActor(eoa, selfActorId));
-
-        _implicitAuthorizeActor(eoa, eoaPk, newActorId, address(k1Authenticator));
-        _revokeActor(eoa, newPk, selfActorId);
-
-        assertFalse(_isActor(eoa, selfActorId));
-        assertTrue(_isActor(eoa, newActorId));
-
-        Keystore.ActorConfig memory cfg = keystore.getActorConfig(eoa, selfActorId);
-        assertEq(cfg.authenticator, address(0));
-        assertEq(cfg.scope, 0);
-    }
-
-    /// @notice A live default EOA reports a synthesized K1 owner config for its self-actorId.
-    function test_selfActorId_success_liveReportsAsK1Owner(uint256 eoaPk) public view {
-        eoaPk = _boundK1Pk(eoaPk);
-        address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
-
-        Keystore.ActorConfig memory cfg = keystore.getActorConfig(eoa, selfActorId);
-        assertEq(cfg.authenticator, keystore.K1_AUTHENTICATOR());
-        assertEq(cfg.scope, 0);
-    }
-
-    /// @notice The account's own key can be downgraded to a scoped actor via the self-actorId.
-    /// @dev With a single k1 path the config alone decides the scope; there is no implicit full-owner escape.
-    function test_selfActorId_success_scopeViaK1(uint256 eoaPk, uint16 scope, bytes32 hash) public {
-        eoaPk = _boundK1Pk(eoaPk);
-        address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
-        scope = uint16(bound(uint256(scope), 1, 255)) & ~SCOPE_POLICY;
-        vm.assume(scope != 0);
-        assertTrue(_isActor(eoa, selfActorId));
-
-        _implicitAuthorizeActorWithScope(eoa, eoaPk, selfActorId, address(k1Authenticator), scope);
-
-        assertTrue(_isActor(eoa, selfActorId));
-        Keystore.ActorConfig memory cfg = keystore.getActorConfig(eoa, selfActorId);
-        assertEq(cfg.authenticator, address(k1Authenticator));
-        assertEq(cfg.scope, scope);
-
-        (, uint16 outScope) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
-        assertEq(outScope, scope);
-    }
-
-    /// @notice A self key scoped to any non-zero scope can no longer authorize, including re-authorizing itself.
-    /// @dev Reverts with UnauthorizedActorChange: the downgraded self fails the scope-0 (admin) gate.
-    function test_selfActorId_revert_scopedSelfCannotReauthorize(uint256 eoaPk, uint16 scope) public {
-        eoaPk = _boundK1Pk(eoaPk);
-        address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
-        scope = uint16(bound(uint256(scope), 1, 255)) & ~SCOPE_POLICY;
-        vm.assume(scope != 0);
-
-        _implicitAuthorizeActorWithScope(eoa, eoaPk, selfActorId, address(k1Authenticator), scope);
-
-        Keystore.ActorChange[] memory ch = _authorizeChange(selfActorId, keystore.K1_AUTHENTICATOR(), 0, "");
-        bytes memory auth = _authOver(eoa, eoaPk, ch);
-        vm.expectRevert(Keystore.UnauthorizedActorChange.selector);
-        keystore.applySignedActorChanges(eoa, uint64(block.chainid), ch, auth);
-    }
-
-    /// @notice A never-created EOA can apply a multichain (chainId 0) actor change via its implicit self key.
-    function test_applySignedActorChanges_success_multichainImplicitEoa(uint256 eoaPk, bytes32 actorId) public {
-        eoaPk = _boundK1Pk(eoaPk);
-        address eoa = vm.addr(eoaPk);
-        vm.assume(actorId != bytes32(bytes20(eoa)));
-
-        Keystore.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), 0, "");
-        uint64 seq = keystore.getChangeSequences(eoa).multichain;
-        bytes32 digest = _computeActorChangeBatchDigest(eoa, 0, seq, ch);
-        keystore.applySignedActorChanges(eoa, 0, ch, _buildK1Auth(eoaPk, digest));
-        assertTrue(_isActor(eoa, actorId));
-    }
-
-    // ── Default EOA self-actorId semantics ──
-    //
-    // The self-actorId for an account is bytes32(bytes20(account)). Without an explicit entry it is the implicit
-    // default EOA (full owner), gated by the AccountState flag. It may also be configured as an explicit actor like
-    // any other (e.g. to scope the account's own key), which sets the flag and disables the implicit address(0)
-    // path. The flag is never cleared, so a managed self-actorId is operated through its explicit entry/prefix.
-    // createAccount and importAccount disable the implicit default EOA by default.
-
-    /// @notice createAccount disables the implicit default EOA, so the self-actorId is not a live actor.
-    function test_selfActorId_success_revokedByDefaultOnCreate(uint256 pk) public {
+    /// @notice An unsequenced grant lands on an empty slot and does not consume the local sequence.
+    function test_authorizeUnsequenced_success_happyPath(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        bytes32 selfActorId = bytes32(bytes20(account));
+        uint64 seqBefore = _localSeqWord(account);
 
-        assertFalse(_isActor(account, selfActorId));
-        Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, selfActorId);
-        assertEq(cfg.authenticator, address(0));
-        assertEq(cfg.scope, 0);
+        _applyUnsequenced(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
+
+        Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, ACTOR_A);
+        assertEq(cfg.authenticator, address(k1Authenticator));
+        assertEq(cfg.scope, SENDER);
+        assertEq(cfg.expiry, _future(1 days));
+        // Unsequenced batches never consume the counter.
+        assertEq(_localSeqWord(account), seqBefore);
     }
 
-    /// @notice An owner re-enables the default EOA by authorizing the self-actorId with the owner shape.
-    function test_selfActorId_success_reEnableOnCreatedAccount(uint256 pk) public {
+    /// @notice Replaying an unsequenced grant after it landed reverts NonMonotoneExpiry (same expiry, occupied slot).
+    function test_authorizeUnsequenced_revert_replayAfterLanding(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        bytes32 selfActorId = bytes32(bytes20(account));
-        assertFalse(_isActor(account, selfActorId));
+        Keystore.SignedAccountChanges memory s = _signBatch(
+            pk,
+            account,
+            Keystore.AccountChangeChannel.Local,
+            _unseqWord(account),
+            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
+        keystore.applySignedAccountChanges(account, s);
 
-        _authorizeActor(account, pk, selfActorId, keystore.K1_AUTHENTICATOR());
-
-        assertTrue(_isActor(account, selfActorId));
-        Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, selfActorId);
-        assertEq(cfg.authenticator, keystore.K1_AUTHENTICATOR());
-        assertEq(cfg.scope, 0);
+        vm.expectRevert(Keystore.NonMonotoneExpiry.selector);
+        keystore.applySignedAccountChanges(account, s);
     }
 
-    /// @notice A revoked default EOA can be re-enabled by authorizing the self-actorId as a native k1 owner.
-    /// @dev While revoked the own key cannot authenticate; after re-enable it resolves via the explicit self config.
-    function test_selfActorId_success_revokeThenReEnable(uint256 eoaPk, uint256 newPk, bytes32 hash) public {
-        eoaPk = _boundK1Pk(eoaPk);
-        newPk = _boundK1Pk(newPk);
-        vm.assume(eoaPk != newPk);
-        address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
-        bytes32 newActorId = bytes32(bytes20(vm.addr(newPk)));
-        vm.assume(newActorId != selfActorId);
-        assertTrue(_isActor(eoa, selfActorId));
-
-        _implicitAuthorizeActor(eoa, eoaPk, newActorId, address(k1Authenticator));
-        _revokeActor(eoa, newPk, selfActorId);
-        assertFalse(_isActor(eoa, selfActorId));
-
-        vm.expectRevert();
-        keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
-
-        _authorizeActor(eoa, newPk, selfActorId, keystore.K1_AUTHENTICATOR());
-        assertTrue(_isActor(eoa, selfActorId));
-
-        (, uint16 scope) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
-        assertEq(scope, 0);
-    }
-
-    /// @notice Full lifecycle: default EOA hands the account to a device key, then re-enables the K1 key.
-    /// @dev The revoke-self + re-enable-self mechanics are authenticator-agnostic; K1 stands in for a passkey here.
-    function test_selfActorId_success_eoaToPasskeyLifecycle(uint256 eoaPk, uint256 devicePk, bytes32 hash) public {
-        eoaPk = _boundK1Pk(eoaPk);
-        devicePk = _boundK1Pk(devicePk);
-        vm.assume(eoaPk != devicePk);
-        address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
-        bytes32 deviceActorId = bytes32(bytes20(vm.addr(devicePk)));
-        vm.assume(deviceActorId != selfActorId);
-
-        // Phase 0: the default EOA is live and authenticates with its own k1 signature.
-        assertTrue(_isActor(eoa, selfActorId));
-        (, uint16 scope0) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
-        assertEq(scope0, 0);
-
-        // Phase 1: in one batch signed by the EOA, add the device key as a full owner and revoke the default EOA.
-        Keystore.ActorChange[] memory switchChanges = new Keystore.ActorChange[](2);
-        switchChanges[0] = _authorizeChange(deviceActorId, address(k1Authenticator), 0, "")[0];
-        switchChanges[1] =
-            Keystore.ActorChange({actorId: selfActorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
-        _signApply(eoa, eoaPk, switchChanges);
-
-        assertFalse(_isActor(eoa, selfActorId));
-        assertTrue(_isActor(eoa, deviceActorId));
-        vm.expectRevert();
-        keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
-        (, uint16 scope1) = keystore.authenticateActor(eoa, hash, _buildK1Auth(devicePk, hash));
-        assertEq(scope1, 0);
-
-        // Phase 2: the device key re-enables the K1 key by authorizing the self-actorId as a native k1 owner.
-        Keystore.ActorChange[] memory reEnable = _authorizeChange(selfActorId, keystore.K1_AUTHENTICATOR(), 0, "");
-        _signApply(eoa, devicePk, reEnable);
-
-        assertTrue(_isActor(eoa, selfActorId));
-        (, uint16 scope2) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
-        assertEq(scope2, 0);
-    }
-
-    /// @notice A single batch signed by the default EOA can add a key and revoke the default EOA together.
-    function test_selfActorId_success_batchRevokeViaFlag(uint256 eoaPk, uint256 newPk) public {
-        eoaPk = _boundK1Pk(eoaPk);
-        newPk = _boundK1Pk(newPk);
-        vm.assume(eoaPk != newPk);
-        address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
-        bytes32 newActorId = bytes32(bytes20(vm.addr(newPk)));
-        vm.assume(newActorId != selfActorId);
-
-        Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](2);
-        ch[0] = _authorizeChange(newActorId, address(k1Authenticator), 0, "")[0];
-        ch[1] = Keystore.ActorChange({actorId: selfActorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
-        _signApply(eoa, eoaPk, ch);
-
-        assertFalse(_isActor(eoa, selfActorId));
-        assertTrue(_isActor(eoa, newActorId));
-
-        Keystore.ActorConfig memory cfg = keystore.getActorConfig(eoa, selfActorId);
-        assertEq(cfg.authenticator, address(0));
-        assertEq(cfg.scope, 0);
-    }
-
-    /// @notice A revoked default EOA can no longer sign actor changes, but a still-active key can.
-    /// @dev The revoked self signature reverts; the second key's signature over the same digest applies.
-    function test_selfActorId_revert_revokedCannotSign(uint256 eoaPk, uint256 newPk, bytes32 targetId) public {
-        eoaPk = _boundK1Pk(eoaPk);
-        newPk = _boundK1Pk(newPk);
-        vm.assume(eoaPk != newPk);
-        address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
-        bytes32 newActorId = bytes32(bytes20(vm.addr(newPk)));
-        vm.assume(newActorId != selfActorId);
-        vm.assume(targetId != selfActorId && targetId != newActorId);
-
-        _implicitAuthorizeActor(eoa, eoaPk, newActorId, address(k1Authenticator));
-        _revokeActor(eoa, newPk, selfActorId);
-
-        Keystore.ActorChange[] memory ch = _authorizeChange(targetId, address(k1Authenticator), 0, "");
-        uint64 seq = keystore.getChangeSequences(eoa).local;
-        bytes32 digest = _computeActorChangeBatchDigest(eoa, uint64(block.chainid), seq, ch);
-
-        vm.expectRevert();
-        keystore.applySignedActorChanges(eoa, uint64(block.chainid), ch, _buildK1Auth(eoaPk, digest));
-
-        keystore.applySignedActorChanges(eoa, uint64(block.chainid), ch, _buildK1Auth(newPk, digest));
-        assertTrue(_isActor(eoa, targetId));
-    }
-
-    /// @notice A revoked signer key can no longer authorize actor changes.
-    function test_applySignedActorChanges_revert_revokedSignerKey(uint256 ownerPk, uint256 newPk, bytes32 targetId)
-        public
-    {
-        ownerPk = _boundK1Pk(ownerPk);
-        newPk = _boundK1Pk(newPk);
-        vm.assume(ownerPk != newPk);
-        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
-        bytes32 newActorId = bytes32(bytes20(vm.addr(newPk)));
-        vm.assume(newActorId != ownerId && newActorId != bytes32(bytes20(account)));
-        vm.assume(targetId != ownerId && targetId != newActorId && targetId != bytes32(bytes20(account)));
-
-        _authorizeActor(account, ownerPk, newActorId, address(k1Authenticator));
-        _revokeActor(account, newPk, ownerId);
-
-        Keystore.ActorChange[] memory ch = _authorizeChange(targetId, address(k1Authenticator), 0, "");
-        bytes memory auth = _authOver(account, ownerPk, ch);
-        vm.expectRevert();
-        keystore.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
-    }
-
-    /// @notice Revoking a non-self actor deletes its config slot.
-    function test_revokeActor_success_deletesSlot(uint256 pk, bytes32 actorId) public {
+    /// @notice Replaying an unsequenced grant after the slot was garbage-collected reverts ExpiredChange (the fixed
+    ///         granted expiry is now in the past).
+    function test_authorizeUnsequenced_revert_replayAfterGC(uint256 pk) public {
         pk = _boundK1Pk(pk);
-        (address account, bytes32 ownerId) = _createK1Account(pk);
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
-        _authorizeActor(account, pk, actorId, address(k1Authenticator));
-
-        _revokeActor(account, pk, actorId);
-
-        Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, actorId);
-        assertEq(cfg.authenticator, address(0));
-        assertEq(cfg.scope, 0);
-    }
-
-    // ── Fuzzed reverts and branch coverage ──
-
-    /// @notice applySignedActorChanges reverts for a chainId that is neither 0 (multichain) nor the current chain.
-    /// @dev Exercises the `chainId != 0 && chainId != block.chainid` guard on the actor-change path.
-    function test_applySignedActorChanges_revert_invalidChainId(uint256 pk, uint256 badChainId) public {
-        pk = _boundK1Pk(pk);
-        badChainId = bound(badChainId, 1, type(uint64).max);
-        vm.assume(badChainId != block.chainid);
         (address account,) = _createK1Account(pk);
+        uint48 expiry = _future(1 days);
+        Keystore.SignedAccountChanges memory s = _signBatch(
+            pk,
+            account,
+            Keystore.AccountChangeChannel.Local,
+            _unseqWord(account),
+            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, expiry, ""))
+        );
+        keystore.applySignedAccountChanges(account, s);
 
-        Keystore.ActorChange[] memory changes =
-            _authorizeChange(bytes32(bytes20(vm.addr(0xBEEF))), address(k1Authenticator), 0, "");
-        bytes memory auth = _buildK1Auth(pk, _computeActorChangeBatchDigest(account, uint64(badChainId), 0, changes));
+        vm.warp(uint256(expiry) + 1);
+        keystore.collectActor(account, ACTOR_A);
+        assertFalse(_isActor(account, ACTOR_A));
 
-        vm.expectRevert(Keystore.InvalidChainId.selector);
-        keystore.applySignedActorChanges(account, uint64(badChainId), changes, auth);
+        vm.expectRevert(Keystore.ExpiredChange.selector);
+        keystore.applySignedAccountChanges(account, s);
     }
 
-    /// @notice Replaying an identical (changes, auth) pair fails once the sequence is consumed.
-    /// @dev The replay recomputes the digest at seq+1, so the stale signature recovers a non-actor and reverts.
-    function test_applySignedActorChanges_revert_replay(uint256 pk, bytes32 actorId) public {
+    /// @notice An unsequenced batch signed at a stale epoch reverts StaleEpoch.
+    function test_authorizeUnsequenced_revert_wrongEpoch(uint256 pk) public {
         pk = _boundK1Pk(pk);
-        (address account, bytes32 ownerId) = _createK1Account(pk);
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+        (address account,) = _createK1Account(pk);
+        // Pre-sign at epoch 0, then bump the epoch out from under it.
+        Keystore.SignedAccountChanges memory s = _signBatch(
+            pk,
+            account,
+            Keystore.AccountChangeChannel.Local,
+            _unseqWord(account),
+            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
+        _applyUnsequenced(pk, account, _one(_bumpChange())); // epoch 0 -> 1
 
-        Keystore.ActorChange[] memory changes = _authorizeChange(actorId, address(k1Authenticator), 0, "");
-        bytes memory auth = _authOver(account, pk, changes);
-
-        keystore.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
-
-        vm.expectRevert();
-        keystore.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+        vm.expectRevert(Keystore.StaleEpoch.selector);
+        keystore.applySignedAccountChanges(account, s);
     }
 
-    /// @notice An ActorChange carrying ActorChangeType.Invalid (0) reverts UnknownActorChangeType (after the scope-0 gate) —
-    ///         the only unrecognized changeType that reaches the handler. Out-of-range wire values (>= 3) are rejected
-    ///         at ABI-decode instead, the same enum-decode guarantee exercised by
-    ///         ApplyAccountChange.test_applySignedLockChanges_revert_outOfRangeOp.
-    function test_applySignedActorChanges_revert_invalidActorChangeType(uint256 pk) public {
+    /// @notice A grant whose expiry is not strictly in the future reverts ExpiredChange (covers expiry == now and 0).
+    function test_authorizeUnsequenced_revert_pastExpiry(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
 
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            actorId: bytes32(bytes20(vm.addr(0xBEEF))), changeType: Keystore.ActorChangeType.Invalid, data: ""
-        });
-
-        bytes memory auth = _authOver(account, pk, changes);
-        vm.expectRevert(Keystore.UnknownActorChangeType.selector);
-        keystore.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
+        Keystore.SignedAccountChanges memory s = _unseqBatch(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, uint48(block.timestamp), ""))
+        );
+        vm.expectRevert(Keystore.ExpiredChange.selector);
+        keystore.applySignedAccountChanges(account, s);
     }
 
-    /// @notice The admin gate: an authenticated actor may change actors iff its scope == 0.
-    /// @dev Fuzzes the signer's scope (SCOPE_POLICY masked out) and asserts success only when scope is 0.
-    function test_applySignedActorChanges_adminGate_acrossScopes(
-        uint256 ownerPk,
-        uint256 signerPk,
-        uint16 signerScope,
-        bytes32 targetId
-    ) public {
-        ownerPk = _boundK1Pk(ownerPk);
-        signerPk = _boundK1Pk(signerPk);
-        vm.assume(ownerPk != signerPk);
-        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
-        bytes32 signerId = bytes32(bytes20(vm.addr(signerPk)));
-        vm.assume(signerId != ownerId && signerId != bytes32(bytes20(account)));
-        vm.assume(targetId != ownerId && targetId != signerId && targetId != bytes32(bytes20(account)));
-
-        signerScope = signerScope & ~SCOPE_POLICY;
-        _authorizeActorWithScope(account, ownerPk, signerId, address(k1Authenticator), signerScope);
-
-        Keystore.ActorChange[] memory ch = _authorizeChange(targetId, address(k1Authenticator), 0, "");
-        if (signerScope == 0) {
-            _signApply(account, signerPk, ch);
-            assertTrue(_isActor(account, targetId));
-        } else {
-            bytes memory auth = _authOver(account, signerPk, ch);
-            vm.expectRevert(Keystore.UnauthorizedActorChange.selector);
-            keystore.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
-        }
-    }
-
-    /// @notice Authorizing with a zero authenticator reverts with InvalidAuthenticator.
-    function test_authorizeActor_revert_invalidAuthenticator(uint256 pk, bytes32 actorId) public {
+    /// @notice An unsequenced grant may not request the unbounded (max) expiry — that is sequenced-only.
+    function test_authorizeUnsequenced_revert_unboundedExpiry(uint256 pk) public {
         pk = _boundK1Pk(pk);
-        (address account, bytes32 ownerId) = _createK1Account(pk);
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+        (address account,) = _createK1Account(pk);
 
-        Keystore.ActorChange[] memory ch = _authorizeChange(actorId, address(0), 0, "");
-        bytes memory auth = _authOver(account, pk, ch);
-        vm.expectRevert(Keystore.InvalidAuthenticator.selector);
-        keystore.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+        Keystore.SignedAccountChanges memory s =
+            _unseqBatch(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, UNBOUNDED, "")));
+        vm.expectRevert(Keystore.UnboundedGrantRequiresSequencing.selector);
+        keystore.applySignedAccountChanges(account, s);
     }
 
-    /// @notice An ungated actor (scope & SCOPE_POLICY == 0) with non-empty policyData reverts with InvalidPolicyData.
-    function test_authorizeActor_revert_invalidPolicyData_ungatedWithData(
-        uint256 pk,
-        bytes32 actorId,
-        bytes memory data
-    ) public {
+    /// @notice An unsequenced upsert may not change an occupied slot's scope.
+    function test_authorizeUnsequenced_revert_scopeChangeOnOccupied(uint256 pk) public {
         pk = _boundK1Pk(pk);
-        vm.assume(data.length != 0);
-        (address account, bytes32 ownerId) = _createK1Account(pk);
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+        (address account,) = _createK1Account(pk);
+        _applyUnsequenced(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
 
-        Keystore.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), 0, data);
-        bytes memory auth = _authOver(account, pk, ch);
-        vm.expectRevert(Keystore.InvalidPolicyData.selector);
-        keystore.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+        Keystore.SignedAccountChanges memory s = _unseqBatch(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), NONCE, _future(2 days), ""))
+        );
+        vm.expectRevert(Keystore.ScopeChangeRequiresSequencing.selector);
+        keystore.applySignedAccountChanges(account, s);
     }
 
-    /// @notice A gated actor (scope & SCOPE_POLICY) whose policyData is not exactly 52 bytes reverts.
-    function test_authorizeActor_revert_invalidPolicyData_gatedWrongLength(
-        uint256 pk,
-        bytes32 actorId,
-        bytes memory data
-    ) public {
+    /// @notice Extend-by-upsert is order-independent: applying two grants (T1 < T2) in either order settles at the
+    ///         max expiry (the lower one either lands-then-is-overwritten or reverts NonMonotoneExpiry).
+    function test_authorizeUnsequenced_extendByUpsert_bothOrdersSettleAtMax(uint256 pk) public {
         pk = _boundK1Pk(pk);
-        vm.assume(data.length != 52);
-        (address account, bytes32 ownerId) = _createK1Account(pk);
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+        uint48 t1 = _future(1 days);
+        uint48 t2 = _future(2 days);
 
-        Keystore.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), SCOPE_POLICY, data);
-        bytes memory auth = _authOver(account, pk, ch);
-        vm.expectRevert(Keystore.InvalidPolicyData.selector);
-        keystore.applySignedActorChanges(account, uint64(block.chainid), ch, auth);
+        // Order (T1, T2): both land, expiry ends at T2.
+        (address accA,) = _createK1Account(pk);
+        _applyUnsequenced(pk, accA, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, t1, "")));
+        _applyUnsequenced(pk, accA, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, t2, "")));
+        assertEq(keystore.getActorConfig(accA, ACTOR_A).expiry, t2);
+
+        // Order (T2, T1): T2 lands, T1 reverts NonMonotoneExpiry, expiry still at T2.
+        (address accB,) = _createK1AccountWithSalt(pk, bytes32(uint256(1)));
+        _applyUnsequenced(pk, accB, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, t2, "")));
+        Keystore.SignedAccountChanges memory low =
+            _unseqBatch(pk, accB, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, t1, "")));
+        vm.expectRevert(Keystore.NonMonotoneExpiry.selector);
+        keystore.applySignedAccountChanges(accB, low);
+        assertEq(keystore.getActorConfig(accB, ACTOR_A).expiry, t2);
     }
 
-    /// @notice A gated actor with a zero manager and zero commitment is valid (relaxed policyData rule).
-    /// @dev The 52-byte all-zero policyData is written verbatim; gating is by the SCOPE_POLICY bit.
-    function test_authorizeActor_success_gatedZeroManagerAndCommitment(uint256 pk, bytes32 actorId) public {
+    /// @notice A different authenticator under the same actorId is not possible (id derives from the authenticator);
+    ///         two distinct actorIds land in two independent slots.
+    function test_authorize_success_distinctSlots(uint256 pk) public {
         pk = _boundK1Pk(pk);
-        (address account, bytes32 ownerId) = _createK1Account(pk);
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+        (address account,) = _createK1Account(pk);
 
-        bytes memory data = abi.encodePacked(bytes20(address(0)), bytes32(0));
-        Keystore.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), SCOPE_POLICY, data);
-        _signApply(account, pk, ch);
+        _applyUnsequenced(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
+        _applyUnsequenced(
+            pk, account, _one(_authorizeChange(ACTOR_B, address(p256Authenticator), SENDER, _future(1 days), ""))
+        );
 
-        Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, actorId);
-        assertTrue(cfg.scope & SCOPE_POLICY != 0);
-        assertEq(keystore.getPolicyManager(account, actorId), address(0));
-        assertEq(keystore.getPolicyCommitment(account, actorId), bytes32(0));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).authenticator, address(k1Authenticator));
+        assertEq(keystore.getActorConfig(account, ACTOR_B).authenticator, address(p256Authenticator));
     }
 
-    /// @notice Duplicate actorIds within one batch apply sequentially (last operation wins).
-    function test_applySignedActorChanges_success_duplicateActorIdInBatch(uint256 pk, bytes32 actorId) public {
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // AUTHORIZE — SEQUENCED
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice A sequenced batch consumes the local sequence (low half) and preserves the epoch.
+    function test_authorizeSequenced_success_consumesSequence(uint256 pk) public {
         pk = _boundK1Pk(pk);
-        (address account, bytes32 ownerId) = _createK1Account(pk);
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+        (address account,) = _createK1Account(pk);
+        (uint32 epoch0, uint32 seq0) = keystore.getLocalEpochAndSequence(account);
 
-        // [authorize A, revoke A] → A ends not live.
-        Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](2);
-        ch[0] = _authorizeChange(actorId, address(k1Authenticator), 0, "")[0];
-        ch[1] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
-        _signApply(account, pk, ch);
-        assertFalse(_isActor(account, actorId));
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
 
-        // Pre-authorize, then [revoke A, authorize A] → A ends live.
-        _authorizeActor(account, pk, actorId, address(k1Authenticator));
-        Keystore.ActorChange[] memory ch2 = new Keystore.ActorChange[](2);
-        ch2[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
-        ch2[1] = _authorizeChange(actorId, address(k1Authenticator), 0, "")[0];
-        _signApply(account, pk, ch2);
-        assertTrue(_isActor(account, actorId));
+        (uint32 epoch1, uint32 seq1) = keystore.getLocalEpochAndSequence(account);
+        assertEq(epoch1, epoch0);
+        assertEq(seq1, seq0 + 1);
     }
 
-    /// @notice An unrestricted (scope 0) signer may revoke itself mid-batch; the scope gate is evaluated once,
-    ///         pre-loop.
-    function test_applySignedActorChanges_success_signerRevokesSelfMidBatch(
-        uint256 ownerPk,
-        uint256 signerPk,
-        bytes32 bId
-    ) public {
-        ownerPk = _boundK1Pk(ownerPk);
-        signerPk = _boundK1Pk(signerPk);
-        vm.assume(ownerPk != signerPk);
-        (address account, bytes32 ownerId) = _createK1Account(ownerPk);
-        bytes32 signerId = bytes32(bytes20(vm.addr(signerPk)));
-        vm.assume(signerId != ownerId && signerId != bytes32(bytes20(account)));
-        vm.assume(bId != ownerId && bId != signerId && bId != bytes32(bytes20(account)));
-
-        _authorizeActor(account, ownerPk, signerId, address(k1Authenticator));
-
-        Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](2);
-        ch[0] = Keystore.ActorChange({actorId: signerId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
-        ch[1] = _authorizeChange(bId, address(k1Authenticator), 0, "")[0];
-        _signApply(account, signerPk, ch);
-
-        assertFalse(_isActor(account, signerId));
-        assertTrue(_isActor(account, bId));
-    }
-
-    /// @notice Self-actorId flip: k1 self → non-k1 (p256) self → k1 self; the non-k1 config replaces then is replaced.
-    function test_selfActorId_success_flipFlopK1NonK1(uint256 eoaPk, uint256 adminPk) public {
-        eoaPk = _boundK1Pk(eoaPk);
-        adminPk = _boundK1Pk(adminPk);
-        vm.assume(eoaPk != adminPk);
-        address eoa = vm.addr(eoaPk);
-        bytes32 selfId = bytes32(bytes20(eoa));
-        bytes32 adminId = bytes32(bytes20(vm.addr(adminPk)));
-        vm.assume(adminId != selfId);
-
-        // Implicit self authorizes an unrestricted admin (scope 0) to drive the flips.
-        _implicitAuthorizeActor(eoa, eoaPk, adminId, address(k1Authenticator));
-
-        // Flip self → non-k1 (p256): sets the revoke flag, stores the non-k1 self config; k1 self dies.
-        _authorizeActorWithScope(eoa, adminPk, selfId, address(p256Authenticator), SCOPE_SENDER);
-        assertEq(keystore.getActorConfig(eoa, selfId).authenticator, address(p256Authenticator));
-        bytes32 h = keccak256("flip");
-        vm.expectRevert();
-        keystore.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
-
-        // Flip self → k1 owner: deletes the non-k1 config, restores inline k1 (flag cleared); k1 self lives again.
-        _authorizeActor(eoa, adminPk, selfId, keystore.K1_AUTHENTICATOR());
-        assertEq(keystore.getActorConfig(eoa, selfId).authenticator, keystore.K1_AUTHENTICATOR());
-        (, uint16 scope) = keystore.authenticateActor(eoa, h, _buildK1Auth(eoaPk, h));
-        assertEq(scope, 0);
-    }
-
-    /// @notice A happy-path authorize emits ActorAuthorized once with the correct account and actorId.
-    function test_applySignedActorChanges_success_emitsActorAuthorized(uint256 pk, bytes32 actorId) public {
+    /// @notice A sequenced reinstall over a lapsed slot (later expiry, same scope) is bump-free.
+    function test_authorizeSequenced_success_reinstallOverLapsed(uint256 pk) public {
         pk = _boundK1Pk(pk);
-        (address account, bytes32 ownerId) = _createK1Account(pk);
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
+        (address account,) = _createK1Account(pk);
+        uint48 e1 = _future(1 days);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, e1, "")));
 
-        Keystore.ActorChange[] memory ch = _authorizeChange(actorId, address(k1Authenticator), 0, "");
+        vm.warp(uint256(e1) + 1);
+        assertFalse(_isActor(account, ACTOR_A)); // lapsed
+
+        uint48 e2 = _future(1 days);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, e2, "")));
+        assertTrue(_isActor(account, ACTOR_A));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, e2);
+    }
+
+    /// @notice A sequenced scope widen (adding grant bits) is bump-free.
+    function test_authorizeSequenced_success_scopeWidenBumpFree(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        uint48 e = _future(10 days);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, e, "")));
+
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER | NONCE, e, "")));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).scope, SENDER | NONCE);
+    }
+
+    /// @notice A sequenced expiry raise is bump-free.
+    function test_authorizeSequenced_success_expiryRaiseBumpFree(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+
+        uint48 higher = _future(5 days);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, higher, "")));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, higher);
+    }
+
+    /// @notice A sequenced expiry lowering without an epoch bump reverts ReductionRequiresEpochBump.
+    function test_authorizeSequenced_revert_expiryLowerWithoutBump(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(5 days), "")));
+
+        Keystore.SignedAccountChanges memory s = _localBatch(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
+        vm.expectRevert(Keystore.ReductionRequiresEpochBump.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    /// @notice A sequenced scope narrowing without an epoch bump reverts ReductionRequiresEpochBump.
+    function test_authorizeSequenced_revert_scopeNarrowWithoutBump(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        uint48 e = _future(10 days);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER | NONCE, e, "")));
+
+        Keystore.SignedAccountChanges memory s =
+            _localBatch(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, e, "")));
+        vm.expectRevert(Keystore.ReductionRequiresEpochBump.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    /// @notice A sequenced expiry lowering batched with a BumpLocalEpoch succeeds (reduction retired by the bump).
+    function test_authorizeSequenced_success_lowerPlusBump(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(5 days), "")));
+
+        uint48 lower = _future(1 days);
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        ch[0] = _authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, lower, "");
+        ch[1] = _bumpChange();
+        _applyLocal(pk, account, ch);
+
+        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, lower);
+        (uint32 epoch,) = keystore.getLocalEpochAndSequence(account);
+        assertEq(epoch, 1);
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // REVOKE
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice A bare revoke of a live actor reverts ReductionRequiresEpochBump.
+    function test_revoke_revert_bareRevokeOfLiveActor(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_revokeChange(ACTOR_A)));
+        vm.expectRevert(Keystore.ReductionRequiresEpochBump.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    /// @notice `[revoke, bump]` succeeds; a pre-signed authorize at the old epoch then dies on StaleEpoch.
+    function test_revoke_success_revokeBumpThenReplayFails(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+
+        // A grant signed at the pre-bump epoch (unsequenced), captured before the revoke+bump lands.
+        Keystore.SignedAccountChanges memory oldGrant = _signBatch(
+            pk,
+            account,
+            Keystore.AccountChangeChannel.Local,
+            _unseqWord(account),
+            _one(_authorizeChange(ACTOR_B, address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
+
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        ch[0] = _revokeChange(ACTOR_A);
+        ch[1] = _bumpChange();
+        _applyLocal(pk, account, ch);
+        assertFalse(_isActor(account, ACTOR_A));
+
+        vm.expectRevert(Keystore.StaleEpoch.selector);
+        keystore.applySignedAccountChanges(account, oldGrant);
+    }
+
+    /// @notice Revoking an already-lapsed actor is GC-equivalent and needs no bump (flag skipped).
+    function test_revoke_success_lapsedActorNoBump(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        uint48 e = _future(1 days);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, e, "")));
+
+        vm.warp(uint256(e) + 1);
+        _applyLocal(pk, account, _one(_revokeChange(ACTOR_A))); // no bump needed
+        assertFalse(_isActor(account, ACTOR_A));
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // BUMP LOCAL EPOCH
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice An unsequenced solo bump increments the epoch and resets the sequence to 0.
+    function test_bump_success_unsequencedSolo(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        // Consume a sequence first so we can observe the reset.
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        (uint32 epoch0,) = keystore.getLocalEpochAndSequence(account);
+
+        _applyUnsequenced(pk, account, _one(_bumpChange()));
+
+        (uint32 epoch1, uint32 seq1) = keystore.getLocalEpochAndSequence(account);
+        assertEq(epoch1, epoch0 + 1);
+        assertEq(seq1, 0);
+    }
+
+    /// @notice A non-solo unsequenced bump reverts SoloOpNotSolo.
+    function test_bump_revert_unsequencedNonSolo(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        ch[0] = _authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "");
+        ch[1] = _bumpChange();
+
+        Keystore.SignedAccountChanges memory s = _unseqBatch(pk, account, ch);
+        vm.expectRevert(Keystore.SoloOpNotSolo.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    /// @notice Two independently signed unsequenced bumps at the same epoch: the first lands, the second dies on
+    ///         StaleEpoch.
+    function test_bump_success_twoSignedBumpsSecondFails(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        uint64 word = _unseqWord(account);
+        Keystore.SignedAccountChanges memory b1 =
+            _signBatch(pk, account, Keystore.AccountChangeChannel.Local, word, _one(_bumpChange()));
+        Keystore.SignedAccountChanges memory b2 =
+            _signBatch(pk, account, Keystore.AccountChangeChannel.Local, word, _one(_bumpChange()));
+
+        keystore.applySignedAccountChanges(account, b1);
+        vm.expectRevert(Keystore.StaleEpoch.selector);
+        keystore.applySignedAccountChanges(account, b2);
+    }
+
+    /// @notice A sequenced bump that is not terminal (an authority op follows it) reverts AuthorityOpAfterEnvOp.
+    function test_bump_revert_sequencedNonTerminal(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        ch[0] = _bumpChange();
+        ch[1] = _authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "");
+
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
+        vm.expectRevert(Keystore.AuthorityOpAfterEnvOp.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    /// @notice A bump at the terminal epoch reverts EpochSaturated.
+    function test_bump_revert_epochSaturated(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        _forceLocalEpoch(account, type(uint32).max - 1);
+
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_bumpChange()));
+        vm.expectRevert(Keystore.EpochSaturated.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    /// @notice A bump does not disturb already-landed actors.
+    function test_bump_success_landedActorsUnaffected(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+
+        _applyUnsequenced(pk, account, _one(_bumpChange()));
+
+        assertTrue(_isActor(account, ACTOR_A));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).scope, SENDER);
+    }
+
+    /// @notice Post-bump, an old unsequenced signature on the local channel is invalid (StaleEpoch).
+    function test_bump_success_oldLocalSignatureInvalid(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        Keystore.SignedAccountChanges memory stale = _signBatch(
+            pk,
+            account,
+            Keystore.AccountChangeChannel.Local,
+            _unseqWord(account),
+            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
+        _applyUnsequenced(pk, account, _one(_bumpChange()));
+
+        vm.expectRevert(Keystore.StaleEpoch.selector);
+        keystore.applySignedAccountChanges(account, stale);
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // ORDERING / SOLO
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice `[lock, revoke]` reverts AuthorityOpAfterEnvOp (a revoke after the lock env op).
+    function test_ordering_revert_lockThenRevoke(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        ch[0] = _lockChange(1 hours);
+        ch[1] = _revokeChange(ACTOR_A);
+
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
+        vm.expectRevert(Keystore.AuthorityOpAfterEnvOp.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    /// @notice `[revoke, bump, lock]` succeeds: authority op first, environment ops after, reduction retired by bump.
+    function test_ordering_success_revokeBumpLock(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](3);
+        ch[0] = _revokeChange(ACTOR_A);
+        ch[1] = _bumpChange();
+        ch[2] = _lockChange(1 hours);
+        _applyLocal(pk, account, ch);
+
+        assertFalse(_isActor(account, ACTOR_A));
+        assertTrue(keystore.isLocked(account));
+        (uint32 epoch,) = keystore.getLocalEpochAndSequence(account);
+        assertEq(epoch, 1);
+    }
+
+    /// @notice `[unlock, <anything>]` reverts SoloOpNotSolo — unlock must be the sole op.
+    function test_solo_revert_unlockNotSolo(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        ch[0] = _unlockChange();
+        ch[1] = _bumpChange();
+
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
+        vm.expectRevert(Keystore.SoloOpNotSolo.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // SEQUENCED CHANNEL EDGES
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice A sequenced batch at the terminal local sequence (UNSEQUENCED - 1) reverts SequenceSaturated.
+    function test_sequenced_revert_saturationAtMaxMinusOne(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        _forceLocalSequence(account, keystore.UNSEQUENCED() - 1);
+
+        Keystore.SignedAccountChanges memory s = _localBatch(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
+        vm.expectRevert(Keystore.SequenceSaturated.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    /// @notice The sequence advances BEFORE apply, so re-submitting the exact same sequenced batch reverts BadSequence.
+    function test_sequenced_revert_replaySameBatch(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        Keystore.SignedAccountChanges memory s = _signBatch(
+            pk,
+            account,
+            Keystore.AccountChangeChannel.Local,
+            _localSeqWord(account),
+            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
+
+        keystore.applySignedAccountChanges(account, s);
+        vm.expectRevert(Keystore.BadSequence.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // EVENTS
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice A happy-path authorize emits ActorAuthorized(account, actorId, ...).
+    function test_authorize_success_emitsActorAuthorized(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+
         vm.expectEmit(true, true, false, false, address(keystore));
-        emit Keystore.ActorAuthorized(account, actorId, "");
-        _signApply(account, pk, ch);
+        emit Keystore.ActorAuthorized(account, ACTOR_A, "");
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
     }
 
-    /// @notice A happy-path revoke emits ActorRevoked once with the correct account and actorId.
-    function test_applySignedActorChanges_success_emitsActorRevoked(uint256 pk, bytes32 actorId) public {
+    /// @notice A `[revoke, bump]` batch emits ActorRevoked(account, actorId).
+    function test_revoke_success_emitsActorRevoked(uint256 pk) public {
         pk = _boundK1Pk(pk);
-        (address account, bytes32 ownerId) = _createK1Account(pk);
-        vm.assume(actorId != ownerId && actorId != bytes32(bytes20(account)));
-        _authorizeActor(account, pk, actorId, address(k1Authenticator));
+        (address account,) = _createK1Account(pk);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
 
-        Keystore.ActorChange[] memory ch = new Keystore.ActorChange[](1);
-        ch[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        ch[0] = _revokeChange(ACTOR_A);
+        ch[1] = _bumpChange();
+
         vm.expectEmit(true, true, false, true, address(keystore));
-        emit Keystore.ActorRevoked(account, actorId);
-        _signApply(account, pk, ch);
-    }
-
-    // ── Helpers ──
-
-    /// @dev Build a one-element authorize batch with a full ActorConfig + policyData (expiry fixed at 0).
-    function _authorizeChange(bytes32 actorId, address auth, uint16 scope, bytes memory policyData)
-        internal
-        pure
-        returns (Keystore.ActorChange[] memory changes)
-    {
-        changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            actorId: actorId,
-            changeType: Keystore.ActorChangeType.Authorize,
-            data: abi.encode(Keystore.ActorConfig({authenticator: auth, scope: scope, expiry: 0}), policyData)
-        });
-    }
-
-    /// @dev Owner/actor signature over a batch at the current local sequence.
-    function _authOver(address account, uint256 pk, Keystore.ActorChange[] memory changes)
-        internal
-        view
-        returns (bytes memory)
-    {
-        uint64 seq = keystore.getChangeSequences(account).local;
-        return _buildK1Auth(pk, _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes));
-    }
-
-    /// @dev Sign (with pk) and apply a batch on the local chain.
-    function _signApply(address account, uint256 pk, Keystore.ActorChange[] memory changes) internal {
-        keystore.applySignedActorChanges(account, uint64(block.chainid), changes, _authOver(account, pk, changes));
-    }
-
-    /// @dev Authorize/overwrite the EOA's own inline k1 self-actorId with the given scope, signed by the EOA key.
-    function _rescopeSelf(address eoa, uint256 eoaPk, uint16 scope) internal {
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            actorId: bytes32(bytes20(eoa)),
-            changeType: Keystore.ActorChangeType.Authorize,
-            data: abi.encode(
-                Keystore.ActorConfig({authenticator: keystore.K1_AUTHENTICATOR(), scope: scope, expiry: 0}), bytes("")
-            )
-        });
-        uint64 seq = keystore.getChangeSequences(eoa).local;
-        bytes32 digest = _computeActorChangeBatchDigest(eoa, uint64(block.chainid), seq, changes);
-        keystore.applySignedActorChanges(eoa, uint64(block.chainid), changes, _buildK1Auth(eoaPk, digest));
-    }
-
-    function _authorizeActor(address account, uint256 pk, bytes32 newActorId, address authenticator) internal {
-        _authorizeActorWithScope(account, pk, newActorId, authenticator, 0x00);
-    }
-
-    function _authorizeActorWithScope(
-        address account,
-        uint256 pk,
-        bytes32 newActorId,
-        address authenticator,
-        uint16 scope
-    ) internal {
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            actorId: newActorId,
-            changeType: Keystore.ActorChangeType.Authorize,
-            data: abi.encode(Keystore.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes(""))
-        });
-
-        uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(pk, digest);
-
-        keystore.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
-    }
-
-    function _revokeActor(address account, uint256 pk, bytes32 actorId) internal {
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
-
-        uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(pk, digest);
-
-        keystore.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
-    }
-
-    function _implicitAuthorizeActor(address account, uint256 pk, bytes32 newActorId, address authenticator) internal {
-        _implicitAuthorizeActorWithScope(account, pk, newActorId, authenticator, 0x00);
-    }
-
-    function _implicitAuthorizeActorWithScope(
-        address account,
-        uint256 pk,
-        bytes32 newActorId,
-        address authenticator,
-        uint16 scope
-    ) internal {
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            actorId: newActorId,
-            changeType: Keystore.ActorChangeType.Authorize,
-            data: abi.encode(Keystore.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes(""))
-        });
-
-        uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(pk, digest);
-
-        keystore.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
-    }
-
-    /// @dev Hard-lock `account` via the signed lock path, authorized by its admin owner key `pk`.
-    function _lockAccount(uint256 pk, address account) internal {
-        _signedLock(pk, account, 1 hours);
+        emit Keystore.ActorRevoked(account, ACTOR_A);
+        _applyLocal(pk, account, ch);
     }
 }

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -418,8 +418,10 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         keystore.applySignedAccountChanges(account, b2);
     }
 
-    /// @notice A sequenced bump that is not terminal (an authority op follows it) reverts AuthorityOpAfterEnvOp.
-    function test_bump_revert_sequencedNonTerminal(uint256 pk) public {
+    /// @notice A sequenced batch may interleave an environment op before an authority op: `[bump, authorize]` bumps
+    ///         the epoch (resetting the sequence) and then installs the actor in the same batch. There is no
+    ///         authority-before-environment ordering constraint (the two op classes commute).
+    function test_bump_success_sequencedNonTerminal(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
@@ -427,8 +429,13 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         ch[1] = _authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "");
 
         Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
-        vm.expectRevert(Keystore.AuthorityOpAfterEnvOp.selector);
         keystore.applySignedAccountChanges(account, s);
+
+        (uint32 epoch, uint32 seq) = _localEpochSeq(account);
+        assertEq(epoch, 1);
+        assertEq(seq, 0);
+        assertTrue(_isActor(account, ACTOR_A));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).scope, SENDER);
     }
 
     /// @notice A bump at the terminal epoch (the full uint32 max — the epoch half reserves no sentinel) reverts
@@ -476,8 +483,10 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
     // ORDERING / BATCHING
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice `[lock, revoke]` reverts AuthorityOpAfterEnvOp (a revoke after the lock env op).
-    function test_ordering_revert_lockThenRevoke(uint256 pk) public {
+    /// @notice `[lock, revoke]` on an account that was UNLOCKED at entry succeeds: the authority-op gate reads the
+    ///         batch-entry snapshot, so a Lock earlier in the same batch does not block the following revoke (the lock
+    ///         takes effect only for later batches). Order within the batch is irrelevant to the authority op.
+    function test_ordering_success_lockThenRevoke(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
@@ -485,10 +494,10 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _lockChange(1 hours);
         ch[1] = _revokeChange(ACTOR_A);
+        _applyLocal(pk, account, ch);
 
-        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
-        vm.expectRevert(Keystore.AuthorityOpAfterEnvOp.selector);
-        keystore.applySignedAccountChanges(account, s);
+        assertFalse(_isActor(account, ACTOR_A));
+        assertTrue(keystore.isLocked(account));
     }
 
     /// @notice `[revoke, bump, lock]` succeeds: authority op first, environment ops after, reduction retired by bump.

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -7,8 +7,8 @@ import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
 /// @notice §10 test matrix for the authority / environment ops driven through {applySignedAccountChanges}:
 ///         AuthorizeActor (sequenced + unsequenced), RevokeActor, BumpLocalEpoch, the op-ordering / solo fences,
-///         the reduction rule, and the sequenced-channel replay/saturation edges. Lock/unlock (admin-only),
-///         garbage collection, and multichain regression live in applyAccountChange.t.sol.
+///         and the sequenced-channel replay/saturation edges. Lock/unlock (admin-only),
+///         and multichain regression live in applyAccountChange.t.sol.
 contract ApplySignedAccountChangesTest is KeystoreTest {
     // Non-self, non-owner actor ids (low right-aligned constants never collide with a bytes20-left-aligned address).
     bytes32 constant ACTOR_A = bytes32(uint256(0xA1));
@@ -66,9 +66,9 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         keystore.applySignedAccountChanges(account, s);
     }
 
-    /// @notice Replaying an unsequenced grant after the slot was garbage-collected reverts ExpiredChange (the fixed
+    /// @notice Replaying an unsequenced grant after its granted expiry has passed reverts ExpiredChange (the fixed
     ///         granted expiry is now in the past).
-    function test_authorizeUnsequenced_revert_replayAfterGC(uint256 pk) public {
+    function test_authorizeUnsequenced_revert_replayAfterExpiry(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         uint48 expiry = _future(1 days);
@@ -82,8 +82,6 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         keystore.applySignedAccountChanges(account, s);
 
         vm.warp(uint256(expiry) + 1);
-        keystore.collectActor(account, ACTOR_A);
-        assertFalse(_isActor(account, ACTOR_A));
 
         vm.expectRevert(Keystore.ExpiredChange.selector);
         keystore.applySignedAccountChanges(account, s);
@@ -240,33 +238,29 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, higher);
     }
 
-    /// @notice A sequenced expiry lowering without an epoch bump reverts ReductionRequiresEpochBump.
-    function test_authorizeSequenced_revert_expiryLowerWithoutBump(uint256 pk) public {
+    /// @notice A sequenced expiry lowering lands on its own (reduction is not contract-enforced to bump).
+    function test_authorizeSequenced_success_expiryLower(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(5 days), "")));
 
-        Keystore.SignedAccountChanges memory s = _localBatch(
-            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
-        );
-        vm.expectRevert(Keystore.ReductionRequiresEpochBump.selector);
-        keystore.applySignedAccountChanges(account, s);
+        uint48 lower = _future(1 days);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, lower, "")));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, lower);
     }
 
-    /// @notice A sequenced scope narrowing without an epoch bump reverts ReductionRequiresEpochBump.
-    function test_authorizeSequenced_revert_scopeNarrowWithoutBump(uint256 pk) public {
+    /// @notice A sequenced scope narrowing lands on its own (reduction is not contract-enforced to bump).
+    function test_authorizeSequenced_success_scopeNarrow(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         uint48 e = _future(10 days);
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER | NONCE, e, "")));
 
-        Keystore.SignedAccountChanges memory s =
-            _localBatch(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, e, "")));
-        vm.expectRevert(Keystore.ReductionRequiresEpochBump.selector);
-        keystore.applySignedAccountChanges(account, s);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, e, "")));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).scope, SENDER);
     }
 
-    /// @notice A sequenced expiry lowering batched with a BumpLocalEpoch succeeds (reduction retired by the bump).
+    /// @notice A sequenced expiry lowering may still be batched with a BumpLocalEpoch (the durable teardown form).
     function test_authorizeSequenced_success_lowerPlusBump(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
@@ -287,15 +281,41 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
     // REVOKE
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice A bare revoke of a live actor reverts ReductionRequiresEpochBump.
-    function test_revoke_revert_bareRevokeOfLiveActor(uint256 pk) public {
+    /// @notice A bare revoke of a live actor lands and clears the slot (reduction is not contract-enforced to bump).
+    function test_revoke_success_bareRevokeOfLiveActor(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
 
-        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_revokeChange(ACTOR_A)));
-        vm.expectRevert(Keystore.ReductionRequiresEpochBump.selector);
-        keystore.applySignedAccountChanges(account, s);
+        _applyLocal(pk, account, _one(_revokeChange(ACTOR_A)));
+        assertFalse(_isActor(account, ACTOR_A));
+    }
+
+    /// @notice Documents the accepted footgun: a bare revoke is NOT durable while a replayable unsequenced grant for
+    ///         the same actor is outstanding — replaying it re-installs the actor into the emptied slot. Durable
+    ///         teardown requires a BumpLocalEpoch (see test_revoke_success_revokeBumpThenReplayFails).
+    function test_revoke_bareRevokeNotDurable_replayReinstalls(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+
+        // An outstanding unsequenced grant for ACTOR_A, captured before it first lands.
+        Keystore.SignedAccountChanges memory grant = _signBatch(
+            pk,
+            account,
+            Keystore.AccountChangeChannel.Local,
+            _unseqWord(account),
+            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+        );
+        keystore.applySignedAccountChanges(account, grant);
+        assertTrue(_isActor(account, ACTOR_A));
+
+        // Bare revoke lands...
+        _applyLocal(pk, account, _one(_revokeChange(ACTOR_A)));
+        assertFalse(_isActor(account, ACTOR_A));
+
+        // ...but the epoch never moved, so the original grant replays straight back into the emptied slot.
+        keystore.applySignedAccountChanges(account, grant);
+        assertTrue(_isActor(account, ACTOR_A));
     }
 
     /// @notice `[revoke, bump]` succeeds; a pre-signed authorize at the old epoch then dies on StaleEpoch.
@@ -323,7 +343,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         keystore.applySignedAccountChanges(account, oldGrant);
     }
 
-    /// @notice Revoking an already-lapsed actor is GC-equivalent and needs no bump (flag skipped).
+    /// @notice Revoking an already-lapsed actor is GC-equivalent and lands as a bare single-op batch.
     function test_revoke_success_lapsedActorNoBump(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -5,11 +5,11 @@ import {Keystore} from "../../../src/Keystore.sol";
 import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
-/// @notice §10 test matrix for the authority / environment ops driven through {applySignedAccountChanges}:
-///         AuthorizeActor (sequenced + unsequenced), RevokeActor, BumpLocalEpoch, the op-ordering fence,
+/// @notice §10 test matrix for the authority / environment ops driven through {applySignedConfigChanges}:
+///         AuthorizeActor (sequenced + unsequenced), RevokeActor, IncrementLocalEpoch, the op-ordering fence,
 ///         and the sequenced-channel replay/saturation edges. Lock/unlock (admin-only),
-///         and multichain regression live in applyAccountChange.t.sol.
-contract ApplySignedAccountChangesTest is KeystoreTest {
+///         and multichain regression live in applyConfigChange.t.sol.
+contract ApplySignedConfigChangesTest is KeystoreTest {
     // Non-self, non-owner actor ids (low right-aligned constants never collide with a bytes20-left-aligned address).
     bytes32 constant ACTOR_A = bytes32(uint256(0xA1));
     bytes32 constant ACTOR_B = bytes32(uint256(0xB2));
@@ -55,15 +55,15 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         uint48 expiry = _future(1 days);
-        Keystore.SignedAccountChanges memory s = _signBatch(
+        Keystore.SignedConfigChanges memory s = _signBatch(
             pk,
             account,
-            Keystore.AccountChangeChannel.Local,
+            Keystore.ConfigChangeChannel.Local,
             _unseqWord(account),
             _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, expiry, ""))
         );
-        keystore.applySignedAccountChanges(account, s);
-        keystore.applySignedAccountChanges(account, s);
+        keystore.applySignedConfigChanges(account, s);
+        keystore.applySignedConfigChanges(account, s);
 
         Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, ACTOR_A);
         assertEq(cfg.scope, SENDER);
@@ -76,19 +76,19 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         uint48 expiry = _future(1 days);
-        Keystore.SignedAccountChanges memory s = _signBatch(
+        Keystore.SignedConfigChanges memory s = _signBatch(
             pk,
             account,
-            Keystore.AccountChangeChannel.Local,
+            Keystore.ConfigChangeChannel.Local,
             _unseqWord(account),
             _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, expiry, ""))
         );
-        keystore.applySignedAccountChanges(account, s);
+        keystore.applySignedConfigChanges(account, s);
 
         vm.warp(uint256(expiry) + 1);
 
         vm.expectRevert(Keystore.ExpiredChange.selector);
-        keystore.applySignedAccountChanges(account, s);
+        keystore.applySignedConfigChanges(account, s);
     }
 
     /// @notice An unsequenced batch signed at a stale epoch reverts StaleEpoch.
@@ -96,17 +96,17 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         // Pre-sign at epoch 0, then bump the epoch out from under it.
-        Keystore.SignedAccountChanges memory s = _signBatch(
+        Keystore.SignedConfigChanges memory s = _signBatch(
             pk,
             account,
-            Keystore.AccountChangeChannel.Local,
+            Keystore.ConfigChangeChannel.Local,
             _unseqWord(account),
             _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
         );
         _applyUnsequenced(pk, account, _one(_bumpChange())); // epoch 0 -> 1
 
         vm.expectRevert(Keystore.StaleEpoch.selector);
-        keystore.applySignedAccountChanges(account, s);
+        keystore.applySignedConfigChanges(account, s);
     }
 
     /// @notice A non-zero grant expiry that is not strictly in the future reverts ExpiredChange (expiry == now).
@@ -114,11 +114,11 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
 
-        Keystore.SignedAccountChanges memory s = _unseqBatch(
+        Keystore.SignedConfigChanges memory s = _unseqBatch(
             pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, uint48(block.timestamp), ""))
         );
         vm.expectRevert(Keystore.ExpiredChange.selector);
-        keystore.applySignedAccountChanges(account, s);
+        keystore.applySignedConfigChanges(account, s);
     }
 
     /// @notice An unsequenced grant may request the unbounded (max) expiry.
@@ -272,14 +272,14 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         assertEq(keystore.getActorConfig(account, ACTOR_A).scope, SENDER);
     }
 
-    /// @notice A sequenced expiry lowering may still be batched with a BumpLocalEpoch (the durable teardown form).
+    /// @notice A sequenced expiry lowering may still be batched with an IncrementLocalEpoch (the durable teardown form).
     function test_authorizeSequenced_success_lowerPlusBump(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(5 days), "")));
 
         uint48 lower = _future(1 days);
-        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](2);
         ch[0] = _authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, lower, "");
         ch[1] = _bumpChange();
         _applyLocal(pk, account, ch);
@@ -305,20 +305,20 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
 
     /// @notice Documents the accepted footgun: a bare revoke is NOT durable while a replayable unsequenced grant for
     ///         the same actor is outstanding — replaying it re-installs the actor into the emptied slot. Durable
-    ///         teardown requires a BumpLocalEpoch (see test_revoke_success_revokeBumpThenReplayFails).
+    ///         teardown requires an IncrementLocalEpoch (see test_revoke_success_revokeBumpThenReplayFails).
     function test_revoke_bareRevokeNotDurable_replayReinstalls(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
 
         // An outstanding unsequenced grant for ACTOR_A, captured before it first lands.
-        Keystore.SignedAccountChanges memory grant = _signBatch(
+        Keystore.SignedConfigChanges memory grant = _signBatch(
             pk,
             account,
-            Keystore.AccountChangeChannel.Local,
+            Keystore.ConfigChangeChannel.Local,
             _unseqWord(account),
             _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
         );
-        keystore.applySignedAccountChanges(account, grant);
+        keystore.applySignedConfigChanges(account, grant);
         assertTrue(_isActor(account, ACTOR_A));
 
         // Bare revoke lands...
@@ -326,7 +326,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         assertFalse(_isActor(account, ACTOR_A));
 
         // ...but the epoch never moved, so the original grant replays straight back into the emptied slot.
-        keystore.applySignedAccountChanges(account, grant);
+        keystore.applySignedConfigChanges(account, grant);
         assertTrue(_isActor(account, ACTOR_A));
     }
 
@@ -337,22 +337,22 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
 
         // A grant signed at the pre-bump epoch (unsequenced), captured before the revoke+bump lands.
-        Keystore.SignedAccountChanges memory oldGrant = _signBatch(
+        Keystore.SignedConfigChanges memory oldGrant = _signBatch(
             pk,
             account,
-            Keystore.AccountChangeChannel.Local,
+            Keystore.ConfigChangeChannel.Local,
             _unseqWord(account),
             _one(_authorizeChange(ACTOR_B, address(k1Authenticator), SENDER, _future(1 days), ""))
         );
 
-        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](2);
         ch[0] = _revokeChange(ACTOR_A);
         ch[1] = _bumpChange();
         _applyLocal(pk, account, ch);
         assertFalse(_isActor(account, ACTOR_A));
 
         vm.expectRevert(Keystore.StaleEpoch.selector);
-        keystore.applySignedAccountChanges(account, oldGrant);
+        keystore.applySignedConfigChanges(account, oldGrant);
     }
 
     /// @notice Revoking an already-lapsed actor is GC-equivalent and lands as a bare single-op batch.
@@ -390,7 +390,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
     function test_bump_success_unsequencedNonSolo(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](2);
         ch[0] = _authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "");
         ch[1] = _bumpChange();
 
@@ -408,38 +408,39 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         uint64 word = _unseqWord(account);
-        Keystore.SignedAccountChanges memory b1 =
-            _signBatch(pk, account, Keystore.AccountChangeChannel.Local, word, _one(_bumpChange()));
-        Keystore.SignedAccountChanges memory b2 =
-            _signBatch(pk, account, Keystore.AccountChangeChannel.Local, word, _one(_bumpChange()));
+        Keystore.SignedConfigChanges memory b1 =
+            _signBatch(pk, account, Keystore.ConfigChangeChannel.Local, word, _one(_bumpChange()));
+        Keystore.SignedConfigChanges memory b2 =
+            _signBatch(pk, account, Keystore.ConfigChangeChannel.Local, word, _one(_bumpChange()));
 
-        keystore.applySignedAccountChanges(account, b1);
+        keystore.applySignedConfigChanges(account, b1);
         vm.expectRevert(Keystore.StaleEpoch.selector);
-        keystore.applySignedAccountChanges(account, b2);
+        keystore.applySignedConfigChanges(account, b2);
     }
 
     /// @notice A sequenced bump that is not terminal (an authority op follows it) reverts AuthorityOpAfterEnvOp.
     function test_bump_revert_sequencedNonTerminal(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](2);
         ch[0] = _bumpChange();
         ch[1] = _authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "");
 
-        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
+        Keystore.SignedConfigChanges memory s = _localBatch(pk, account, ch);
         vm.expectRevert(Keystore.AuthorityOpAfterEnvOp.selector);
-        keystore.applySignedAccountChanges(account, s);
+        keystore.applySignedConfigChanges(account, s);
     }
 
-    /// @notice A bump at the terminal epoch reverts EpochSaturated.
+    /// @notice A bump at the terminal epoch (the full uint32 max — the epoch half reserves no sentinel) reverts
+    ///         EpochSaturated.
     function test_bump_revert_epochSaturated(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        _forceLocalEpoch(account, type(uint32).max - 1);
+        _forceLocalEpoch(account, type(uint32).max);
 
-        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_bumpChange()));
+        Keystore.SignedConfigChanges memory s = _localBatch(pk, account, _one(_bumpChange()));
         vm.expectRevert(Keystore.EpochSaturated.selector);
-        keystore.applySignedAccountChanges(account, s);
+        keystore.applySignedConfigChanges(account, s);
     }
 
     /// @notice A bump does not disturb already-landed actors.
@@ -458,17 +459,17 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
     function test_bump_success_oldLocalSignatureInvalid(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        Keystore.SignedAccountChanges memory stale = _signBatch(
+        Keystore.SignedConfigChanges memory stale = _signBatch(
             pk,
             account,
-            Keystore.AccountChangeChannel.Local,
+            Keystore.ConfigChangeChannel.Local,
             _unseqWord(account),
             _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
         );
         _applyUnsequenced(pk, account, _one(_bumpChange()));
 
         vm.expectRevert(Keystore.StaleEpoch.selector);
-        keystore.applySignedAccountChanges(account, stale);
+        keystore.applySignedConfigChanges(account, stale);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -481,13 +482,13 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
 
-        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](2);
         ch[0] = _lockChange(1 hours);
         ch[1] = _revokeChange(ACTOR_A);
 
-        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
+        Keystore.SignedConfigChanges memory s = _localBatch(pk, account, ch);
         vm.expectRevert(Keystore.AuthorityOpAfterEnvOp.selector);
-        keystore.applySignedAccountChanges(account, s);
+        keystore.applySignedConfigChanges(account, s);
     }
 
     /// @notice `[revoke, bump, lock]` succeeds: authority op first, environment ops after, reduction retired by bump.
@@ -496,7 +497,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
 
-        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](3);
+        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](3);
         ch[0] = _revokeChange(ACTOR_A);
         ch[1] = _bumpChange();
         ch[2] = _lockChange(1 hours);
@@ -516,7 +517,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         _signedLock(pk, account, 1 hours);
         assertTrue(keystore.isLocked(account));
 
-        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](2);
         ch[0] = _unlockChange();
         ch[1] = _bumpChange();
         _applyLocal(pk, account, ch);
@@ -537,28 +538,28 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
         _forceLocalSequence(account, keystore.UNSEQUENCED() - 1);
 
-        Keystore.SignedAccountChanges memory s = _localBatch(
+        Keystore.SignedConfigChanges memory s = _localBatch(
             pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
         );
         vm.expectRevert(Keystore.SequenceSaturated.selector);
-        keystore.applySignedAccountChanges(account, s);
+        keystore.applySignedConfigChanges(account, s);
     }
 
     /// @notice The sequence advances BEFORE apply, so re-submitting the exact same sequenced batch reverts BadSequence.
     function test_sequenced_revert_replaySameBatch(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        Keystore.SignedAccountChanges memory s = _signBatch(
+        Keystore.SignedConfigChanges memory s = _signBatch(
             pk,
             account,
-            Keystore.AccountChangeChannel.Local,
+            Keystore.ConfigChangeChannel.Local,
             _localSeqWord(account),
             _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
         );
 
-        keystore.applySignedAccountChanges(account, s);
+        keystore.applySignedConfigChanges(account, s);
         vm.expectRevert(Keystore.BadSequence.selector);
-        keystore.applySignedAccountChanges(account, s);
+        keystore.applySignedConfigChanges(account, s);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -581,7 +582,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
 
-        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](2);
         ch[0] = _revokeChange(ACTOR_A);
         ch[1] = _bumpChange();
 

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -109,7 +109,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         keystore.applySignedAccountChanges(account, s);
     }
 
-    /// @notice A grant whose expiry is not strictly in the future reverts ExpiredChange (covers expiry == now and 0).
+    /// @notice A non-zero grant expiry that is not strictly in the future reverts ExpiredChange (expiry == now).
     function test_authorizeUnsequenced_revert_pastExpiry(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
@@ -128,6 +128,20 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
 
         _applyUnsequenced(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, UNBOUNDED, "")));
         assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, UNBOUNDED);
+    }
+
+    /// @notice A grant may use expiry 0, the "no expiry" sentinel: it lands and never lapses.
+    function test_authorizeUnsequenced_success_zeroExpiryUnlimited(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+
+        _applyUnsequenced(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, 0, "")));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, 0);
+
+        // Never lapses: still authorized far in the future.
+        vm.warp(block.timestamp + 3650 days);
+        assertTrue(_isActor(account, ACTOR_A));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).authenticator, address(k1Authenticator));
     }
 
     /// @notice An unsequenced upsert may change an occupied slot's scope (last-write-wins, no sequencing gate).

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -472,7 +472,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // ORDERING / SOLO
+    // ORDERING / BATCHING
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     /// @notice `[lock, revoke]` reverts AuthorityOpAfterEnvOp (a revoke after the lock env op).

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -10,7 +10,8 @@ import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 ///         and the sequenced-channel replay/saturation edges. Lock/unlock (admin-only),
 ///         and multichain regression live in applyAccountChange.t.sol.
 contract ApplySignedAccountChangesTest is KeystoreTest {
-    // Non-self, non-owner actor ids (low right-aligned constants never collide with a bytes20-left-aligned address).
+    // Non-self, non-owner actor ids: small distinct constants that never collide with a real (address-derived) actorId
+    // used in these tests.
     bytes32 constant ACTOR_A = bytes32(uint256(0xA1));
     bytes32 constant ACTOR_B = bytes32(uint256(0xB2));
 

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -5,11 +5,11 @@ import {Keystore} from "../../../src/Keystore.sol";
 import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
-/// @notice §10 test matrix for the authority / environment ops driven through {applySignedConfigChanges}:
+/// @notice §10 test matrix for the authority / environment ops driven through {applySignedAccountChanges}:
 ///         AuthorizeActor (sequenced + unsequenced), RevokeActor, IncrementLocalEpoch, the op-ordering fence,
 ///         and the sequenced-channel replay/saturation edges. Lock/unlock (admin-only),
-///         and multichain regression live in applyConfigChange.t.sol.
-contract ApplySignedConfigChangesTest is KeystoreTest {
+///         and multichain regression live in applyAccountChange.t.sol.
+contract ApplySignedAccountChangesTest is KeystoreTest {
     // Non-self, non-owner actor ids (low right-aligned constants never collide with a bytes20-left-aligned address).
     bytes32 constant ACTOR_A = bytes32(uint256(0xA1));
     bytes32 constant ACTOR_B = bytes32(uint256(0xB2));
@@ -55,15 +55,15 @@ contract ApplySignedConfigChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         uint48 expiry = _future(1 days);
-        Keystore.SignedConfigChanges memory s = _signBatch(
+        Keystore.SignedAccountChanges memory s = _signBatch(
             pk,
             account,
-            Keystore.ConfigChangeChannel.Local,
+            Keystore.AccountChangeChannel.Local,
             _unseqWord(account),
             _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, expiry, ""))
         );
-        keystore.applySignedConfigChanges(account, s);
-        keystore.applySignedConfigChanges(account, s);
+        keystore.applySignedAccountChanges(account, s);
+        keystore.applySignedAccountChanges(account, s);
 
         Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, ACTOR_A);
         assertEq(cfg.scope, SENDER);
@@ -76,19 +76,19 @@ contract ApplySignedConfigChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         uint48 expiry = _future(1 days);
-        Keystore.SignedConfigChanges memory s = _signBatch(
+        Keystore.SignedAccountChanges memory s = _signBatch(
             pk,
             account,
-            Keystore.ConfigChangeChannel.Local,
+            Keystore.AccountChangeChannel.Local,
             _unseqWord(account),
             _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, expiry, ""))
         );
-        keystore.applySignedConfigChanges(account, s);
+        keystore.applySignedAccountChanges(account, s);
 
         vm.warp(uint256(expiry) + 1);
 
         vm.expectRevert(Keystore.ExpiredChange.selector);
-        keystore.applySignedConfigChanges(account, s);
+        keystore.applySignedAccountChanges(account, s);
     }
 
     /// @notice An unsequenced batch signed at a stale epoch reverts StaleEpoch.
@@ -96,17 +96,17 @@ contract ApplySignedConfigChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         // Pre-sign at epoch 0, then bump the epoch out from under it.
-        Keystore.SignedConfigChanges memory s = _signBatch(
+        Keystore.SignedAccountChanges memory s = _signBatch(
             pk,
             account,
-            Keystore.ConfigChangeChannel.Local,
+            Keystore.AccountChangeChannel.Local,
             _unseqWord(account),
             _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
         );
         _applyUnsequenced(pk, account, _one(_bumpChange())); // epoch 0 -> 1
 
         vm.expectRevert(Keystore.StaleEpoch.selector);
-        keystore.applySignedConfigChanges(account, s);
+        keystore.applySignedAccountChanges(account, s);
     }
 
     /// @notice A non-zero grant expiry that is not strictly in the future reverts ExpiredChange (expiry == now).
@@ -114,11 +114,11 @@ contract ApplySignedConfigChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
 
-        Keystore.SignedConfigChanges memory s = _unseqBatch(
+        Keystore.SignedAccountChanges memory s = _unseqBatch(
             pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, uint48(block.timestamp), ""))
         );
         vm.expectRevert(Keystore.ExpiredChange.selector);
-        keystore.applySignedConfigChanges(account, s);
+        keystore.applySignedAccountChanges(account, s);
     }
 
     /// @notice An unsequenced grant may request the unbounded (max) expiry.
@@ -279,7 +279,7 @@ contract ApplySignedConfigChangesTest is KeystoreTest {
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(5 days), "")));
 
         uint48 lower = _future(1 days);
-        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](2);
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, lower, "");
         ch[1] = _bumpChange();
         _applyLocal(pk, account, ch);
@@ -311,14 +311,14 @@ contract ApplySignedConfigChangesTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
 
         // An outstanding unsequenced grant for ACTOR_A, captured before it first lands.
-        Keystore.SignedConfigChanges memory grant = _signBatch(
+        Keystore.SignedAccountChanges memory grant = _signBatch(
             pk,
             account,
-            Keystore.ConfigChangeChannel.Local,
+            Keystore.AccountChangeChannel.Local,
             _unseqWord(account),
             _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
         );
-        keystore.applySignedConfigChanges(account, grant);
+        keystore.applySignedAccountChanges(account, grant);
         assertTrue(_isActor(account, ACTOR_A));
 
         // Bare revoke lands...
@@ -326,7 +326,7 @@ contract ApplySignedConfigChangesTest is KeystoreTest {
         assertFalse(_isActor(account, ACTOR_A));
 
         // ...but the epoch never moved, so the original grant replays straight back into the emptied slot.
-        keystore.applySignedConfigChanges(account, grant);
+        keystore.applySignedAccountChanges(account, grant);
         assertTrue(_isActor(account, ACTOR_A));
     }
 
@@ -337,22 +337,22 @@ contract ApplySignedConfigChangesTest is KeystoreTest {
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
 
         // A grant signed at the pre-bump epoch (unsequenced), captured before the revoke+bump lands.
-        Keystore.SignedConfigChanges memory oldGrant = _signBatch(
+        Keystore.SignedAccountChanges memory oldGrant = _signBatch(
             pk,
             account,
-            Keystore.ConfigChangeChannel.Local,
+            Keystore.AccountChangeChannel.Local,
             _unseqWord(account),
             _one(_authorizeChange(ACTOR_B, address(k1Authenticator), SENDER, _future(1 days), ""))
         );
 
-        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](2);
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _revokeChange(ACTOR_A);
         ch[1] = _bumpChange();
         _applyLocal(pk, account, ch);
         assertFalse(_isActor(account, ACTOR_A));
 
         vm.expectRevert(Keystore.StaleEpoch.selector);
-        keystore.applySignedConfigChanges(account, oldGrant);
+        keystore.applySignedAccountChanges(account, oldGrant);
     }
 
     /// @notice Revoking an already-lapsed actor is GC-equivalent and lands as a bare single-op batch.
@@ -390,7 +390,7 @@ contract ApplySignedConfigChangesTest is KeystoreTest {
     function test_bump_success_unsequencedNonSolo(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](2);
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "");
         ch[1] = _bumpChange();
 
@@ -408,27 +408,27 @@ contract ApplySignedConfigChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         uint64 word = _unseqWord(account);
-        Keystore.SignedConfigChanges memory b1 =
-            _signBatch(pk, account, Keystore.ConfigChangeChannel.Local, word, _one(_bumpChange()));
-        Keystore.SignedConfigChanges memory b2 =
-            _signBatch(pk, account, Keystore.ConfigChangeChannel.Local, word, _one(_bumpChange()));
+        Keystore.SignedAccountChanges memory b1 =
+            _signBatch(pk, account, Keystore.AccountChangeChannel.Local, word, _one(_bumpChange()));
+        Keystore.SignedAccountChanges memory b2 =
+            _signBatch(pk, account, Keystore.AccountChangeChannel.Local, word, _one(_bumpChange()));
 
-        keystore.applySignedConfigChanges(account, b1);
+        keystore.applySignedAccountChanges(account, b1);
         vm.expectRevert(Keystore.StaleEpoch.selector);
-        keystore.applySignedConfigChanges(account, b2);
+        keystore.applySignedAccountChanges(account, b2);
     }
 
     /// @notice A sequenced bump that is not terminal (an authority op follows it) reverts AuthorityOpAfterEnvOp.
     function test_bump_revert_sequencedNonTerminal(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](2);
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _bumpChange();
         ch[1] = _authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "");
 
-        Keystore.SignedConfigChanges memory s = _localBatch(pk, account, ch);
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
         vm.expectRevert(Keystore.AuthorityOpAfterEnvOp.selector);
-        keystore.applySignedConfigChanges(account, s);
+        keystore.applySignedAccountChanges(account, s);
     }
 
     /// @notice A bump at the terminal epoch (the full uint32 max — the epoch half reserves no sentinel) reverts
@@ -438,9 +438,9 @@ contract ApplySignedConfigChangesTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
         _forceLocalEpoch(account, type(uint32).max);
 
-        Keystore.SignedConfigChanges memory s = _localBatch(pk, account, _one(_bumpChange()));
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_bumpChange()));
         vm.expectRevert(Keystore.EpochSaturated.selector);
-        keystore.applySignedConfigChanges(account, s);
+        keystore.applySignedAccountChanges(account, s);
     }
 
     /// @notice A bump does not disturb already-landed actors.
@@ -459,17 +459,17 @@ contract ApplySignedConfigChangesTest is KeystoreTest {
     function test_bump_success_oldLocalSignatureInvalid(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        Keystore.SignedConfigChanges memory stale = _signBatch(
+        Keystore.SignedAccountChanges memory stale = _signBatch(
             pk,
             account,
-            Keystore.ConfigChangeChannel.Local,
+            Keystore.AccountChangeChannel.Local,
             _unseqWord(account),
             _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
         );
         _applyUnsequenced(pk, account, _one(_bumpChange()));
 
         vm.expectRevert(Keystore.StaleEpoch.selector);
-        keystore.applySignedConfigChanges(account, stale);
+        keystore.applySignedAccountChanges(account, stale);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -482,13 +482,13 @@ contract ApplySignedConfigChangesTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
 
-        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](2);
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _lockChange(1 hours);
         ch[1] = _revokeChange(ACTOR_A);
 
-        Keystore.SignedConfigChanges memory s = _localBatch(pk, account, ch);
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
         vm.expectRevert(Keystore.AuthorityOpAfterEnvOp.selector);
-        keystore.applySignedConfigChanges(account, s);
+        keystore.applySignedAccountChanges(account, s);
     }
 
     /// @notice `[revoke, bump, lock]` succeeds: authority op first, environment ops after, reduction retired by bump.
@@ -497,7 +497,7 @@ contract ApplySignedConfigChangesTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
 
-        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](3);
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](3);
         ch[0] = _revokeChange(ACTOR_A);
         ch[1] = _bumpChange();
         ch[2] = _lockChange(1 hours);
@@ -517,7 +517,7 @@ contract ApplySignedConfigChangesTest is KeystoreTest {
         _signedLock(pk, account, 1 hours);
         assertTrue(keystore.isLocked(account));
 
-        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](2);
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _unlockChange();
         ch[1] = _bumpChange();
         _applyLocal(pk, account, ch);
@@ -538,28 +538,28 @@ contract ApplySignedConfigChangesTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
         _forceLocalSequence(account, keystore.UNSEQUENCED() - 1);
 
-        Keystore.SignedConfigChanges memory s = _localBatch(
+        Keystore.SignedAccountChanges memory s = _localBatch(
             pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
         );
         vm.expectRevert(Keystore.SequenceSaturated.selector);
-        keystore.applySignedConfigChanges(account, s);
+        keystore.applySignedAccountChanges(account, s);
     }
 
     /// @notice The sequence advances BEFORE apply, so re-submitting the exact same sequenced batch reverts BadSequence.
     function test_sequenced_revert_replaySameBatch(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        Keystore.SignedConfigChanges memory s = _signBatch(
+        Keystore.SignedAccountChanges memory s = _signBatch(
             pk,
             account,
-            Keystore.ConfigChangeChannel.Local,
+            Keystore.AccountChangeChannel.Local,
             _localSeqWord(account),
             _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
         );
 
-        keystore.applySignedConfigChanges(account, s);
+        keystore.applySignedAccountChanges(account, s);
         vm.expectRevert(Keystore.BadSequence.selector);
-        keystore.applySignedConfigChanges(account, s);
+        keystore.applySignedAccountChanges(account, s);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -582,7 +582,7 @@ contract ApplySignedConfigChangesTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
 
-        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](2);
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _revokeChange(ACTOR_A);
         ch[1] = _bumpChange();
 

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -7,8 +7,8 @@ import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
 /// @notice §10 test matrix for the authority / environment ops driven through {applySignedAccountChanges}:
 ///         AuthorizeActor (sequenced + unsequenced), RevokeActor, BumpLocalEpoch, the op-ordering / solo fences,
-///         the reduction rule, and the sequenced-channel replay/saturation edges. Lock/unlock, recovery-key
-///         authorization, garbage collection, and multichain regression live in applyAccountChange.t.sol.
+///         the reduction rule, and the sequenced-channel replay/saturation edges. Lock/unlock (admin-only),
+///         garbage collection, and multichain regression live in applyAccountChange.t.sol.
 contract ApplySignedAccountChangesTest is KeystoreTest {
     // Non-self, non-owner actor ids (low right-aligned constants never collide with a bytes20-left-aligned address).
     bytes32 constant ACTOR_A = bytes32(uint256(0xA1));

--- a/test/unit/Keystore/authenticate.t.sol
+++ b/test/unit/Keystore/authenticate.t.sol
@@ -741,13 +741,13 @@ contract AuthenticateTest is KeystoreTest {
         // verifySignature applies the account-scoped EIP-7739 wrap; replaySafeHash(account, hash) is scope-independent.
         bytes memory auth = _buildK1Auth(actorPk, keystore.replaySafeHash(account, hash));
 
-        _authorizeScopeBump(account, ownerPk, actorId, SCOPE_SENDER);
+        _authorizeAtScope(account, ownerPk, actorId, SCOPE_SENDER);
         assertTrue(keystore.verifySignature(account, hash, auth));
 
-        _authorizeScopeBump(account, ownerPk, actorId, SCOPE_SENDER | SCOPE_SELF_PAYER);
+        _authorizeAtScope(account, ownerPk, actorId, SCOPE_SENDER | SCOPE_SELF_PAYER);
         assertTrue(keystore.verifySignature(account, hash, auth));
 
-        _authorizeScopeBump(account, ownerPk, actorId, SCOPE_SENDER | SCOPE_NONCE);
+        _authorizeAtScope(account, ownerPk, actorId, SCOPE_SENDER | SCOPE_NONCE);
         assertTrue(keystore.verifySignature(account, hash, auth));
     }
 
@@ -765,13 +765,13 @@ contract AuthenticateTest is KeystoreTest {
         vm.assume(vm.addr(actorPk) != account);
         bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
 
-        _authorizeScopeBump(account, ownerPk, actorId, SCOPE_SELF_PAYER);
+        _authorizeAtScope(account, ownerPk, actorId, SCOPE_SELF_PAYER);
         assertFalse(keystore.verifySignature(account, hash, _buildK1Auth(actorPk, hash)));
 
-        _authorizeScopeBump(account, ownerPk, actorId, SCOPE_SPONSOR_PAYER);
+        _authorizeAtScope(account, ownerPk, actorId, SCOPE_SPONSOR_PAYER);
         assertFalse(keystore.verifySignature(account, hash, _buildK1Auth(actorPk, hash)));
 
-        _authorizeScopeBump(account, ownerPk, actorId, SCOPE_NONCE);
+        _authorizeAtScope(account, ownerPk, actorId, SCOPE_NONCE);
         assertFalse(keystore.verifySignature(account, hash, _buildK1Auth(actorPk, hash)));
     }
 
@@ -921,8 +921,7 @@ contract AuthenticateTest is KeystoreTest {
     // (re-implemented on applySignedAccountChanges). Only the expiry- and policy-specific helpers below are local.
 
     /// @dev Authorize `newActorId` under `authenticator` with the given `expiry` (scope 0, no policy), signed by `pk`.
-    ///      A zero expiry (the old "no expiry") is translated to the unbounded sentinel, granted on a sequenced local
-    ///      batch (unbounded grants are sequenced-only).
+    ///      A zero expiry (the old "no expiry") is translated to the unbounded sentinel.
     function _authorizeActorWithExpiry(
         address account,
         uint256 pk,
@@ -931,17 +930,11 @@ contract AuthenticateTest is KeystoreTest {
         uint48 expiry
     ) internal {
         uint48 grant = expiry == 0 ? UNBOUNDED : expiry;
-        // Batch an epoch bump: granting a finite expiry to the implicit self-actor narrows its default UNBOUNDED
-        // grant (a reduction), which the new API requires to be paired with a bump. Harmless for fresh actors.
-        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
-        ch[0] = _authorizeChange(newActorId, authenticator, 0x00, grant, "");
-        ch[1] = _bumpChange();
-        _applyLocal(pk, account, ch);
+        _applyLocal(pk, account, _one(_authorizeChange(newActorId, authenticator, 0x00, grant, "")));
     }
 
     /// @dev Authorize a K1 policy-gated actor: manager[20] || commitment[32] policy data, signed by the owner `pk`.
-    ///      `scope` must carry SCOPE_POLICY. Granted UNBOUNDED on a sequenced local batch and batched with an epoch
-    ///      bump so a re-authorize that narrows scope does not trip the reduction rule.
+    ///      `scope` must carry SCOPE_POLICY. Granted UNBOUNDED.
     function _authorizeGatedActor(
         address account,
         uint256 ownerPk,
@@ -950,20 +943,19 @@ contract AuthenticateTest is KeystoreTest {
         address policyManager,
         bytes32 commitment
     ) internal {
-        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
-        ch[0] = _authorizeChange(
-            newActorId, address(k1Authenticator), scope, UNBOUNDED, abi.encodePacked(policyManager, commitment)
+        _applyLocal(
+            ownerPk,
+            account,
+            _one(
+                _authorizeChange(
+                    newActorId, address(k1Authenticator), scope, UNBOUNDED, abi.encodePacked(policyManager, commitment)
+                )
+            )
         );
-        ch[1] = _bumpChange();
-        _applyLocal(ownerPk, account, ch);
     }
 
-    /// @dev Authorize `actorId` at `scope` (UNBOUNDED, no policy) batched with an epoch bump so a scope reduction
-    ///      relative to a prior grant on the same slot does not trip the reduction rule. Signed by `pk`.
-    function _authorizeScopeBump(address account, uint256 pk, bytes32 actorId, uint16 scope) internal {
-        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
-        ch[0] = _authorizeChange(actorId, address(k1Authenticator), scope, UNBOUNDED, "");
-        ch[1] = _bumpChange();
-        _applyLocal(pk, account, ch);
+    /// @dev Authorize `actorId` at `scope` (UNBOUNDED, no policy), signed by `pk`.
+    function _authorizeAtScope(address account, uint256 pk, bytes32 actorId, uint16 scope) internal {
+        _applyLocal(pk, account, _one(_authorizeChange(actorId, address(k1Authenticator), scope, UNBOUNDED, "")));
     }
 }

--- a/test/unit/Keystore/authenticate.t.sol
+++ b/test/unit/Keystore/authenticate.t.sol
@@ -918,7 +918,7 @@ contract AuthenticateTest is KeystoreTest {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     // _authorizeActorWithScope, _implicitAuthorizeActor, and _revokeActor are provided by the KeystoreTest harness
-    // (re-implemented on applySignedAccountChanges). Only the expiry- and policy-specific helpers below are local.
+    // (re-implemented on applySignedConfigChanges). Only the expiry- and policy-specific helpers below are local.
 
     /// @dev Authorize `newActorId` under `authenticator` with the given `expiry` (scope 0, no policy), signed by `pk`.
     ///      A zero expiry (the old "no expiry") is translated to the unbounded sentinel.

--- a/test/unit/Keystore/authenticate.t.sol
+++ b/test/unit/Keystore/authenticate.t.sol
@@ -152,7 +152,7 @@ contract AuthenticateTest is KeystoreTest {
         vm.assume(vm.addr(ownerPk) != vm.addr(actorPk));
 
         (address account,) = _createK1Account(ownerPk);
-        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        bytes32 actorId = bytes32(uint256(uint160(vm.addr(actorPk))));
         _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), 0x00);
         _revokeActor(account, ownerPk, actorId);
 
@@ -172,7 +172,7 @@ contract AuthenticateTest is KeystoreTest {
     ) public {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
+        bytes32 selfActorId = bytes32(uint256(uint160(eoa)));
 
         uint48 expiry = uint48(bound(uint256(expirySeed), block.timestamp + 1, uint256(type(uint48).max) - 1));
         // Authorize the self-actorId as a scoped-0 K1 actor carrying an expiry (re-enables the inline self).
@@ -197,7 +197,7 @@ contract AuthenticateTest is KeystoreTest {
         vm.assume(vm.addr(ownerPk) != vm.addr(sessionPk));
 
         (address account,) = _createK1Account(ownerPk);
-        bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
+        bytes32 sessionActorId = bytes32(uint256(uint160(vm.addr(sessionPk))));
         uint48 expiry = uint48(bound(uint256(expirySeed), block.timestamp + 1, uint256(type(uint48).max) - 1));
         _authorizeActorWithExpiry(account, ownerPk, sessionActorId, address(k1Authenticator), expiry);
 
@@ -236,7 +236,7 @@ contract AuthenticateTest is KeystoreTest {
     function test_authenticateActor_revert_defaultEoaRevoked_afterSelfRevoke(uint256 eoaSeed, bytes32 hash) public {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
+        bytes32 selfActorId = bytes32(uint256(uint160(eoa)));
 
         // The implicit self (unrestricted) signs a batch revoking its own self-actorId; auth precedes the revoke.
         _revokeActor(eoa, eoaPk, selfActorId);
@@ -252,7 +252,7 @@ contract AuthenticateTest is KeystoreTest {
     {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
+        bytes32 selfActorId = bytes32(uint256(uint160(eoa)));
 
         // Implicit self authorizes itself to a non-K1 authenticator (P256), flipping the mutual-exclusion flag.
         _authorizeActorWithScope(eoa, eoaPk, selfActorId, address(p256Authenticator), 0x00);
@@ -370,7 +370,9 @@ contract AuthenticateTest is KeystoreTest {
 
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(actorPk) != account);
-        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), 0x00);
+        _authorizeActorWithScope(
+            account, ownerPk, bytes32(uint256(uint160(vm.addr(actorPk)))), address(k1Authenticator), 0x00
+        );
 
         (, uint16 scope) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(scope, uint8(0x00));
@@ -430,7 +432,9 @@ contract AuthenticateTest is KeystoreTest {
 
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(actorPk) != account);
-        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), scope);
+        _authorizeActorWithScope(
+            account, ownerPk, bytes32(uint256(uint160(vm.addr(actorPk)))), address(k1Authenticator), scope
+        );
 
         (, uint16 outScope) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(outScope, scope);
@@ -447,7 +451,9 @@ contract AuthenticateTest is KeystoreTest {
 
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(actorPk) != account);
-        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), 0x00);
+        _authorizeActorWithScope(
+            account, ownerPk, bytes32(uint256(uint160(vm.addr(actorPk)))), address(k1Authenticator), 0x00
+        );
 
         (, uint16 scope) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
         assertEq(scope, uint8(0x00));
@@ -467,7 +473,9 @@ contract AuthenticateTest is KeystoreTest {
 
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(sessionPk) != account);
-        _authorizeActorWithExpiry(account, ownerPk, bytes32(bytes20(vm.addr(sessionPk))), address(k1Authenticator), 0);
+        _authorizeActorWithExpiry(
+            account, ownerPk, bytes32(uint256(uint160(vm.addr(sessionPk)))), address(k1Authenticator), 0
+        );
 
         vm.warp(block.timestamp + bound(warpSeed, 1, 3650 days));
         (, uint16 scope) = keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
@@ -490,7 +498,7 @@ contract AuthenticateTest is KeystoreTest {
         vm.assume(vm.addr(sessionPk) != account);
         uint48 expiry = uint48(bound(uint256(expirySeed), block.timestamp + 1, uint256(type(uint48).max)));
         _authorizeActorWithExpiry(
-            account, ownerPk, bytes32(bytes20(vm.addr(sessionPk))), address(k1Authenticator), expiry
+            account, ownerPk, bytes32(uint256(uint160(vm.addr(sessionPk)))), address(k1Authenticator), expiry
         );
 
         vm.warp(expiry);
@@ -518,7 +526,7 @@ contract AuthenticateTest is KeystoreTest {
 
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(sessionPk) != account);
-        bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
+        bytes32 sessionActorId = bytes32(uint256(uint160(vm.addr(sessionPk))));
         _authorizeGatedActor(account, ownerPk, sessionActorId, scope, manager, commitment);
 
         (, uint16 outScope) = keystore.authenticateActor(account, hash, _buildK1Auth(sessionPk, hash));
@@ -536,7 +544,7 @@ contract AuthenticateTest is KeystoreTest {
         (, uint16 scope) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
 
         assertEq(scope, uint16(0x00));
-        assertEq(keystore.getPolicyManager(eoa, bytes32(bytes20(eoa))), address(0));
+        assertEq(keystore.getPolicyManager(eoa, bytes32(uint256(uint160(eoa)))), address(0));
     }
 
     /// @notice Scoping the account's own key downgrades it: the inline self returns the reduced scope, never owner.
@@ -544,7 +552,7 @@ contract AuthenticateTest is KeystoreTest {
     function test_authenticateActor_success_selfScopedDowngrade(uint256 eoaSeed, uint8 scopeSeed, bytes32 hash) public {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
+        bytes32 selfActorId = bytes32(uint256(uint160(eoa)));
         uint16 scope = uint16(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_POLICY;
         vm.assume(scope != 0);
 
@@ -564,7 +572,7 @@ contract AuthenticateTest is KeystoreTest {
         address eoa = vm.addr(eoaPk);
         vm.assume(vm.addr(bobPk) != eoa);
 
-        _implicitAuthorizeActor(eoa, eoaPk, bytes32(bytes20(vm.addr(bobPk))), address(k1Authenticator));
+        _implicitAuthorizeActor(eoa, eoaPk, bytes32(uint256(uint160(vm.addr(bobPk)))), address(k1Authenticator));
 
         (, uint16 scope) = keystore.authenticateActor(eoa, hash, _buildK1Auth(bobPk, hash));
         assertEq(scope, uint8(0x00));
@@ -596,16 +604,16 @@ contract AuthenticateTest is KeystoreTest {
     // Off-8130 consumers (e.g. an ERC-4337 account) need the resolved actorId to drive getPolicyCommitment without
     // re-invoking the authenticator — parity with the tx-context precompile on an 8130 chain.
 
-    /// @notice The inline-self k1 path returns actorId == bytes32(bytes20(account)).
+    /// @notice The inline-self k1 path returns actorId == bytes32(uint256(uint160(account))).
     function test_authenticateActor_success_returnsActorId_inlineSelf(uint256 eoaSeed, bytes32 hash) public view {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
 
         (bytes32 actorId,) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
-        assertEq(actorId, bytes32(bytes20(eoa)));
+        assertEq(actorId, bytes32(uint256(uint160(eoa))));
     }
 
-    /// @notice A non-self k1 actor returns actorId == bytes32(bytes20(signer)).
+    /// @notice A non-self k1 actor returns actorId == bytes32(uint256(uint160(signer))).
     function test_authenticateActor_success_returnsActorId_nonSelfK1(uint256 ownerSeed, uint256 actorSeed, bytes32 hash)
         public
     {
@@ -615,7 +623,7 @@ contract AuthenticateTest is KeystoreTest {
 
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(actorPk) != account);
-        bytes32 expectedActorId = bytes32(bytes20(vm.addr(actorPk)));
+        bytes32 expectedActorId = bytes32(uint256(uint160(vm.addr(actorPk))));
         _authorizeActorWithScope(account, ownerPk, expectedActorId, address(k1Authenticator), 0x00);
 
         (bytes32 actorId,) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
@@ -668,7 +676,7 @@ contract AuthenticateTest is KeystoreTest {
 
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(actorPk) != account);
-        bytes32 expectedActorId = bytes32(bytes20(vm.addr(actorPk)));
+        bytes32 expectedActorId = bytes32(uint256(uint160(vm.addr(actorPk))));
         _authorizeActorWithScope(account, ownerPk, expectedActorId, address(k1Authenticator), scope);
 
         (bytes32 actorId, uint16 outScope) = keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
@@ -676,7 +684,7 @@ contract AuthenticateTest is KeystoreTest {
         assertEq(outScope, scope);
     }
 
-    /// @notice A scoped (downgraded) inline self still returns actorId == bytes32(bytes20(account)).
+    /// @notice A scoped (downgraded) inline self still returns actorId == bytes32(uint256(uint160(account))).
     function test_authenticateActor_success_returnsActorId_scopedInlineSelf(
         uint256 eoaSeed,
         uint8 scopeSeed,
@@ -684,7 +692,7 @@ contract AuthenticateTest is KeystoreTest {
     ) public {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
+        bytes32 selfActorId = bytes32(uint256(uint160(eoa)));
         uint16 scope = uint16(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_POLICY;
 
         _authorizeActorWithScope(eoa, eoaPk, selfActorId, address(k1Authenticator), scope);
@@ -716,7 +724,9 @@ contract AuthenticateTest is KeystoreTest {
 
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(actorPk) != account);
-        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(actorPk))), address(k1Authenticator), scope);
+        _authorizeActorWithScope(
+            account, ownerPk, bytes32(uint256(uint160(vm.addr(actorPk)))), address(k1Authenticator), scope
+        );
 
         bool expected = scope == 0 || (scope & SCOPE_SENDER != 0);
         // verifySignature applies the account-scoped EIP-7739 wrap.
@@ -737,7 +747,7 @@ contract AuthenticateTest is KeystoreTest {
 
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(actorPk) != account);
-        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        bytes32 actorId = bytes32(uint256(uint160(vm.addr(actorPk))));
         // verifySignature applies the account-scoped EIP-7739 wrap; replaySafeHash(account, hash) is scope-independent.
         bytes memory auth = _buildK1Auth(actorPk, keystore.replaySafeHash(account, hash));
 
@@ -763,7 +773,7 @@ contract AuthenticateTest is KeystoreTest {
 
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(actorPk) != account);
-        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        bytes32 actorId = bytes32(uint256(uint160(vm.addr(actorPk))));
 
         _authorizeAtScope(account, ownerPk, actorId, SCOPE_SELF_PAYER);
         assertFalse(keystore.verifySignature(account, hash, _buildK1Auth(actorPk, hash)));
@@ -792,7 +802,7 @@ contract AuthenticateTest is KeystoreTest {
 
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(sessionPk) != account);
-        bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
+        bytes32 sessionActorId = bytes32(uint256(uint160(vm.addr(sessionPk))));
         _authorizeGatedActor(account, ownerPk, sessionActorId, SCOPE_POLICY, manager, commitment);
         assertFalse(keystore.verifySignature(account, hash, _buildK1Auth(sessionPk, hash)));
 
@@ -837,7 +847,7 @@ contract AuthenticateTest is KeystoreTest {
         uint16 scope = uint16(scopeSeed) | SCOPE_POLICY;
 
         (address account,) = _createK1Account(ownerPk);
-        bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
+        bytes32 sessionActorId = bytes32(uint256(uint160(vm.addr(sessionPk))));
         _authorizeGatedActor(account, ownerPk, sessionActorId, scope, manager, commitment);
 
         (address outTarget, bytes32 outCommitment) = keystore.getPolicy(account, sessionActorId);
@@ -854,7 +864,7 @@ contract AuthenticateTest is KeystoreTest {
 
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(actorPk) != account);
-        bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
+        bytes32 actorId = bytes32(uint256(uint160(vm.addr(actorPk))));
         _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), 0x00);
 
         (address target, bytes32 commitment) = keystore.getPolicy(account, actorId);
@@ -879,7 +889,7 @@ contract AuthenticateTest is KeystoreTest {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
         (address account, bytes32 actorId) = _createK1Account(ownerPk);
         vm.assume(unknownActorId != actorId);
-        vm.assume(unknownActorId != bytes32(bytes20(account)));
+        vm.assume(unknownActorId != bytes32(uint256(uint160(account))));
 
         Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, unknownActorId);
         assertEq(cfg.authenticator, address(0));
@@ -890,14 +900,14 @@ contract AuthenticateTest is KeystoreTest {
     /// @dev No _actorConfig entry, actorId == self, flag unset -> true.
     function test_isActor_success_implicitEoaTrue(uint256 eoaSeed) public view {
         address eoa = vm.addr(_boundK1Pk(eoaSeed));
-        assertTrue(_isActor(eoa, bytes32(bytes20(eoa))));
+        assertTrue(_isActor(eoa, bytes32(uint256(uint160(eoa)))));
     }
 
     /// @notice isActor reports a non-self actorId on a never-created EOA as not live.
-    /// @dev A random actorId != bytes32(bytes20(eoa)) has no inline home and no _actorConfig entry -> false.
+    /// @dev A random actorId != bytes32(uint256(uint160(eoa))) has no inline home and no _actorConfig entry -> false.
     function test_isActor_success_nonSelfActorIdNotImplicit(uint256 eoaSeed, bytes32 randomActorId) public view {
         address eoa = vm.addr(_boundK1Pk(eoaSeed));
-        vm.assume(randomActorId != bytes32(bytes20(eoa)));
+        vm.assume(randomActorId != bytes32(uint256(uint160(eoa))));
         assertFalse(_isActor(eoa, randomActorId));
     }
 
@@ -906,7 +916,7 @@ contract AuthenticateTest is KeystoreTest {
     function test_isActor_success_falseAfterSelfRevoke(uint256 eoaSeed) public {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
+        bytes32 selfActorId = bytes32(uint256(uint160(eoa)));
 
         _revokeActor(eoa, eoaPk, selfActorId);
 

--- a/test/unit/Keystore/authenticate.t.sol
+++ b/test/unit/Keystore/authenticate.t.sol
@@ -918,7 +918,7 @@ contract AuthenticateTest is KeystoreTest {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     // _authorizeActorWithScope, _implicitAuthorizeActor, and _revokeActor are provided by the KeystoreTest harness
-    // (re-implemented on applySignedConfigChanges). Only the expiry- and policy-specific helpers below are local.
+    // (re-implemented on applySignedAccountChanges). Only the expiry- and policy-specific helpers below are local.
 
     /// @dev Authorize `newActorId` under `authenticator` with the given `expiry` (scope 0, no policy), signed by `pk`.
     ///      A zero expiry (the old "no expiry") is translated to the unbounded sentinel.

--- a/test/unit/Keystore/authenticate.t.sol
+++ b/test/unit/Keystore/authenticate.t.sol
@@ -174,7 +174,7 @@ contract AuthenticateTest is KeystoreTest {
         address eoa = vm.addr(eoaPk);
         bytes32 selfActorId = bytes32(bytes20(eoa));
 
-        uint48 expiry = uint48(bound(uint256(expirySeed), 1, uint256(type(uint48).max) - 1));
+        uint48 expiry = uint48(bound(uint256(expirySeed), block.timestamp + 1, uint256(type(uint48).max) - 1));
         // Authorize the self-actorId as a scoped-0 K1 actor carrying an expiry (re-enables the inline self).
         _authorizeActorWithExpiry(eoa, eoaPk, selfActorId, address(k1Authenticator), expiry);
 
@@ -198,7 +198,7 @@ contract AuthenticateTest is KeystoreTest {
 
         (address account,) = _createK1Account(ownerPk);
         bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
-        uint48 expiry = uint48(bound(uint256(expirySeed), 1, uint256(type(uint48).max) - 1));
+        uint48 expiry = uint48(bound(uint256(expirySeed), block.timestamp + 1, uint256(type(uint48).max) - 1));
         _authorizeActorWithExpiry(account, ownerPk, sessionActorId, address(k1Authenticator), expiry);
 
         vm.warp(uint256(expiry) + bound(warpSeed, 1, 1_000_000));
@@ -219,7 +219,7 @@ contract AuthenticateTest is KeystoreTest {
         uint256 pk = _boundP256Pk(pkSeed);
 
         (address account,) = _createK1Account(ownerPk);
-        uint48 expiry = uint48(bound(uint256(expirySeed), 1, uint256(type(uint48).max) - 1));
+        uint48 expiry = uint48(bound(uint256(expirySeed), block.timestamp + 1, uint256(type(uint48).max) - 1));
         _authorizeActorWithExpiry(account, ownerPk, _p256ActorId(pk), address(p256Authenticator), expiry);
 
         vm.warp(uint256(expiry) + bound(warpSeed, 1, 1_000_000));
@@ -741,13 +741,13 @@ contract AuthenticateTest is KeystoreTest {
         // verifySignature applies the account-scoped EIP-7739 wrap; replaySafeHash(account, hash) is scope-independent.
         bytes memory auth = _buildK1Auth(actorPk, keystore.replaySafeHash(account, hash));
 
-        _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_SENDER);
+        _authorizeScopeBump(account, ownerPk, actorId, SCOPE_SENDER);
         assertTrue(keystore.verifySignature(account, hash, auth));
 
-        _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_SENDER | SCOPE_SELF_PAYER);
+        _authorizeScopeBump(account, ownerPk, actorId, SCOPE_SENDER | SCOPE_SELF_PAYER);
         assertTrue(keystore.verifySignature(account, hash, auth));
 
-        _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_SENDER | SCOPE_NONCE);
+        _authorizeScopeBump(account, ownerPk, actorId, SCOPE_SENDER | SCOPE_NONCE);
         assertTrue(keystore.verifySignature(account, hash, auth));
     }
 
@@ -765,13 +765,13 @@ contract AuthenticateTest is KeystoreTest {
         vm.assume(vm.addr(actorPk) != account);
         bytes32 actorId = bytes32(bytes20(vm.addr(actorPk)));
 
-        _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_SELF_PAYER);
+        _authorizeScopeBump(account, ownerPk, actorId, SCOPE_SELF_PAYER);
         assertFalse(keystore.verifySignature(account, hash, _buildK1Auth(actorPk, hash)));
 
-        _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_SPONSOR_PAYER);
+        _authorizeScopeBump(account, ownerPk, actorId, SCOPE_SPONSOR_PAYER);
         assertFalse(keystore.verifySignature(account, hash, _buildK1Auth(actorPk, hash)));
 
-        _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), SCOPE_NONCE);
+        _authorizeScopeBump(account, ownerPk, actorId, SCOPE_NONCE);
         assertFalse(keystore.verifySignature(account, hash, _buildK1Auth(actorPk, hash)));
     }
 
@@ -917,30 +917,12 @@ contract AuthenticateTest is KeystoreTest {
     // HELPERS
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @dev Authorize `newActorId` under `authenticator` with `scope` (no expiry, no policy), signed by `pk`.
-    ///      For the self-actorId with the K1 authenticator this drives the inline-self home; for any other
-    ///      authenticator on the self-actorId it drives the mutually-exclusive non-K1 self home. `scope` must not
-    ///      carry SCOPE_POLICY (no policyData is provided).
-    function _authorizeActorWithScope(
-        address account,
-        uint256 pk,
-        bytes32 newActorId,
-        address authenticator,
-        uint16 scope
-    ) internal {
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            actorId: newActorId,
-            changeType: Keystore.ActorChangeType.Authorize,
-            data: abi.encode(Keystore.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes(""))
-        });
-
-        uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        keystore.applySignedActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));
-    }
+    // _authorizeActorWithScope, _implicitAuthorizeActor, and _revokeActor are provided by the KeystoreTest harness
+    // (re-implemented on applySignedAccountChanges). Only the expiry- and policy-specific helpers below are local.
 
     /// @dev Authorize `newActorId` under `authenticator` with the given `expiry` (scope 0, no policy), signed by `pk`.
+    ///      A zero expiry (the old "no expiry") is translated to the unbounded sentinel, granted on a sequenced local
+    ///      batch (unbounded grants are sequenced-only).
     function _authorizeActorWithExpiry(
         address account,
         uint256 pk,
@@ -948,37 +930,18 @@ contract AuthenticateTest is KeystoreTest {
         address authenticator,
         uint48 expiry
     ) internal {
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            actorId: newActorId,
-            changeType: Keystore.ActorChangeType.Authorize,
-            data: abi.encode(
-                Keystore.ActorConfig({authenticator: authenticator, scope: 0x00, expiry: expiry}), bytes("")
-            )
-        });
-
-        uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        keystore.applySignedActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));
-    }
-
-    /// @dev Authorize `newActorId` under `authenticator` as an unrestricted owner (scope 0), signed by `pk`.
-    function _implicitAuthorizeActor(address account, uint256 pk, bytes32 newActorId, address authenticator) internal {
-        _authorizeActorWithScope(account, pk, newActorId, authenticator, 0x00);
-    }
-
-    /// @dev Revoke `actorId` from `account`, signed by `pk`.
-    function _revokeActor(address account, uint256 pk, bytes32 actorId) internal {
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
-
-        uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        keystore.applySignedActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));
+        uint48 grant = expiry == 0 ? UNBOUNDED : expiry;
+        // Batch an epoch bump: granting a finite expiry to the implicit self-actor narrows its default UNBOUNDED
+        // grant (a reduction), which the new API requires to be paired with a bump. Harmless for fresh actors.
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        ch[0] = _authorizeChange(newActorId, authenticator, 0x00, grant, "");
+        ch[1] = _bumpChange();
+        _applyLocal(pk, account, ch);
     }
 
     /// @dev Authorize a K1 policy-gated actor: manager[20] || commitment[32] policy data, signed by the owner `pk`.
-    ///      `scope` must carry SCOPE_POLICY.
+    ///      `scope` must carry SCOPE_POLICY. Granted UNBOUNDED on a sequenced local batch and batched with an epoch
+    ///      bump so a re-authorize that narrows scope does not trip the reduction rule.
     function _authorizeGatedActor(
         address account,
         uint256 ownerPk,
@@ -987,18 +950,20 @@ contract AuthenticateTest is KeystoreTest {
         address policyManager,
         bytes32 commitment
     ) internal {
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            actorId: newActorId,
-            changeType: Keystore.ActorChangeType.Authorize,
-            data: abi.encode(
-                Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0}),
-                abi.encodePacked(policyManager, commitment)
-            )
-        });
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        ch[0] = _authorizeChange(
+            newActorId, address(k1Authenticator), scope, UNBOUNDED, abi.encodePacked(policyManager, commitment)
+        );
+        ch[1] = _bumpChange();
+        _applyLocal(ownerPk, account, ch);
+    }
 
-        uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        keystore.applySignedActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(ownerPk, digest));
+    /// @dev Authorize `actorId` at `scope` (UNBOUNDED, no policy) batched with an epoch bump so a scope reduction
+    ///      relative to a prior grant on the same slot does not trip the reduction rule. Signed by `pk`.
+    function _authorizeScopeBump(address account, uint256 pk, bytes32 actorId, uint16 scope) internal {
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        ch[0] = _authorizeChange(actorId, address(k1Authenticator), scope, UNBOUNDED, "");
+        ch[1] = _bumpChange();
+        _applyLocal(pk, account, ch);
     }
 }

--- a/test/unit/Keystore/branchCoverage.t.sol
+++ b/test/unit/Keystore/branchCoverage.t.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Keystore} from "../../../src/Keystore.sol";
+import {KeystoreTest} from "../../lib/KeystoreTest.sol";
+
+/// @notice Targeted tests closing the remaining reachable branches in {Keystore}: the zero-account guard, the
+///         revoke-unknown-actor guard, the environment-op payload-length guards, the expired inline-self read, the
+///         elapsed-unlock lock-status read, and the policy-slice length guards. Grouped here rather than scattered
+///         across the behavioral suites because each is a defensive edge rather than a feature.
+contract KeystoreBranchCoverageTest is KeystoreTest {
+    uint256 constant OWNER_PK = 0xB0B;
+
+    // ── nonZeroAccount modifier ──
+
+    /// @notice The zero address is rejected before any signature work (modifier runs first).
+    function test_applySignedAccountChanges_revert_zeroAccount() public {
+        Keystore.SignedAccountChanges memory s = Keystore.SignedAccountChanges({
+            channel: Keystore.AccountChangeChannel.Local,
+            sequence: 0,
+            changes: new Keystore.AccountChange[](0),
+            signature: ""
+        });
+        vm.expectRevert(Keystore.ZeroAccount.selector);
+        keystore.applySignedAccountChanges(address(0), s);
+    }
+
+    // ── RevokeActor ──
+
+    /// @notice Revoking an actorId that was never authorized reverts UnknownActor.
+    function test_revoke_revert_unknownActor() public {
+        (address account,) = _createK1Account(OWNER_PK);
+        bytes32 ghost = bytes32(uint256(0xDEAD));
+        Keystore.SignedAccountChanges memory s = _localBatch(OWNER_PK, account, _one(_revokeChange(ghost)));
+        vm.expectRevert(Keystore.UnknownActor.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    // ── Environment-op payload guards ──
+
+    /// @notice IncrementLocalEpoch carries an empty payload; a non-empty one reverts InvalidChangePayload.
+    function test_incrementLocalEpoch_revert_nonEmptyPayload() public {
+        (address account,) = _createK1Account(OWNER_PK);
+        Keystore.AccountChange memory change =
+            Keystore.AccountChange({changeType: Keystore.ChangeType.IncrementLocalEpoch, payload: hex"01"});
+        Keystore.SignedAccountChanges memory s = _localBatch(OWNER_PK, account, _one(change));
+        vm.expectRevert(Keystore.InvalidChangePayload.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    /// @notice Unlock carries an empty payload; a non-empty one reverts InvalidChangePayload (checked before state).
+    function test_unlock_revert_nonEmptyPayload() public {
+        (address account,) = _createK1Account(OWNER_PK);
+        Keystore.AccountChange memory change =
+            Keystore.AccountChange({changeType: Keystore.ChangeType.Unlock, payload: hex"01"});
+        Keystore.SignedAccountChanges memory s = _localBatch(OWNER_PK, account, _one(change));
+        vm.expectRevert(Keystore.InvalidChangePayload.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    // ── getActorConfig: expired inline self ──
+
+    /// @notice getActorConfig returns the empty config for the inline self once its granted expiry has elapsed.
+    function test_getActorConfig_success_selfExpiredReturnsEmpty() public {
+        (address account,) = _createK1Account(OWNER_PK);
+        bytes32 selfId = bytes32(uint256(uint160(account)));
+
+        // Re-enable the inline self with a bounded expiry (createAccount revokes the default EOA).
+        uint48 expiry = uint48(block.timestamp + 1 hours);
+        _applyLocal(OWNER_PK, account, _one(_authorizeChange(selfId, k1Authenticator, 0, expiry, "")));
+
+        // Live before expiry.
+        assertEq(keystore.getActorConfig(account, selfId).authenticator, k1Authenticator);
+
+        vm.warp(block.timestamp + 2 hours);
+
+        // Expired: the self path returns the empty config rather than the stale slot.
+        assertEq(keystore.getActorConfig(account, selfId).authenticator, address(0));
+    }
+
+    // ── getLockStatus: elapsed pending unlock ──
+
+    /// @notice Once a pending unlock's timestamp has elapsed, getLockStatus reports the clean unlocked state.
+    function test_getLockStatus_success_elapsedUnlockReportsUnlocked() public {
+        (address account,) = _createK1Account(OWNER_PK);
+
+        _signedLock(OWNER_PK, account, 100);
+        _signedUnlock(OWNER_PK, account); // initiates: unlocksAt = now + 100
+
+        (bool lockedBefore, bool initiatedBefore,,) = keystore.getLockStatus(account);
+        assertTrue(lockedBefore);
+        assertTrue(initiatedBefore);
+
+        vm.warp(block.timestamp + 101);
+
+        (bool locked, bool initiated, uint48 unlocksAt, uint16 delay) = keystore.getLockStatus(account);
+        assertFalse(locked);
+        assertFalse(initiated);
+        assertEq(unlocksAt, 0);
+        assertEq(delay, 0);
+    }
+
+    // ── Multichain sequence saturation ──
+
+    /// @notice A Multichain batch at the terminal counter (type(uint64).max) reverts SequenceSaturated.
+    function test_multichain_revert_sequenceSaturated() public {
+        (address account,) = _createK1Account(OWNER_PK);
+
+        // Force the multichain counter (low 64 bits of the packed AccountState slot at base-slot 3) to its max.
+        bytes32 slot = keccak256(abi.encode(account, uint256(3)));
+        uint256 cur = uint256(vm.load(address(keystore), slot));
+        uint256 updated = (cur & ~uint256(type(uint64).max)) | uint256(type(uint64).max);
+        vm.store(address(keystore), slot, bytes32(updated));
+
+        Keystore.AccountChange memory change = _authorizeChange(bytes32(uint256(1)), k1Authenticator, 0, UNBOUNDED, "");
+        Keystore.SignedAccountChanges memory s = _multichainBatch(OWNER_PK, account, _one(change));
+        vm.expectRevert(Keystore.SequenceSaturated.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    // ── _slicePolicy length guards ──
+
+    /// @notice An ungated actor (scope without POLICY) must carry no policy data.
+    function test_authorize_revert_ungatedActorWithPolicyData() public {
+        (address account,) = _createK1Account(OWNER_PK);
+        bytes32 actorId = bytes32(uint256(0xA11CE));
+        Keystore.AccountChange memory change = _authorizeChange(actorId, k1Authenticator, 0, UNBOUNDED, hex"01");
+        Keystore.SignedAccountChanges memory s = _localBatch(OWNER_PK, account, _one(change));
+        vm.expectRevert(Keystore.InvalidPolicyData.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    /// @notice A policy-gated actor must carry exactly 52 bytes (manager(20) || commitment(32)) of policy data.
+    function test_authorize_revert_policyActorWrongLengthData() public {
+        (address account,) = _createK1Account(OWNER_PK);
+        bytes32 actorId = bytes32(uint256(0xA11CE));
+        // Scopes.POLICY == 0x02; 5 bytes is neither empty nor the required 52.
+        Keystore.AccountChange memory change =
+            _authorizeChange(actorId, k1Authenticator, 0x02, UNBOUNDED, hex"0102030405");
+        Keystore.SignedAccountChanges memory s = _localBatch(OWNER_PK, account, _one(change));
+        vm.expectRevert(Keystore.InvalidPolicyData.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    /// @notice A policy-gated actor with the exact 52-byte policy data authorizes successfully.
+    function test_authorize_success_policyActorValidData() public {
+        (address account,) = _createK1Account(OWNER_PK);
+        bytes32 actorId = bytes32(uint256(0xA11CE));
+        address policyManager = address(0xCAFE);
+        bytes32 commitment = keccak256("commitment");
+        bytes memory policyData = abi.encodePacked(policyManager, commitment); // 20 + 32 = 52 bytes
+        _applyLocal(OWNER_PK, account, _one(_authorizeChange(actorId, k1Authenticator, 0x02, UNBOUNDED, policyData)));
+
+        assertEq(keystore.getActorConfig(account, actorId).authenticator, k1Authenticator);
+        assertEq(keystore.getPolicyManager(account, actorId), policyManager);
+        assertEq(keystore.getPolicyCommitment(account, actorId), commitment);
+    }
+}

--- a/test/unit/Keystore/createAccount.t.sol
+++ b/test/unit/Keystore/createAccount.t.sol
@@ -183,7 +183,7 @@ contract CreateAccountTest is KeystoreTest {
         keystore.createAccount(salt, bytecode, actors);
 
         assertEq(predicted.code.length, 0);
-        assertEq(keystore.getChangeSequences(predicted).local, 0);
+        assertEq(keystore.getChangeSequences(predicted).localSequence, 0);
         assertEq(keystore.getChangeSequences(predicted).multichain, 0);
         assertFalse(_isActor(predicted, actorId));
 
@@ -272,7 +272,7 @@ contract CreateAccountTest is KeystoreTest {
         assertEq(cfg.scope, 0x00);
         assertEq(cfg.expiry, 0);
 
-        assertEq(keystore.getChangeSequences(account).local, 1);
+        assertEq(keystore.getChangeSequences(account).localSequence, 1);
         assertEq(keystore.getChangeSequences(account).multichain, 0);
 
         (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 unlockDelay) = keystore.getLockStatus(account);

--- a/test/unit/Keystore/createAccount.t.sol
+++ b/test/unit/Keystore/createAccount.t.sol
@@ -27,7 +27,7 @@ contract CreateAccountTest is KeystoreTest {
     }
 
     /// @dev Deterministically materialize a strictly-ascending k1 actor set of `count` address-shaped actorIds
-    ///      (low 12 bytes zero, mirroring a real k1 actorId = bytes32(bytes20(signer))). Ascending uint160 base+i
+    ///      (high 12 bytes zero, mirroring a real k1 actorId = bytes32(uint256(uint160(signer)))). Ascending uint160 base+i
     ///      maps to ascending bytes32, so no in-Solidity sort is needed. base >= 1 keeps the first id > 0.
     function _ascendingK1Actors(uint256 count, uint256 base)
         internal
@@ -36,7 +36,7 @@ contract CreateAccountTest is KeystoreTest {
     {
         actors = new Keystore.InitialActor[](count);
         for (uint256 i; i < count; i++) {
-            bytes32 actorId = bytes32(bytes20(address(uint160(base + i))));
+            bytes32 actorId = bytes32(uint256(uint160(address(uint160(base + i)))));
             actors[i] = _initialActor(actorId, address(k1Authenticator));
         }
     }
@@ -60,7 +60,7 @@ contract CreateAccountTest is KeystoreTest {
     /// @notice Verifies createAccount reverts when deployment bytecode is empty
     /// @dev Empty runtime code would break the 8130 isEOA invariant: (7702-delegated) || (no code).
     function test_createAccount_revert_emptyBytecode(bytes32 salt) public {
-        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(1))));
+        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(uint256(uint160(vm.addr(1)))));
 
         vm.expectRevert(Keystore.EmptyBytecode.selector);
         keystore.createAccount(salt, "", actors);
@@ -73,7 +73,7 @@ contract CreateAccountTest is KeystoreTest {
         bytes memory bytecode = new bytes(len);
         bytecode[0] = fill;
 
-        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(1))));
+        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(uint256(uint160(vm.addr(1)))));
 
         vm.expectRevert(Keystore.BytecodeTooLarge.selector);
         keystore.createAccount(salt, bytecode, actors);
@@ -85,7 +85,7 @@ contract CreateAccountTest is KeystoreTest {
         public
     {
         pk = _boundK1Pk(pk);
-        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(pk))));
+        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(uint256(uint160(vm.addr(pk)))));
         bytes memory bytecode = _validBytecode(lenSeed, content);
 
         keystore.createAccount(salt, bytecode, actors);
@@ -160,7 +160,7 @@ contract CreateAccountTest is KeystoreTest {
             bytecode[i] = bytes1(uint8(uint256(keccak256(abi.encodePacked(content, i)))));
         }
 
-        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(1))));
+        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(uint256(uint160(vm.addr(1)))));
 
         vm.expectRevert(Keystore.AccountDeploymentFailed.selector);
         keystore.createAccount(salt, bytecode, actors);
@@ -172,7 +172,7 @@ contract CreateAccountTest is KeystoreTest {
     ///      rather than reverting AlreadyInitialized.
     function test_createAccount_revert_deploymentFailedNoOrphanedState(uint256 pk, bytes32 salt) public {
         pk = _boundK1Pk(pk);
-        bytes32 actorId = bytes32(bytes20(vm.addr(pk)));
+        bytes32 actorId = bytes32(uint256(uint160(vm.addr(pk))));
 
         Keystore.InitialActor[] memory actors = _oneK1Actor(actorId);
         bytes memory bytecode = hex"EF";
@@ -201,7 +201,7 @@ contract CreateAccountTest is KeystoreTest {
     /// @dev Canonical clone bytecode; fuzzed key and salt confirm the property holds across the actor/salt space
     function test_createAccount_success_singleK1Actor(uint256 pk, bytes32 salt) public {
         pk = _boundK1Pk(pk);
-        bytes32 actorId = bytes32(bytes20(vm.addr(pk)));
+        bytes32 actorId = bytes32(uint256(uint160(vm.addr(pk))));
 
         Keystore.InitialActor[] memory actors = _oneK1Actor(actorId);
         bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
@@ -238,9 +238,10 @@ contract CreateAccountTest is KeystoreTest {
         public
     {
         vm.assume(authenticator != address(0));
-        // Keep actorId away from the self-actorId shape (low 12 bytes non-zero) so it routes to the generic actor
-        // home rather than the inline-self path, which would report the K1 sentinel instead of the fuzzed address.
-        vm.assume(uint96(uint256(actorId)) != 0);
+        // Keep actorId away from the self-actorId shape (a right-aligned address has its high 12 bytes zero) so it
+        // routes to the generic actor home rather than the inline-self path, which would report the K1 sentinel
+        // instead of the fuzzed address.
+        vm.assume((uint256(actorId) >> 160) != 0);
 
         Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](1);
         actors[0] = _initialActor(actorId, authenticator);
@@ -260,7 +261,7 @@ contract CreateAccountTest is KeystoreTest {
     ///      unlocked with a zeroed unlock schedule
     function test_createAccount_success_unrestrictedInitialActor(uint256 pk, bytes32 salt) public {
         pk = _boundK1Pk(pk);
-        bytes32 actorId = bytes32(bytes20(vm.addr(pk)));
+        bytes32 actorId = bytes32(uint256(uint160(vm.addr(pk))));
 
         Keystore.InitialActor[] memory actors = _oneK1Actor(actorId);
         bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
@@ -287,7 +288,7 @@ contract CreateAccountTest is KeystoreTest {
     ///      absent an explicit self initial actor
     function test_createAccount_success_defaultEoaRevokedByDefault(uint256 pk, bytes32 salt) public {
         pk = _boundK1Pk(pk);
-        bytes32 actorId = bytes32(bytes20(vm.addr(pk)));
+        bytes32 actorId = bytes32(uint256(uint160(vm.addr(pk))));
 
         Keystore.InitialActor[] memory actors = _oneK1Actor(actorId);
         bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
@@ -295,8 +296,8 @@ contract CreateAccountTest is KeystoreTest {
         address account = keystore.createAccount(salt, bytecode, actors);
 
         // The account's own self-actorId is not the seeded actor, so the inline k1 self stays disabled.
-        vm.assume(bytes32(bytes20(account)) != actorId);
-        assertFalse(_isActor(account, bytes32(bytes20(account))));
+        vm.assume(bytes32(uint256(uint160(account))) != actorId);
+        assertFalse(_isActor(account, bytes32(uint256(uint160(account)))));
     }
 
     /// @notice Verifies arbitrary valid runtime bytecode of a fuzzed length/content deploys successfully
@@ -306,7 +307,7 @@ contract CreateAccountTest is KeystoreTest {
         public
     {
         pk = _boundK1Pk(pk);
-        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(pk))));
+        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(uint256(uint160(vm.addr(pk)))));
         bytes memory bytecode = _validBytecode(lenSeed, content);
 
         address account = keystore.createAccount(salt, bytecode, actors);
@@ -322,7 +323,7 @@ contract CreateAccountTest is KeystoreTest {
     function test_createAccount_success_bytecodeAtEncodableMax(bytes32 salt) public {
         bytes memory bytecode = new bytes(0xFFFF); // zero-filled: EIP-3541-clean (no leading 0xEF)
 
-        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(1))));
+        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(uint256(uint160(vm.addr(1)))));
 
         address account = keystore.createAccount(salt, bytecode, actors);
         assertEq(account.code.length, 0xFFFF);
@@ -334,7 +335,7 @@ contract CreateAccountTest is KeystoreTest {
         public
     {
         pk = _boundK1Pk(pk);
-        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(pk))));
+        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(uint256(uint160(vm.addr(pk)))));
         bytes memory bytecode = _validBytecode(lenSeed, content);
 
         address predicted = keystore.computeAddress(salt, bytecode, actors);
@@ -350,7 +351,7 @@ contract CreateAccountTest is KeystoreTest {
         public
     {
         pk = _boundK1Pk(pk);
-        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(pk))));
+        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(uint256(uint160(vm.addr(pk)))));
         bytes memory bytecode = _validBytecode(lenSeed, content);
 
         address predicted = keystore.computeAddress(salt, bytecode, actors);
@@ -366,7 +367,7 @@ contract CreateAccountTest is KeystoreTest {
 
     /// @notice Verifies computeAddress reverts when deployment bytecode is empty
     function test_computeAddress_revert_emptyBytecode(bytes32 salt) public {
-        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(1))));
+        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(uint256(uint160(vm.addr(1)))));
 
         vm.expectRevert(Keystore.EmptyBytecode.selector);
         keystore.computeAddress(salt, "", actors);
@@ -379,7 +380,7 @@ contract CreateAccountTest is KeystoreTest {
         bytes memory bytecode = new bytes(len);
         bytecode[0] = fill;
 
-        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(1))));
+        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(uint256(uint160(vm.addr(1)))));
 
         vm.expectRevert(Keystore.BytecodeTooLarge.selector);
         keystore.computeAddress(salt, bytecode, actors);
@@ -390,7 +391,7 @@ contract CreateAccountTest is KeystoreTest {
     ///      _buildDeploymentCode but never deploys, so 0xFFFF returns an address while n == 0x10000 reverts (above)
     function test_computeAddress_success_bytecodeAtEncodableMax(bytes32 salt) public view {
         bytes memory bytecode = new bytes(0xFFFF);
-        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(1))));
+        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(uint256(uint160(vm.addr(1)))));
 
         address predicted = keystore.computeAddress(salt, bytecode, actors);
         assertTrue(predicted != address(0));
@@ -401,7 +402,7 @@ contract CreateAccountTest is KeystoreTest {
     function test_computeAddress_success_differentSalts(uint256 pk, bytes32 saltA, bytes32 saltB) public view {
         vm.assume(saltA != saltB);
         pk = _boundK1Pk(pk);
-        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(pk))));
+        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(uint256(uint160(vm.addr(pk)))));
         bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
 
         address addrA = keystore.computeAddress(saltA, bytecode, actors);
@@ -430,7 +431,7 @@ contract CreateAccountTest is KeystoreTest {
         view
     {
         pk = _boundK1Pk(pk);
-        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(pk))));
+        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(uint256(uint160(vm.addr(pk)))));
 
         bytes memory bytecodeA = _validBytecode(lenSeed, content);
         bytes memory bytecodeB = _computeERC1167Bytecode(defaultAccountImplementation);

--- a/test/unit/Keystore/importAccount.t.sol
+++ b/test/unit/Keystore/importAccount.t.sol
@@ -52,7 +52,7 @@ contract ImportAccountTest is KeystoreTest {
     // retains the full Actor/ActorConfig typehash structure; for imported (always unrestricted) actors the config
     // fields are zero and policyData is empty.
     bytes32 constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
-        "ActorInitialization(bytes32 salt,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
+        "ActorInitialization(bytes32 accountId,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
     );
     bytes32 constant ACTOR_TYPEHASH = keccak256(
         "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"

--- a/test/unit/Keystore/importAccount.t.sol
+++ b/test/unit/Keystore/importAccount.t.sol
@@ -100,12 +100,15 @@ contract ImportAccountTest is KeystoreTest {
     function _singleUnrestrictedActor(address signer) internal view returns (Keystore.InitialActor[] memory actors) {
         actors = new Keystore.InitialActor[](1);
         actors[0] = Keystore.InitialActor({
-            actorId: bytes32(bytes20(signer)), authenticator: address(k1Authenticator), scope: 0, policyData: ""
+            actorId: bytes32(uint256(uint160(signer))),
+            authenticator: address(k1Authenticator),
+            scope: 0,
+            policyData: ""
         });
     }
 
     /// @dev A strictly-ascending k1 actor set of `count` address-shaped actorIds (mirroring a real k1 actorId =
-    ///      bytes32(bytes20(signer))). Ascending uint160 base+i maps to ascending bytes32, so no sort is needed.
+    ///      bytes32(uint256(uint160(signer)))). Ascending uint160 base+i maps to ascending bytes32, so no sort is needed.
     function _ascendingK1Actors(uint256 count, uint256 base)
         internal
         view
@@ -114,7 +117,7 @@ contract ImportAccountTest is KeystoreTest {
         actors = new Keystore.InitialActor[](count);
         for (uint256 i; i < count; i++) {
             actors[i] = Keystore.InitialActor({
-                actorId: bytes32(bytes20(address(uint160(base + i)))),
+                actorId: bytes32(uint256(uint160(address(uint160(base + i))))),
                 authenticator: address(k1Authenticator),
                 scope: 0,
                 policyData: ""
@@ -218,7 +221,9 @@ contract ImportAccountTest is KeystoreTest {
 
         // A global (multichain / chainId 0) actor change signed by the EOA's implicit default owner.
         _applyMultichain(
-            eoaPk, eoa, _one(_authorizeChange(bytes32(bytes20(device)), address(k1Authenticator), 0x00, UNBOUNDED, ""))
+            eoaPk,
+            eoa,
+            _one(_authorizeChange(bytes32(uint256(uint160(device))), address(k1Authenticator), 0x00, UNBOUNDED, ""))
         );
 
         // Multichain channel advanced; local channel untouched.
@@ -395,7 +400,7 @@ contract ImportAccountTest is KeystoreTest {
         keystore.importAccount(address(wallet), block.chainid, actors, sig);
 
         assertEq(keystore.getChangeSequences(address(wallet)).localSequence, 1);
-        assertTrue(_isActor(address(wallet), bytes32(bytes20(vm.addr(ownerPk)))));
+        assertTrue(_isActor(address(wallet), bytes32(uint256(uint160(vm.addr(ownerPk))))));
     }
 
     /// @notice Verifies a chainId == 0 (multichain) import signature authorizes import and still sets localSequence.
@@ -410,7 +415,7 @@ contract ImportAccountTest is KeystoreTest {
 
         assertEq(keystore.getChangeSequences(address(wallet)).localSequence, 1);
         assertEq(keystore.getChangeSequences(address(wallet)).multichain, 0);
-        assertTrue(_isActor(address(wallet), bytes32(bytes20(vm.addr(ownerPk)))));
+        assertTrue(_isActor(address(wallet), bytes32(uint256(uint160(vm.addr(ownerPk))))));
     }
 
     /// @notice Verifies importAccount emits AccountImported(account) exactly once on the happy path.
@@ -437,9 +442,9 @@ contract ImportAccountTest is KeystoreTest {
         keystore.importAccount(address(wallet), chainId, actors, sig);
 
         // The implicit default EOA (self-actorId) is disabled by default on import.
-        assertFalse(_isActor(address(wallet), bytes32(bytes20(address(wallet)))));
+        assertFalse(_isActor(address(wallet), bytes32(uint256(uint160(address(wallet))))));
         Keystore.ActorConfig memory selfConfig =
-            keystore.getActorConfig(address(wallet), bytes32(bytes20(address(wallet))));
+            keystore.getActorConfig(address(wallet), bytes32(uint256(uint160(address(wallet)))));
         assertEq(selfConfig.authenticator, address(0));
     }
 
@@ -491,8 +496,8 @@ contract ImportAccountTest is KeystoreTest {
         keystore.importAccount(eoa, uint64(block.chainid), actors, sig);
 
         assertEq(keystore.getChangeSequences(eoa).localSequence, 1);
-        assertTrue(_isActor(eoa, bytes32(bytes20(device))));
-        assertFalse(_isActor(eoa, bytes32(bytes20(eoa))));
+        assertTrue(_isActor(eoa, bytes32(uint256(uint160(device)))));
+        assertFalse(_isActor(eoa, bytes32(uint256(uint160(eoa)))));
     }
 
     /// @notice Verifies a real EIP-7702 EOA delegated to DefaultAccount can self-import with its own k1 signature.
@@ -515,8 +520,8 @@ contract ImportAccountTest is KeystoreTest {
         );
 
         assertEq(keystore.getChangeSequences(eoa).localSequence, 1);
-        assertTrue(_isActor(eoa, bytes32(bytes20(device))));
-        assertFalse(_isActor(eoa, bytes32(bytes20(eoa))));
+        assertTrue(_isActor(eoa, bytes32(uint256(uint160(device)))));
+        assertFalse(_isActor(eoa, bytes32(uint256(uint160(eoa)))));
 
         // The implicit default EOA is disabled after import: its own k1 sig now finds no config.
         bytes32 h = keccak256("post import");
@@ -534,7 +539,10 @@ contract ImportAccountTest is KeystoreTest {
 
         Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](1);
         actors[0] = Keystore.InitialActor({
-            actorId: bytes32(bytes20(eoa)), authenticator: keystore.K1_AUTHENTICATOR(), scope: 0, policyData: ""
+            actorId: bytes32(uint256(uint160(eoa))),
+            authenticator: keystore.K1_AUTHENTICATOR(),
+            scope: 0,
+            policyData: ""
         });
 
         bytes32 digest = _computeImportDigest(eoa, actors);
@@ -545,7 +553,7 @@ contract ImportAccountTest is KeystoreTest {
 
         assertEq(keystore.getChangeSequences(eoa).localSequence, 1);
         // The self-actorId is a live explicit owner.
-        assertTrue(_isActor(eoa, bytes32(bytes20(eoa))));
+        assertTrue(_isActor(eoa, bytes32(uint256(uint160(eoa)))));
 
         // The same key still authenticates as a full owner — now via its explicit self config, not the (disabled)
         // implicit fallback.

--- a/test/unit/Keystore/importAccount.t.sol
+++ b/test/unit/Keystore/importAccount.t.sol
@@ -216,17 +216,10 @@ contract ImportAccountTest is KeystoreTest {
         address device = vm.addr(devicePk);
         vm.assume(eoa != device);
 
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            actorId: bytes32(bytes20(device)),
-            changeType: Keystore.ActorChangeType.Authorize,
-            data: abi.encode(
-                Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: 0x00, expiry: 0}), bytes("")
-            )
-        });
-        uint64 seq = keystore.getChangeSequences(eoa).multichain;
-        bytes32 changeDigest = _computeActorChangeBatchDigest(eoa, 0, seq, changes);
-        keystore.applySignedActorChanges(eoa, 0, changes, _buildK1Auth(eoaPk, changeDigest));
+        // A global (multichain / chainId 0) actor change signed by the EOA's implicit default owner.
+        _applyMultichain(
+            eoaPk, eoa, _one(_authorizeChange(bytes32(bytes20(device)), address(k1Authenticator), 0x00, UNBOUNDED, ""))
+        );
 
         // Multichain channel advanced; local channel untouched.
         assertEq(keystore.getChangeSequences(eoa).multichain, 1);

--- a/test/unit/Keystore/importAccount.t.sol
+++ b/test/unit/Keystore/importAccount.t.sol
@@ -223,7 +223,7 @@ contract ImportAccountTest is KeystoreTest {
 
         // Multichain channel advanced; local channel untouched.
         assertEq(keystore.getChangeSequences(eoa).multichain, 1);
-        assertEq(keystore.getChangeSequences(eoa).local, 0);
+        assertEq(keystore.getChangeSequences(eoa).localSequence, 0);
 
         Keystore.InitialActor[] memory actors = _singleUnrestrictedActor(device);
         bytes32 importDigest = _computeImportDigest(eoa, actors);
@@ -394,7 +394,7 @@ contract ImportAccountTest is KeystoreTest {
 
         keystore.importAccount(address(wallet), block.chainid, actors, sig);
 
-        assertEq(keystore.getChangeSequences(address(wallet)).local, 1);
+        assertEq(keystore.getChangeSequences(address(wallet)).localSequence, 1);
         assertTrue(_isActor(address(wallet), bytes32(bytes20(vm.addr(ownerPk)))));
     }
 
@@ -408,7 +408,7 @@ contract ImportAccountTest is KeystoreTest {
 
         keystore.importAccount(address(wallet), 0, actors, sig);
 
-        assertEq(keystore.getChangeSequences(address(wallet)).local, 1);
+        assertEq(keystore.getChangeSequences(address(wallet)).localSequence, 1);
         assertEq(keystore.getChangeSequences(address(wallet)).multichain, 0);
         assertTrue(_isActor(address(wallet), bytes32(bytes20(vm.addr(ownerPk)))));
     }
@@ -459,7 +459,7 @@ contract ImportAccountTest is KeystoreTest {
 
         keystore.importAccount(address(wallet), block.chainid, actors, sig);
 
-        assertEq(keystore.getChangeSequences(address(wallet)).local, 1);
+        assertEq(keystore.getChangeSequences(address(wallet)).localSequence, 1);
         for (uint256 i; i < count; i++) {
             bytes32 actorId = actors[i].actorId;
             assertTrue(_isActor(address(wallet), actorId));
@@ -490,7 +490,7 @@ contract ImportAccountTest is KeystoreTest {
 
         keystore.importAccount(eoa, uint64(block.chainid), actors, sig);
 
-        assertEq(keystore.getChangeSequences(eoa).local, 1);
+        assertEq(keystore.getChangeSequences(eoa).localSequence, 1);
         assertTrue(_isActor(eoa, bytes32(bytes20(device))));
         assertFalse(_isActor(eoa, bytes32(bytes20(eoa))));
     }
@@ -514,7 +514,7 @@ contract ImportAccountTest is KeystoreTest {
             eoa, uint64(block.chainid), actors, _buildK1Auth(eoaPk, keystore.replaySafeHash(eoa, digest))
         );
 
-        assertEq(keystore.getChangeSequences(eoa).local, 1);
+        assertEq(keystore.getChangeSequences(eoa).localSequence, 1);
         assertTrue(_isActor(eoa, bytes32(bytes20(device))));
         assertFalse(_isActor(eoa, bytes32(bytes20(eoa))));
 
@@ -543,7 +543,7 @@ contract ImportAccountTest is KeystoreTest {
             eoa, uint64(block.chainid), actors, _buildK1Auth(eoaPk, keystore.replaySafeHash(eoa, digest))
         );
 
-        assertEq(keystore.getChangeSequences(eoa).local, 1);
+        assertEq(keystore.getChangeSequences(eoa).localSequence, 1);
         // The self-actorId is a live explicit owner.
         assertTrue(_isActor(eoa, bytes32(bytes20(eoa))));
 

--- a/test/unit/Keystore/importAccount.t.sol
+++ b/test/unit/Keystore/importAccount.t.sol
@@ -88,7 +88,7 @@ contract ImportAccountTest is KeystoreTest {
         return keccak256(
             abi.encode(
                 ACTOR_INITIALIZATION_TYPEHASH,
-                bytes32(bytes20(account)),
+                bytes32(uint256(uint160(account))),
                 chainId,
                 keccak256(abi.encodePacked(actorHashes))
             )

--- a/test/unit/Keystore/policyAccessors.t.sol
+++ b/test/unit/Keystore/policyAccessors.t.sol
@@ -458,7 +458,8 @@ contract PolicyAccessorsTest is KeystoreTest {
         (address accountA,) = _createK1AccountWithSalt(rootPk, saltA);
         (address accountB,) = _createK1AccountWithSalt(rootPk, saltB);
         bytes32 rootActorId = bytes32(bytes20(vm.addr(rootPk)));
-        // Keep the shared actorId a non-self, non-owner explicit actor on both accounts.
+        // Keep the shared actorId a non-zero, non-self, non-owner explicit actor on both accounts.
+        vm.assume(sharedActorId != bytes32(0)); // the zero actorId is rejected by AuthorizeActor (InvalidActorId)
         vm.assume(sharedActorId != rootActorId);
         vm.assume(sharedActorId != bytes32(bytes20(accountA)));
         vm.assume(sharedActorId != bytes32(bytes20(accountB)));
@@ -585,6 +586,7 @@ contract PolicyAccessorsTest is KeystoreTest {
     ///      self-actorId (which would route to the inline-self home) and from the root owner's actorId (which would
     ///      overwrite the owner). actorId is otherwise an opaque bytes32 the protocol does not format-check.
     function _boundExplicitActorId(address account, uint256 rootPk, bytes32 actorId) internal pure returns (bytes32) {
+        vm.assume(actorId != bytes32(0)); // the zero actorId is rejected by AuthorizeActor (InvalidActorId)
         vm.assume(actorId != bytes32(bytes20(account)));
         vm.assume(actorId != bytes32(bytes20(vm.addr(rootPk))));
         return actorId;

--- a/test/unit/Keystore/policyAccessors.t.sol
+++ b/test/unit/Keystore/policyAccessors.t.sol
@@ -673,7 +673,7 @@ contract PolicyAccessorsTest is KeystoreTest {
     /// @dev Authorize an ungated (scope 0) actor under `authenticator`, signed by `pk`. Batched with an epoch bump so
     ///      overwriting a previously gated actor down to ungated (a scope reduction) is permitted.
     function _authorizeUngatedActor(address account, uint256 pk, bytes32 newActorId, address authenticator) internal {
-        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](2);
         ch[0] = _authorizeChange(newActorId, authenticator, 0x00, UNBOUNDED, "");
         ch[1] = _bumpChange();
         _applyLocal(pk, account, ch);

--- a/test/unit/Keystore/policyAccessors.t.sol
+++ b/test/unit/Keystore/policyAccessors.t.sol
@@ -78,7 +78,7 @@ contract PolicyAccessorsTest is KeystoreTest {
     ) public {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
+        bytes32 selfActorId = bytes32(uint256(uint160(eoa)));
 
         uint16 scope = _boundGatedScope(scopeSeed);
         address manager = _boundNonZeroAddress(managerSeed);
@@ -97,7 +97,7 @@ contract PolicyAccessorsTest is KeystoreTest {
     ///         home (else-if true, no _actorConfig, not revoked) with no policy slots written.
     function test_getPolicy_success_inlineSelfUngated_returnsNone(uint256 eoaSeed) public view {
         address eoa = vm.addr(_boundK1Pk(eoaSeed));
-        bytes32 selfActorId = bytes32(bytes20(eoa));
+        bytes32 selfActorId = bytes32(uint256(uint160(eoa)));
 
         (address outManager, bytes32 outCommitment) = keystore.getPolicy(eoa, selfActorId);
         assertEq(outManager, address(0));
@@ -110,7 +110,7 @@ contract PolicyAccessorsTest is KeystoreTest {
 
     /// @notice An unknown (never-authorized, non-self) actor: getPolicy returns (0, 0) over empty state.
     function test_getPolicy_success_unknownActor_returnsNone(address account, bytes32 actorId) public view {
-        vm.assume(actorId != bytes32(bytes20(account))); // stay off the inline-self else-if
+        vm.assume(actorId != bytes32(uint256(uint160(account)))); // stay off the inline-self else-if
 
         (address outManager, bytes32 outCommitment) = keystore.getPolicy(account, actorId);
         assertEq(outManager, address(0));
@@ -129,7 +129,7 @@ contract PolicyAccessorsTest is KeystoreTest {
         (address eoa, uint256 ownerPk) = _seedGatedInlineSelfWithSpareOwner(
             eoaSeed, ownerSeed, scopeSeed, managerSeed, commitmentSeed
         );
-        bytes32 selfActorId = bytes32(bytes20(eoa));
+        bytes32 selfActorId = bytes32(uint256(uint160(eoa)));
 
         // Revoke the (downgraded) self via the spare unrestricted owner; the policy-scoped self cannot sign config.
         _revokeActor(eoa, ownerPk, selfActorId);
@@ -189,7 +189,7 @@ contract PolicyAccessorsTest is KeystoreTest {
     ) public {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
+        bytes32 selfActorId = bytes32(uint256(uint160(eoa)));
 
         address manager = _boundNonZeroAddress(managerSeed);
         _authorizeInlineSelfWithPolicy(
@@ -207,7 +207,7 @@ contract PolicyAccessorsTest is KeystoreTest {
     ) public {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
+        bytes32 selfActorId = bytes32(uint256(uint160(eoa)));
 
         bytes32 commitment = _boundNonZeroWord(commitmentSeed);
         _authorizeInlineSelfWithPolicy(
@@ -288,7 +288,7 @@ contract PolicyAccessorsTest is KeystoreTest {
     ) public {
         (address eoa, uint256 ownerPk) =
             _seedGatedInlineSelfWithSpareOwner(eoaSeed, ownerSeed, scopeSeed, managerSeed, commitmentSeed);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
+        bytes32 selfActorId = bytes32(uint256(uint160(eoa)));
 
         // Live first.
         assertTrue(keystore.getPolicyManager(eoa, selfActorId) != address(0));
@@ -395,7 +395,7 @@ contract PolicyAccessorsTest is KeystoreTest {
         for (uint256 i; i < otherScopes.length; i++) {
             // Policy actors are keyed by actorId only; no signing key is needed, so a distinct address-shaped id
             // avoids the vm.addr curve-order bound on an unbounded rootPk + i.
-            bytes32 actorId = bytes32(bytes20(address(uint160(1000 + i))));
+            bytes32 actorId = bytes32(uint256(uint160(address(uint160(1000 + i)))));
             uint16 scope = otherScopes[i] | Scopes.POLICY;
             _authorizePolicyActor(account, rootPk, actorId, scope, manager, commitment);
 
@@ -457,12 +457,12 @@ contract PolicyAccessorsTest is KeystoreTest {
         uint256 rootPk = _boundK1Pk(rootSeed);
         (address accountA,) = _createK1AccountWithSalt(rootPk, saltA);
         (address accountB,) = _createK1AccountWithSalt(rootPk, saltB);
-        bytes32 rootActorId = bytes32(bytes20(vm.addr(rootPk)));
+        bytes32 rootActorId = bytes32(uint256(uint160(vm.addr(rootPk))));
         // Keep the shared actorId a non-zero, non-self, non-owner explicit actor on both accounts.
         vm.assume(sharedActorId != bytes32(0)); // the zero actorId is rejected by AuthorizeActor (InvalidActorId)
         vm.assume(sharedActorId != rootActorId);
-        vm.assume(sharedActorId != bytes32(bytes20(accountA)));
-        vm.assume(sharedActorId != bytes32(bytes20(accountB)));
+        vm.assume(sharedActorId != bytes32(uint256(uint160(accountA))));
+        vm.assume(sharedActorId != bytes32(uint256(uint160(accountB))));
 
         uint16 scope = _boundGatedScope(scopeSeed);
         address managerA = _boundNonZeroAddress(managerSeedA);
@@ -501,7 +501,7 @@ contract PolicyAccessorsTest is KeystoreTest {
 
         (address account,) = _createK1Account(rootPk);
         vm.assume(vm.addr(sessionPk) != account); // stay off the inline-self path
-        bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
+        bytes32 sessionActorId = bytes32(uint256(uint160(vm.addr(sessionPk))));
 
         address manager = _boundNonZeroAddress(managerSeed);
         _authorizePolicyActor(
@@ -523,7 +523,7 @@ contract PolicyAccessorsTest is KeystoreTest {
 
         (address account,) = _createK1Account(rootPk);
         vm.assume(vm.addr(sessionPk) != account);
-        bytes32 sessionActorId = bytes32(bytes20(vm.addr(sessionPk)));
+        bytes32 sessionActorId = bytes32(uint256(uint160(vm.addr(sessionPk))));
 
         _authorizeUngatedActor(account, rootPk, sessionActorId, address(k1Authenticator));
 
@@ -541,7 +541,7 @@ contract PolicyAccessorsTest is KeystoreTest {
     ) public {
         uint256 eoaPk = _boundK1Pk(eoaSeed);
         address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(bytes20(eoa));
+        bytes32 selfActorId = bytes32(uint256(uint160(eoa)));
 
         address manager = _boundNonZeroAddress(managerSeed);
         _authorizeInlineSelfWithPolicy(
@@ -560,7 +560,7 @@ contract PolicyAccessorsTest is KeystoreTest {
 
         (, uint16 outScope) = keystore.authenticateActor(eoa, hash, _buildK1Auth(eoaPk, hash));
         assertEq(outScope, uint16(0x00));
-        assertEq(keystore.getPolicyManager(eoa, bytes32(bytes20(eoa))), address(0));
+        assertEq(keystore.getPolicyManager(eoa, bytes32(uint256(uint160(eoa)))), address(0));
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -587,8 +587,8 @@ contract PolicyAccessorsTest is KeystoreTest {
     ///      overwrite the owner). actorId is otherwise an opaque bytes32 the protocol does not format-check.
     function _boundExplicitActorId(address account, uint256 rootPk, bytes32 actorId) internal pure returns (bytes32) {
         vm.assume(actorId != bytes32(0)); // the zero actorId is rejected by AuthorizeActor (InvalidActorId)
-        vm.assume(actorId != bytes32(bytes20(account)));
-        vm.assume(actorId != bytes32(bytes20(vm.addr(rootPk))));
+        vm.assume(actorId != bytes32(uint256(uint160(account))));
+        vm.assume(actorId != bytes32(uint256(uint160(vm.addr(rootPk)))));
         return actorId;
     }
 
@@ -606,8 +606,8 @@ contract PolicyAccessorsTest is KeystoreTest {
         ownerPk = _boundK1Pk(ownerSeed);
         vm.assume(vm.addr(eoaPk) != vm.addr(ownerPk));
         eoa = vm.addr(eoaPk);
-        bytes32 ownerActorId = bytes32(bytes20(vm.addr(ownerPk)));
-        vm.assume(ownerActorId != bytes32(bytes20(eoa)));
+        bytes32 ownerActorId = bytes32(uint256(uint160(vm.addr(ownerPk))));
+        vm.assume(ownerActorId != bytes32(uint256(uint160(eoa))));
 
         // Pre-authorize the spare unrestricted owner (signed by the still-full-owner self).
         _authorizeUngatedActor(eoa, eoaPk, ownerActorId, address(k1Authenticator));
@@ -662,7 +662,7 @@ contract PolicyAccessorsTest is KeystoreTest {
             eoa,
             _one(
                 _authorizeChange(
-                    bytes32(bytes20(eoa)),
+                    bytes32(uint256(uint160(eoa))),
                     keystore.K1_AUTHENTICATOR(),
                     scope,
                     UNBOUNDED,

--- a/test/unit/Keystore/policyAccessors.t.sol
+++ b/test/unit/Keystore/policyAccessors.t.sol
@@ -592,7 +592,7 @@ contract PolicyAccessorsTest is KeystoreTest {
 
     /// @dev Seed a gated inline-k1 self plus a spare unrestricted owner able to sign a later self-revoke. Returns
     ///      (eoa, spareOwnerPk). The self is downgraded to a policy scope (admin is exactly scope == 0) and thus
-    ///      cannot sign config changes, so the spare owner is what revokes it.
+    ///      cannot sign account changes, so the spare owner is what revokes it.
     function _seedGatedInlineSelfWithSpareOwner(
         uint256 eoaSeed,
         uint256 ownerSeed,
@@ -673,7 +673,7 @@ contract PolicyAccessorsTest is KeystoreTest {
     /// @dev Authorize an ungated (scope 0) actor under `authenticator`, signed by `pk`. Batched with an epoch bump so
     ///      overwriting a previously gated actor down to ungated (a scope reduction) is permitted.
     function _authorizeUngatedActor(address account, uint256 pk, bytes32 newActorId, address authenticator) internal {
-        Keystore.ConfigChange[] memory ch = new Keystore.ConfigChange[](2);
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _authorizeChange(newActorId, authenticator, 0x00, UNBOUNDED, "");
         ch[1] = _bumpChange();
         _applyLocal(pk, account, ch);

--- a/test/unit/Keystore/policyAccessors.t.sol
+++ b/test/unit/Keystore/policyAccessors.t.sol
@@ -625,7 +625,7 @@ contract PolicyAccessorsTest is KeystoreTest {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     /// @dev Authorize a non-self actor with a gated policy bound to (manager, commitment), signed by the root owner.
-    ///      `scope` must carry SCOPE_POLICY.
+    ///      `scope` must carry SCOPE_POLICY. Granted UNBOUNDED on a sequenced local batch (the new "no expiry").
     function _authorizePolicyActor(
         address account,
         uint256 rootPk,
@@ -634,18 +634,15 @@ contract PolicyAccessorsTest is KeystoreTest {
         address policyManager,
         bytes32 commitment
     ) internal {
-        Keystore.ActorConfig memory cfg =
-            Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0});
-        bytes memory policyData = abi.encodePacked(policyManager, commitment);
-
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            actorId: actorId, changeType: Keystore.ActorChangeType.Authorize, data: abi.encode(cfg, policyData)
-        });
-
-        uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        keystore.applySignedActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(rootPk, digest));
+        _applyLocal(
+            rootPk,
+            account,
+            _one(
+                _authorizeChange(
+                    actorId, address(k1Authenticator), scope, UNBOUNDED, abi.encodePacked(policyManager, commitment)
+                )
+            )
+        );
     }
 
     /// @dev Authorize the EOA's self-actorId as a scoped k1 actor carrying a gated policy. The EOA is not
@@ -658,40 +655,27 @@ contract PolicyAccessorsTest is KeystoreTest {
         address policyManager,
         bytes32 commitment
     ) internal {
-        bytes32 selfActorId = bytes32(bytes20(eoa));
-        Keystore.ActorConfig memory cfg =
-            Keystore.ActorConfig({authenticator: keystore.K1_AUTHENTICATOR(), scope: scope, expiry: 0});
-        bytes memory policyData = abi.encodePacked(policyManager, commitment);
-
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            actorId: selfActorId, changeType: Keystore.ActorChangeType.Authorize, data: abi.encode(cfg, policyData)
-        });
-
-        uint64 seq = keystore.getChangeSequences(eoa).local;
-        bytes32 digest = _computeActorChangeBatchDigest(eoa, uint64(block.chainid), seq, changes);
-        keystore.applySignedActorChanges(eoa, uint64(block.chainid), changes, _buildK1Auth(eoaPk, digest));
+        _applyLocal(
+            eoaPk,
+            eoa,
+            _one(
+                _authorizeChange(
+                    bytes32(bytes20(eoa)),
+                    keystore.K1_AUTHENTICATOR(),
+                    scope,
+                    UNBOUNDED,
+                    abi.encodePacked(policyManager, commitment)
+                )
+            )
+        );
     }
 
-    /// @dev Authorize an ungated (scope 0) actor under `authenticator`, signed by `pk`.
+    /// @dev Authorize an ungated (scope 0) actor under `authenticator`, signed by `pk`. Batched with an epoch bump so
+    ///      overwriting a previously gated actor down to ungated (a scope reduction) is permitted.
     function _authorizeUngatedActor(address account, uint256 pk, bytes32 newActorId, address authenticator) internal {
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            actorId: newActorId,
-            changeType: Keystore.ActorChangeType.Authorize,
-            data: abi.encode(Keystore.ActorConfig({authenticator: authenticator, scope: 0x00, expiry: 0}), bytes(""))
-        });
-        uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        keystore.applySignedActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));
-    }
-
-    /// @dev Revoke `actorId` from `account`, signed by `pk`.
-    function _revokeActor(address account, uint256 pk, bytes32 actorId) internal {
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
-        uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        keystore.applySignedActorChanges(account, uint64(block.chainid), changes, _buildK1Auth(pk, digest));
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        ch[0] = _authorizeChange(newActorId, authenticator, 0x00, UNBOUNDED, "");
+        ch[1] = _bumpChange();
+        _applyLocal(pk, account, ch);
     }
 }

--- a/test/unit/accounts/CanonicalHighRatePayerAccount.t.sol
+++ b/test/unit/accounts/CanonicalHighRatePayerAccount.t.sol
@@ -31,7 +31,7 @@ contract CanonicalHighRatePayerAccountTest is KeystoreTest {
 
     function _createHighRatePayerK1Account(uint256 pk) internal returns (address account, bytes32 actorId) {
         address signer = vm.addr(pk);
-        actorId = bytes32(bytes20(signer));
+        actorId = bytes32(uint256(uint160(signer)));
 
         Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](1);
         actors[0] = Keystore.InitialActor({

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -214,6 +214,70 @@ contract DefaultAccountTest is KeystoreTest {
         assertEq(target.value(), v);
     }
 
+    /// @notice A TRUSTED_EXECUTOR actor whose scope is not operational (a capability-only scope, e.g. SELF_PAYER)
+    ///         cannot drive execution: _isAuthorizedCaller returns false via the isOperator(scope) == false leg.
+    function test_executeBatch_revert_trustedExecutorNonOperationalScope(uint256 execSeed) public {
+        (address account,) = _createK1Account(ACTOR_PK);
+
+        address executor = address(uint160(bound(execSeed, 10, type(uint160).max)));
+        vm.assume(executor != account && executor != vm.addr(ACTOR_PK));
+
+        // Registered as a trusted executor, but with a non-operational (capability-only) scope.
+        _authorizeActorWithScope(
+            account, ACTOR_PK, bytes32(uint256(uint160(executor))), TRUSTED_EXECUTOR, SCOPE_SELF_PAYER
+        );
+
+        vm.prank(executor);
+        vm.expectRevert(DefaultAccount.UnauthorizedCaller.selector);
+        DefaultAccount(payable(account))
+            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (1))));
+    }
+
+    /// @notice A TRUSTED_EXECUTOR actor with an unbounded (expiry == 0) grant may drive execution.
+    /// @dev Covers the `config.expiry != 0` false leg of the expiry guard (the && short-circuits before the
+    ///      timestamp comparison), which the UNBOUNDED-expiry executor helper never exercises.
+    function test_executeBatch_success_trustedExecutorZeroExpiry(uint256 execSeed, uint256 v) public {
+        (address account,) = _createK1Account(ACTOR_PK);
+
+        address executor = address(uint160(bound(execSeed, 10, type(uint160).max)));
+        vm.assume(executor != account && executor != vm.addr(ACTOR_PK));
+
+        // Operational admin scope, expiry == 0 (unlimited).
+        _applyLocal(
+            ACTOR_PK, account, _one(_authorizeChange(bytes32(uint256(uint160(executor))), TRUSTED_EXECUTOR, 0, 0, ""))
+        );
+
+        vm.prank(executor);
+        DefaultAccount(payable(account))
+            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (v))));
+
+        assertEq(target.value(), v);
+    }
+
+    /// @notice A TRUSTED_EXECUTOR config whose non-zero expiry has elapsed is rejected.
+    /// @dev getActorConfig already zeroes expired configs, so the elapsed-expiry leg of _isAuthorizedCaller is
+    ///      defense-in-depth; mock the keystore to return a stale (expired) executor config and prove it fails closed.
+    function test_executeBatch_revert_trustedExecutorExpired(uint256 execSeed) public {
+        (address account,) = _createK1Account(ACTOR_PK);
+
+        address executor = address(uint160(bound(execSeed, 10, type(uint160).max)));
+        vm.assume(executor != account && executor != vm.addr(ACTOR_PK));
+
+        vm.warp(1000);
+        Keystore.ActorConfig memory stale =
+            Keystore.ActorConfig({authenticator: TRUSTED_EXECUTOR, expiry: 500, scope: 0}); // expiry < now
+        vm.mockCall(
+            address(keystore),
+            abi.encodeWithSelector(Keystore.getActorConfig.selector, account, bytes32(uint256(uint160(executor)))),
+            abi.encode(stale)
+        );
+
+        vm.prank(executor);
+        vm.expectRevert(DefaultAccount.UnauthorizedCaller.selector);
+        DefaultAccount(payable(account))
+            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (1))));
+    }
+
     /// @notice A call to a target with no code succeeds (the low-level call returns success).
     /// @dev executeBatch does not verify the target has code, so codeless targets return success.
     function test_executeBatch_success_callToCodelessTarget(address t) public {

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -47,33 +47,9 @@ contract DefaultAccountTest is KeystoreTest {
         calls[0] = Call(t, v, d);
     }
 
-    /// @dev Authorize an actor with unrestricted scope on `account`, signed by `pk`.
-    function _authorizeActor(address account, uint256 pk, bytes32 newActorId, address authenticator) internal {
-        _authorizeActorWithScope(account, pk, newActorId, authenticator, 0x00);
-    }
-
-    /// @dev Authorize an actor with a given scope, signed by `pk`. Used to register both TRUSTED_EXECUTOR actors and
-    ///      scoped k1 actors from the account owner.
-    function _authorizeActorWithScope(
-        address account,
-        uint256 pk,
-        bytes32 newActorId,
-        address authenticator,
-        uint16 scope
-    ) internal {
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            actorId: newActorId,
-            changeType: Keystore.ActorChangeType.Authorize,
-            data: abi.encode(Keystore.ActorConfig({authenticator: authenticator, scope: scope, expiry: 0}), bytes(""))
-        });
-
-        uint64 seq = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, uint64(block.chainid), seq, changes);
-        bytes memory auth = _buildK1Auth(pk, digest);
-
-        keystore.applySignedActorChanges(account, uint64(block.chainid), changes, auth);
-    }
+    // _authorizeActor and _authorizeActorWithScope are provided by the KeystoreTest harness (re-implemented on
+    // applySignedAccountChanges, granting UNBOUNDED on a sequenced local batch). TRUSTED_EXECUTOR and scoped k1
+    // actors are registered through those helpers.
 
     // ══════════════════════════════════════════════
     //  executeBatch — reverts (source order)

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -48,7 +48,7 @@ contract DefaultAccountTest is KeystoreTest {
     }
 
     // _authorizeActor and _authorizeActorWithScope are provided by the KeystoreTest harness (re-implemented on
-    // applySignedAccountChanges, granting UNBOUNDED on a sequenced local batch). TRUSTED_EXECUTOR and scoped k1
+    // applySignedConfigChanges, granting UNBOUNDED on a sequenced local batch). TRUSTED_EXECUTOR and scoped k1
     // actors are registered through those helpers.
 
     // ══════════════════════════════════════════════

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -91,7 +91,7 @@ contract DefaultAccountTest is KeystoreTest {
         vm.assume(actor != account && actor != vm.addr(ACTOR_PK));
 
         // Register `actor` as an ordinary k1 actor (authenticator == K1_AUTHENTICATOR), NOT a trusted executor.
-        _authorizeActor(account, ACTOR_PK, bytes32(bytes20(actor)), k1Authenticator);
+        _authorizeActor(account, ACTOR_PK, bytes32(uint256(uint160(actor))), k1Authenticator);
 
         vm.prank(actor);
         vm.expectRevert(DefaultAccount.UnauthorizedCaller.selector);
@@ -205,7 +205,7 @@ contract DefaultAccountTest is KeystoreTest {
         vm.assume(executor != account && executor != vm.addr(ACTOR_PK));
 
         // The owner signs an actor change registering `executor` with the TRUSTED_EXECUTOR authenticator.
-        _authorizeActor(account, ACTOR_PK, bytes32(bytes20(executor)), TRUSTED_EXECUTOR);
+        _authorizeActor(account, ACTOR_PK, bytes32(uint256(uint160(executor))), TRUSTED_EXECUTOR);
 
         vm.prank(executor);
         DefaultAccount(payable(account))
@@ -314,7 +314,7 @@ contract DefaultAccountTest is KeystoreTest {
         vm.assume(actor != vm.addr(ownerPk) && actor != account);
 
         // Authorize the actor with SELF_PAYER scope only — it is not operational and cannot validate signatures.
-        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(actor)), k1Authenticator, SCOPE_SELF_PAYER);
+        _authorizeActorWithScope(account, ownerPk, bytes32(uint256(uint160(actor))), k1Authenticator, SCOPE_SELF_PAYER);
 
         bytes memory authData = _buildK1Auth(actorPk, hash);
 
@@ -336,7 +336,7 @@ contract DefaultAccountTest is KeystoreTest {
         vm.assume(actor != vm.addr(ownerPk) && actor != account);
 
         // Authorize the actor with SENDER scope only (no POLICY) — it is operational and can validate signatures.
-        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(actor)), k1Authenticator, SCOPE_SENDER);
+        _authorizeActorWithScope(account, ownerPk, bytes32(uint256(uint160(actor))), k1Authenticator, SCOPE_SENDER);
 
         // verifySignature applies the account-scoped EIP-7739 wrap, so sign the replaySafeHash digest.
         bytes memory authData = _buildK1Auth(actorPk, keystore.replaySafeHash(account, hash));
@@ -392,7 +392,9 @@ contract DefaultAccountTest is KeystoreTest {
         address actor = vm.addr(actorPk);
         vm.assume(actor != vm.addr(ownerPk) && actor != account);
 
-        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(actor)), k1Authenticator, SCOPE_SPONSOR_PAYER);
+        _authorizeActorWithScope(
+            account, ownerPk, bytes32(uint256(uint160(actor))), k1Authenticator, SCOPE_SPONSOR_PAYER
+        );
 
         bytes memory authData = _buildK1Auth(actorPk, hash);
 
@@ -421,7 +423,7 @@ contract DefaultAccountTest is KeystoreTest {
         address executor = address(uint160(bound(execSeed, 10, type(uint160).max)));
         vm.assume(executor != account && executor != vm.addr(ACTOR_PK));
 
-        _authorizeActor(account, ACTOR_PK, bytes32(bytes20(executor)), TRUSTED_EXECUTOR);
+        _authorizeActor(account, ACTOR_PK, bytes32(uint256(uint160(executor))), TRUSTED_EXECUTOR);
 
         assertTrue(DefaultAccount(payable(account)).isAuthorizedCaller(executor));
     }
@@ -435,7 +437,7 @@ contract DefaultAccountTest is KeystoreTest {
         address actor = vm.addr(actorPk);
         vm.assume(actor != account && actor != vm.addr(ACTOR_PK));
 
-        _authorizeActor(account, ACTOR_PK, bytes32(bytes20(actor)), k1Authenticator);
+        _authorizeActor(account, ACTOR_PK, bytes32(uint256(uint160(actor))), k1Authenticator);
 
         assertFalse(DefaultAccount(payable(account)).isAuthorizedCaller(actor));
     }

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -48,7 +48,7 @@ contract DefaultAccountTest is KeystoreTest {
     }
 
     // _authorizeActor and _authorizeActorWithScope are provided by the KeystoreTest harness (re-implemented on
-    // applySignedConfigChanges, granting UNBOUNDED on a sequenced local batch). TRUSTED_EXECUTOR and scoped k1
+    // applySignedAccountChanges, granting UNBOUNDED on a sequenced local batch). TRUSTED_EXECUTOR and scoped k1
     // actors are registered through those helpers.
 
     // ══════════════════════════════════════════════

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -12,7 +12,7 @@ import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 ///           1. InvalidDataLength       — data.length < 40
 ///           2. RecursiveDelegation     — nestedAuthenticator == address(this) (blocks 1-hop recursion)
 ///           3. InvalidNestedSignature  — the nested auth does not resolve to the admin actor on `delegate`
-///         On success returns actorId = bytes32(bytes20(delegate)).
+///         On success returns actorId = bytes32(uint256(uint160(delegate))).
 ///
 ///         The delegate vouch requires the nested auth to resolve to the ADMIN actor on `delegate` (scope ==
 ///         0x00). This admin-only requirement is enforced independently of verifySignature (via authenticateActor
@@ -153,7 +153,7 @@ contract DelegateAuthenticatorTest is KeystoreTest {
     // ── Happy paths ──
 
     /// @dev An unrestricted (scope 0x00) initial owner is admin, so the delegate vouch succeeds;
-    ///      authenticate returns actorId = bytes32(bytes20(delegate)).
+    ///      authenticate returns actorId = bytes32(uint256(uint160(delegate))).
     function test_authenticate_success_unrestrictedNestedSigner(uint256 ownerSeed, bytes32 hash) public {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
         (address delegateAccount,) = _createK1Account(ownerPk);
@@ -162,7 +162,7 @@ contract DelegateAuthenticatorTest is KeystoreTest {
         bytes memory data = abi.encodePacked(delegateAccount, nestedAuth);
 
         bytes32 actorId = delegateAuthenticator.authenticate(hash, data);
-        assertEq(actorId, bytes32(bytes20(delegateAccount)));
+        assertEq(actorId, bytes32(uint256(uint160(delegateAccount))));
     }
 
     /// @dev The former SIGNER bit (0x10, now SCOPE_SPONSOR_PAYER) no longer grants signing: a nested actor holding
@@ -189,6 +189,8 @@ contract DelegateAuthenticatorTest is KeystoreTest {
     /// @dev Authorizes a new K1 actor (`newPk`) with `scope` on `account`, signed by the unrestricted owner
     ///      (`ownerPk`). Granted UNBOUNDED (the new "no expiry") on a sequenced local batch via the harness helper.
     function _authorizeScopedK1Actor(address account, uint256 ownerPk, uint256 newPk, uint16 scope) internal {
-        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(newPk))), address(k1Authenticator), scope);
+        _authorizeActorWithScope(
+            account, ownerPk, bytes32(uint256(uint160(vm.addr(newPk)))), address(k1Authenticator), scope
+        );
     }
 }

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -186,22 +186,9 @@ contract DelegateAuthenticatorTest is KeystoreTest {
 
     // ── Helpers ──
 
-    /// @dev Authorizes a new K1 actor (`newPk`) with `scope` on `account`, signed by the unrestricted
-    ///      owner (`ownerPk`) via applySignedActorChanges on the local chain.
+    /// @dev Authorizes a new K1 actor (`newPk`) with `scope` on `account`, signed by the unrestricted owner
+    ///      (`ownerPk`). Granted UNBOUNDED (the new "no expiry") on a sequenced local batch via the harness helper.
     function _authorizeScopedK1Actor(address account, uint256 ownerPk, uint256 newPk, uint16 scope) internal {
-        Keystore.ActorConfig memory config =
-            Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: scope, expiry: 0});
-
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            changeType: Keystore.ActorChangeType.Authorize,
-            actorId: bytes32(bytes20(vm.addr(newPk))),
-            data: abi.encode(config, bytes(""))
-        });
-
-        uint64 chainId = uint64(block.chainid);
-        uint64 sequence = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, chainId, sequence, changes);
-        keystore.applySignedActorChanges(account, chainId, changes, _buildK1Auth(ownerPk, digest));
+        _authorizeActorWithScope(account, ownerPk, bytes32(bytes20(vm.addr(newPk))), address(k1Authenticator), scope);
     }
 }

--- a/test/unit/authenticators/GasBenchmark.t.sol
+++ b/test/unit/authenticators/GasBenchmark.t.sol
@@ -50,7 +50,7 @@ contract GasBenchmarkTest is Test {
         {
             uint256 pkA = 0xA001;
             address signerA = vm.addr(pkA);
-            bytes32 actorIdA = bytes32(bytes20(signerA));
+            bytes32 actorIdA = bytes32(uint256(uint160(signerA)));
             Keystore.InitialActor[] memory actorsA = new Keystore.InitialActor[](1);
             actorsA[0] = Keystore.InitialActor({
                 actorId: actorIdA, authenticator: config.K1_AUTHENTICATOR(), scope: 0, policyData: ""

--- a/test/unit/policies/ExternalPolicyCaller.t.sol
+++ b/test/unit/policies/ExternalPolicyCaller.t.sol
@@ -27,7 +27,7 @@ contract ExtMockERC20 {
 /// @notice Exercises the external-caller flow of {PolicyManager}: a party that is *not* a key on the account (e.g. a
 ///         subscription provider) is authorized by accounts to pull within a policy, and drives one or many accounts
 ///         via {PolicyManager.executeFor} / {executeForMany}. Identity is the caller itself
-///         (`actorId == bytes20(msg.sender)`); the provider actor is registered with `EXTERNAL_POLICY_AUTHENTICATOR`
+///         (`actorId == ActorId.fromAddress(msg.sender)`); the provider actor is registered with `EXTERNAL_POLICY_AUTHENTICATOR`
 ///         so it can only act through the manager, never directly.
 contract ExternalPolicyCallerTest is KeystoreTest {
     PolicyManager internal manager;
@@ -72,7 +72,9 @@ contract ExternalPolicyCallerTest is KeystoreTest {
 
         // A different external address was never authorized by the account → not a live actor of it.
         address stranger = address(0xBAD);
-        vm.expectRevert(abi.encodeWithSelector(PolicyManager.InvalidActor.selector, bytes32(bytes20(stranger))));
+        vm.expectRevert(
+            abi.encodeWithSelector(PolicyManager.InvalidActor.selector, bytes32(uint256(uint160(stranger))))
+        );
         vm.prank(stranger);
         manager.executeFor(lastBinding, _pull(1));
     }
@@ -84,7 +86,9 @@ contract ExternalPolicyCallerTest is KeystoreTest {
         (PolicyManager.PolicyBinding memory binding, bytes32 commitment) = _binding(account, 7, 100e6, MONTH);
         _authorizeProvider(account, address(0xDEAD), commitment); // wrong manager
 
-        vm.expectRevert(abi.encodeWithSelector(PolicyManager.NoActivePolicy.selector, bytes32(bytes20(provider))));
+        vm.expectRevert(
+            abi.encodeWithSelector(PolicyManager.NoActivePolicy.selector, bytes32(uint256(uint160(provider))))
+        );
         vm.prank(provider);
         manager.executeFor(binding, _pull(1));
     }
@@ -96,7 +100,9 @@ contract ExternalPolicyCallerTest is KeystoreTest {
         (PolicyManager.PolicyBinding memory binding,) = _binding(account, 1, 100e6, MONTH);
         _authorizeProvider(account, address(manager), bytes32(0));
 
-        vm.expectRevert(abi.encodeWithSelector(PolicyManager.NoActivePolicy.selector, bytes32(bytes20(provider))));
+        vm.expectRevert(
+            abi.encodeWithSelector(PolicyManager.NoActivePolicy.selector, bytes32(uint256(uint160(provider))))
+        );
         vm.prank(provider);
         manager.executeFor(binding, _pull(1));
     }
@@ -107,7 +113,9 @@ contract ExternalPolicyCallerTest is KeystoreTest {
         _revokeProvider(account);
 
         // A revoked provider is no longer a live actor of the account.
-        vm.expectRevert(abi.encodeWithSelector(PolicyManager.InvalidActor.selector, bytes32(bytes20(provider))));
+        vm.expectRevert(
+            abi.encodeWithSelector(PolicyManager.InvalidActor.selector, bytes32(uint256(uint160(provider))))
+        );
         vm.prank(provider);
         manager.executeFor(lastBinding, _pull(1));
     }
@@ -119,7 +127,9 @@ contract ExternalPolicyCallerTest is KeystoreTest {
         address account = _optInWithExpiry(bytes32(uint256(1)), 100e6, MONTH, expiry);
 
         vm.warp(uint256(expiry) + 1);
-        vm.expectRevert(abi.encodeWithSelector(PolicyManager.InvalidActor.selector, bytes32(bytes20(provider))));
+        vm.expectRevert(
+            abi.encodeWithSelector(PolicyManager.InvalidActor.selector, bytes32(uint256(uint160(provider))))
+        );
         vm.prank(provider);
         manager.executeFor(lastBinding, _pull(1));
     }
@@ -132,7 +142,9 @@ contract ExternalPolicyCallerTest is KeystoreTest {
         (PolicyManager.PolicyBinding memory binding, bytes32 commitment) = _binding(account, 1, 100e6, MONTH);
         _authorizeProviderWithAuthenticator(account, address(k1Authenticator), address(manager), commitment, 0);
 
-        vm.expectRevert(abi.encodeWithSelector(PolicyManager.InvalidActor.selector, bytes32(bytes20(provider))));
+        vm.expectRevert(
+            abi.encodeWithSelector(PolicyManager.InvalidActor.selector, bytes32(uint256(uint160(provider))))
+        );
         vm.prank(provider);
         manager.executeFor(binding, _pull(1));
     }
@@ -185,7 +197,7 @@ contract ExternalPolicyCallerTest is KeystoreTest {
         data[2] = _pull(20e6);
 
         vm.expectEmit(true, true, true, false);
-        emit PolicyManager.ExecutionSkipped(a2, address(policy), bytes32(bytes20(provider)));
+        emit PolicyManager.ExecutionSkipped(a2, address(policy), bytes32(uint256(uint160(provider))));
 
         vm.prank(provider);
         bool[] memory results = manager.executeForMany(bindings, data);
@@ -203,7 +215,7 @@ contract ExternalPolicyCallerTest is KeystoreTest {
         address victim = _optIn(bytes32(uint256(1)), 100e6, MONTH);
         (, bytes32 victimCommitment) = _binding(victim, 1, 100e6, MONTH);
 
-        // Attacker points its OWN actor (actorId = bytes20(provider)) at the victim's opaque commitment + this
+        // Attacker points its OWN actor (actorId = ActorId.fromAddress(provider)) at the victim's opaque commitment + this
         // manager. Keystore stores the commitment verbatim, so nothing stops this registration.
         address attacker = _createAccount(bytes32(uint256(2)));
         _authorizeProvider(attacker, address(manager), victimCommitment);
@@ -239,7 +251,7 @@ contract ExternalPolicyCallerTest is KeystoreTest {
         binding.account = address(0x1);
         vm.expectRevert(PolicyManager.OnlySelf.selector);
         vm.prank(provider);
-        manager.enforceExternalSelf(binding, bytes32(bytes20(provider)), _pull(1), provider);
+        manager.enforceExternalSelf(binding, bytes32(uint256(uint160(provider))), _pull(1), provider);
     }
 
     // ── Helpers ──
@@ -300,13 +312,16 @@ contract ExternalPolicyCallerTest is KeystoreTest {
 
     function _createAccount(bytes32 salt) internal returns (address account) {
         Keystore.InitialActor memory root = Keystore.InitialActor({
-            actorId: bytes32(bytes20(vm.addr(ROOT_PK))),
+            actorId: bytes32(uint256(uint160(vm.addr(ROOT_PK)))),
             authenticator: address(k1Authenticator),
             scope: 0,
             policyData: ""
         });
         Keystore.InitialActor memory mgr = Keystore.InitialActor({
-            actorId: bytes32(bytes20(address(manager))), authenticator: TRUSTED_EXECUTOR, scope: 0, policyData: ""
+            actorId: bytes32(uint256(uint160(address(manager)))),
+            authenticator: TRUSTED_EXECUTOR,
+            scope: 0,
+            policyData: ""
         });
         Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](2);
         (actors[0], actors[1]) = root.actorId < mgr.actorId ? (root, mgr) : (mgr, root);
@@ -343,7 +358,7 @@ contract ExternalPolicyCallerTest is KeystoreTest {
             account,
             _one(
                 _authorizeChange(
-                    bytes32(bytes20(provider)),
+                    bytes32(uint256(uint160(provider))),
                     authenticator,
                     SCOPE_POLICY,
                     grant,
@@ -355,6 +370,6 @@ contract ExternalPolicyCallerTest is KeystoreTest {
 
     function _revokeProvider(address account) internal {
         // A bare admin-signed revoke; it clears the slot here (no outstanding replayable grant to retire).
-        _revokeActor(account, ROOT_PK, bytes32(bytes20(provider)));
+        _revokeActor(account, ROOT_PK, bytes32(uint256(uint160(provider))));
     }
 }

--- a/test/unit/policies/ExternalPolicyCaller.t.sol
+++ b/test/unit/policies/ExternalPolicyCaller.t.sol
@@ -336,8 +336,7 @@ contract ExternalPolicyCallerTest is KeystoreTest {
         bytes32 commitment,
         uint48 expiry
     ) internal {
-        // A zero expiry (the old "no expiry") maps to UNBOUNDED, granted on a sequenced local batch (unbounded
-        // grants are sequenced-only), signed by the root owner.
+        // A zero expiry (the old "no expiry") maps to UNBOUNDED, signed by the root owner.
         uint48 grant = expiry == 0 ? UNBOUNDED : expiry;
         _applyLocal(
             ROOT_PK,

--- a/test/unit/policies/ExternalPolicyCaller.t.sol
+++ b/test/unit/policies/ExternalPolicyCaller.t.sol
@@ -354,7 +354,7 @@ contract ExternalPolicyCallerTest is KeystoreTest {
     }
 
     function _revokeProvider(address account) internal {
-        // Revoking a live actor is a reduction; the harness helper batches the required epoch bump.
+        // A bare admin-signed revoke; it clears the slot here (no outstanding replayable grant to retire).
         _revokeActor(account, ROOT_PK, bytes32(bytes20(provider)));
     }
 }

--- a/test/unit/policies/ExternalPolicyCaller.t.sol
+++ b/test/unit/policies/ExternalPolicyCaller.t.sol
@@ -336,30 +336,26 @@ contract ExternalPolicyCallerTest is KeystoreTest {
         bytes32 commitment,
         uint48 expiry
     ) internal {
-        Keystore.ActorConfig memory cfg = Keystore.ActorConfig({
-            authenticator: authenticator, scope: SCOPE_POLICY, expiry: expiry
-        });
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            actorId: bytes32(bytes20(provider)),
-            changeType: Keystore.ActorChangeType.Authorize,
-            data: abi.encode(cfg, abi.encodePacked(policyManager, commitment))
-        });
-        _applyAsRoot(account, changes);
+        // A zero expiry (the old "no expiry") maps to UNBOUNDED, granted on a sequenced local batch (unbounded
+        // grants are sequenced-only), signed by the root owner.
+        uint48 grant = expiry == 0 ? UNBOUNDED : expiry;
+        _applyLocal(
+            ROOT_PK,
+            account,
+            _one(
+                _authorizeChange(
+                    bytes32(bytes20(provider)),
+                    authenticator,
+                    SCOPE_POLICY,
+                    grant,
+                    abi.encodePacked(policyManager, commitment)
+                )
+            )
+        );
     }
 
     function _revokeProvider(address account) internal {
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            actorId: bytes32(bytes20(provider)), changeType: Keystore.ActorChangeType.Revoke, data: ""
-        });
-        _applyAsRoot(account, changes);
-    }
-
-    function _applyAsRoot(address account, Keystore.ActorChange[] memory changes) internal {
-        uint64 chainId = uint64(block.chainid);
-        uint64 sequence = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, chainId, sequence, changes);
-        keystore.applySignedActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
+        // Revoking a live actor is a reduction; the harness helper batches the required epoch bump.
+        _revokeActor(account, ROOT_PK, bytes32(bytes20(provider)));
     }
 }

--- a/test/unit/policies/PolicyManager.t.sol
+++ b/test/unit/policies/PolicyManager.t.sol
@@ -354,19 +354,21 @@ contract PolicyManagerTest is KeystoreTest {
     }
 
     function _authorizePolicyActor(bytes32 actorId, bytes32 commitment, uint48 expiry) internal {
-        Keystore.ActorConfig memory cfg =
-            Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: expiry});
-        bytes memory policyData = abi.encodePacked(address(manager), commitment);
-
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            actorId: actorId, changeType: Keystore.ActorChangeType.Authorize, data: abi.encode(cfg, policyData)
-        });
-
-        uint64 chainId = uint64(block.chainid);
-        uint64 sequence = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, chainId, sequence, changes);
-        keystore.applySignedActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
+        // A zero expiry (the old "no expiry") maps to UNBOUNDED, granted on a sequenced local batch.
+        uint48 grant = expiry == 0 ? UNBOUNDED : expiry;
+        _applyLocal(
+            ROOT_PK,
+            account,
+            _one(
+                _authorizeChange(
+                    actorId,
+                    address(k1Authenticator),
+                    SCOPE_POLICY,
+                    grant,
+                    abi.encodePacked(address(manager), commitment)
+                )
+            )
+        );
     }
 
     function _createAttackerAccount() internal returns (address attacker, uint256 attackerOwnerPk) {
@@ -388,28 +390,23 @@ contract PolicyManagerTest is KeystoreTest {
     }
 
     function _authorizePolicyActorOn(address target_, uint256 ownerPk, bytes32 actorId, bytes32 commitment) internal {
-        Keystore.ActorConfig memory cfg =
-            Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0});
-        bytes memory policyData = abi.encodePacked(address(manager), commitment);
-
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            actorId: actorId, changeType: Keystore.ActorChangeType.Authorize, data: abi.encode(cfg, policyData)
-        });
-
-        uint64 chainId = uint64(block.chainid);
-        uint64 sequence = keystore.getChangeSequences(target_).local;
-        bytes32 digest = _computeActorChangeBatchDigest(target_, chainId, sequence, changes);
-        keystore.applySignedActorChanges(target_, chainId, changes, _buildK1Auth(ownerPk, digest));
+        _applyLocal(
+            ownerPk,
+            target_,
+            _one(
+                _authorizeChange(
+                    actorId,
+                    address(k1Authenticator),
+                    SCOPE_POLICY,
+                    UNBOUNDED,
+                    abi.encodePacked(address(manager), commitment)
+                )
+            )
+        );
     }
 
     function _revokePolicyActor(bytes32 actorId) internal {
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({actorId: actorId, changeType: Keystore.ActorChangeType.Revoke, data: ""});
-
-        uint64 chainId = uint64(block.chainid);
-        uint64 sequence = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, chainId, sequence, changes);
-        keystore.applySignedActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
+        // Revoking a live actor is a reduction; the harness helper batches the required epoch bump.
+        _revokeActor(account, ROOT_PK, actorId);
     }
 }

--- a/test/unit/policies/PolicyManager.t.sol
+++ b/test/unit/policies/PolicyManager.t.sol
@@ -333,13 +333,16 @@ contract PolicyManagerTest is KeystoreTest {
 
     function _createAccountWithRootAndManager() internal returns (address) {
         Keystore.InitialActor memory root = Keystore.InitialActor({
-            actorId: bytes32(bytes20(vm.addr(ROOT_PK))),
+            actorId: bytes32(uint256(uint160(vm.addr(ROOT_PK)))),
             authenticator: address(k1Authenticator),
             scope: 0,
             policyData: ""
         });
         Keystore.InitialActor memory mgr = Keystore.InitialActor({
-            actorId: bytes32(bytes20(address(manager))), authenticator: TRUSTED_EXECUTOR, scope: 0, policyData: ""
+            actorId: bytes32(uint256(uint160(address(manager)))),
+            authenticator: TRUSTED_EXECUTOR,
+            scope: 0,
+            policyData: ""
         });
 
         Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](2);
@@ -374,13 +377,16 @@ contract PolicyManagerTest is KeystoreTest {
     function _createAttackerAccount() internal returns (address attacker, uint256 attackerOwnerPk) {
         attackerOwnerPk = 0xB0B;
         Keystore.InitialActor memory root = Keystore.InitialActor({
-            actorId: bytes32(bytes20(vm.addr(attackerOwnerPk))),
+            actorId: bytes32(uint256(uint160(vm.addr(attackerOwnerPk)))),
             authenticator: address(k1Authenticator),
             scope: 0,
             policyData: ""
         });
         Keystore.InitialActor memory mgr = Keystore.InitialActor({
-            actorId: bytes32(bytes20(address(manager))), authenticator: TRUSTED_EXECUTOR, scope: 0, policyData: ""
+            actorId: bytes32(uint256(uint160(address(manager)))),
+            authenticator: TRUSTED_EXECUTOR,
+            scope: 0,
+            policyData: ""
         });
         Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](2);
         (actors[0], actors[1]) = root.actorId < mgr.actorId ? (root, mgr) : (mgr, root);

--- a/test/unit/policies/PolicyManager.t.sol
+++ b/test/unit/policies/PolicyManager.t.sol
@@ -406,7 +406,7 @@ contract PolicyManagerTest is KeystoreTest {
     }
 
     function _revokePolicyActor(bytes32 actorId) internal {
-        // Revoking a live actor is a reduction; the harness helper batches the required epoch bump.
+        // A bare admin-signed revoke; it clears the slot here (no outstanding replayable grant to retire).
         _revokeActor(account, ROOT_PK, actorId);
     }
 }

--- a/test/unit/policies/SessionPolicy.t.sol
+++ b/test/unit/policies/SessionPolicy.t.sol
@@ -745,17 +745,20 @@ contract SessionPolicyTest is KeystoreTest {
         });
         bytes32 commitment = manager.commitmentOf(binding);
 
-        Keystore.ActorConfig memory cfg =
-            Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0});
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            actorId: actorId,
-            changeType: Keystore.ActorChangeType.Authorize,
-            data: abi.encode(cfg, abi.encodePacked(address(manager), commitment))
-        });
-        uint64 chainId = uint64(block.chainid);
-        uint64 sequence = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, chainId, sequence, changes);
-        keystore.applySignedActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
+        // Authorize the fresh session-key actor gated to the manager, granted UNBOUNDED (the new "no expiry") on a
+        // sequenced local batch, signed by the root owner.
+        _applyLocal(
+            ROOT_PK,
+            account,
+            _one(
+                _authorizeChange(
+                    actorId,
+                    address(k1Authenticator),
+                    SCOPE_POLICY,
+                    UNBOUNDED,
+                    abi.encodePacked(address(manager), commitment)
+                )
+            )
+        );
     }
 }

--- a/test/unit/policies/SessionPolicy.t.sol
+++ b/test/unit/policies/SessionPolicy.t.sol
@@ -516,6 +516,63 @@ contract SessionPolicyTest is KeystoreTest {
         );
     }
 
+    function test_execute_allowsApproveDecodesSpender() public {
+        // A limited token pinning approve exercises the APPROVE leg of the ERC-20 decoder (`selector == APPROVE`).
+        SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
+        rules[0] =
+            SessionPolicy.SelectorRule({selector: SessionMockERC20.approve.selector, recipients: _noRecipients()});
+        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
+        scopes[0] = SessionPolicy.CallScope({target: address(token), selectorRules: rules});
+        bytes32 actorId = _install(_config(_limit(address(token), 500e18, WEEK), scopes));
+
+        _execute(actorId, address(token), 0, abi.encodeCall(SessionMockERC20.approve, (bob, 1e18)));
+        assertEq(token.allowance(account, bob), 1e18);
+    }
+
+    function test_execute_allowsSelfTransferFromDecodesAmount() public {
+        // A self-transferFrom (from == account) with a token limit passes the TransferFromNotSelf gate and reaches
+        // the ERC-20 amount decode — the else (transferFrom) leg of _decodeErc20 — then consumes the decoded amount.
+        SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
+        rules[0] = SessionPolicy.SelectorRule({selector: TRANSFER_FROM, recipients: _noRecipients()});
+        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
+        scopes[0] = SessionPolicy.CallScope({target: address(token), selectorRules: rules});
+        (bytes32 actorId, bytes32 commitment) =
+            _authorizeWithCommitment(_config(_limit(address(token), 500e18, WEEK), scopes));
+
+        // Fund the account and let it pull from itself so the underlying transferFrom succeeds.
+        token.mint(account, 100e18);
+        vm.prank(account);
+        token.approve(account, 100e18);
+
+        _execute(actorId, address(token), 0, abi.encodeCall(SessionMockERC20.transferFrom, (account, bob, 10e18)));
+
+        // The decoded amount was consumed against the token cap, proving the transferFrom decode leg ran.
+        assertEq(
+            policy.getCurrentSpend(
+                commitment, SessionPolicy.TokenLimit({token: address(token), limit: 500e18, period: WEEK})
+            )
+            .spend,
+            10e18
+        );
+        assertEq(token.balanceOf(bob), 10e18);
+    }
+
+    /// @notice Defensive guard: _findTokenLimit re-checks LimitTooLarge before the uint160 cast even though
+    ///         _validateConfig already rejects it at enforce entry. Reached only via a harness that bypasses
+    ///         validation, since the enforce path can never present an oversized limit here.
+    function test_findTokenLimit_revert_limitTooLargeDefensive() public {
+        SessionPolicyHarness harness = new SessionPolicyHarness(address(manager));
+        uint256 tooLarge = uint256(type(uint160).max) + 1;
+
+        SessionPolicy.TokenLimit[] memory limits = new SessionPolicy.TokenLimit[](1);
+        limits[0] = SessionPolicy.TokenLimit({token: address(token), limit: tooLarge, period: WEEK});
+        SessionPolicy.Config memory cfg =
+            SessionPolicy.Config({tokenLimits: limits, callScopes: new SessionPolicy.CallScope[](0)});
+
+        vm.expectRevert(abi.encodeWithSelector(SessionPolicy.LimitTooLarge.selector, address(token), tooLarge));
+        harness.exposedFindTokenLimit(cfg, address(token));
+    }
+
     function test_execute_allowsEmptyCalldata() public {
         // 0 bytes of calldata is a plain value call: it skips selector gating entirely.
         SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
@@ -618,9 +675,69 @@ contract SessionPolicyTest is KeystoreTest {
         assertEq(period, type(uint40).max);
     }
 
+    /// @notice Exercises the mismatch/empty branches of getSelectorRule and isRecipientAllowed: a non-matching
+    ///         target is skipped, an any-selector scope resolves without a recipient binding, an unknown selector
+    ///         resolves to (false,false), a non-matching rule is skipped, and an empty recipient list allows anyone.
+    function test_views_selectorAndRecipientEdges() public view {
+        address[] memory bobOnly = new address[](1);
+        bobOnly[0] = bob;
+
+        // token scope: TRANSFER bound to [bob]; OTHER open to anyone (empty recipient list).
+        SessionPolicy.SelectorRule[] memory tokenRules = new SessionPolicy.SelectorRule[](2);
+        tokenRules[0] = SessionPolicy.SelectorRule({selector: TRANSFER, recipients: bobOnly});
+        tokenRules[1] = SessionPolicy.SelectorRule({selector: OTHER_SELECTOR, recipients: _noRecipients()});
+
+        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](2);
+        scopes[0] = SessionPolicy.CallScope({target: address(token), selectorRules: tokenRules});
+        scopes[1] = _anySelectorScope(address(target)); // any selector (empty rules)
+
+        SessionPolicy.Config memory cfg = SessionPolicy.Config({tokenLimits: _noLimits(), callScopes: scopes});
+
+        // getSelectorRule: querying `target` skips scope[0] (target mismatch) and matches the any-selector scope[1].
+        (bool allowed, bool recipientBound) = policy.getSelectorRule(cfg, address(target), TRANSFER);
+        assertTrue(allowed);
+        assertFalse(recipientBound);
+
+        // getSelectorRule: matched target, unknown selector → (false, false).
+        (allowed, recipientBound) = policy.getSelectorRule(cfg, address(token), UNKNOWN_SELECTOR);
+        assertFalse(allowed);
+        assertFalse(recipientBound);
+
+        // isRecipientAllowed: `target` matches the any-selector scope but has no rules → false.
+        assertFalse(policy.isRecipientAllowed(cfg, address(target), TRANSFER, bob));
+
+        // isRecipientAllowed: token/OTHER skips the TRANSFER rule then hits the empty-recipients rule → anyone allowed.
+        assertTrue(policy.isRecipientAllowed(cfg, address(token), OTHER_SELECTOR, mallory));
+
+        // isRecipientAllowed: token/TRANSFER is bound to bob only.
+        assertTrue(policy.isRecipientAllowed(cfg, address(token), TRANSFER, bob));
+        assertFalse(policy.isRecipientAllowed(cfg, address(token), TRANSFER, mallory));
+    }
+
+    /// @notice getCurrentSpend short-circuits to an empty usage when the queried limit is zero.
+    function test_getCurrentSpend_zeroLimitReturnsEmpty() public view {
+        RecurringAllowance.PeriodUsage memory u = policy.getCurrentSpend(
+            bytes32(0), SessionPolicy.TokenLimit({token: address(token), limit: 0, period: WEEK})
+        );
+        assertEq(u.start, 0);
+        assertEq(u.end, 0);
+        assertEq(u.spend, 0);
+    }
+
+    /// @notice getCurrentSpend rejects a limit that does not fit in uint160 (matching the config-time invariant).
+    function test_getCurrentSpend_revertsLimitTooLarge() public {
+        uint256 tooLarge = uint256(type(uint160).max) + 1;
+        vm.expectRevert(abi.encodeWithSelector(SessionPolicy.LimitTooLarge.selector, address(token), tooLarge));
+        policy.getCurrentSpend(
+            bytes32(0), SessionPolicy.TokenLimit({token: address(token), limit: tooLarge, period: WEEK})
+        );
+    }
+
     // ── Helpers ──
 
     bytes4 internal constant TRANSFER_FROM = bytes4(keccak256("transferFrom(address,address,uint256)"));
+    bytes4 internal constant OTHER_SELECTOR = bytes4(0x12345678);
+    bytes4 internal constant UNKNOWN_SELECTOR = bytes4(0xaabbccdd);
 
     function _anySelectorScopes(address t) internal pure returns (SessionPolicy.CallScope[] memory scopes) {
         scopes = new SessionPolicy.CallScope[](1);
@@ -763,5 +880,19 @@ contract SessionPolicyTest is KeystoreTest {
                 )
             )
         );
+    }
+}
+
+/// @dev Exposes {SessionPolicy._findTokenLimit} so the defensive LimitTooLarge guard — unreachable through the
+///      validated {_enforce} path — can be exercised directly with an oversized limit.
+contract SessionPolicyHarness is SessionPolicy {
+    constructor(address policyManager) SessionPolicy(policyManager) {}
+
+    function exposedFindTokenLimit(SessionPolicy.Config calldata config, address token)
+        external
+        pure
+        returns (bool set, uint160 allowance, uint40 period)
+    {
+        return _findTokenLimit(config, token);
     }
 }

--- a/test/unit/policies/SessionPolicy.t.sol
+++ b/test/unit/policies/SessionPolicy.t.sol
@@ -700,13 +700,16 @@ contract SessionPolicyTest is KeystoreTest {
 
     function _createAccountWithRootAndManager() internal returns (address) {
         Keystore.InitialActor memory root = Keystore.InitialActor({
-            actorId: bytes32(bytes20(vm.addr(ROOT_PK))),
+            actorId: bytes32(uint256(uint160(vm.addr(ROOT_PK)))),
             authenticator: address(k1Authenticator),
             scope: 0,
             policyData: ""
         });
         Keystore.InitialActor memory mgr = Keystore.InitialActor({
-            actorId: bytes32(bytes20(address(manager))), authenticator: TRUSTED_EXECUTOR, scope: 0, policyData: ""
+            actorId: bytes32(uint256(uint160(address(manager)))),
+            authenticator: TRUSTED_EXECUTOR,
+            scope: 0,
+            policyData: ""
         });
 
         Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](2);

--- a/test/unit/policies/SessionPolicyGas.t.sol
+++ b/test/unit/policies/SessionPolicyGas.t.sol
@@ -368,17 +368,20 @@ contract SessionPolicyGasTest is KeystoreTest {
         });
         bytes32 commitment = manager.commitmentOf(binding);
 
-        Keystore.ActorConfig memory cfg =
-            Keystore.ActorConfig({authenticator: address(k1Authenticator), scope: SCOPE_POLICY, expiry: 0});
-        Keystore.ActorChange[] memory changes = new Keystore.ActorChange[](1);
-        changes[0] = Keystore.ActorChange({
-            actorId: actorId,
-            changeType: Keystore.ActorChangeType.Authorize,
-            data: abi.encode(cfg, abi.encodePacked(address(manager), commitment))
-        });
-        uint64 chainId = uint64(block.chainid);
-        uint64 sequence = keystore.getChangeSequences(account).local;
-        bytes32 digest = _computeActorChangeBatchDigest(account, chainId, sequence, changes);
-        keystore.applySignedActorChanges(account, chainId, changes, _buildK1Auth(ROOT_PK, digest));
+        // Authorize the fresh session-key actor gated to the manager, granted UNBOUNDED (the new "no expiry") on a
+        // sequenced local batch, signed by the root owner.
+        _applyLocal(
+            ROOT_PK,
+            account,
+            _one(
+                _authorizeChange(
+                    actorId,
+                    address(k1Authenticator),
+                    SCOPE_POLICY,
+                    UNBOUNDED,
+                    abi.encodePacked(address(manager), commitment)
+                )
+            )
+        );
     }
 }

--- a/test/unit/policies/SessionPolicyGas.t.sol
+++ b/test/unit/policies/SessionPolicyGas.t.sol
@@ -331,13 +331,16 @@ contract SessionPolicyGasTest is KeystoreTest {
 
     function _createAccountWithRootAndManager() internal returns (address) {
         Keystore.InitialActor memory root = Keystore.InitialActor({
-            actorId: bytes32(bytes20(vm.addr(ROOT_PK))),
+            actorId: bytes32(uint256(uint160(vm.addr(ROOT_PK)))),
             authenticator: address(k1Authenticator),
             scope: 0,
             policyData: ""
         });
         Keystore.InitialActor memory mgr = Keystore.InitialActor({
-            actorId: bytes32(bytes20(address(manager))), authenticator: TRUSTED_EXECUTOR, scope: 0, policyData: ""
+            actorId: bytes32(uint256(uint160(address(manager)))),
+            authenticator: TRUSTED_EXECUTOR,
+            scope: 0,
+            policyData: ""
         });
 
         Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](2);


### PR DESCRIPTION
## Summary

Implements the EIP-8130 Local Epoch System: a single entry point for all signed account changes plus an epoch-based replay domain for local signers.

- **Storage**: the local replay counter is stored as two explicit `uint32` fields — `localEpoch` (high) and `localSequence` (low) — occupying the same 8 bytes as the signed 64-bit word. Size-neutral, no pack/unpack math on the hot path. The combined local word (either field non-zero) is the account's initialized flag.
- **Entry point**: adds `applySignedAccountChanges(address, SignedAccountChanges)` as the sole signed-change entry point and deletes `applySignedActorChanges` / `applySignedLockChanges` (no shims).
- **Types**: `ChangeType { AuthorizeActor, RevokeActor, IncrementLocalEpoch, Lock, Unlock }` split into authority ops (authorize/revoke — mutate who can act) and environment ops (increment-epoch/lock/unlock — mutate the rules ops are checked against); an `AccountChangeChannel { Local, Multichain }` replacing the raw `chainId` argument; and `AccountChange` / `SignedAccountChanges` structs.
- **Replay (the governing axiom)**: a signed local change is valid only while it could still be validly applied — the committed local epoch must match, and grants self-expire (`cfg.expiry > now`, with `expiry == 0` the never-expiring sentinel). `IncrementLocalEpoch` invalidates every unlanded local signature on both channels; it does not affect landed actors.
- **Reduction is NOT contract-enforced**: a bare revoke / shorter expiry / narrower scope lands as-is. Making a reduction durable against an outstanding replayable unsequenced grant (batching it with an `IncrementLocalEpoch`) is a documented wallet responsibility, not a contract check.
- **Flat authorization**: every signed account change is admin-only (signer `scope == 0`), enforced by one up-front check; no per-op authorization and no per-op sequencing restriction. Anyone may relay — authority comes entirely from the signature.
- **Op ordering**: unconstrained — authority and environment ops commute, so order within a batch does not change outcomes and there is no authority-before-environment rule.
- **Lock policy**: authority ops (authorize/revoke) gate on the **batch-entry** lock snapshot. That snapshot is exact for the whole batch precisely because `Lock`/`Unlock` must be standalone (`n == 1`): the only ops that mutate lock state can never share a batch with an authority op. The `Lock`/`Unlock` handlers self-police against **live** state; `Lock` writes a clean hard-locked flag set (clearing any elapsed-unlock residue).
- **Unsequenced (JIT) grants**: the local sequence low-half sentinel `UNSEQUENCED` marks a batch that consumes no counter and stays replayable until the epoch increments; last-write-wins on the target slot. A fresh account's first unsequenced batch burns local sequence 0 → 1 to mark initialization.
- **Channels are Local-only for environment ops**: `IncrementLocalEpoch`, `Lock`, and `Unlock` are rejected on the Multichain channel (lock and epoch are per-chain concepts). Multichain otherwise keeps its own monotonic counter with no epochs and no unsequenced mode.
- **ActorId encoding**: address-derived actorIds (k1 self, recovered signer, delegate, external policy caller, `DefaultAccount` caller lookup) use the ABI `address` layout — the address **right-aligned** in a 32-byte word (`bytes32(uint256(uint160(addr)))`, high 12 bytes zero) — centralized in a single `ActorId.fromAddress` primitive so the self and recovered-signer derivations can never drift. See Notes.

## Test plan

- [x] `forge build` green
- [x] `forge test` green — 335 passed, 0 failed, 0 skipped
- [x] EIP-8130 §10 test matrix (authorize sequenced/unsequenced, revoke, epoch increment, lock/unlock state machine, sequenced-channel saturation/replay, multichain, split-layout regression)
- [x] Invariant tests pinning the reviewer-flagged edges: lock-residue overwrite, both initialization branches (fresh-account vs multichain-active), and a right-aligned actorId round-trip against the indexed `ActorAuthorized` topic
- [x] Collateral suites (policies, authenticators, accounts, authenticate, importAccount, policyAccessors) ported to the new API

## Notes

- The `Keystore.sol` NatSpec is the spec surface here; the standalone ERC prose (panic-batch worked example, actorId alignment, per-chain lock) is handled separately by the author.
- **ActorId encoding decision (ratified)**: switched from left-aligned `bytes32(bytes20(addr))` to right-aligned `bytes32(uint256(uint160(addr)))`. Read/write cost is identical (a `bytes32` mapping key either way); the deciding factor is interop — right-aligned matches `abi.encode(address)`, indexed `address` event topics, and the canonical `address(uint160(uint256(id)))` round-trip. Defined once in `src/libraries/ActorId.sol` and used by every address-derived identity. The `ACTOR_INITIALIZATION` import digest's account field is now right-aligned too, so the codebase carries a single address→bytes32 convention throughout.
- **Standalone Lock (ratified)**: the atomic panic batch `[Revoke…, IncrementLocalEpoch, Lock]` is now two signatures. Accepted: lock is mempool tiering rather than privilege separation, and standalone is what makes the batch-entry lock snapshot provably exact.