### PR TITLE
Reject empty bytecode in createAccount

### DIFF
--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -329,8 +329,9 @@ contract Keystore {
     error BytecodeTooLarge();
 
     /// @notice createAccount was called with empty deployment bytecode.
-    /// @dev Zero-length runtime code would leave a Keystore-initialized address with no code — indistinguishable from
-    ///      an EOA on non-8130 chains while carrying 8130 actor state.
+    /// @dev Zero-length runtime code would leave a Keystore-initialized address with no code. On 8130 chains that
+    ///      looks like an EOA that removed its EIP-7702 delegation, breaking the invariant
+    ///      isEOA = (7702-delegated) || (no code).
     error EmptyBytecode();
 
     /// @notice CREATE2 did not deploy code at the expected account address (e.g. bytecode too large per EIP-170,

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -328,6 +328,11 @@ contract Keystore {
     /// @notice The provided account bytecode exceeds the maximum encodable length.
     error BytecodeTooLarge();
 
+    /// @notice createAccount was called with empty deployment bytecode.
+    /// @dev Zero-length runtime code would leave a Keystore-initialized address with no code — indistinguishable from
+    ///      an EOA on non-8130 chains while carrying 8130 actor state.
+    error EmptyBytecode();
+
     /// @notice CREATE2 did not deploy code at the expected account address (e.g. bytecode too large per EIP-170,
     ///      leading 0xEF byte per EIP-3541, or out of gas). Reverting unwinds all state writes so no orphaned
     ///      EIP-8130 configuration is left behind.
@@ -379,6 +384,7 @@ contract Keystore {
     ///         always 0 at create — scoped-with-expiry keys are added afterwards via applySignedActorChanges. The
     ///         implicit default-EOA key is disabled on creation.
     ///
+    /// @dev Reverts with EmptyBytecode when `bytecode` is empty.
     /// @dev Reverts with BytecodeTooLarge when `bytecode` exceeds the maximum encodable length.
     /// @dev Reverts with AlreadyInitialized when the account already has EIP-8130 state.
     /// @dev Reverts with NoInitialActors when `initialActors` is empty.
@@ -702,6 +708,7 @@ contract Keystore {
 
     /// @notice Computes the counterfactual CREATE2 address for an account without deploying it.
     ///
+    /// @dev Reverts with EmptyBytecode when `bytecode` is empty.
     /// @dev Reverts with BytecodeTooLarge when `bytecode` exceeds the maximum encodable length.
     ///
     /// @param userSalt Caller-chosen salt mixed into the CREATE2 address derivation.
@@ -1271,12 +1278,13 @@ contract Keystore {
     // ----------------------------------------------------------------------------------------------------------------
 
     /// @notice Constructs the deployment code for an account in a manner that doesn't immediately run constructor code.
-    /// @dev Returns a 14-byte EVM loader followed by `bytecode`. The loader copies the trailing `bytecode` into
-    ///      memory and returns it as the deployed runtime:
+    /// @dev Returns a 14-byte EVM loader followed by `bytecode`. Reverts {EmptyBytecode} when `bytecode` is empty.
+    ///      The loader copies the trailing `bytecode` into memory and returns it as the deployed runtime:
     ///        PUSH2 n; PUSH1 0x0e; PUSH1 0x00; CODECOPY   // copy n bytes from code offset 14 to mem 0
     ///        PUSH2 n; PUSH1 0x00; RETURN                 // return mem[0..n]
     function _buildDeploymentCode(bytes calldata bytecode) internal pure returns (bytes memory) {
         uint256 n = bytecode.length;
+        if (n == 0) revert EmptyBytecode();
         if (n > 0xFFFF) revert BytecodeTooLarge();
         return abi.encodePacked(
             bytes1(0x61), bytes2(uint16(n)), hex"600e600039", bytes1(0x61), bytes2(uint16(n)), hex"6000f3", bytecode

--- a/test/unit/Keystore/createAccount.t.sol
+++ b/test/unit/Keystore/createAccount.t.sol
@@ -57,6 +57,15 @@ contract CreateAccountTest is KeystoreTest {
     // REVERTS (source-execution order)
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
+    /// @notice Verifies createAccount reverts when deployment bytecode is empty
+    /// @dev Empty runtime code would leave a Keystore-initialized address with no code — EOA-like on non-8130 chains.
+    function test_createAccount_revert_emptyBytecode(bytes32 salt) public {
+        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(1))));
+
+        vm.expectRevert(Keystore.EmptyBytecode.selector);
+        keystore.createAccount(salt, "", actors);
+    }
+
     /// @notice Verifies createAccount reverts when bytecode length exceeds the 0xFFFF encodable maximum
     /// @dev _buildDeploymentCode (reached first, via computeAddress) reverts BytecodeTooLarge for n > 0xFFFF
     function test_createAccount_revert_bytecodeTooLarge(uint256 lenSeed, bytes1 fill, bytes32 salt) public {
@@ -354,6 +363,14 @@ contract CreateAccountTest is KeystoreTest {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // computeAddress (pure/view: _buildDeploymentCode + _computeEffectiveSalt + _computeActorsCommitment)
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice Verifies computeAddress reverts when deployment bytecode is empty
+    function test_computeAddress_revert_emptyBytecode(bytes32 salt) public {
+        Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(1))));
+
+        vm.expectRevert(Keystore.EmptyBytecode.selector);
+        keystore.computeAddress(salt, "", actors);
+    }
 
     /// @notice Verifies computeAddress reverts for bytecode larger than the 0xFFFF encodable maximum
     /// @dev computeAddress -> _buildDeploymentCode reverts BytecodeTooLarge for n > 0xFFFF, independent of create

--- a/test/unit/Keystore/createAccount.t.sol
+++ b/test/unit/Keystore/createAccount.t.sol
@@ -58,7 +58,7 @@ contract CreateAccountTest is KeystoreTest {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     /// @notice Verifies createAccount reverts when deployment bytecode is empty
-    /// @dev Empty runtime code would leave a Keystore-initialized address with no code — EOA-like on non-8130 chains.
+    /// @dev Empty runtime code would break the 8130 isEOA invariant: (7702-delegated) || (no code).
     function test_createAccount_revert_emptyBytecode(bytes32 salt) public {
         Keystore.InitialActor[] memory actors = _oneK1Actor(bytes32(bytes20(vm.addr(1))));
 


### PR DESCRIPTION
## Summary
- Reject empty deployment bytecode in `_buildDeploymentCode` with a new `EmptyBytecode()` error, so `createAccount` and `computeAddress` cannot bootstrap a Keystore-initialized address with no runtime code.
- On 8130 chains, a codeless but initialized address looks like an EOA that removed its EIP-7702 delegation, breaking the invariant `isEOA = (7702-delegated) || (no code)`.

## Test plan
- [x] `forge build` clean
- [x] `forge test` — 337 passing
- [x] `test_createAccount_revert_emptyBytecode` — empty calldata reverts `EmptyBytecode`
- [x] `test_computeAddress_revert_emptyBytecode` — same guard on the counterfactual path