### PR TITLE
Rename scope operator predicate

### DIFF
--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -126,15 +126,15 @@ contract DefaultAccount is Receiver {
     /// @dev Authorized if `caller` is the account itself, or holds the TRUSTED_EXECUTOR authenticator with an
     ///      unexpired config AND operational authority. Expiry: 0 means none; a non-zero expiry is enforced so a
     ///      user-set expiry is honored on the execution path. Scope: driving execution requires operational
-    ///      authority ({Scopes.isOperational}) — the unrestricted admin (scope == 0x00) or a SENDER actor not gated
+    ///      authority ({Scopes.isOperator}) — the unrestricted admin (scope == 0x00) or a SENDER actor not gated
     ///      by a policy. A POLICY-gated actor must route every call through its manager, so granting it direct
-    ///      executeBatch would bypass that gate; fail closed. Sharing {Scopes.isOperational} keeps the execution and
+    ///      executeBatch would bypass that gate; fail closed. Sharing {Scopes.isOperator} keeps the execution and
     ///      signing (ERC-1271) authorization surfaces aligned.
     function _isAuthorizedCaller(address caller) internal view virtual returns (bool) {
         if (caller == address(this)) return true;
         Keystore.ActorConfig memory config = KEYSTORE.getActorConfig(address(this), bytes32(bytes20(caller)));
         if (config.authenticator != TRUSTED_EXECUTOR) return false;
         if (config.expiry != 0 && block.timestamp > config.expiry) return false;
-        return Scopes.isOperational(config.scope);
+        return Scopes.isOperator(config.scope);
     }
 }

--- a/src/libraries/Scopes.sol
+++ b/src/libraries/Scopes.sol
@@ -52,7 +52,7 @@ library Scopes {
     /// @param scope The actor scope bitmask to test.
     ///
     /// @return True iff `scope` carries operational authority.
-    function isOperational(uint16 scope) internal pure returns (bool) {
+    function isOperator(uint16 scope) internal pure returns (bool) {
         return scope == 0 || ((scope & SENDER != 0) && (scope & POLICY == 0));
     }
 }


### PR DESCRIPTION
## Summary
- rename `Scopes.isOperational` to `Scopes.isOperator`
- update the `DefaultAccount` call site and documentation references

## Test plan
- [x] `forge test`