### PR TITLE
Reject code-less account imports

### DIFF
--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -291,7 +291,7 @@ contract Keystore {
     /// @notice The batch signer is not the account admin (scope 0). Every signed account change is admin-only.
     error UnauthorizedAccountChange();
 
-    /// @notice The importAccount ERC-1271 signature check did not return the magic value.
+    /// @notice The import target has no bytecode or its ERC-1271 signature check did not return the magic value.
     error InvalidImportSignature();
 
     /// @notice A lock op carried a zero unlock delay.
@@ -492,7 +492,8 @@ contract Keystore {
     /// @dev Reverts with AccountIsLocked when the account is locked.
     /// @dev Reverts with InvalidChainId when `chainId` is neither 0 (multichain) nor the current chain.
     /// @dev Reverts with AlreadyInitialized when the account already has EIP-8130 state.
-    /// @dev Reverts with InvalidImportSignature when the account's ERC-1271 check does not return the magic value.
+    /// @dev Reverts with InvalidImportSignature when the account has no bytecode or its ERC-1271 check does not return
+    ///      the magic value.
     /// @dev Reverts with NoInitialActors when `initialActors` is empty.
     /// @dev Reverts with ActorsNotSortedOrDuplicate when `initialActors` is not strictly ascending by actorId.
     /// @dev Reverts with InvalidAuthenticator when an initial actor names a zero authenticator.
@@ -515,6 +516,9 @@ contract Keystore {
         // Import is a one-time bootstrap for accounts with no 8130 state yet.
         if (_isInitialized(account)) {
             revert AlreadyInitialized();
+        }
+        if (account.code.length == 0) {
+            revert InvalidImportSignature();
         }
         _accountState[account].localSequence = 1;
 

--- a/test/unit/Keystore/importAccount.t.sol
+++ b/test/unit/Keystore/importAccount.t.sol
@@ -275,9 +275,8 @@ contract ImportAccountTest is KeystoreTest {
         keystore.importAccount(address(wallet), chainId, actors, sig);
     }
 
-    /// @notice Verifies importAccount reverts against a code-less account (staticcall returns empty returndata).
-    /// @dev A plain EOA has no code, so the staticcall succeeds with zero-length returndata, tripping the
-    ///      `result.length != 32` term (the natural "account has no ERC-1271 implementation" case).
+    /// @notice Verifies importAccount reverts against a code-less account.
+    /// @dev A plain EOA has no code, so the explicit bytecode guard rejects it before the ERC-1271 staticcall.
     function test_importAccount_revert_invalidImportSignature_noCode(uint256 accountSeed, bool multichain) public {
         uint256 accountPk = _boundK1Pk(accountSeed);
         address account = vm.addr(accountPk);
@@ -289,6 +288,25 @@ contract ImportAccountTest is KeystoreTest {
 
         vm.expectRevert(Keystore.InvalidImportSignature.selector);
         keystore.importAccount(account, chainId, actors, sig);
+    }
+
+    /// @notice A code-less target cannot masquerade as an ERC-1271 account when its returndata has the expected shape.
+    /// @dev Models a precompile returning 32 bytes prefixed by the ERC-1271 magic value. Foundry inserts dummy code for
+    ///      mocked targets, so the test removes it before proving the explicit bytecode guard rejects the response.
+    function test_importAccount_revert_noCodeReturningMagic() public {
+        address target = address(0xBEEF);
+        bytes memory signature = "forged";
+        Keystore.InitialActor[] memory actors = _singleUnrestrictedActor(address(0xA11CE));
+        bytes32 digest = _computeImportDigest(target, block.chainid, actors);
+
+        assertEq(target.code.length, 0);
+        vm.mockCall(target, abi.encodeWithSelector(ERC1271_MAGIC, digest, signature), abi.encode(ERC1271_MAGIC));
+        // Foundry inserts dummy code for a mocked no-code address; remove it while retaining the registered mock.
+        vm.etch(target, "");
+        assertEq(target.code.length, 0);
+
+        vm.expectRevert(Keystore.InvalidImportSignature.selector);
+        keystore.importAccount(target, block.chainid, actors, signature);
     }
 
     /// @notice Verifies importAccount reverts when isValidSignature returns non-32-byte returndata.


### PR DESCRIPTION
## Summary
- require imported ERC-1271 accounts to contain bytecode before signature validation
- prevent precompiles and other code-less addresses from satisfying the import check with valid-looking returndata
- add regression coverage for a code-less target returning the ERC-1271 magic value

## Test plan
- [x] `forge test`
- [x] `forge fmt --check`