### PR TITLE
Require canonical ERC-1271 import response

### DIFF
--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -291,7 +291,8 @@ contract Keystore {
     /// @notice The batch signer is not the account admin (scope 0). Every signed account change is admin-only.
     error UnauthorizedAccountChange();
 
-    /// @notice The import target has no bytecode or its ERC-1271 signature check did not return the magic value.
+    /// @notice The import target has no bytecode or its ERC-1271 signature check did not return the canonical magic
+    ///         word.
     error InvalidImportSignature();
 
     /// @notice A lock op carried a zero unlock delay.
@@ -493,7 +494,7 @@ contract Keystore {
     /// @dev Reverts with InvalidChainId when `chainId` is neither 0 (multichain) nor the current chain.
     /// @dev Reverts with AlreadyInitialized when the account already has EIP-8130 state.
     /// @dev Reverts with InvalidImportSignature when the account has no bytecode or its ERC-1271 check does not return
-    ///      the magic value.
+    ///      the canonical 32-byte ABI encoding of the magic value.
     /// @dev Reverts with NoInitialActors when `initialActors` is empty.
     /// @dev Reverts with ActorsNotSortedOrDuplicate when `initialActors` is not strictly ascending by actorId.
     /// @dev Reverts with InvalidAuthenticator when an initial actor names a zero authenticator.
@@ -525,7 +526,7 @@ contract Keystore {
         bytes32 digest = _computeImportDigest(account, chainId, initialActors);
         (bool success, bytes memory result) =
             account.staticcall(abi.encodeWithSelector(ERC1271_SELECTOR, digest, signature));
-        if (!success || result.length != 32 || abi.decode(result, (bytes4)) != ERC1271_SELECTOR) {
+        if (!success || result.length != 32 || abi.decode(result, (bytes32)) != bytes32(ERC1271_SELECTOR)) {
             revert InvalidImportSignature();
         }
 

--- a/test/unit/Keystore/importAccount.t.sol
+++ b/test/unit/Keystore/importAccount.t.sol
@@ -40,6 +40,14 @@ contract ShortReturnERC1271Wallet {
     }
 }
 
+/// @dev ERC-1271-shaped wallet that returns the magic prefix with dirty trailing bytes. A bytes4 decode would accept
+///      this response, but it is not the canonical 32-byte ABI encoding of the ERC-1271 magic value.
+contract DirtyReturnERC1271Wallet {
+    function isValidSignature(bytes32, bytes calldata) external pure returns (bytes32) {
+        return 0x1626ba7effffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+    }
+}
+
 /// @dev Fully fuzzed, branch-complete suite for Keystore.importAccount and the pure digest machinery it
 ///      drives (_computeImportDigest), plus the _initializeAccount reverts it inherits. Reverts are ordered to
 ///      mirror importAccount's source control flow (onlyUnlocked → InvalidChainId → AlreadyInitialized →
@@ -325,6 +333,15 @@ contract ImportAccountTest is KeystoreTest {
 
         vm.expectRevert(Keystore.InvalidImportSignature.selector);
         keystore.importAccount(address(wallet), chainId, actors, sig);
+    }
+
+    /// @notice Verifies importAccount rejects a 32-byte response with the magic prefix but non-zero ABI padding.
+    function test_importAccount_revert_invalidImportSignature_dirtyReturn(bool multichain) public {
+        DirtyReturnERC1271Wallet wallet = new DirtyReturnERC1271Wallet();
+        Keystore.InitialActor[] memory actors = _singleUnrestrictedActor(address(0xA11CE));
+
+        vm.expectRevert(Keystore.InvalidImportSignature.selector);
+        keystore.importAccount(address(wallet), _acceptedChainId(multichain), actors, "");
     }
 
     /// @notice Verifies importAccount reverts with NoInitialActors when the actor set is empty.


### PR DESCRIPTION
## Summary
- require the exact canonical 32-byte ABI encoding of the ERC-1271 magic value during account import
- reject code-bearing contracts that return the magic prefix with dirty trailing bytes
- add regression coverage for non-canonical 32-byte responses

## Test plan
- [x] `forge test`
- [x] `forge fmt --check`