### PR TITLE
Gate policy read accessors on liveness; add getActor aggregate view

### DIFF
--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -935,23 +935,27 @@ contract Keystore {
     ///      what makes "expired" read identically to "revoked" on every surface — the invariant that lets a node
     ///      garbage-collect an expired actor's slots without changing anything observable on-chain.
     function _resolveActorConfig(address account, bytes32 actorId) private view returns (ActorConfig memory) {
-        ActorConfig memory config = _actorConfig[actorId][account];
-        // Non-zero authenticator = a stored entry. Uses the same `>= K1_AUTHENTICATOR` namespace idiom as _isAuthorized:
-        // every stored authenticator is K1_AUTHENTICATOR (0x1) or a contract, so this is equivalent to != address(0).
-        if (config.authenticator >= K1_AUTHENTICATOR) {
-            // An expired stored actor reports as empty (as if never authorized), never its stale config.
-            if (_isExpired(config.expiry)) {
-                return _emptyActorConfig();
-            }
-            return config;
-        }
-        if (actorId == _selfActorId(account) && !_isDefaultEoaRevoked(account)) {
+        // Common path first: the inline k1 self. A clear FLAG_REVOKE_DEFAULT_EOA means the inline self is live, so
+        // resolve it from AccountState alone (all-zero = full owner). When the flag is set the inline self is off —
+        // either a non-k1 self lives in _actorConfig, or the self was revoked — so fall through to the shared home.
+        if (actorId == _selfActorId(account)) {
             AccountState storage st = _accountState[account];
-            if (_isExpired(st.defaultEOAExpiry)) {
-                return _emptyActorConfig();
+            if (st.flags & FLAG_REVOKE_DEFAULT_EOA == 0) {
+                if (_isExpired(st.defaultEOAExpiry)) {
+                    return _emptyActorConfig();
+                }
+                return
+                    ActorConfig({
+                        authenticator: K1_AUTHENTICATOR, scope: st.defaultEOAScope, expiry: st.defaultEOAExpiry
+                    });
             }
-            return
-                ActorConfig({authenticator: K1_AUTHENTICATOR, scope: st.defaultEOAScope, expiry: st.defaultEOAExpiry});
+        }
+
+        // Explicit actor (or a non-k1 self): the single _actorConfig home. A stored authenticator is K1_AUTHENTICATOR
+        // (0x1) or a contract, so `>= K1_AUTHENTICATOR` is the "slot populated" test. An expired entry reports empty.
+        ActorConfig memory config = _actorConfig[actorId][account];
+        if (config.authenticator >= K1_AUTHENTICATOR) {
+            return _isExpired(config.expiry) ? _emptyActorConfig() : config;
         }
         return config;
     }

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -914,56 +914,34 @@ contract Keystore {
     // STORAGE VIEWS
     // ----------------------------------------------------------------------------------------------------------------
 
-    /// @notice Resolves the effective ActorConfig for `actorId` on `account`.
-    ///
-    /// @dev With a populated _actorConfig entry, returns it verbatim (any non-self actor, or a non-k1 self). For the
-    ///      self-actorId without such an entry, the k1 self lives inline in AccountState: a live one (flag unset)
-    ///      reports as a native ecrecover owner carrying its inline scope/expiry (all-zero = full owner); a
-    ///      disabled one, or any unknown actor, reports as the all-zero (empty) config, keeping live-vs-disabled
-    ///      unambiguous without a sentinel.
-    ///
-    /// @param account The account to read.
-    /// @param actorId The actor identifier to resolve.
-    ///
-    /// @return The resolved actor configuration, or the all-zero config if the actor is not live (unknown, disabled,
-    ///         or expired).
+    /// @notice The liveness-gated {ActorConfig} for `actorId` — the all-zero config when the actor is not live
+    ///         (unknown, revoked, disabled, or expired). See {_resolveActorConfig}.
     function getActorConfig(address account, bytes32 actorId) external view returns (ActorConfig memory) {
         return _resolveActorConfig(account, actorId);
     }
 
-    /// @notice Resolved, liveness-gated snapshot of an actor for off-chain consumers: the effective {ActorConfig}
-    ///         together with its policy gate, packed as `policyData` in the same shape as the {Actor}/{InitialActor}
-    ///         import structs — manager(20) || commitment(32) when scope & Scopes.POLICY != 0, else empty (this is the
-    ///         trailing policy portion of the {ActorAuthorized} payload, without the config prefix).
-    ///
-    /// @dev One uniformly-gated read: a non-live actor (unknown, revoked, disabled, or expired) resolves to the
-    ///      all-zero config with empty `policyData`, so a consumer never sees a live-looking policy gate for an actor
-    ///      that can no longer authenticate. This is the recommended one-shot accessor; the granular reads
-    ///      ({getPolicyManager}, {getPolicyCommitment}) apply the identical liveness gate but each re-resolves the
-    ///      config, so this call is cheaper than combining them.
-    ///
-    /// @param account The account to read.
-    /// @param actorId The actor identifier to resolve (echoed back in the returned struct).
-    ///
-    /// @return actor The resolved actor: `actorId`, the effective (liveness-gated) config, and its packed policyData.
+    /// @notice One-shot liveness-gated snapshot for off-chain consumers: the resolved {ActorConfig} plus the policy
+    ///         gate packed as `policyData` (manager(20) || commitment(32) when scope & Scopes.POLICY is set, else
+    ///         empty — the same shape as the {Actor} import struct). Preferred aggregate: the granular
+    ///         {getPolicyCommitment} / {getPolicyManager} each re-resolve liveness, so this is cheaper than combining
+    ///         them. A non-live actor resolves to the empty config with empty `policyData`.
     function getActor(address account, bytes32 actorId) external view returns (Actor memory actor) {
         actor.actorId = actorId;
         ActorConfig memory config = _resolveActorConfig(account, actorId);
         actor.config = config;
-        // A non-live actor resolves to the all-zero config; leave policyData empty so expired reads exactly like
-        // revoked. Gating is by the scope bit, matching {_emitActorAuthorized}: a live gated actor's policyData is
-        // always 52 bytes (even with a zero manager/commitment), an ungated actor's is empty.
+        // Gating is by the scope bit, matching {_emitActorAuthorized}: a live gated actor's policyData is always 52
+        // bytes (even with a zero manager/commitment); a non-live or ungated actor's is empty.
         if (config.authenticator != address(0) && config.scope & Scopes.POLICY != 0) {
             actor.policyData = abi.encodePacked(_policyManager[actorId][account], _policyCommitment[actorId][account]);
         }
     }
 
-    /// @dev Shared liveness resolver behind {getActorConfig}, {getActor}, and the policy read accessors. With a
-    ///      populated _actorConfig entry, returns it verbatim unless expired (any non-self actor, or a non-k1 self).
-    ///      For the self-actorId without such an entry, resolves the inline k1 self from AccountState: a live one
-    ///      (flag unset, unexpired) reports as a native ecrecover owner carrying its inline scope/expiry; a disabled,
-    ///      expired, or unknown actor reports as the all-zero (empty) config. Centralizing this keeps every read
-    ///      surface treating "expired" identically to "revoked".
+    /// @dev The single liveness resolver behind every read surface ({getActorConfig}, {getActor},
+    ///      {getPolicyCommitment}, {getPolicyManager}). A populated _actorConfig entry returns verbatim unless expired;
+    ///      the k1 self (inline in AccountState) resolves to a native ecrecover owner unless disabled or expired;
+    ///      anything unknown/revoked/disabled/expired resolves to the all-zero (empty) config. Centralizing this is
+    ///      what makes "expired" read identically to "revoked" on every surface — the invariant that lets a node
+    ///      garbage-collect an expired actor's slots without changing anything observable on-chain.
     function _resolveActorConfig(address account, bytes32 actorId) private view returns (ActorConfig memory) {
         ActorConfig memory config = _actorConfig[actorId][account];
         // Non-zero authenticator = a stored entry. Uses the same `>= K1_AUTHENTICATOR` namespace idiom as _isAuthorized:
@@ -991,35 +969,8 @@ contract Keystore {
         return ActorConfig({authenticator: address(0), expiry: 0, scope: 0});
     }
 
-    /// @notice Returns an actor's policy manager and commitment, gated by liveness.
-    ///
-    /// @dev Convenience aggregator for off-chain consumers. Returns (0, 0) for a non-live actor (unknown, revoked,
-    ///      disabled, or expired), matching {getActorConfig}: no read surface distinguishes expired from revoked, so
-    ///      a node that garbage-collects an expired actor's slots changes nothing observable. Consumers wanting the
-    ///      config alongside the gate in a single call should prefer {getActor}.
-    ///
-    /// @param account The account to read.
-    /// @param actorId The actor identifier to resolve.
-    ///
-    /// @return target The policy manager (0 when the actor is not live).
-    /// @return commitment The policy commitment (0 when the actor is not live).
-    function getPolicy(address account, bytes32 actorId) external view returns (address target, bytes32 commitment) {
-        if (_resolveActorConfig(account, actorId).authenticator == address(0)) {
-            return (address(0), bytes32(0));
-        }
-        return (_policyManager[actorId][account], _policyCommitment[actorId][account]);
-    }
-
-    /// @notice Returns an actor's policy commitment, gated by liveness.
-    ///
-    /// @dev Gating is determined by Scopes.POLICY, not by a non-zero commitment. Returns 0 for a non-live actor
-    ///      (unknown, revoked, disabled, or expired), matching {getActorConfig}, so an expired actor reads exactly
-    ///      like a revoked one. Resolving liveness costs one extra SLOAD over the raw slot (the actor's config).
-    ///
-    /// @param account The account to read.
-    /// @param actorId The actor identifier to resolve.
-    ///
-    /// @return The policy commitment (0 when the actor is not live).
+    /// @notice The actor's policy commitment, or 0 when the actor is not live. Gating is by liveness (see
+    ///         {_resolveActorConfig}), not by a non-zero commitment, and costs one extra SLOAD over the raw slot.
     function getPolicyCommitment(address account, bytes32 actorId) external view returns (bytes32) {
         if (_resolveActorConfig(account, actorId).authenticator == address(0)) {
             return bytes32(0);
@@ -1027,16 +978,7 @@ contract Keystore {
         return _policyCommitment[actorId][account];
     }
 
-    /// @notice Returns an actor's policy manager, gated by liveness.
-    ///
-    /// @dev Returns 0 for a non-live actor (unknown, revoked, disabled, or expired), matching {getActorConfig}, so an
-    ///      expired actor reads exactly like a revoked one. Resolving liveness costs one extra SLOAD over the raw slot
-    ///      (the actor's config).
-    ///
-    /// @param account The account to read.
-    /// @param actorId The actor identifier to resolve.
-    ///
-    /// @return The policy manager (0 when the actor is not live).
+    /// @notice The actor's policy manager, or 0 when the actor is not live. See {_resolveActorConfig}.
     function getPolicyManager(address account, bytes32 actorId) external view returns (address) {
         if (_resolveActorConfig(account, actorId).authenticator == address(0)) {
             return address(0);

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -928,6 +928,43 @@ contract Keystore {
     /// @return The resolved actor configuration, or the all-zero config if the actor is not live (unknown, disabled,
     ///         or expired).
     function getActorConfig(address account, bytes32 actorId) external view returns (ActorConfig memory) {
+        return _resolveActorConfig(account, actorId);
+    }
+
+    /// @notice Resolved, liveness-gated snapshot of an actor for off-chain consumers: the effective {ActorConfig}
+    ///         together with its policy gate, packed as `policyData` in the same shape as the {Actor}/{InitialActor}
+    ///         import structs — manager(20) || commitment(32) when scope & Scopes.POLICY != 0, else empty (this is the
+    ///         trailing policy portion of the {ActorAuthorized} payload, without the config prefix).
+    ///
+    /// @dev One uniformly-gated read: a non-live actor (unknown, revoked, disabled, or expired) resolves to the
+    ///      all-zero config with empty `policyData`, so a consumer never sees a live-looking policy gate for an actor
+    ///      that can no longer authenticate. This is the recommended one-shot accessor; the granular reads
+    ///      ({getPolicyManager}, {getPolicyCommitment}) apply the identical liveness gate but each re-resolves the
+    ///      config, so this call is cheaper than combining them.
+    ///
+    /// @param account The account to read.
+    /// @param actorId The actor identifier to resolve (echoed back in the returned struct).
+    ///
+    /// @return actor The resolved actor: `actorId`, the effective (liveness-gated) config, and its packed policyData.
+    function getActor(address account, bytes32 actorId) external view returns (Actor memory actor) {
+        actor.actorId = actorId;
+        ActorConfig memory config = _resolveActorConfig(account, actorId);
+        actor.config = config;
+        // A non-live actor resolves to the all-zero config; leave policyData empty so expired reads exactly like
+        // revoked. Gating is by the scope bit, matching {_emitActorAuthorized}: a live gated actor's policyData is
+        // always 52 bytes (even with a zero manager/commitment), an ungated actor's is empty.
+        if (config.authenticator != address(0) && config.scope & Scopes.POLICY != 0) {
+            actor.policyData = abi.encodePacked(_policyManager[actorId][account], _policyCommitment[actorId][account]);
+        }
+    }
+
+    /// @dev Shared liveness resolver behind {getActorConfig}, {getActor}, and the policy read accessors. With a
+    ///      populated _actorConfig entry, returns it verbatim unless expired (any non-self actor, or a non-k1 self).
+    ///      For the self-actorId without such an entry, resolves the inline k1 self from AccountState: a live one
+    ///      (flag unset, unexpired) reports as a native ecrecover owner carrying its inline scope/expiry; a disabled,
+    ///      expired, or unknown actor reports as the all-zero (empty) config. Centralizing this keeps every read
+    ///      surface treating "expired" identically to "revoked".
+    function _resolveActorConfig(address account, bytes32 actorId) private view returns (ActorConfig memory) {
         ActorConfig memory config = _actorConfig[actorId][account];
         // Non-zero authenticator = a stored entry. Uses the same `>= K1_AUTHENTICATOR` namespace idiom as _isAuthorized:
         // every stored authenticator is K1_AUTHENTICATOR (0x1) or a contract, so this is equivalent to != address(0).
@@ -954,42 +991,56 @@ contract Keystore {
         return ActorConfig({authenticator: address(0), expiry: 0, scope: 0});
     }
 
-    /// @notice Returns an actor's stored policy manager and commitment.
+    /// @notice Returns an actor's policy manager and commitment, gated by liveness.
     ///
-    /// @dev Convenience aggregator for off-chain consumers. Returns raw slots even after actor expiry; authentication
-    ///      enforces expiry, while standalone readers should cross-check {getActorConfig}.
+    /// @dev Convenience aggregator for off-chain consumers. Returns (0, 0) for a non-live actor (unknown, revoked,
+    ///      disabled, or expired), matching {getActorConfig}: no read surface distinguishes expired from revoked, so
+    ///      a node that garbage-collects an expired actor's slots changes nothing observable. Consumers wanting the
+    ///      config alongside the gate in a single call should prefer {getActor}.
     ///
     /// @param account The account to read.
     /// @param actorId The actor identifier to resolve.
     ///
-    /// @return target The stored policy manager.
-    /// @return commitment The stored policy commitment.
+    /// @return target The policy manager (0 when the actor is not live).
+    /// @return commitment The policy commitment (0 when the actor is not live).
     function getPolicy(address account, bytes32 actorId) external view returns (address target, bytes32 commitment) {
+        if (_resolveActorConfig(account, actorId).authenticator == address(0)) {
+            return (address(0), bytes32(0));
+        }
         return (_policyManager[actorId][account], _policyCommitment[actorId][account]);
     }
 
-    /// @notice Returns an actor's stored policy commitment.
+    /// @notice Returns an actor's policy commitment, gated by liveness.
     ///
-    /// @dev Single SLOAD. Gating is determined by Scopes.POLICY, not by a non-zero commitment. Returns the raw slot
-    ///      after expiry; standalone readers should cross-check {getActorConfig}.
+    /// @dev Gating is determined by Scopes.POLICY, not by a non-zero commitment. Returns 0 for a non-live actor
+    ///      (unknown, revoked, disabled, or expired), matching {getActorConfig}, so an expired actor reads exactly
+    ///      like a revoked one. Resolving liveness costs one extra SLOAD over the raw slot (the actor's config).
     ///
     /// @param account The account to read.
     /// @param actorId The actor identifier to resolve.
     ///
-    /// @return The stored policy commitment.
+    /// @return The policy commitment (0 when the actor is not live).
     function getPolicyCommitment(address account, bytes32 actorId) external view returns (bytes32) {
+        if (_resolveActorConfig(account, actorId).authenticator == address(0)) {
+            return bytes32(0);
+        }
         return _policyCommitment[actorId][account];
     }
 
-    /// @notice Returns an actor's stored policy manager.
+    /// @notice Returns an actor's policy manager, gated by liveness.
     ///
-    /// @dev Single SLOAD. Returns the raw slot after expiry; standalone readers should cross-check {getActorConfig}.
+    /// @dev Returns 0 for a non-live actor (unknown, revoked, disabled, or expired), matching {getActorConfig}, so an
+    ///      expired actor reads exactly like a revoked one. Resolving liveness costs one extra SLOAD over the raw slot
+    ///      (the actor's config).
     ///
     /// @param account The account to read.
     /// @param actorId The actor identifier to resolve.
     ///
-    /// @return The stored policy manager.
+    /// @return The policy manager (0 when the actor is not live).
     function getPolicyManager(address account, bytes32 actorId) external view returns (address) {
+        if (_resolveActorConfig(account, actorId).authenticator == address(0)) {
+            return address(0);
+        }
         return _policyManager[actorId][account];
     }
 

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -41,14 +41,6 @@ contract Keystore {
         bytes policyData; // empty unless scope & Scopes.POLICY; then manager(20) || commitment(32)
     }
 
-    /// @notice A full actor record: identifier, config, and policy data.
-    struct Actor {
-        bytes32 actorId;
-        ActorConfig config;
-        // Sliced by scope: empty when scope & Scopes.POLICY == 0; manager[20] || commitment[32] when set.
-        bytes policyData;
-    }
-
     /// @notice The operation an {AccountChange} applies within an {applySignedAccountChanges} batch.
     ///
     /// @dev ABI-encodes as uint8. Authority ops (AuthorizeActor, RevokeActor) are rejected while locked. Environment
@@ -920,19 +912,19 @@ contract Keystore {
         return _resolveActorConfig(account, actorId);
     }
 
-    /// @notice One-shot liveness-gated snapshot for off-chain consumers: the resolved {ActorConfig} plus the policy
-    ///         gate packed as `policyData` (manager(20) || commitment(32) when scope & Scopes.POLICY is set, else
-    ///         empty — the same shape as the {Actor} import struct). Preferred aggregate: the granular
-    ///         {getPolicyCommitment} / {getPolicyManager} each re-resolve liveness, so this is cheaper than combining
-    ///         them. A non-live actor resolves to the empty config with empty `policyData`.
-    function getActor(address account, bytes32 actorId) external view returns (Actor memory actor) {
-        actor.actorId = actorId;
-        ActorConfig memory config = _resolveActorConfig(account, actorId);
-        actor.config = config;
-        // Gating is by the scope bit, matching {_emitActorAuthorized}: a live gated actor's policyData is always 52
-        // bytes (even with a zero manager/commitment); a non-live or ungated actor's is empty.
+    /// @notice Returns an actor's config, policy manager, and policy commitment in one read. The manager and
+    ///         commitment are non-zero only for a live actor with scope & Scopes.POLICY set; a non-live actor
+    ///         returns the empty config and a zero manager/commitment.
+    function getActor(address account, bytes32 actorId)
+        external
+        view
+        returns (ActorConfig memory config, address policyManager, bytes32 policyCommitment)
+    {
+        config = _resolveActorConfig(account, actorId);
+        // Gating is by the scope bit, matching {_emitActorAuthorized}; a non-live or ungated actor has a zero gate.
         if (config.authenticator != address(0) && config.scope & Scopes.POLICY != 0) {
-            actor.policyData = abi.encodePacked(_policyManager[actorId][account], _policyCommitment[actorId][account]);
+            policyManager = _policyManager[actorId][account];
+            policyCommitment = _policyCommitment[actorId][account];
         }
     }
 

--- a/src/policies/PolicyManager.sol
+++ b/src/policies/PolicyManager.sol
@@ -207,7 +207,15 @@ contract PolicyManager is ReentrancyGuard {
     }
 
     /// @dev External-path validation: live external-pull actor, manager-match, live commitment vs binding, then
-    ///      enforce.
+    ///      enforce. The external path has no protocol auth (omitted on {execute}, where authentication already
+    ///      enforced this before dispatch), so the manager itself gates the caller with a single liveness-resolved
+    ///      {Keystore.getActor} read: the actor must be provisioned with EXTERNAL_POLICY_AUTHENTICATOR — the no-code
+    ///      sentinel marking an external-pull actor (one that can act ONLY through this path and can never
+    ///      authenticate a native 8130 tx). A non-live actor (unknown/revoked/expired) resolves to the all-zero
+    ///      config, so this both enforces liveness AND restricts executeFor to actors the account explicitly opted
+    ///      into external pull; a native signing key gated to this manager (a real authenticator) is not drivable
+    ///      here, where it would bypass protocol replay protection. The gated actor's policyData carries the same
+    ///      manager/commitment the granular accessors would return, so one read replaces three.
     function _enforceExternal(
         PolicyBinding calldata binding,
         bytes32 actorId,
@@ -216,29 +224,31 @@ contract PolicyManager is ReentrancyGuard {
     ) internal {
         address account = binding.account;
 
-        // Liveness + verifier precondition. The external path has no protocol auth (omitted on {execute}, where
-        // authentication already enforced this before dispatch), so the manager itself gates the caller. It requires
-        // the actor to be provisioned with EXTERNAL_POLICY_AUTHENTICATOR — the no-code sentinel that marks an
-        // external-pull actor (one that can act ONLY through this path and can never authenticate a native 8130 tx).
-        // getActorConfig resolves an unknown, revoked, or expired actor to the all-zero config (authenticator 0), so
-        // this single read both enforces liveness AND restricts executeFor to actors the account explicitly opted
-        // into external pull. A native signing key gated to this manager (a real authenticator) is therefore not
-        // drivable through the auth-less external path, where it would bypass protocol replay protection. Checked
-        // before the policy-binding checks so those stay specific to a live external-pull actor.
-        if (KEYSTORE.getActorConfig(account, actorId).authenticator != EXTERNAL_POLICY_AUTHENTICATOR) {
+        Keystore.Actor memory actor = KEYSTORE.getActor(account, actorId);
+        if (actor.config.authenticator != EXTERNAL_POLICY_AUTHENTICATOR) {
             revert InvalidActor(actorId);
         }
+        // A live gated actor's policyData is manager(20) || commitment(32); anything else (ungated or non-live) is not
+        // a policy actor routed through a manager.
+        if (actor.policyData.length != 52) revert NoActivePolicy(actorId);
+        (address manager, bytes32 signed) = _unpackPolicyGate(actor.policyData);
 
-        if (KEYSTORE.getPolicyManager(account, actorId) != address(this)) {
-            revert NoActivePolicy(actorId);
-        }
+        if (manager != address(this)) revert NoActivePolicy(actorId);
 
         bytes32 commitment = _commitment(binding);
-        bytes32 signed = KEYSTORE.getPolicyCommitment(account, actorId);
         if (signed == bytes32(0)) revert NoActivePolicy(actorId);
         if (signed != commitment) revert BindingCommitmentMismatch(signed, commitment);
 
         _enforce(binding, commitment, executionData, caller);
+    }
+
+    /// @dev Unpacks a gated actor's `policyData` (manager(20) || commitment(32), tightly packed to 52 bytes, so
+    ///      abi.decode cannot parse it) into its two fixed-offset fields without copying.
+    function _unpackPolicyGate(bytes memory policyData) private pure returns (address manager, bytes32 commitment) {
+        assembly ("memory-safe") {
+            manager := shr(96, mload(add(policyData, 0x20)))
+            commitment := mload(add(policyData, 0x34))
+        }
     }
 
     /// @dev Common enforcement: enforce the binding's validity window (authenticated by the commitment check at the

--- a/src/policies/PolicyManager.sol
+++ b/src/policies/PolicyManager.sol
@@ -207,15 +207,10 @@ contract PolicyManager is ReentrancyGuard {
     }
 
     /// @dev External-path validation: live external-pull actor, manager-match, live commitment vs binding, then
-    ///      enforce. The external path has no protocol auth (omitted on {execute}, where authentication already
-    ///      enforced this before dispatch), so the manager itself gates the caller with a single liveness-resolved
-    ///      {Keystore.getActor} read: the actor must be provisioned with EXTERNAL_POLICY_AUTHENTICATOR — the no-code
-    ///      sentinel marking an external-pull actor (one that can act ONLY through this path and can never
-    ///      authenticate a native 8130 tx). A non-live actor (unknown/revoked/expired) resolves to the all-zero
-    ///      config, so this both enforces liveness AND restricts executeFor to actors the account explicitly opted
-    ///      into external pull; a native signing key gated to this manager (a real authenticator) is not drivable
-    ///      here, where it would bypass protocol replay protection. The gated actor's policyData carries the same
-    ///      manager/commitment the granular accessors would return, so one read replaces three.
+    ///      enforce. The external path has no protocol auth, so the manager gates the caller itself with a single
+    ///      liveness-resolved {Keystore.getActor} read: the actor must carry EXTERNAL_POLICY_AUTHENTICATOR (the
+    ///      no-code sentinel marking an external-pull actor) and be gated to this manager. A non-live or ungated
+    ///      actor resolves to a zero manager, failing the manager-match.
     function _enforceExternal(
         PolicyBinding calldata binding,
         bytes32 actorId,
@@ -224,15 +219,8 @@ contract PolicyManager is ReentrancyGuard {
     ) internal {
         address account = binding.account;
 
-        Keystore.Actor memory actor = KEYSTORE.getActor(account, actorId);
-        if (actor.config.authenticator != EXTERNAL_POLICY_AUTHENTICATOR) {
-            revert InvalidActor(actorId);
-        }
-        // A live gated actor's policyData is manager(20) || commitment(32); anything else (ungated or non-live) is not
-        // a policy actor routed through a manager.
-        if (actor.policyData.length != 52) revert NoActivePolicy(actorId);
-        (address manager, bytes32 signed) = _unpackPolicyGate(actor.policyData);
-
+        (Keystore.ActorConfig memory config, address manager, bytes32 signed) = KEYSTORE.getActor(account, actorId);
+        if (config.authenticator != EXTERNAL_POLICY_AUTHENTICATOR) revert InvalidActor(actorId);
         if (manager != address(this)) revert NoActivePolicy(actorId);
 
         bytes32 commitment = _commitment(binding);
@@ -240,15 +228,6 @@ contract PolicyManager is ReentrancyGuard {
         if (signed != commitment) revert BindingCommitmentMismatch(signed, commitment);
 
         _enforce(binding, commitment, executionData, caller);
-    }
-
-    /// @dev Unpacks a gated actor's `policyData` (manager(20) || commitment(32), tightly packed to 52 bytes, so
-    ///      abi.decode cannot parse it) into its two fixed-offset fields without copying.
-    function _unpackPolicyGate(bytes memory policyData) private pure returns (address manager, bytes32 commitment) {
-        assembly ("memory-safe") {
-            manager := shr(96, mload(add(policyData, 0x20)))
-            commitment := mload(add(policyData, 0x34))
-        }
     }
 
     /// @dev Common enforcement: enforce the binding's validity window (authenticated by the commitment check at the

--- a/src/policies/README.md
+++ b/src/policies/README.md
@@ -25,10 +25,12 @@ protocol-side, not enforced by this contract.
    to equal the live `getPolicyCommitment(account, actorId)`. That single check authenticates config, validity
    window, and owning account — so neither the manager nor the policy stores a config hash (strictly better than
    [Account Policies](https://github.com/base/account-policies)' per-binding `_configHashByPolicyId` slot). A
-   revoked key has a zero commitment and stops immediately. Actor expiry is not re-checked on this path: protocol
-   authentication already rejects expired actors before dispatch. (The external `executeFor` path does enforce
-   expiry.) The manager then invokes the policy, forwards a non-empty `executeBatch` plan to the account, and
-   calls `onPostExecute` when applicable.
+   revoked *or expired* key reads back a zero commitment and stops immediately: `getPolicyCommitment` (like every
+   Keystore read accessor) is liveness-gated and resolves an expired actor to zero, identical to a revoked one.
+   `execute` doesn't rely on this — protocol authentication already rejects expired actors before dispatch (the
+   external `executeFor` path enforces expiry itself, via `getActorConfig`) — but the gating means no off-chain
+   reader ever sees a live-looking commitment for a dead actor. The manager then invokes the policy, forwards a
+   non-empty `executeBatch` plan to the account, and calls `onPostExecute` when applicable.
 
 ```
 session key ──(8130 gate: only PolicyManager)──▶ PolicyManager.execute

--- a/src/policies/README.md
+++ b/src/policies/README.md
@@ -15,8 +15,8 @@ protocol-side, not enforced by this contract.
 1. **Authorize + commit.** The account authorizes the session key with `scope = Scopes.POLICY`,
    `policy_manager = PolicyManager`, and `policy_commitment = keccak256` of an account-authorized
    [`PolicyBinding`](./PolicyManager.sol). The Keystore contract exposes this via
-   [`getPolicy(account, actorId)`](../../Keystore.sol). That signed actor change *is* the
-   authorization — there is no separate install step on the manager.
+   [`getActor(account, actorId)`](../../Keystore.sol) (or the granular `getPolicyManager` / `getPolicyCommitment`).
+   That signed actor change *is* the authorization — there is no separate install step on the manager.
 2. **Use.** When the session key transacts, the protocol gate resolves the key's allowed target
    (`policy_manager(account, actorId)`) and reverts any call whose `call.to` isn't that address before dispatch, so
    the key's call can only arrive at `PolicyManager.execute(binding, executionData)` with `msg.sender == account`.
@@ -28,7 +28,7 @@ protocol-side, not enforced by this contract.
    revoked *or expired* key reads back a zero commitment and stops immediately: `getPolicyCommitment` (like every
    Keystore read accessor) is liveness-gated and resolves an expired actor to zero, identical to a revoked one.
    `execute` doesn't rely on this — protocol authentication already rejects expired actors before dispatch (the
-   external `executeFor` path enforces expiry itself, via `getActorConfig`) — but the gating means no off-chain
+   external `executeFor` path enforces expiry itself, via a single `getActor` read) — but the gating means no off-chain
    reader ever sees a live-looking commitment for a dead actor. The manager then invokes the policy, forwards a
    non-empty `executeBatch` plan to the account, and calls `onPostExecute` when applicable.
 

--- a/test/unit/Keystore/authenticate.t.sol
+++ b/test/unit/Keystore/authenticate.t.sol
@@ -807,11 +807,11 @@ contract AuthenticateTest is KeystoreTest {
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // getPolicy / getActorConfig / isActor (actor-resolution views)
+    // getPolicyManager / getPolicyCommitment / getActorConfig / isActor (actor-resolution views)
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice getPolicy resolves a gated actor's manager and signed commitment.
-    /// @dev Returns (manager, commitment) from the policy keyspace when scope & SCOPE_POLICY is set.
+    /// @notice The policy accessors resolve a gated actor's manager and signed commitment.
+    /// @dev Return (manager, commitment) from the policy keyspace when scope & SCOPE_POLICY is set.
     function test_getPolicy_success_gatedActor(
         uint256 ownerSeed,
         uint256 sessionSeed,
@@ -830,12 +830,11 @@ contract AuthenticateTest is KeystoreTest {
         bytes32 sessionActorId = bytes32(uint256(uint160(vm.addr(sessionPk))));
         _authorizeGatedActor(account, ownerPk, sessionActorId, scope, manager, commitment);
 
-        (address outTarget, bytes32 outCommitment) = keystore.getPolicy(account, sessionActorId);
-        assertEq(outTarget, manager);
-        assertEq(outCommitment, commitment);
+        assertEq(keystore.getPolicyManager(account, sessionActorId), manager);
+        assertEq(keystore.getPolicyCommitment(account, sessionActorId), commitment);
     }
 
-    /// @notice getPolicy returns the zero policy for an ungated actor.
+    /// @notice The policy accessors return the zero policy for an ungated actor.
     /// @dev No policy slots written for scope & SCOPE_POLICY == 0 -> (address(0), bytes32(0)).
     function test_getPolicy_success_ungatedActor(uint256 ownerSeed, uint256 actorSeed) public {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
@@ -847,9 +846,8 @@ contract AuthenticateTest is KeystoreTest {
         bytes32 actorId = bytes32(uint256(uint160(vm.addr(actorPk))));
         _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), 0x00);
 
-        (address target, bytes32 commitment) = keystore.getPolicy(account, actorId);
-        assertEq(target, address(0));
-        assertEq(commitment, bytes32(0));
+        assertEq(keystore.getPolicyManager(account, actorId), address(0));
+        assertEq(keystore.getPolicyCommitment(account, actorId), bytes32(0));
     }
 
     /// @notice getActorConfig returns a registered actor's authenticator and scope verbatim.

--- a/test/unit/Keystore/policyAccessors.t.sol
+++ b/test/unit/Keystore/policyAccessors.t.sol
@@ -564,6 +564,208 @@ contract PolicyAccessorsTest is KeystoreTest {
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // Expiry gating — expired reads exactly like revoked (uniform across every read surface)
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    //
+    // A gated actor with a finite expiry is live before its expiry and empty after: once expired, the policy
+    // accessors resolve to zero (matching getActorConfig) so a node that garbage-collects the slots changes nothing
+    // observable.
+
+    /// @notice Before expiry a gated explicit actor resolves live; after expiry all read surfaces report empty.
+    function test_getPolicyAccessors_success_expiredReadsAsRevoked(
+        uint256 rootSeed,
+        bytes32 actorId,
+        uint8 scopeSeed,
+        uint256 managerSeed,
+        uint256 commitmentSeed,
+        uint48 expirySeed
+    ) public {
+        uint256 rootPk = _boundK1Pk(rootSeed);
+        (address account,) = _createK1Account(rootPk);
+        actorId = _boundExplicitActorId(account, rootPk, actorId);
+
+        uint16 scope = _boundGatedScope(scopeSeed);
+        address manager = _boundNonZeroAddress(managerSeed);
+        bytes32 commitment = _boundNonZeroWord(commitmentSeed);
+        // A grant must be strictly in the future; keep a margin below the uint48 ceiling to warp past it.
+        uint48 expiry = uint48(bound(expirySeed, block.timestamp + 1, uint256(type(uint48).max) - 1));
+
+        _authorizePolicyActorWithExpiry(account, rootPk, actorId, scope, manager, commitment, expiry);
+
+        // Live before expiry.
+        assertEq(keystore.getPolicyManager(account, actorId), manager);
+        assertEq(keystore.getPolicyCommitment(account, actorId), commitment);
+        (address liveTarget, bytes32 liveCommitment) = keystore.getPolicy(account, actorId);
+        assertEq(liveTarget, manager);
+        assertEq(liveCommitment, commitment);
+
+        // Cross the expiry boundary.
+        vm.warp(uint256(expiry) + 1);
+
+        // Every read surface now reports empty, identical to a revoked actor.
+        assertEq(keystore.getPolicyManager(account, actorId), address(0));
+        assertEq(keystore.getPolicyCommitment(account, actorId), bytes32(0));
+        (address deadTarget, bytes32 deadCommitment) = keystore.getPolicy(account, actorId);
+        assertEq(deadTarget, address(0));
+        assertEq(deadCommitment, bytes32(0));
+        // And the config resolver already treated it as empty — the accessors now agree with it.
+        assertEq(keystore.getActorConfig(account, actorId).authenticator, address(0));
+    }
+
+    /// @notice The inline-k1 self home is gated identically: an expired gated self reads empty across accessors.
+    function test_getPolicyAccessors_success_expiredInlineSelfReadsAsRevoked(
+        uint256 eoaSeed,
+        uint8 scopeSeed,
+        uint256 managerSeed,
+        uint256 commitmentSeed,
+        uint48 expirySeed
+    ) public {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
+        address eoa = vm.addr(eoaPk);
+        bytes32 selfActorId = bytes32(uint256(uint160(eoa)));
+
+        uint16 scope = _boundGatedScope(scopeSeed);
+        address manager = _boundNonZeroAddress(managerSeed);
+        bytes32 commitment = _boundNonZeroWord(commitmentSeed);
+        uint48 expiry = uint48(bound(expirySeed, block.timestamp + 1, uint256(type(uint48).max) - 1));
+
+        // Authorize the inline self as a gated actor with a finite expiry (signed by the still-full-owner self).
+        _applyLocal(
+            eoaPk,
+            eoa,
+            _one(
+                _authorizeChange(
+                    selfActorId, keystore.K1_AUTHENTICATOR(), scope, expiry, abi.encodePacked(manager, commitment)
+                )
+            )
+        );
+
+        assertEq(keystore.getPolicyManager(eoa, selfActorId), manager);
+        assertEq(keystore.getPolicyCommitment(eoa, selfActorId), commitment);
+
+        vm.warp(uint256(expiry) + 1);
+
+        assertEq(keystore.getPolicyManager(eoa, selfActorId), address(0));
+        assertEq(keystore.getPolicyCommitment(eoa, selfActorId), bytes32(0));
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // getActor — one-shot liveness-gated snapshot (config + packed policyData)
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    //
+    // getActor echoes the queried actorId, returns the resolved (liveness-gated) config, and packs the policy gate
+    // as policyData exactly like the ActorAuthorized event: manager(20) || commitment(32) when gated, else empty.
+
+    /// @notice A gated explicit actor: getActor returns the config and packs (manager, commitment) into policyData,
+    ///         agreeing byte-for-byte with the granular accessors.
+    function test_getActor_success_gatedExplicitActor(
+        uint256 rootSeed,
+        bytes32 actorId,
+        uint8 scopeSeed,
+        uint256 managerSeed,
+        uint256 commitmentSeed
+    ) public {
+        uint256 rootPk = _boundK1Pk(rootSeed);
+        (address account,) = _createK1Account(rootPk);
+        actorId = _boundExplicitActorId(account, rootPk, actorId);
+
+        uint16 scope = _boundGatedScope(scopeSeed);
+        address manager = _boundNonZeroAddress(managerSeed);
+        bytes32 commitment = _boundNonZeroWord(commitmentSeed);
+        _authorizePolicyActor(account, rootPk, actorId, scope, manager, commitment);
+
+        Keystore.Actor memory actor = keystore.getActor(account, actorId);
+        assertEq(actor.actorId, actorId);
+        assertEq(actor.config.authenticator, address(k1Authenticator));
+        assertEq(actor.config.scope, scope);
+        assertEq(actor.policyData, abi.encodePacked(manager, commitment));
+    }
+
+    /// @notice An ungated live actor: getActor returns the config with EMPTY policyData (gating is by scope bit).
+    function test_getActor_success_ungatedActor_emptyPolicyData(uint256 rootSeed, bytes32 actorId) public {
+        uint256 rootPk = _boundK1Pk(rootSeed);
+        (address account,) = _createK1Account(rootPk);
+        actorId = _boundExplicitActorId(account, rootPk, actorId);
+
+        _authorizeUngatedActor(account, rootPk, actorId, address(k1Authenticator));
+
+        Keystore.Actor memory actor = keystore.getActor(account, actorId);
+        assertEq(actor.actorId, actorId);
+        assertEq(actor.config.authenticator, address(k1Authenticator));
+        assertEq(actor.config.scope, uint16(0));
+        assertEq(actor.policyData.length, 0);
+    }
+
+    /// @notice An expired gated actor: getActor resolves to the all-zero config with empty policyData — identical to
+    ///         an unknown/revoked actor.
+    function test_getActor_success_expired_returnsEmpty(
+        uint256 rootSeed,
+        bytes32 actorId,
+        uint8 scopeSeed,
+        uint256 managerSeed,
+        uint256 commitmentSeed,
+        uint48 expirySeed
+    ) public {
+        uint256 rootPk = _boundK1Pk(rootSeed);
+        (address account,) = _createK1Account(rootPk);
+        actorId = _boundExplicitActorId(account, rootPk, actorId);
+
+        uint48 expiry = uint48(bound(expirySeed, block.timestamp + 1, uint256(type(uint48).max) - 1));
+        _authorizePolicyActorWithExpiry(
+            account,
+            rootPk,
+            actorId,
+            _boundGatedScope(scopeSeed),
+            _boundNonZeroAddress(managerSeed),
+            _boundNonZeroWord(commitmentSeed),
+            expiry
+        );
+
+        vm.warp(uint256(expiry) + 1);
+
+        Keystore.Actor memory actor = keystore.getActor(account, actorId);
+        assertEq(actor.actorId, actorId); // actorId is echoed even for a non-live actor
+        assertEq(actor.config.authenticator, address(0));
+        assertEq(actor.config.scope, uint16(0));
+        assertEq(actor.config.expiry, uint48(0));
+        assertEq(actor.policyData.length, 0);
+    }
+
+    /// @notice An unknown (never-authorized, non-self) actor: getActor echoes the id over an all-zero config with
+    ///         empty policyData.
+    function test_getActor_success_unknownActor_returnsEmpty(address account, bytes32 actorId) public view {
+        vm.assume(actorId != bytes32(uint256(uint160(account)))); // stay off the inline-self path
+
+        Keystore.Actor memory actor = keystore.getActor(account, actorId);
+        assertEq(actor.actorId, actorId);
+        assertEq(actor.config.authenticator, address(0));
+        assertEq(actor.policyData.length, 0);
+    }
+
+    /// @notice A gated inline-k1 self: getActor resolves the inline config and packs the shared-keyspace policy gate.
+    function test_getActor_success_inlineSelfGatedActor(
+        uint256 eoaSeed,
+        uint8 scopeSeed,
+        uint256 managerSeed,
+        uint256 commitmentSeed
+    ) public {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
+        address eoa = vm.addr(eoaPk);
+        bytes32 selfActorId = bytes32(uint256(uint160(eoa)));
+
+        uint16 scope = _boundGatedScope(scopeSeed);
+        address manager = _boundNonZeroAddress(managerSeed);
+        bytes32 commitment = _boundNonZeroWord(commitmentSeed);
+        _authorizeInlineSelfWithPolicy(eoa, eoaPk, scope, manager, commitment);
+
+        Keystore.Actor memory actor = keystore.getActor(eoa, selfActorId);
+        assertEq(actor.actorId, selfActorId);
+        assertEq(actor.config.authenticator, keystore.K1_AUTHENTICATOR());
+        assertEq(actor.config.scope, scope);
+        assertEq(actor.policyData, abi.encodePacked(manager, commitment));
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // Fuzz-input bounding helpers
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
@@ -642,6 +844,28 @@ contract PolicyAccessorsTest is KeystoreTest {
             _one(
                 _authorizeChange(
                     actorId, address(k1Authenticator), scope, UNBOUNDED, abi.encodePacked(policyManager, commitment)
+                )
+            )
+        );
+    }
+
+    /// @dev As {_authorizePolicyActor} but granting a finite `expiry` (must be strictly in the future) so a test can
+    ///      warp past it and observe the liveness gate. `scope` must carry SCOPE_POLICY.
+    function _authorizePolicyActorWithExpiry(
+        address account,
+        uint256 rootPk,
+        bytes32 actorId,
+        uint16 scope,
+        address policyManager,
+        bytes32 commitment,
+        uint48 expiry
+    ) internal {
+        _applyLocal(
+            rootPk,
+            account,
+            _one(
+                _authorizeChange(
+                    actorId, address(k1Authenticator), scope, expiry, abi.encodePacked(policyManager, commitment)
                 )
             )
         );

--- a/test/unit/Keystore/policyAccessors.t.sol
+++ b/test/unit/Keystore/policyAccessors.t.sol
@@ -6,9 +6,9 @@ import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
 /// @notice Fully-fuzzed unit tests for the policy accessors on `Keystore`:
-///           - `getPolicy(account, actorId)`           — off-chain aggregate: (manager, commitment)
-///           - `getPolicyCommitment(account, actorId)` — single-SLOAD hot-path read
-///           - `getPolicyManager(account, actorId)`    — single-SLOAD hot-path read (the resolved policy target)
+///           - `getPolicyCommitment(account, actorId)` — liveness-gated hot-path read
+///           - `getPolicyManager(account, actorId)`    — liveness-gated hot-path read (the resolved policy target)
+///           - `getActor(account, actorId)`            — one-shot liveness-gated aggregate (config + policyData)
 ///
 ///         All are `view`; there are no events to assert. Every test fuzzes its inputs (managers, commitments,
 ///         actorIds, keys, scopes). Gating is determined by the SCOPE_POLICY bit, never by "slot non-zero": a
@@ -17,130 +17,7 @@ import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 ///         value is distinguishable from the ungated (unwritten, zero) case.
 contract PolicyAccessorsTest is KeystoreTest {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // getPolicy — explicit (non-self) actor home  (stored.authenticator != 0)
-    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-
-    /// @notice A gated non-self actor: getPolicy returns (manager, commitment) and the aggregate agrees with the
-    ///         granular accessors. Covers the explicit-actor home.
-    function test_getPolicy_success_explicitGatedActor(
-        uint256 rootSeed,
-        bytes32 actorId,
-        uint8 scopeSeed,
-        uint256 managerSeed,
-        uint256 commitmentSeed
-    ) public {
-        uint256 rootPk = _boundK1Pk(rootSeed);
-        (address account,) = _createK1Account(rootPk);
-        actorId = _boundExplicitActorId(account, rootPk, actorId);
-
-        uint16 scope = _boundGatedScope(scopeSeed);
-        address manager = _boundNonZeroAddress(managerSeed);
-        bytes32 commitment = _boundNonZeroWord(commitmentSeed);
-
-        _authorizePolicyActor(account, rootPk, actorId, scope, manager, commitment);
-
-        (address outManager, bytes32 outCommitment) = keystore.getPolicy(account, actorId);
-        assertEq(outManager, manager);
-        assertEq(outCommitment, commitment);
-        // Aggregate agrees with the single-SLOAD granular accessors.
-        assertEq(outManager, keystore.getPolicyManager(account, actorId));
-        assertEq(outCommitment, keystore.getPolicyCommitment(account, actorId));
-    }
-
-    /// @notice A non-self actor authorized ungated (scope & SCOPE_POLICY == 0): getPolicy returns (0, 0). Covers
-    ///         the explicit-actor home with no policy slots written.
-    function test_getPolicy_success_ungatedExplicitActor_returnsNone(uint256 rootSeed, bytes32 actorId) public {
-        uint256 rootPk = _boundK1Pk(rootSeed);
-        (address account,) = _createK1Account(rootPk);
-        actorId = _boundExplicitActorId(account, rootPk, actorId);
-
-        _authorizeUngatedActor(account, rootPk, actorId, address(k1Authenticator));
-
-        (address outManager, bytes32 outCommitment) = keystore.getPolicy(account, actorId);
-        assertEq(outManager, address(0));
-        assertEq(outCommitment, bytes32(0));
-    }
-
-    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // getPolicy — inline-k1-self home  (else-if actorId == self && !revoked)
-    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    //
-    // The inline-k1 self stores scope/expiry in AccountState, but manager/commitment live in the shared
-    // actorId-keyed keyspace — so the accessors must resolve identically to the explicit-actor home.
-
-    /// @notice A gated inline-k1 self: getPolicy returns (manager, commitment) and agrees with the granular
-    ///         accessors. Covers the inline-self home.
-    function test_getPolicy_success_inlineSelfGatedActor(
-        uint256 eoaSeed,
-        uint8 scopeSeed,
-        uint256 managerSeed,
-        uint256 commitmentSeed
-    ) public {
-        uint256 eoaPk = _boundK1Pk(eoaSeed);
-        address eoa = vm.addr(eoaPk);
-        bytes32 selfActorId = bytes32(uint256(uint160(eoa)));
-
-        uint16 scope = _boundGatedScope(scopeSeed);
-        address manager = _boundNonZeroAddress(managerSeed);
-        bytes32 commitment = _boundNonZeroWord(commitmentSeed);
-
-        _authorizeInlineSelfWithPolicy(eoa, eoaPk, scope, manager, commitment);
-
-        (address outManager, bytes32 outCommitment) = keystore.getPolicy(eoa, selfActorId);
-        assertEq(outManager, manager);
-        assertEq(outCommitment, commitment);
-        assertEq(outManager, keystore.getPolicyManager(eoa, selfActorId));
-        assertEq(outCommitment, keystore.getPolicyCommitment(eoa, selfActorId));
-    }
-
-    /// @notice A fresh EOA's implicit self (full owner, ungated): getPolicy returns (0, 0). Covers the inline-self
-    ///         home (else-if true, no _actorConfig, not revoked) with no policy slots written.
-    function test_getPolicy_success_inlineSelfUngated_returnsNone(uint256 eoaSeed) public view {
-        address eoa = vm.addr(_boundK1Pk(eoaSeed));
-        bytes32 selfActorId = bytes32(uint256(uint160(eoa)));
-
-        (address outManager, bytes32 outCommitment) = keystore.getPolicy(eoa, selfActorId);
-        assertEq(outManager, address(0));
-        assertEq(outCommitment, bytes32(0));
-    }
-
-    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // getPolicy — else branch  (unknown actor / revoked self)
-    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-
-    /// @notice An unknown (never-authorized, non-self) actor: getPolicy returns (0, 0) over empty state.
-    function test_getPolicy_success_unknownActor_returnsNone(address account, bytes32 actorId) public view {
-        vm.assume(actorId != bytes32(uint256(uint160(account)))); // stay off the inline-self else-if
-
-        (address outManager, bytes32 outCommitment) = keystore.getPolicy(account, actorId);
-        assertEq(outManager, address(0));
-        assertEq(outCommitment, bytes32(0));
-    }
-
-    /// @notice A gated inline self that is then revoked: getPolicy returns (0, 0). The revoke clears the shared
-    ///         (actorId-keyed) policy slots.
-    function test_getPolicy_success_revokedInlineSelf_returnsNone(
-        uint256 eoaSeed,
-        uint256 ownerSeed,
-        uint8 scopeSeed,
-        uint256 managerSeed,
-        uint256 commitmentSeed
-    ) public {
-        (address eoa, uint256 ownerPk) = _seedGatedInlineSelfWithSpareOwner(
-            eoaSeed, ownerSeed, scopeSeed, managerSeed, commitmentSeed
-        );
-        bytes32 selfActorId = bytes32(uint256(uint160(eoa)));
-
-        // Revoke the (downgraded) self via the spare unrestricted owner; the policy-scoped self cannot sign config.
-        _revokeActor(eoa, ownerPk, selfActorId);
-
-        (address outManager, bytes32 outCommitment) = keystore.getPolicy(eoa, selfActorId);
-        assertEq(outManager, address(0));
-        assertEq(outCommitment, bytes32(0));
-    }
-
-    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // getPolicyManager / getPolicyCommitment — single-SLOAD granular reads
+    // getPolicyManager / getPolicyCommitment — liveness-gated granular reads
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     function test_getPolicyManager_success_explicitGatedActor(
@@ -595,9 +472,7 @@ contract PolicyAccessorsTest is KeystoreTest {
         // Live before expiry.
         assertEq(keystore.getPolicyManager(account, actorId), manager);
         assertEq(keystore.getPolicyCommitment(account, actorId), commitment);
-        (address liveTarget, bytes32 liveCommitment) = keystore.getPolicy(account, actorId);
-        assertEq(liveTarget, manager);
-        assertEq(liveCommitment, commitment);
+        assertEq(keystore.getActor(account, actorId).policyData, abi.encodePacked(manager, commitment));
 
         // Cross the expiry boundary.
         vm.warp(uint256(expiry) + 1);
@@ -605,9 +480,7 @@ contract PolicyAccessorsTest is KeystoreTest {
         // Every read surface now reports empty, identical to a revoked actor.
         assertEq(keystore.getPolicyManager(account, actorId), address(0));
         assertEq(keystore.getPolicyCommitment(account, actorId), bytes32(0));
-        (address deadTarget, bytes32 deadCommitment) = keystore.getPolicy(account, actorId);
-        assertEq(deadTarget, address(0));
-        assertEq(deadCommitment, bytes32(0));
+        assertEq(keystore.getActor(account, actorId).policyData.length, 0);
         // And the config resolver already treated it as empty — the accessors now agree with it.
         assertEq(keystore.getActorConfig(account, actorId).authenticator, address(0));
     }

--- a/test/unit/Keystore/policyAccessors.t.sol
+++ b/test/unit/Keystore/policyAccessors.t.sol
@@ -8,7 +8,7 @@ import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 /// @notice Fully-fuzzed unit tests for the policy accessors on `Keystore`:
 ///           - `getPolicyCommitment(account, actorId)` — liveness-gated hot-path read
 ///           - `getPolicyManager(account, actorId)`    — liveness-gated hot-path read (the resolved policy target)
-///           - `getActor(account, actorId)`            — one-shot liveness-gated aggregate (config + policyData)
+///           - `getActor(account, actorId)`            — one-shot liveness-gated aggregate (config + manager + commitment)
 ///
 ///         All are `view`; there are no events to assert. Every test fuzzes its inputs (managers, commitments,
 ///         actorIds, keys, scopes). Gating is determined by the SCOPE_POLICY bit, never by "slot non-zero": a
@@ -472,7 +472,9 @@ contract PolicyAccessorsTest is KeystoreTest {
         // Live before expiry.
         assertEq(keystore.getPolicyManager(account, actorId), manager);
         assertEq(keystore.getPolicyCommitment(account, actorId), commitment);
-        assertEq(keystore.getActor(account, actorId).policyData, abi.encodePacked(manager, commitment));
+        (, address liveManager, bytes32 liveCommitment) = keystore.getActor(account, actorId);
+        assertEq(liveManager, manager);
+        assertEq(liveCommitment, commitment);
 
         // Cross the expiry boundary.
         vm.warp(uint256(expiry) + 1);
@@ -480,7 +482,9 @@ contract PolicyAccessorsTest is KeystoreTest {
         // Every read surface now reports empty, identical to a revoked actor.
         assertEq(keystore.getPolicyManager(account, actorId), address(0));
         assertEq(keystore.getPolicyCommitment(account, actorId), bytes32(0));
-        assertEq(keystore.getActor(account, actorId).policyData.length, 0);
+        (, address deadManager, bytes32 deadCommitment) = keystore.getActor(account, actorId);
+        assertEq(deadManager, address(0));
+        assertEq(deadCommitment, bytes32(0));
         // And the config resolver already treated it as empty — the accessors now agree with it.
         assertEq(keystore.getActorConfig(account, actorId).authenticator, address(0));
     }
@@ -523,14 +527,14 @@ contract PolicyAccessorsTest is KeystoreTest {
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // getActor — one-shot liveness-gated snapshot (config + packed policyData)
+    // getActor — config + policy manager + commitment in one read
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     //
-    // getActor echoes the queried actorId, returns the resolved (liveness-gated) config, and packs the policy gate
-    // as policyData exactly like the ActorAuthorized event: manager(20) || commitment(32) when gated, else empty.
+    // getActor returns the resolved (liveness-gated) config plus the policy gate as (manager, commitment): non-zero
+    // for a live gated actor, zero for an ungated or non-live one.
 
-    /// @notice A gated explicit actor: getActor returns the config and packs (manager, commitment) into policyData,
-    ///         agreeing byte-for-byte with the granular accessors.
+    /// @notice A gated explicit actor: getActor returns the config and the (manager, commitment) gate, agreeing with
+    ///         the granular accessors.
     function test_getActor_success_gatedExplicitActor(
         uint256 rootSeed,
         bytes32 actorId,
@@ -547,30 +551,32 @@ contract PolicyAccessorsTest is KeystoreTest {
         bytes32 commitment = _boundNonZeroWord(commitmentSeed);
         _authorizePolicyActor(account, rootPk, actorId, scope, manager, commitment);
 
-        Keystore.Actor memory actor = keystore.getActor(account, actorId);
-        assertEq(actor.actorId, actorId);
-        assertEq(actor.config.authenticator, address(k1Authenticator));
-        assertEq(actor.config.scope, scope);
-        assertEq(actor.policyData, abi.encodePacked(manager, commitment));
+        (Keystore.ActorConfig memory config, address outManager, bytes32 outCommitment) =
+            keystore.getActor(account, actorId);
+        assertEq(config.authenticator, address(k1Authenticator));
+        assertEq(config.scope, scope);
+        assertEq(outManager, manager);
+        assertEq(outCommitment, commitment);
     }
 
-    /// @notice An ungated live actor: getActor returns the config with EMPTY policyData (gating is by scope bit).
-    function test_getActor_success_ungatedActor_emptyPolicyData(uint256 rootSeed, bytes32 actorId) public {
+    /// @notice An ungated live actor: getActor returns the config with a zero gate (gating is by scope bit).
+    function test_getActor_success_ungatedActor_zeroGate(uint256 rootSeed, bytes32 actorId) public {
         uint256 rootPk = _boundK1Pk(rootSeed);
         (address account,) = _createK1Account(rootPk);
         actorId = _boundExplicitActorId(account, rootPk, actorId);
 
         _authorizeUngatedActor(account, rootPk, actorId, address(k1Authenticator));
 
-        Keystore.Actor memory actor = keystore.getActor(account, actorId);
-        assertEq(actor.actorId, actorId);
-        assertEq(actor.config.authenticator, address(k1Authenticator));
-        assertEq(actor.config.scope, uint16(0));
-        assertEq(actor.policyData.length, 0);
+        (Keystore.ActorConfig memory config, address outManager, bytes32 outCommitment) =
+            keystore.getActor(account, actorId);
+        assertEq(config.authenticator, address(k1Authenticator));
+        assertEq(config.scope, uint16(0));
+        assertEq(outManager, address(0));
+        assertEq(outCommitment, bytes32(0));
     }
 
-    /// @notice An expired gated actor: getActor resolves to the all-zero config with empty policyData — identical to
-    ///         an unknown/revoked actor.
+    /// @notice An expired gated actor: getActor resolves to the all-zero config with a zero gate — identical to an
+    ///         unknown/revoked actor.
     function test_getActor_success_expired_returnsEmpty(
         uint256 rootSeed,
         bytes32 actorId,
@@ -596,26 +602,27 @@ contract PolicyAccessorsTest is KeystoreTest {
 
         vm.warp(uint256(expiry) + 1);
 
-        Keystore.Actor memory actor = keystore.getActor(account, actorId);
-        assertEq(actor.actorId, actorId); // actorId is echoed even for a non-live actor
-        assertEq(actor.config.authenticator, address(0));
-        assertEq(actor.config.scope, uint16(0));
-        assertEq(actor.config.expiry, uint48(0));
-        assertEq(actor.policyData.length, 0);
+        (Keystore.ActorConfig memory config, address outManager, bytes32 outCommitment) =
+            keystore.getActor(account, actorId);
+        assertEq(config.authenticator, address(0));
+        assertEq(config.scope, uint16(0));
+        assertEq(config.expiry, uint48(0));
+        assertEq(outManager, address(0));
+        assertEq(outCommitment, bytes32(0));
     }
 
-    /// @notice An unknown (never-authorized, non-self) actor: getActor echoes the id over an all-zero config with
-    ///         empty policyData.
+    /// @notice An unknown (never-authorized, non-self) actor: getActor returns an all-zero config with a zero gate.
     function test_getActor_success_unknownActor_returnsEmpty(address account, bytes32 actorId) public view {
         vm.assume(actorId != bytes32(uint256(uint160(account)))); // stay off the inline-self path
 
-        Keystore.Actor memory actor = keystore.getActor(account, actorId);
-        assertEq(actor.actorId, actorId);
-        assertEq(actor.config.authenticator, address(0));
-        assertEq(actor.policyData.length, 0);
+        (Keystore.ActorConfig memory config, address outManager, bytes32 outCommitment) =
+            keystore.getActor(account, actorId);
+        assertEq(config.authenticator, address(0));
+        assertEq(outManager, address(0));
+        assertEq(outCommitment, bytes32(0));
     }
 
-    /// @notice A gated inline-k1 self: getActor resolves the inline config and packs the shared-keyspace policy gate.
+    /// @notice A gated inline-k1 self: getActor resolves the inline config and the shared-keyspace policy gate.
     function test_getActor_success_inlineSelfGatedActor(
         uint256 eoaSeed,
         uint8 scopeSeed,
@@ -631,11 +638,12 @@ contract PolicyAccessorsTest is KeystoreTest {
         bytes32 commitment = _boundNonZeroWord(commitmentSeed);
         _authorizeInlineSelfWithPolicy(eoa, eoaPk, scope, manager, commitment);
 
-        Keystore.Actor memory actor = keystore.getActor(eoa, selfActorId);
-        assertEq(actor.actorId, selfActorId);
-        assertEq(actor.config.authenticator, keystore.K1_AUTHENTICATOR());
-        assertEq(actor.config.scope, scope);
-        assertEq(actor.policyData, abi.encodePacked(manager, commitment));
+        (Keystore.ActorConfig memory config, address outManager, bytes32 outCommitment) =
+            keystore.getActor(eoa, selfActorId);
+        assertEq(config.authenticator, keystore.K1_AUTHENTICATOR());
+        assertEq(config.scope, scope);
+        assertEq(outManager, manager);
+        assertEq(outCommitment, commitment);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

--- a/test/unit/policies/PolicyManager.t.sol
+++ b/test/unit/policies/PolicyManager.t.sol
@@ -258,17 +258,18 @@ contract PolicyManagerTest is KeystoreTest {
 
     // ── Config resolution ──
 
-    /// @notice Verifies getPolicy returns the manager address and signed commitment for an authorized policy actor.
-    /// @dev Asserts Keystore.getPolicy resolves the configured policy_manager and policy_commitment.
+    /// @notice Verifies the policy accessors resolve the manager address and signed commitment for an authorized
+    ///         policy actor.
+    /// @dev Asserts Keystore.getPolicyManager / getPolicyCommitment resolve the configured policy_manager and
+    ///      policy_commitment.
     function test_getPolicy_success_resolvesManagerAndCommitment() public {
         PolicyManager.PolicyBinding memory binding = _binding(9);
         bytes32 commitment = manager.commitmentOf(binding);
         bytes32 actorId = _sessionActorId(9);
         _authorizePolicyActor(actorId, commitment);
 
-        (address resolvedTarget, bytes32 signed) = keystore.getPolicy(account, actorId);
-        assertEq(resolvedTarget, address(manager));
-        assertEq(signed, commitment);
+        assertEq(keystore.getPolicyManager(account, actorId), address(manager));
+        assertEq(keystore.getPolicyCommitment(account, actorId), commitment);
     }
 
     // ── Helpers ──


### PR DESCRIPTION
## Summary

Makes every Keystore read accessor treat an **expired** actor identically to a **revoked** one, and adds a one-shot aggregate view for off-chain consumers.

- `getPolicy`, `getPolicyManager`, and `getPolicyCommitment` now resolve an expired (or unknown/disabled/revoked) actor to zero, matching `getActorConfig`. Previously they returned the raw slot after expiry and told readers to cross-check `getActorConfig` themselves.
- Adds **`getActor(account, actorId)`** — a single liveness-gated snapshot returning the resolved `ActorConfig` plus the policy gate packed as `policyData` (`manager(20) || commitment(32)` when gated, else empty; same shape as the import `Actor` struct / trailing portion of the `ActorAuthorized` payload).
- All liveness resolution is centralized in a shared `_resolveActorConfig` helper (the former `getActorConfig` body), so there is a single source of truth for "is this actor live."

### Why

The motivating goal is **uniform `expired == revoked == empty` across all interfaces**. Beyond removing an off-chain footgun (a naive reader seeing a live-looking commitment for a dead actor), this is the invariant that makes **node/protocol-level garbage collection of expired actors sound**: if no interface distinguishes an expired-but-present actor from a deleted one, a node can reclaim expired slots without changing anything observable on-chain.

### Deliberately out of scope

- **No storage layout change.** We considered merging the three per-actor mappings into one struct-valued mapping. The gas win is ~168 gas (only the redundant keccak hashing; the SLOADs are identical) and zero on the hot auth path, while it would turn a normative single-slot layout into something requiring EIP/node coordination. Not worth it.
- **Revoke path unchanged.** Revoking an expired actor changes no authority (an expired actor already authenticates to nothing), so GC-observability through `RevokeActor` reverting `UnknownActor` is benign. `_isAuthorized` still ignores expiry so expired actors remain explicitly revokable until GC'd.
- **No permissionless on-chain sweeper.** The EIP-3529 refund cap (20% of tx gas) plus the absence of any caller incentive make an on-chain deleter uneconomical; GC belongs at the protocol layer.

### Consumer impact

`PolicyManager` behavior is unchanged: `execute` only reads the commitment for actors already liveness-checked by protocol dispatch (same block, same expiry), and `executeFor` already gates on `getActorConfig` before reading the policy slots. The gating is therefore a strengthening for third-party readers, at the cost of one extra SLOAD (the actor's config) per policy read.

## Test plan

- [x] `forge build` clean (only pre-existing library warnings)
- [x] `forge test` — 374 passed, 0 failed
- [x] New fuzz tests in `policyAccessors.t.sol`:
  - expired explicit actor + expired inline-k1 self read as revoked across `getPolicy`/`getPolicyManager`/`getPolicyCommitment`
  - `getActor` for gated explicit / ungated / expired / unknown / gated inline-self actors