### PR TITLE
Consolidate the lock check; merge _isLocked overloads

### DIFF
--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -622,6 +622,8 @@ contract Keystore {
         uint256 n = s.changes.length;
         for (uint256 i; i < n; i++) {
             ChangeType t = s.changes[i].changeType;
+
+            // Preconditions: freeze non-exempt ops on a locked account, and hold Lock/Unlock to a standalone local batch.
             if (locked && t != ChangeType.Unlock && t != ChangeType.IncrementLocalEpoch) {
                 revert AccountIsLocked();
             }
@@ -633,6 +635,8 @@ contract Keystore {
                     revert LockChangeMustBeStandalone();
                 }
             }
+
+            // Apply: dispatch the op to its handler.
             if (t == ChangeType.AuthorizeActor) {
                 _applyAuthorize(account, s.changes[i].payload);
             } else if (t == ChangeType.RevokeActor) {

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -613,25 +613,24 @@ contract Keystore {
             revert UnauthorizedAccountChange();
         }
 
-        // Authority ops use the lock state at batch entry. Local-only changes reject the Multichain channel; Lock and
-        // Unlock are also standalone. That standalone rule is what makes this entry snapshot EXACT for the whole batch:
-        // the only ops that mutate lock state (Lock/Unlock) can never share a batch with an authority op, so no op
-        // observes a lock state that a peer changed mid-loop. Relaxing standalone re-opens snapshot staleness — a later
-        // authority op could then run against a lock a Lock earlier in the same batch just set (or a stale-unlocked one).
-        bool locked = _isLocked(a);
+        // Lock state at batch entry gates every op below. This snapshot is EXACT for the whole batch: the only ops
+        // that mutate lock state (Lock/Unlock) must be standalone, so no op observes a lock state that a peer changed
+        // mid-loop. Relaxing standalone re-opens snapshot staleness — a later authority op could then run against a
+        // lock a Lock earlier in the same batch just set (or a stale-unlocked one).
+        bool locked = _isLocked(account);
 
         uint256 n = s.changes.length;
         for (uint256 i; i < n; i++) {
             ChangeType t = s.changes[i].changeType;
+            // A locked account is frozen for every op except Unlock (which requires the lock, enforced in
+            // _applyUnlock) and IncrementLocalEpoch (retiring keys stays available while locked). Any future op
+            // defaults to requiring an unlocked account (fail-safe).
+            if (locked && t != ChangeType.Unlock && t != ChangeType.IncrementLocalEpoch) {
+                revert AccountIsLocked();
+            }
             if (t == ChangeType.AuthorizeActor) {
-                if (locked) {
-                    revert AccountIsLocked();
-                }
                 _applyAuthorize(account, s.changes[i].payload);
             } else if (t == ChangeType.RevokeActor) {
-                if (locked) {
-                    revert AccountIsLocked();
-                }
                 _applyRevoke(account, s.changes[i].payload);
             } else if (t == ChangeType.IncrementLocalEpoch) {
                 if (!isLocal) {
@@ -721,13 +720,11 @@ contract Keystore {
         a.localSequence = 0;
     }
 
-    /// @dev Lock. Local-only; `payload = abi.encode(uint16 unlockDelay)`. Must be standalone and requires the account
-    ///      to be currently unlocked. Overwrites any residue from an elapsed prior lock.
+    /// @dev Lock. Local-only; `payload = abi.encode(uint16 unlockDelay)`. Must be standalone. The caller
+    ///      ({applySignedAccountChanges}) guarantees the account is unlocked before dispatch, so this overwrites any
+    ///      residue from an elapsed prior lock unconditionally.
     function _applyLock(address account, bytes calldata payload) private {
         AccountState storage a = _accountState[account];
-        if (_isLocked(a)) {
-            revert AccountIsLocked();
-        }
         uint16 unlockDelay = abi.decode(payload, (uint16));
         if (unlockDelay == 0) {
             revert ZeroUnlockDelay();
@@ -1001,7 +998,7 @@ contract Keystore {
     ///
     /// @return True if the account is locked at the current block timestamp.
     function isLocked(address account) external view returns (bool) {
-        return _isLocked(_accountState[account]);
+        return _isLocked(account);
     }
 
     /// @notice Returns the account's full lock status.
@@ -1043,7 +1040,8 @@ contract Keystore {
 
     /// @dev Returns whether the account's configuration is currently frozen without mutating storage.
     /// @dev An elapsed unlock reads as unlocked; a later {_applyLock} overwrites the stale lock fields.
-    function _isLocked(AccountState storage st) private view returns (bool) {
+    function _isLocked(address account) private view returns (bool) {
+        AccountState storage st = _accountState[account];
         uint8 flags = st.flags;
         if (flags & FLAG_LOCKED == 0) {
             return false;
@@ -1052,11 +1050,6 @@ contract Keystore {
             return true;
         }
         return block.timestamp < st.lockUnion; // pending unlock: frozen until the timestamp elapses
-    }
-
-    /// @dev Convenience overload of {_isLocked} keyed by address.
-    function _isLocked(address account) private view returns (bool) {
-        return _isLocked(_accountState[account]);
     }
 
     /// @dev True after bootstrap or any successful signed change. The epoch and multichain counter keep initialization

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -622,11 +622,16 @@ contract Keystore {
         uint256 n = s.changes.length;
         for (uint256 i; i < n; i++) {
             ChangeType t = s.changes[i].changeType;
-            // A locked account is frozen for every op except Unlock (which requires the lock, enforced in
-            // _applyUnlock) and IncrementLocalEpoch (retiring keys stays available while locked). Any future op
-            // defaults to requiring an unlocked account (fail-safe).
             if (locked && t != ChangeType.Unlock && t != ChangeType.IncrementLocalEpoch) {
                 revert AccountIsLocked();
+            }
+            if (t == ChangeType.Lock || t == ChangeType.Unlock) {
+                if (!isLocal) {
+                    revert ChangeRequiresLocalChannel();
+                }
+                if (n != 1) {
+                    revert LockChangeMustBeStandalone();
+                }
             }
             if (t == ChangeType.AuthorizeActor) {
                 _applyAuthorize(account, s.changes[i].payload);
@@ -635,20 +640,8 @@ contract Keystore {
             } else if (t == ChangeType.IncrementLocalEpoch) {
                 _applyIncrementLocalEpoch(account, s.changes[i].payload);
             } else if (t == ChangeType.Lock) {
-                if (!isLocal) {
-                    revert ChangeRequiresLocalChannel();
-                }
-                if (n != 1) {
-                    revert LockChangeMustBeStandalone();
-                }
                 _applyLock(account, s.changes[i].payload);
             } else if (t == ChangeType.Unlock) {
-                if (!isLocal) {
-                    revert ChangeRequiresLocalChannel();
-                }
-                if (n != 1) {
-                    revert LockChangeMustBeStandalone();
-                }
                 _applyUnlock(account, s.changes[i].payload);
             } else {
                 // Defensive guard: every ChangeType must be dispatched explicitly. Unreachable today — out-of-range


### PR DESCRIPTION
Stacked on #69 (base: `expiry-gate-policy-reads`).

## Summary
- Merge the two `_isLocked` overloads into a single function keyed by `address` (the storage-taking variant did the same slot read); all callers use the address form.
- Consolidate the lock precondition into a single guard in `applySignedAccountChanges`, replacing the per-op `if (locked)` checks on `AuthorizeActor`/`RevokeActor` and the redundant `_isLocked` check inside `_applyLock`.

## Behavior (unchanged)
A locked account is frozen for every op **except**:
- `Unlock` — requires the lock (enforced in `_applyUnlock`).
- `IncrementLocalEpoch` — retiring keys stays available while locked.

`Lock` while locked still reverts `AccountIsLocked` (now via the guard instead of `_applyLock`). The batch-entry snapshot stays exact because `Lock`/`Unlock` must be standalone. Any future op defaults to requiring an unlocked account (fail-safe).

## Test plan
- [x] `forge build` clean
- [x] `forge fmt --check` clean
- [x] `forge test` — 368 passed, 0 failed