### PR TITLE
Consolidate lock checks in applySignedAccountChanges

### DIFF
--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -622,6 +622,8 @@ contract Keystore {
         uint256 n = s.changes.length;
         for (uint256 i; i < n; i++) {
             ChangeType t = s.changes[i].changeType;
+
+            // Preconditions: freeze non-exempt ops on a locked account, and hold Lock/Unlock to a standalone local batch.
             if (locked && t != ChangeType.Unlock && t != ChangeType.IncrementLocalEpoch) {
                 revert AccountIsLocked();
             }
@@ -633,6 +635,8 @@ contract Keystore {
                     revert LockChangeMustBeStandalone();
                 }
             }
+
+            // Apply: dispatch the op to its handler.
             if (t == ChangeType.AuthorizeActor) {
                 _applyAuthorize(account, s.changes[i].payload);
             } else if (t == ChangeType.RevokeActor) {

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -622,11 +622,16 @@ contract Keystore {
         uint256 n = s.changes.length;
         for (uint256 i; i < n; i++) {
             ChangeType t = s.changes[i].changeType;
-            // A locked account is frozen for every op except Unlock (which requires the lock, enforced in
-            // _applyUnlock) and IncrementLocalEpoch (retiring keys stays available while locked). Any future op
-            // defaults to requiring an unlocked account (fail-safe).
             if (locked && t != ChangeType.Unlock && t != ChangeType.IncrementLocalEpoch) {
                 revert AccountIsLocked();
+            }
+            if (t == ChangeType.Lock || t == ChangeType.Unlock) {
+                if (!isLocal) {
+                    revert ChangeRequiresLocalChannel();
+                }
+                if (n != 1) {
+                    revert LockChangeMustBeStandalone();
+                }
             }
             if (t == ChangeType.AuthorizeActor) {
                 _applyAuthorize(account, s.changes[i].payload);
@@ -635,20 +640,8 @@ contract Keystore {
             } else if (t == ChangeType.IncrementLocalEpoch) {
                 _applyIncrementLocalEpoch(account, s.changes[i].payload);
             } else if (t == ChangeType.Lock) {
-                if (!isLocal) {
-                    revert ChangeRequiresLocalChannel();
-                }
-                if (n != 1) {
-                    revert LockChangeMustBeStandalone();
-                }
                 _applyLock(account, s.changes[i].payload);
             } else if (t == ChangeType.Unlock) {
-                if (!isLocal) {
-                    revert ChangeRequiresLocalChannel();
-                }
-                if (n != 1) {
-                    revert LockChangeMustBeStandalone();
-                }
                 _applyUnlock(account, s.changes[i].payload);
             } else {
                 // Defensive guard: every ChangeType must be dispatched explicitly. Unreachable today — out-of-range

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -613,25 +613,24 @@ contract Keystore {
             revert UnauthorizedAccountChange();
         }
 
-        // Authority ops use the lock state at batch entry. Lock and Unlock reject the Multichain channel and are
-        // standalone. That standalone rule is what makes this entry snapshot EXACT for the whole batch:
-        // the only ops that mutate lock state (Lock/Unlock) can never share a batch with an authority op, so no op
-        // observes a lock state that a peer changed mid-loop. Relaxing standalone re-opens snapshot staleness — a later
-        // authority op could then run against a lock a Lock earlier in the same batch just set (or a stale-unlocked one).
-        bool locked = _isLocked(a);
+        // Lock state at batch entry gates every op below. This snapshot is EXACT for the whole batch: the only ops
+        // that mutate lock state (Lock/Unlock) must be standalone, so no op observes a lock state that a peer changed
+        // mid-loop. Relaxing standalone re-opens snapshot staleness — a later authority op could then run against a
+        // lock a Lock earlier in the same batch just set (or a stale-unlocked one).
+        bool locked = _isLocked(account);
 
         uint256 n = s.changes.length;
         for (uint256 i; i < n; i++) {
             ChangeType t = s.changes[i].changeType;
+            // A locked account is frozen for every op except Unlock (which requires the lock, enforced in
+            // _applyUnlock) and IncrementLocalEpoch (retiring keys stays available while locked). Any future op
+            // defaults to requiring an unlocked account (fail-safe).
+            if (locked && t != ChangeType.Unlock && t != ChangeType.IncrementLocalEpoch) {
+                revert AccountIsLocked();
+            }
             if (t == ChangeType.AuthorizeActor) {
-                if (locked) {
-                    revert AccountIsLocked();
-                }
                 _applyAuthorize(account, s.changes[i].payload);
             } else if (t == ChangeType.RevokeActor) {
-                if (locked) {
-                    revert AccountIsLocked();
-                }
                 _applyRevoke(account, s.changes[i].payload);
             } else if (t == ChangeType.IncrementLocalEpoch) {
                 _applyIncrementLocalEpoch(account, s.changes[i].payload);
@@ -719,13 +718,11 @@ contract Keystore {
         a.localSequence = 0;
     }
 
-    /// @dev Lock. Local-only; `payload = abi.encode(uint16 unlockDelay)`. Must be standalone and requires the account
-    ///      to be currently unlocked. Overwrites any residue from an elapsed prior lock.
+    /// @dev Lock. Local-only; `payload = abi.encode(uint16 unlockDelay)`. Must be standalone. The caller
+    ///      ({applySignedAccountChanges}) guarantees the account is unlocked before dispatch, so this overwrites any
+    ///      residue from an elapsed prior lock unconditionally.
     function _applyLock(address account, bytes calldata payload) private {
         AccountState storage a = _accountState[account];
-        if (_isLocked(a)) {
-            revert AccountIsLocked();
-        }
         uint16 unlockDelay = abi.decode(payload, (uint16));
         if (unlockDelay == 0) {
             revert ZeroUnlockDelay();
@@ -999,7 +996,7 @@ contract Keystore {
     ///
     /// @return True if the account is locked at the current block timestamp.
     function isLocked(address account) external view returns (bool) {
-        return _isLocked(_accountState[account]);
+        return _isLocked(account);
     }
 
     /// @notice Returns the account's full lock status.
@@ -1041,7 +1038,8 @@ contract Keystore {
 
     /// @dev Returns whether the account's configuration is currently frozen without mutating storage.
     /// @dev An elapsed unlock reads as unlocked; a later {_applyLock} overwrites the stale lock fields.
-    function _isLocked(AccountState storage st) private view returns (bool) {
+    function _isLocked(address account) private view returns (bool) {
+        AccountState storage st = _accountState[account];
         uint8 flags = st.flags;
         if (flags & FLAG_LOCKED == 0) {
             return false;
@@ -1050,11 +1048,6 @@ contract Keystore {
             return true;
         }
         return block.timestamp < st.lockUnion; // pending unlock: frozen until the timestamp elapses
-    }
-
-    /// @dev Convenience overload of {_isLocked} keyed by address.
-    function _isLocked(address account) private view returns (bool) {
-        return _isLocked(_accountState[account]);
     }
 
     /// @dev True after bootstrap or any successful signed change. The epoch and multichain counter keep initialization


### PR DESCRIPTION
## Summary
- Merges the two `_isLocked` overloads into a single address-keyed `_isLocked(address account)`.
- Hoists the locked-account freeze into one guard at the top of the change loop and drops the redundant per-branch `AccountIsLocked` checks (and `_applyLock`'s internal check).
- Dedupes the shared local-channel + standalone-batch checks for `Lock`/`Unlock` into a single guard clause, leaving the dispatch branches as flat one-line apply calls.
- Behavior is unchanged; revert precedence is preserved.

## Test plan
- [x] `forge build`
- [x] `forge test` — 368 passed, 0 failed