### PR TITLE
Fix doc/link drift and unify self-actorId derivation

### DIFF
--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -1289,10 +1289,7 @@ contract Keystore {
 
         return keccak256(
             abi.encode(
-                ACTOR_INITIALIZATION_TYPEHASH,
-                ActorId.fromAddress(account),
-                chainId,
-                keccak256(abi.encodePacked(actorHashes))
+                ACTOR_INITIALIZATION_TYPEHASH, _selfActorId(account), chainId, keccak256(abi.encodePacked(actorHashes))
             )
         );
     }

--- a/src/policies/README.md
+++ b/src/policies/README.md
@@ -15,7 +15,7 @@ protocol-side, not enforced by this contract.
 1. **Authorize + commit.** The account authorizes the session key with `scope = Scopes.POLICY`,
    `policy_manager = PolicyManager`, and `policy_commitment = keccak256` of an account-authorized
    [`PolicyBinding`](./PolicyManager.sol). The Keystore contract exposes this via
-   [`getActor(account, actorId)`](../../Keystore.sol) (or the granular `getPolicyManager` / `getPolicyCommitment`).
+   [`getActor(account, actorId)`](../Keystore.sol) (or the granular `getPolicyManager` / `getPolicyCommitment`).
    That signed actor change *is* the authorization — there is no separate install step on the manager.
 2. **Use.** When the session key transacts, the protocol gate resolves the key's allowed target
    (`policy_manager(account, actorId)`) and reverts any call whose `call.to` isn't that address before dispatch, so

--- a/test/unit/Keystore/authenticate.t.sol
+++ b/test/unit/Keystore/authenticate.t.sol
@@ -6,7 +6,8 @@ import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
 /// @notice Fuzzed, branch-complete suite for the authentication paths of Keystore:
 ///         authenticateActor -> _authenticate -> {_authenticateK1, IAuthenticator} -> _recoverSigner, plus the
-///         validateSignature / getActorConfig / getPolicy views that read the same actor resolution.
+///         validateSignature / getActorConfig / getPolicyManager / getPolicyCommitment views that read the same
+///         actor resolution.
 ///
 ///         Source-order revert coverage (as declared / hit through authenticateActor):
 ///           1. InvalidAuthLength      authenticateActor: auth.length < 20


### PR DESCRIPTION
## Summary
Consistency-only follow-up pass; no behavior change.

- **README link:** `src/policies/README.md` linked `getActor` to `../../Keystore.sol`, which resolves to a nonexistent repo-root path. Fixed to `../Keystore.sol`.
- **Stale test doc:** the `authenticate.t.sol` suite header still referenced the removed `getPolicy` view. Updated to `getPolicyManager` / `getPolicyCommitment`.
- **Self-actorId derivation:** `_computeImportDigest` used the raw `ActorId.fromAddress(account)` where every other "this account's self id" site uses the `_selfActorId(account)` helper. Switched for consistency — identical value, so the import digest is unchanged.

## Test plan
- [x] `forge build`
- [x] `forge fmt`
- [x] `forge test` — 368 passed, 0 failed (import/authentication suites confirm the digest is unchanged)