### PR TITLE
Add contract-established marker and shared initial-actor validator

### DIFF
--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -210,21 +210,13 @@ contract Keystore {
     ///         (the timestamp at which the pending unlock takes effect). Only meaningful when FLAG_LOCKED is set.
     uint8 public constant FLAG_UNLOCK_INITIATED = 0x04;
 
-    /// @notice AccountState.flags bit: set on every account whose EIP-8130 authority the keystore establishes — by
-    ///         createAccount and by importAccount alike, regardless of the target's code shape (contract wallet,
-    ///         EIP-7702/7819 delegate, etc.). EIP-8130 deliberately does not infer an address-bound private key from
-    ///         code shape: an EOA's power to (un)delegate is exercised with its key at the protocol layer, outside this
-    ///         contract, so there is nothing for the keystore to record. The bit therefore marks "keystore-established,
-    ///         not a proven address key."
+    /// @notice AccountState.flags bit: set on every account the keystore establishes (createAccount and importAccount),
+    ///         marking it "keystore-established, not a proven address key."
     ///
-    /// @dev Once set, the bit is permanent: no op clears it. It exists to survive EIP-6780, under which a contract
-    ///      created and SELFDESTRUCTed in the same transaction leaves empty code but retains its EIP-8130 state. Such
-    ///      an account has no address-backed key, so consumers MUST NOT treat "empty code (or a delegate) plus
-    ///      EIP-8130 state" as proof of a known EOA key when this flag is set (see {isContractEstablished}). It has no
-    ///      effect on authentication — authority still rests entirely on the configured actor set.
-    ///
-    ///      Every current establishment path sets it. The bit's forward meaning is the inverse case: a future,
-    ///      genuinely key-backed native path (e.g. an EIP-8164 ML-DSA self-import) may deliberately leave it clear.
+    /// @dev Permanent once set; has no effect on authentication. The protocol can read it to make code-delegation or
+    ///      other decisions — e.g. an account may have empty code yet retain EIP-8130 state (an EIP-6780 same-transaction
+    ///      SELFDESTRUCT), so this flag lets consumers avoid treating empty code as proof of a known EOA key. A future
+    ///      key-backed native path may deliberately leave it clear.
     uint8 public constant FLAG_CONTRACT_ESTABLISHED = 0x08;
 
     /// @dev secp256k1 half-order (n/2). Per EIP-2, only the lower-half `s` value is accepted to reject signature
@@ -451,7 +443,7 @@ contract Keystore {
     /// @dev Reverts with AlreadyInitialized when the account already has EIP-8130 state.
     /// @dev Reverts with NoInitialActors when `initialActors` is empty.
     /// @dev Reverts with ActorsNotSortedOrDuplicate when `initialActors` is not strictly ascending by actorId.
-    /// @dev Reverts with InvalidAuthenticator when an initial actor names a sub-K1 (zero) authenticator.
+    /// @dev Reverts with InvalidAuthenticator when an initial actor names a zero authenticator.
     /// @dev Reverts with InvalidPolicyData when an initial actor's policyData length does not match its scope.
     /// @dev Reverts with AccountDeploymentFailed when CREATE2 does not deploy code at the expected address.
     ///
@@ -476,9 +468,8 @@ contract Keystore {
         }
 
         // Created accounts disable the implicit EOA key. Set this before actor initialization so an explicit k1 self
-        // actor can re-enable it. FLAG_CONTRACT_ESTABLISHED is set unconditionally: the account lives at a CREATE2
-        // address that has no private key, so even if its runtime later becomes empty (e.g. an EIP-6780 same-tx
-        // SELFDESTRUCT) it must never be mistaken for a key-backed EOA.
+        // actor can re-enable it. FLAG_CONTRACT_ESTABLISHED is set for every created account. See
+        // {FLAG_CONTRACT_ESTABLISHED}.
         _accountState[account].localSequence = 1;
         _accountState[account].flags = FLAG_REVOKE_DEFAULT_EOA | FLAG_CONTRACT_ESTABLISHED;
 
@@ -543,15 +534,8 @@ contract Keystore {
         }
 
         // Disable the implicit EOA key after ERC-1271 validation so a delegated EOA can use that key to authorize its
-        // import. Including the k1 self in initialActors re-enables it explicitly.
-        //
-        // FLAG_CONTRACT_ESTABLISHED is set unconditionally, independent of the target's code shape. Import accepts any
-        // ERC-1271 target — contract wallets and EIP-7702/7819 delegates alike (the 7819 factory relies on importing
-        // delegates) — and the keystore does not infer an address-bound key from code: an EOA's ability to redelegate
-        // lives with its key at the protocol layer, not in this flag. The accepted consequence is that an imported
-        // delegate that later delegates to the zero address (empty code) has no keystore-visible key and cannot be
-        // treated as a key-backed EOA — which is correct for a 7819 clone and irrelevant to a genuine EOA (which
-        // redelegates with its key directly). See {FLAG_CONTRACT_ESTABLISHED}.
+        // import. Including the k1 self in initialActors re-enables it explicitly. FLAG_CONTRACT_ESTABLISHED is set for
+        // every import regardless of code shape (delegates included). See {FLAG_CONTRACT_ESTABLISHED}.
         _accountState[account].flags = FLAG_REVOKE_DEFAULT_EOA | FLAG_CONTRACT_ESTABLISHED;
 
         _initializeAccount(account, initialActors);
@@ -1027,14 +1011,8 @@ contract Keystore {
         return _isLocked(account);
     }
 
-    /// @notice Whether the account's EIP-8130 authority was established by the keystore (via createAccount or
-    ///         importAccount) rather than by a proven address key. True for every account the keystore establishes
-    ///         today; see {FLAG_CONTRACT_ESTABLISHED} for the forward case that leaves it clear.
-    ///
-    /// @dev Consumers that treat "empty code (or a delegate) plus EIP-8130 state" as evidence of a known EOA key MUST
-    ///      exclude accounts for which this returns true: under EIP-6780 such an account can be created (or its
-    ///      importing contract destroyed) and SELFDESTRUCTed in the same transaction, leaving empty code and persisted
-    ///      EIP-8130 state at an address that has no private key. See {FLAG_CONTRACT_ESTABLISHED}.
+    /// @notice Whether the account was keystore-established (createAccount or importAccount) rather than backed by a
+    ///         proven address key. See {FLAG_CONTRACT_ESTABLISHED}.
     ///
     /// @param account The account to check.
     ///

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -114,7 +114,7 @@ contract Keystore {
         uint64 multichainSequence; // 8 bytes
         uint32 localSequence; // 4 bytes – low half of the signed local word
         uint32 localEpoch; // 4 bytes – high half of the signed local word
-        uint8 flags; // 1 byte – bitfield: bit 0 REVOKE_DEFAULT_EOA, bit 1 LOCKED, bit 2 UNLOCK_INITIATED
+        uint8 flags; // 1 byte – bitfield: bit 0 REVOKE_DEFAULT_EOA, bit 1 LOCKED, bit 2 UNLOCK_INITIATED, bit 3 CONTRACT_ESTABLISHED
         uint48 lockUnion; // 6 bytes – union: unlockDelay while UNLOCK_INITIATED clear, else unlocksAt (timestamp)
         uint48 defaultEOAExpiry; // 6 bytes – inline self k1 expiry (Unix seconds; 0 = no expiry)
         uint16 defaultEOAScope; // 2 bytes – inline self k1 scope (0 = full owner)
@@ -209,6 +209,23 @@ contract Keystore {
     ///         While clear, `lockUnion` holds the configured unlock delay (seconds); while set, it holds unlocksAt
     ///         (the timestamp at which the pending unlock takes effect). Only meaningful when FLAG_LOCKED is set.
     uint8 public constant FLAG_UNLOCK_INITIATED = 0x04;
+
+    /// @notice AccountState.flags bit: set on every account whose EIP-8130 authority the keystore establishes — by
+    ///         createAccount and by importAccount alike, regardless of the target's code shape (contract wallet,
+    ///         EIP-7702/7819 delegate, etc.). EIP-8130 deliberately does not infer an address-bound private key from
+    ///         code shape: an EOA's power to (un)delegate is exercised with its key at the protocol layer, outside this
+    ///         contract, so there is nothing for the keystore to record. The bit therefore marks "keystore-established,
+    ///         not a proven address key."
+    ///
+    /// @dev Once set, the bit is permanent: no op clears it. It exists to survive EIP-6780, under which a contract
+    ///      created and SELFDESTRUCTed in the same transaction leaves empty code but retains its EIP-8130 state. Such
+    ///      an account has no address-backed key, so consumers MUST NOT treat "empty code (or a delegate) plus
+    ///      EIP-8130 state" as proof of a known EOA key when this flag is set (see {isContractEstablished}). It has no
+    ///      effect on authentication — authority still rests entirely on the configured actor set.
+    ///
+    ///      Every current establishment path sets it. The bit's forward meaning is the inverse case: a future,
+    ///      genuinely key-backed native path (e.g. an EIP-8164 ML-DSA self-import) may deliberately leave it clear.
+    uint8 public constant FLAG_CONTRACT_ESTABLISHED = 0x08;
 
     /// @dev secp256k1 half-order (n/2). Per EIP-2, only the lower-half `s` value is accepted to reject signature
     ///      malleability. Equal to (secp256k1n - 1) / 2.
@@ -434,7 +451,8 @@ contract Keystore {
     /// @dev Reverts with AlreadyInitialized when the account already has EIP-8130 state.
     /// @dev Reverts with NoInitialActors when `initialActors` is empty.
     /// @dev Reverts with ActorsNotSortedOrDuplicate when `initialActors` is not strictly ascending by actorId.
-    /// @dev Reverts with InvalidAuthenticator when an initial actor names a zero authenticator.
+    /// @dev Reverts with InvalidAuthenticator when an initial actor names a sub-K1 (zero) authenticator.
+    /// @dev Reverts with InvalidPolicyData when an initial actor's policyData length does not match its scope.
     /// @dev Reverts with AccountDeploymentFailed when CREATE2 does not deploy code at the expected address.
     ///
     /// @param userSalt Caller-chosen salt mixed into the CREATE2 address derivation.
@@ -458,9 +476,11 @@ contract Keystore {
         }
 
         // Created accounts disable the implicit EOA key. Set this before actor initialization so an explicit k1 self
-        // actor can re-enable it.
+        // actor can re-enable it. FLAG_CONTRACT_ESTABLISHED is set unconditionally: the account lives at a CREATE2
+        // address that has no private key, so even if its runtime later becomes empty (e.g. an EIP-6780 same-tx
+        // SELFDESTRUCT) it must never be mistaken for a key-backed EOA.
         _accountState[account].localSequence = 1;
-        _accountState[account].flags = FLAG_REVOKE_DEFAULT_EOA;
+        _accountState[account].flags = FLAG_REVOKE_DEFAULT_EOA | FLAG_CONTRACT_ESTABLISHED;
 
         _initializeAccount(account, initialActors);
 
@@ -524,7 +544,15 @@ contract Keystore {
 
         // Disable the implicit EOA key after ERC-1271 validation so a delegated EOA can use that key to authorize its
         // import. Including the k1 self in initialActors re-enables it explicitly.
-        _accountState[account].flags = FLAG_REVOKE_DEFAULT_EOA;
+        //
+        // FLAG_CONTRACT_ESTABLISHED is set unconditionally, independent of the target's code shape. Import accepts any
+        // ERC-1271 target — contract wallets and EIP-7702/7819 delegates alike (the 7819 factory relies on importing
+        // delegates) — and the keystore does not infer an address-bound key from code: an EOA's ability to redelegate
+        // lives with its key at the protocol layer, not in this flag. The accepted consequence is that an imported
+        // delegate that later delegates to the zero address (empty code) has no keystore-visible key and cannot be
+        // treated as a key-backed EOA — which is correct for a 7819 clone and irrelevant to a genuine EOA (which
+        // redelegates with its key directly). See {FLAG_CONTRACT_ESTABLISHED}.
+        _accountState[account].flags = FLAG_REVOKE_DEFAULT_EOA | FLAG_CONTRACT_ESTABLISHED;
 
         _initializeAccount(account, initialActors);
         emit AccountImported(account);
@@ -879,6 +907,9 @@ contract Keystore {
     ///
     /// @dev Reverts with EmptyBytecode when `bytecode` is empty.
     /// @dev Reverts with BytecodeTooLarge when `bytecode` exceeds the maximum encodable length.
+    /// @dev Applies the same initial-actor validation as {createAccount} (see {_validateInitialActors}), so it never
+    ///      returns an address for an actor set a later createAccount would reject. Reverts with NoInitialActors,
+    ///      ActorsNotSortedOrDuplicate, InvalidAuthenticator, or InvalidPolicyData.
     ///
     /// @param userSalt Caller-chosen salt mixed into the CREATE2 address derivation.
     /// @param bytecode Account deployment bytecode.
@@ -994,6 +1025,22 @@ contract Keystore {
     /// @return True if the account is locked at the current block timestamp.
     function isLocked(address account) external view returns (bool) {
         return _isLocked(account);
+    }
+
+    /// @notice Whether the account's EIP-8130 authority was established by the keystore (via createAccount or
+    ///         importAccount) rather than by a proven address key. True for every account the keystore establishes
+    ///         today; see {FLAG_CONTRACT_ESTABLISHED} for the forward case that leaves it clear.
+    ///
+    /// @dev Consumers that treat "empty code (or a delegate) plus EIP-8130 state" as evidence of a known EOA key MUST
+    ///      exclude accounts for which this returns true: under EIP-6780 such an account can be created (or its
+    ///      importing contract destroyed) and SELFDESTRUCTed in the same transaction, leaving empty code and persisted
+    ///      EIP-8130 state at an address that has no private key. See {FLAG_CONTRACT_ESTABLISHED}.
+    ///
+    /// @param account The account to check.
+    ///
+    /// @return True when the account was keystore-established and must not be treated as a key-backed EOA.
+    function isContractEstablished(address account) external view returns (bool) {
+        return _accountState[account].flags & FLAG_CONTRACT_ESTABLISHED != 0;
     }
 
     /// @notice Returns the account's full lock status.
@@ -1217,14 +1264,50 @@ contract Keystore {
         return false;
     }
 
+    /// @dev The shared, read-only static gate on a bootstrap actor set, applying the exact rules that
+    ///      _initializeAccount/_authorizeActor enforce at write time: non-empty, strictly ascending by actorId (which
+    ///      also rejects duplicates and the zero actorId), a K1-or-above authenticator, and a policyData length that
+    ///      matches scope & Scopes.POLICY (52 bytes when set, empty when clear). Running it inside {_prepareDeployment}
+    ///      gives {computeAddress} the same validity as {createAccount}, so a predicted address is never returned for
+    ///      an actor set a later createAccount would reject (which would otherwise let a client prefund and strand
+    ///      funds at an undeployable address). Reverts with NoInitialActors, ActorsNotSortedOrDuplicate,
+    ///      InvalidAuthenticator, or InvalidPolicyData.
+    function _validateInitialActors(InitialActor[] calldata initialActors) private pure {
+        if (initialActors.length == 0) {
+            revert NoInitialActors();
+        }
+
+        bytes32 previousActorId;
+        for (uint256 i; i < initialActors.length; i++) {
+            InitialActor calldata actor = initialActors[i];
+
+            // Strictly ascending: rejects unsorted, duplicate, and the zero actorId (previousActorId starts at 0).
+            if (actor.actorId <= previousActorId) {
+                revert ActorsNotSortedOrDuplicate();
+            }
+            if (actor.authenticator < K1_AUTHENTICATOR) {
+                revert InvalidAuthenticator();
+            }
+            // Same frozen rule as _slicePolicy: 52 bytes when POLICY-scoped, empty otherwise.
+            if (actor.policyData.length != (actor.scope & Scopes.POLICY != 0 ? 52 : 0)) {
+                revert InvalidPolicyData();
+            }
+
+            previousActorId = actor.actorId;
+        }
+    }
+
     /// @dev Derives the CREATE2 inputs once for both {createAccount} and {computeAddress}: the effective salt, the
     ///      deployment code, and the resulting counterfactual address. Sharing this avoids rebuilding and re-hashing
-    ///      the (up to ~24KB) deployment code — and recomputing the actors commitment — twice per creation.
+    ///      the (up to ~24KB) deployment code — and recomputing the actors commitment — twice per creation. The actor
+    ///      set is validated up front so a prediction is never returned for a set createAccount would later reject.
     function _prepareDeployment(bytes32 userSalt, bytes calldata bytecode, InitialActor[] calldata initialActors)
         private
         view
         returns (address account, bytes32 effectiveSalt, bytes memory deploymentCode)
     {
+        _validateInitialActors(initialActors);
+
         effectiveSalt = _computeEffectiveSalt(userSalt, initialActors);
         deploymentCode = _buildDeploymentCode(bytecode);
         bytes32 codeHash = keccak256(deploymentCode);

--- a/test/unit/Keystore/contractEstablished.t.sol
+++ b/test/unit/Keystore/contractEstablished.t.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Keystore} from "../../../src/Keystore.sol";
+import {KeystoreTest} from "../../lib/KeystoreTest.sol";
+
+/// @dev ERC-1271 wallet that accepts any signature. Stands in for a contract account under test; the import path
+///      only checks for the canonical magic return, so an empty signature suffices.
+contract AlwaysValidWallet {
+    function isValidSignature(bytes32, bytes calldata) external pure returns (bytes4) {
+        return 0x1626ba7e;
+    }
+}
+
+/// @notice Coverage for FLAG_CONTRACT_ESTABLISHED / isContractEstablished: the marker set on every keystore-established
+///         account (createAccount and importAccount alike, regardless of code shape) that keeps it from being mistaken
+///         for a key-backed EOA after its code becomes empty (e.g. an EIP-6780 same-transaction SELFDESTRUCT).
+contract ContractEstablishedTest is KeystoreTest {
+    function _singleUnrestrictedActor(bytes32 actorId) internal view returns (Keystore.InitialActor[] memory actors) {
+        actors = new Keystore.InitialActor[](1);
+        actors[0] = Keystore.InitialActor({
+            actorId: actorId, authenticator: address(k1Authenticator), scope: 0, policyData: ""
+        });
+    }
+
+    /// @notice createAccount marks the account contract-established (a CREATE2 address has no private key).
+    function test_createAccount_setsContractEstablished(uint256 pkSeed, bytes32 salt) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        (address account,) = _createK1AccountWithSalt(pk, salt);
+
+        assertTrue(keystore.isContractEstablished(account));
+    }
+
+    /// @notice Importing a plain (non-7702) contract wallet marks it contract-established.
+    function test_importAccount_plainContract_setsContractEstablished(bytes32 actorId) public {
+        vm.assume(actorId != 0);
+        AlwaysValidWallet wallet = new AlwaysValidWallet();
+
+        keystore.importAccount(address(wallet), block.chainid, _singleUnrestrictedActor(actorId), "");
+
+        assertTrue(keystore.isContractEstablished(address(wallet)));
+    }
+
+    /// @notice Importing an EIP-7702/7819 delegate is allowed (the 7819 factory relies on it) and, like every other
+    ///         import, marks the account contract-established: the keystore does not infer an address-bound key from the
+    ///         delegation code shape.
+    function test_importAccount_delegate_setsContractEstablished(uint256 eoaSeed, bytes32 actorId) public {
+        uint256 eoaPk = _boundK1Pk(eoaSeed);
+        vm.assume(actorId != 0);
+        address eoa = vm.addr(eoaPk);
+        vm.assume(eoa != address(keystore));
+
+        AlwaysValidWallet impl = new AlwaysValidWallet();
+        // Delegate the EOA to the ERC-1271 implementation (code = 0xef0100 || delegate), the 23-byte 7702 indicator.
+        vm.etch(eoa, abi.encodePacked(hex"ef0100", address(impl)));
+
+        keystore.importAccount(eoa, block.chainid, _singleUnrestrictedActor(actorId), "");
+
+        assertTrue(keystore.isContractEstablished(eoa));
+    }
+
+    /// @notice EIP-6780 ephemeral importer: a contract wallet imported then SELFDESTRUCTed leaves empty code while its
+    ///         EIP-8130 state persists. The account must stay flagged contract-established so empty code alone is never
+    ///         read as a known EOA. The post-SELFDESTRUCT empty-code state is modelled with vm.etch, since a real
+    ///         same-transaction deletion only settles at transaction end (unobservable within one test call).
+    function test_importAccount_emptyCodeAfterSelfDestruct_staysFlagged(bytes32 actorId) public {
+        vm.assume(actorId != 0);
+        AlwaysValidWallet wallet = new AlwaysValidWallet();
+        address account = address(wallet);
+
+        keystore.importAccount(account, block.chainid, _singleUnrestrictedActor(actorId), "");
+        assertTrue(keystore.isContractEstablished(account));
+
+        // Model the EIP-6780 same-transaction SELFDESTRUCT: runtime code is gone, Keystore storage is not.
+        vm.etch(account, "");
+
+        assertEq(account.code.length, 0);
+        assertEq(keystore.getChangeSequences(account).localSequence, 1);
+        assertTrue(_isActor(account, actorId));
+        // Empty code, but still not key-backed.
+        assertTrue(keystore.isContractEstablished(account));
+    }
+
+    /// @notice A never-initialized account reports not contract-established.
+    function test_uninitialized_isNotContractEstablished(address account) public view {
+        assertFalse(keystore.isContractEstablished(account));
+    }
+}

--- a/test/unit/Keystore/createAccount.t.sol
+++ b/test/unit/Keystore/createAccount.t.sol
@@ -386,6 +386,89 @@ contract CreateAccountTest is KeystoreTest {
         keystore.computeAddress(salt, bytecode, actors);
     }
 
+    /// @notice Verifies computeAddress rejects an empty actor set, matching createAccount (M-02 parity)
+    /// @dev _prepareDeployment runs _validateInitialActors before deriving the address, so no address is predicted
+    ///      for a set createAccount would reject.
+    function test_computeAddress_revert_noInitialActors(bytes32 salt) public {
+        Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](0);
+        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
+
+        vm.expectRevert(Keystore.NoInitialActors.selector);
+        keystore.computeAddress(salt, bytecode, actors);
+    }
+
+    /// @notice Verifies computeAddress rejects an unsorted actor set, matching createAccount (M-02 parity)
+    function test_computeAddress_revert_actorsNotSorted(bytes32 idA, bytes32 idB, bytes32 salt) public {
+        vm.assume(idA != 0 && idB != 0 && idA != idB);
+        bytes32 smaller = idA < idB ? idA : idB;
+        bytes32 larger = idA < idB ? idB : idA;
+
+        Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](2);
+        actors[0] = _initialActor(larger, address(k1Authenticator));
+        actors[1] = _initialActor(smaller, address(k1Authenticator));
+
+        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
+        vm.expectRevert(Keystore.ActorsNotSortedOrDuplicate.selector);
+        keystore.computeAddress(salt, bytecode, actors);
+    }
+
+    /// @notice Verifies computeAddress rejects a duplicate actorId, matching createAccount (M-02 parity)
+    function test_computeAddress_revert_actorsDuplicate(bytes32 id, bytes32 salt) public {
+        vm.assume(id != 0);
+
+        Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](2);
+        actors[0] = _initialActor(id, address(k1Authenticator));
+        actors[1] = _initialActor(id, address(k1Authenticator));
+
+        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
+        vm.expectRevert(Keystore.ActorsNotSortedOrDuplicate.selector);
+        keystore.computeAddress(salt, bytecode, actors);
+    }
+
+    /// @notice Verifies computeAddress rejects a sub-K1 authenticator, matching createAccount (M-02 parity)
+    function test_computeAddress_revert_invalidAuthenticator(bytes32 actorId, bytes32 salt) public {
+        vm.assume(actorId != 0);
+
+        Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](1);
+        actors[0] = _initialActor(actorId, address(0));
+
+        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
+        vm.expectRevert(Keystore.InvalidAuthenticator.selector);
+        keystore.computeAddress(salt, bytecode, actors);
+    }
+
+    /// @notice Verifies computeAddress rejects malformed policyData, matching createAccount (M-02 parity)
+    /// @dev Scope carries Scopes.POLICY (0x02) but policyData is not the required 52 bytes, so _validateInitialActors
+    ///      reverts InvalidPolicyData before an address is predicted.
+    function test_computeAddress_revert_invalidPolicyData(bytes32 actorId, bytes32 salt) public {
+        vm.assume(actorId != 0);
+
+        Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](1);
+        actors[0] = Keystore.InitialActor({
+            actorId: actorId, authenticator: address(k1Authenticator), scope: 0x02, policyData: hex"deadbeef"
+        });
+
+        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
+        vm.expectRevert(Keystore.InvalidPolicyData.selector);
+        keystore.computeAddress(salt, bytecode, actors);
+    }
+
+    /// @notice Verifies createAccount rejects malformed policyData up front via the shared validator
+    /// @dev Complements the existing sorted/duplicate/authenticator revert tests: scope has Scopes.POLICY set but
+    ///      policyData is not 52 bytes, so _prepareDeployment -> _validateInitialActors reverts InvalidPolicyData.
+    function test_createAccount_revert_invalidPolicyData(bytes32 actorId, bytes32 salt) public {
+        vm.assume(actorId != 0);
+
+        Keystore.InitialActor[] memory actors = new Keystore.InitialActor[](1);
+        actors[0] = Keystore.InitialActor({
+            actorId: actorId, authenticator: address(k1Authenticator), scope: 0x02, policyData: hex"deadbeef"
+        });
+
+        bytes memory bytecode = _computeERC1167Bytecode(defaultAccountImplementation);
+        vm.expectRevert(Keystore.InvalidPolicyData.selector);
+        keystore.createAccount(salt, bytecode, actors);
+    }
+
     /// @notice Verifies computeAddress accepts bytecode of exactly 0xFFFF bytes without reverting
     /// @dev Config-independent proof that the BytecodeTooLarge boundary is exclusive: computeAddress runs
     ///      _buildDeploymentCode but never deploys, so 0xFFFF returns an address while n == 0x10000 reverts (above)


### PR DESCRIPTION
## Summary

- **`FLAG_CONTRACT_ESTABLISHED` + `isContractEstablished`**: set on every keystore-established account (`createAccount` and `importAccount` alike, regardless of code shape). It survives EIP-6780 — an account created/imported and `SELFDESTRUCT`ed in the same transaction leaves empty code but retains its EIP-8130 state — so consumers must not read "empty code (or a delegate) plus EIP-8130 state" as proof of a known EOA key. Delegate imports stay supported (the EIP-7819 factory relies on them); an EOA's (un)delegation power lives with its key at the protocol layer, so the flag deliberately does not infer an address-bound key from code shape. A future genuinely key-backed native path (e.g. an EIP-8164 ML-DSA self-import) may leave the bit clear.
- **Shared `_validateInitialActors`**: extracted and run in `_prepareDeployment` so `computeAddress` applies the same validity rules as `createAccount` (non-empty, strictly ascending/no-dup actorIds, K1-or-above authenticator, policyData length matching scope). Closes the gap where an address could be predicted — and prefunded — for an actor set a later `createAccount` would reject and strand funds.
- Docs: updated `computeAddress`/`createAccount` NatSpec revert lists and the flag/getter NatSpec.

## Test plan

- [x] `test/unit/Keystore/contractEstablished.t.sol`: create / plain-contract import / delegate import all set the flag; empty-code-after-SELFDESTRUCT stays flagged; uninitialized is false.
- [x] `test/unit/Keystore/createAccount.t.sol`: added `computeAddress` parity reverts (empty / unsorted / duplicate / sub-K1 authenticator / malformed policyData) and a `createAccount` malformed-policyData case.
- [x] `forge test`: 379 passed, 0 failed.