### PR TITLE
AuthorizeActor: fail-fast on expired JIT grants only; sequenced batches install inert

### DIFF
--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -316,8 +316,11 @@ contract Keystore {
     /// @notice The local epoch is at its terminal value and cannot be incremented.
     error EpochSaturated();
 
-    /// @notice An AuthorizeActor's granted expiry is non-zero and not strictly in the future (self-expired on
-    ///         arrival). A zero expiry is the "no expiry" sentinel and is accepted.
+    /// @notice A Local-channel AuthorizeActor's granted expiry is non-zero and already in the past (self-expired on
+    ///         arrival). Local changes are chain-bound and never replayed, so a dead grant is rejected fail-fast. The
+    ///         Multichain channel does NOT raise this: a historical expiring grant must stay replayable so a chain
+    ///         onboarded later can consume its sequence slot and converge, so there it is installed inert instead. A
+    ///         zero expiry is the "no expiry" sentinel and is always accepted.
     error ExpiredChange();
 
     /// @notice A local-only change (Lock or Unlock) was submitted on the Multichain channel.
@@ -650,7 +653,7 @@ contract Keystore {
 
             // Apply: dispatch the op to its handler.
             if (t == ChangeType.AuthorizeActor) {
-                _applyAuthorize(account, s.changes[i].payload);
+                _applyAuthorize(account, s.changes[i].payload, isLocal);
             } else if (t == ChangeType.RevokeActor) {
                 _applyRevoke(account, s.changes[i].payload);
             } else if (t == ChangeType.IncrementLocalEpoch) {
@@ -674,18 +677,30 @@ contract Keystore {
 
     /// @dev AuthorizeActor. `payload = abi.encode(bytes32 actorId, ActorConfig cfg, bytes policyData)`; `cfg.expiry`
     ///      is the granted expiry and the signature self-expires at it (or never, if `cfg.expiry == 0`). A plain
-    ///      upsert on both channels and both sequencing modes — the only gate is that a non-zero expiry be in the
-    ///      future. An unsequenced grant is replayable (it consumes no counter) and last-write-wins on its slot until
-    ///      the grant lapses or the epoch is incremented; durable reduction (revoke, shorter expiry, narrower scope) is
-    ///      therefore a wallet responsibility — batch the reducing op with a {IncrementLocalEpoch} to retire outstanding
-    ///      grants.
-    function _applyAuthorize(address account, bytes calldata payload) private {
+    ///      upsert on both channels and both sequencing modes.
+    ///
+    ///      Expiry handling is channel-aware. On Local (`isLocal`), an already-past non-zero expiry is rejected up
+    ///      front (ExpiredChange): local changes are chain-bound and never replayed, so a dead-on-arrival grant is a
+    ///      client mistake worth failing fast. On Multichain it is NOT rejected — the grant is installed even though
+    ///      already expired. Multichain changes share one gap-free counter replayed across chains, so a historical
+    ///      expiring grant (e.g. a yearly-renewed operator) MUST stay replayable: a chain onboarded later has to
+    ///      consume that sequence slot in order to reach the current live grant. Reverting would strand its counter
+    ///      behind the expired slot; installing it inert consumes the slot and converges the chain to the same state,
+    ///      granting no authority — the actor is dead on arrival (see {_isExpired}, which yields ActorExpired at
+    ///      authentication).
+    ///
+    ///      An unsequenced grant is replayable (it consumes no counter) and last-write-wins on its slot until the grant
+    ///      lapses or the epoch is incremented; durable reduction (revoke, shorter expiry, narrower scope) is therefore
+    ///      a wallet responsibility — batch the reducing op with a {IncrementLocalEpoch} to retire outstanding grants.
+    function _applyAuthorize(address account, bytes calldata payload, bool isLocal) private {
         (bytes32 actorId, ActorConfig memory cfg, bytes memory policyData) =
             abi.decode(payload, (bytes32, ActorConfig, bytes));
 
-        // A grant must not be already-expired: reject a non-zero expiry that is not strictly in the future. A zero
-        // expiry is the canonical "no expiry" sentinel (unlimited, per {ActorConfig}) and is accepted.
-        if (cfg.expiry != 0 && cfg.expiry <= block.timestamp) {
+        // Local only: reject a non-zero expiry that is not strictly in the future (dead on arrival). A zero expiry is
+        // the canonical "no expiry" sentinel (unlimited, per {ActorConfig}) and is accepted. Multichain deliberately
+        // omits this fence so an expired grant installs inert and its sequence slot stays replayable for chains
+        // catching up — see the doc above.
+        if (isLocal && cfg.expiry != 0 && cfg.expiry <= block.timestamp) {
             revert ExpiredChange();
         }
 

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -316,11 +316,11 @@ contract Keystore {
     /// @notice The local epoch is at its terminal value and cannot be incremented.
     error EpochSaturated();
 
-    /// @notice A Local-channel AuthorizeActor's granted expiry is non-zero and already in the past (self-expired on
-    ///         arrival). Local changes are chain-bound and never replayed, so a dead grant is rejected fail-fast. The
-    ///         Multichain channel does NOT raise this: a historical expiring grant must stay replayable so a chain
-    ///         onboarded later can consume its sequence slot and converge, so there it is installed inert instead. A
-    ///         zero expiry is the "no expiry" sentinel and is always accepted.
+    /// @notice An unsequenced (JIT) AuthorizeActor's granted expiry is non-zero and already in the past. A JIT grant is
+    ///         replayable, so its expiry must bound replay: once lapsed it can no longer land. Sequenced batches (local
+    ///         or multichain) do NOT raise this — being single-consume they cannot be replayed, so an expired grant
+    ///         installs inert and consumes its slot (multichain needs this for cross-chain catch-up). A zero expiry is
+    ///         the "no expiry" sentinel and is always accepted.
     error ExpiredChange();
 
     /// @notice A local-only change (Lock or Unlock) was submitted on the Multichain channel.
@@ -577,6 +577,10 @@ contract Keystore {
     {
         AccountState storage st = _accountState[account];
         bool isLocal = s.channel == AccountChangeChannel.Local;
+        // A JIT (unsequenced) batch — local channel with the low sequence half == UNSEQUENCED — is the only replayable
+        // form (it consumes no counter). This gates the AuthorizeActor expiry fail-fast: only a replayable grant needs
+        // its expiry to bound replay. Multichain is never unsequenced, so this short-circuits false there.
+        bool isUnsequenced = isLocal && uint32(s.sequence) == UNSEQUENCED;
 
         // Reject an empty batch: a no-op signed change would otherwise consume a sequence (or initialize a fresh
         // account, below) without altering any configuration.
@@ -653,7 +657,7 @@ contract Keystore {
 
             // Apply: dispatch the op to its handler.
             if (t == ChangeType.AuthorizeActor) {
-                _applyAuthorize(account, s.changes[i].payload, isLocal);
+                _applyAuthorize(account, s.changes[i].payload, isUnsequenced);
             } else if (t == ChangeType.RevokeActor) {
                 _applyRevoke(account, s.changes[i].payload);
             } else if (t == ChangeType.IncrementLocalEpoch) {
@@ -677,30 +681,25 @@ contract Keystore {
 
     /// @dev AuthorizeActor. `payload = abi.encode(bytes32 actorId, ActorConfig cfg, bytes policyData)`; `cfg.expiry`
     ///      is the granted expiry and the signature self-expires at it (or never, if `cfg.expiry == 0`). A plain
-    ///      upsert on both channels and both sequencing modes.
+    ///      upsert.
     ///
-    ///      Expiry handling is channel-aware. On Local (`isLocal`), an already-past non-zero expiry is rejected up
-    ///      front (ExpiredChange): local changes are chain-bound and never replayed, so a dead-on-arrival grant is a
-    ///      client mistake worth failing fast. On Multichain it is NOT rejected — the grant is installed even though
-    ///      already expired. Multichain changes share one gap-free counter replayed across chains, so a historical
-    ///      expiring grant (e.g. a yearly-renewed operator) MUST stay replayable: a chain onboarded later has to
-    ///      consume that sequence slot in order to reach the current live grant. Reverting would strand its counter
-    ///      behind the expired slot; installing it inert consumes the slot and converges the chain to the same state,
-    ///      granting no authority — the actor is dead on arrival (see {_isExpired}, which yields ActorExpired at
-    ///      authentication).
-    ///
-    ///      An unsequenced grant is replayable (it consumes no counter) and last-write-wins on its slot until the grant
-    ///      lapses or the epoch is incremented; durable reduction (revoke, shorter expiry, narrower scope) is therefore
-    ///      a wallet responsibility — batch the reducing op with a {IncrementLocalEpoch} to retire outstanding grants.
-    function _applyAuthorize(address account, bytes calldata payload, bool isLocal) private {
+    ///      Expiry fail-fast applies only to an unsequenced (JIT) grant (`isUnsequenced`). A JIT grant consumes no
+    ///      counter and is replayable, so its expiry is what retires it: once lapsed it must never re-land, hence
+    ///      ExpiredChange (it also last-write-wins on its slot until the epoch is incremented — durable reduction is a
+    ///      wallet responsibility: batch the reducing op with {IncrementLocalEpoch}). A sequenced batch (local or
+    ///      multichain) is single-consume and cannot be replayed, so an already-expired grant instead installs inert —
+    ///      dead on arrival ({_isExpired} yields ActorExpired at authentication), granting no authority — and simply
+    ///      consumes its slot. Multichain relies on this: a chain catching up must replay a historical expiring grant's
+    ///      slot (e.g. a yearly-renewed operator) to reach the current live grant, so reverting would strand its
+    ///      counter behind the expired slot.
+    function _applyAuthorize(address account, bytes calldata payload, bool isUnsequenced) private {
         (bytes32 actorId, ActorConfig memory cfg, bytes memory policyData) =
             abi.decode(payload, (bytes32, ActorConfig, bytes));
 
-        // Local only: reject a non-zero expiry that is not strictly in the future (dead on arrival). A zero expiry is
-        // the canonical "no expiry" sentinel (unlimited, per {ActorConfig}) and is accepted. Multichain deliberately
-        // omits this fence so an expired grant installs inert and its sequence slot stays replayable for chains
-        // catching up — see the doc above.
-        if (isLocal && cfg.expiry != 0 && cfg.expiry <= block.timestamp) {
+        // Unsequenced (JIT) only: reject a non-zero expiry that is not strictly in the future, so a lapsed replayable
+        // grant can never re-land. Sequenced batches are single-consume (no replay) and install an expired grant inert
+        // instead — see the doc above. A zero expiry is the "no expiry" sentinel (unlimited, per {ActorConfig}).
+        if (isUnsequenced && cfg.expiry != 0 && cfg.expiry <= block.timestamp) {
             revert ExpiredChange();
         }
 

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -292,6 +292,94 @@ contract AccountEnvironmentTest is KeystoreTest {
         assertEq(_multichainSeq(account), mcBefore + 1);
     }
 
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // MULTICHAIN — EXPIRY (channel-aware install-inert)
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice A Multichain AuthorizeActor whose granted expiry is already in the past does NOT revert (unlike Local):
+    ///         it installs the actor inert and consumes the multichain sequence, so the slot stays replayable for a
+    ///         chain catching up. The actor is present (revocable) but not live.
+    function test_multichain_authorize_expiredInstallsInert(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        uint64 mcBefore = _multichainSeq(account);
+
+        // Strictly-past expiry: this would be ExpiredChange on Local, but Multichain installs it inert.
+        uint48 pastExpiry = uint48(block.timestamp - 1);
+        _applyMultichain(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, pastExpiry, "")));
+
+        // Sequence consumed (no revert), yet the actor is not live (getActorConfig is expiry-aware).
+        assertEq(_multichainSeq(account), mcBefore + 1);
+        assertFalse(_isActor(account, ACTOR_A));
+
+        // It is nonetheless present: an explicit revoke succeeds (presence is checked without expiry), proving the
+        // slot was written rather than skipped. Reverts UnknownActor if the slot were empty.
+        _revokeActor(account, pk, ACTOR_A);
+    }
+
+    /// @notice New-chain catch-up: a chain onboarded late replays the full multichain history in order. Historical
+    ///         expiring grants (already expired at replay time) install inert and advance the counter instead of
+    ///         bricking it, so the final still-live grant lands and the chain converges. This is the core reason the
+    ///         Multichain channel does not fail-fast on expiry.
+    function test_multichain_authorize_expiredHistoryReplaysToLiveGrant(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+
+        // Onboarding "in year 3": every past yearly renewal is already expired; only the current grant is live.
+        uint48 expiredOld = uint48(block.timestamp - 2);
+        uint48 expiredMid = uint48(block.timestamp - 1);
+        uint48 liveNow = _future(365 days);
+
+        // seq 0 and seq 1: historical (expired) operator grants — inert, but each consumes its slot.
+        _applyMultichain(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, expiredOld, "")));
+        assertFalse(_isActor(account, ACTOR_A));
+        _applyMultichain(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, expiredMid, "")));
+        assertFalse(_isActor(account, ACTOR_A));
+
+        // seq 2: the current renewal is still live -> the operator is now authorized, converged with chains that
+        // applied the same history earlier.
+        _applyMultichain(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, liveNow, "")));
+
+        assertTrue(_isActor(account, ACTOR_A));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, liveNow);
+        assertEq(_multichainSeq(account), 3); // all three slots consumed, gap-free
+    }
+
+    /// @notice Self-actor edge: an expired non-k1 self grant on the Multichain channel is handled like any other —
+    ///         installed inert (no revert) and consuming the sequence — so replay stays convergent. As with any non-k1
+    ///         self grant it also disables the inline k1 self (mutual exclusion); here that self is simply dead on
+    ///         arrival, matching the state a chain that applied it while live reaches once it expires.
+    function test_multichain_authorize_expiredSelfInstallsInert(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        bytes32 selfActorId = bytes32(uint256(uint160(account)));
+        uint64 mcBefore = _multichainSeq(account);
+
+        // Signed by the (still-live at auth time) k1 self; installs an already-expired non-k1 self.
+        uint48 pastExpiry = uint48(block.timestamp - 1);
+        _applyMultichain(
+            pk, account, _one(_authorizeChange(selfActorId, address(p256Authenticator), SENDER, pastExpiry, ""))
+        );
+
+        // No revert; slot consumed. The non-k1 self is present but not live (expired).
+        assertEq(_multichainSeq(account), mcBefore + 1);
+        assertFalse(_isActor(account, selfActorId));
+    }
+
+    /// @notice Regression: the channel-aware fence still fails fast on the LOCAL channel — a sequenced local
+    ///         AuthorizeActor with an already-past expiry reverts ExpiredChange. Only Multichain installs inert.
+    function test_local_authorize_pastExpiryStillReverts(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+
+        uint48 pastExpiry = uint48(block.timestamp - 1);
+        Keystore.SignedAccountChanges memory s =
+            _localBatch(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, pastExpiry, "")));
+
+        vm.expectRevert(Keystore.ExpiredChange.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
     /// @notice A Multichain IncrementLocalEpoch bumps the local epoch (resetting the local sequence) and consumes the
     ///         multichain counter, retiring outstanding unlanded local signatures without a Local batch.
     function test_multichain_success_bump(uint256 pk) public {

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -366,18 +366,22 @@ contract AccountEnvironmentTest is KeystoreTest {
         assertFalse(_isActor(account, selfActorId));
     }
 
-    /// @notice Regression: the channel-aware fence still fails fast on the LOCAL channel — a sequenced local
-    ///         AuthorizeActor with an already-past expiry reverts ExpiredChange. Only Multichain installs inert.
-    function test_local_authorize_pastExpiryStillReverts(uint256 pk) public {
+    /// @notice A SEQUENCED local AuthorizeActor with an already-past expiry installs inert (like Multichain), not
+    ///         reverts: a sequenced batch is single-consume and cannot be replayed, so the expiry-bound-replay concern
+    ///         does not apply. The fail-fast is reserved for the replayable unsequenced (JIT) path (see
+    ///         test_authorizeUnsequenced_revert_pastExpiry in applyKeyChange.t.sol).
+    function test_local_sequenced_authorize_pastExpiry_installsInert(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
+        uint64 seqBefore = _localSeqWord(account);
 
         uint48 pastExpiry = uint48(block.timestamp - 1);
-        Keystore.SignedAccountChanges memory s =
-            _localBatch(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, pastExpiry, "")));
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, pastExpiry, "")));
 
-        vm.expectRevert(Keystore.ExpiredChange.selector);
-        keystore.applySignedAccountChanges(account, s);
+        // Sequence consumed (no revert); the actor is present but not live.
+        assertEq(_localSeqWord(account), seqBefore + 1);
+        assertFalse(_isActor(account, ACTOR_A));
+        _revokeActor(account, pk, ACTOR_A); // present -> explicit revoke succeeds (reverts UnknownActor if empty)
     }
 
     /// @notice A Multichain IncrementLocalEpoch bumps the local epoch (resetting the local sequence) and consumes the


### PR DESCRIPTION
## Summary
`AuthorizeActor` expiry handling is gated on **sequencing**, not channel:

- **Unsequenced (JIT, local only):** an already-past non-zero expiry still reverts `ExpiredChange`. A JIT grant consumes no counter and is *replayable*, so its expiry is what retires it — once lapsed it must never re-land (the JIT "self-cleaning" invariant).
- **Sequenced (local OR multichain):** an already-expired grant **installs inert** and consumes its sequence slot. Sequenced batches are single-consume and cannot be replayed, so the expiry-bounds-replay concern doesn't apply.

## Why
The original guard reverted on *any* past expiry. That bricked the **multichain** channel: multichain changes share one gap-free counter replayed across chains, so a historical expiring grant (e.g. a yearly-renewed operator) has to stay replayable — a chain onboarded later must consume that sequence slot to reach the current live grant. Reverting stranded the counter behind the expired slot and diverged per-chain counters.

The fix generalizes correctly once you see the fence is really about **replay**, and the only replayable batch is the unsequenced JIT one:
- Keeping fail-fast on JIT preserves the invariant that a lapsed JIT signature can never again write its slot (removing it would hand stale, public JIT signatures a permanent force-actor-to-dead capability until an epoch bump).
- Relaxing every sequenced batch (multichain *and* local) is safe (single-consume, no replay) and lets grants keep advancing uniformly.

Installing an expired grant grants **no authority**: it is dead on arrival (`_isExpired` → `ActorExpired` at authentication). Revoke still works (presence is checked without expiry); the admin-scope gate on the batch is unchanged.

## Implementation
- Compute `isUnsequenced = isLocal && uint32(sequence) == UNSEQUENCED` in the checks phase; thread it into `_applyAuthorize` (replacing the earlier `isLocal`).
- Gate the `ExpiredChange` revert on `isUnsequenced`.
- Updated NatSpec on `_applyAuthorize` and the `ExpiredChange` error.

## Tests (all 383 pass)
- `test_multichain_authorize_expiredInstallsInert` — expired multichain grant installs inert, advances the counter, present-but-not-live.
- `test_multichain_authorize_expiredHistoryReplaysToLiveGrant` — new-chain catch-up: `[expired, expired, live]` replays gap-free and the live grant lands.
- `test_multichain_authorize_expiredSelfInstallsInert` — non-k1 self edge on multichain.
- `test_local_sequenced_authorize_pastExpiry_installsInert` — sequenced local now installs inert too.
- Unchanged: `test_authorizeUnsequenced_revert_pastExpiry` / `test_authorizeUnsequenced_revert_replayAfterExpiry` still assert `ExpiredChange` on the JIT path.

## Spec follow-up
The EIP-8130 text for `AuthorizeActor` should note the sequencing-aware expiry semantics (JIT fail-fast; sequenced install-inert).