### PR TITLE
SessionPolicy: fail closed on native ETH value when no native limit is set

### DIFF
--- a/src/policies/SessionPolicy.sol
+++ b/src/policies/SessionPolicy.sol
@@ -39,6 +39,11 @@ import {RecurringAllowance} from "./RecurringAllowance.sol";
 ///          closed: a call carrying `value` reverts ({NativeValueNotAllowed}) unless the config pins a native
 ///          {TokenLimit} (`token == address(0)`). Absence means "no ETH", not "unlimited ETH" — so a grant can call a
 ///          value-accepting target while sending it zero ETH, and this does not depend on the target rejecting value.
+///          Note the resulting asymmetry with ERC-20 defaults is structural, not an oversight: an ERC-20 must be
+///          called at its own address to move, so the target allowlist already gates it (omit the token ⇒ "can't
+///          touch it") and an absent cap can safely mean "unlimited amount". Native value has no such target to omit,
+///          so it fails closed instead. Both assets share the same *expressible* states — forbidden, capped, and
+///          unlimited (`limit == type(uint160).max`) — only the meaning of an omitted entry differs.
 ///
 ///      Approvals vs. periods: `approve` is debited from the *current* period at grant time, but an ERC-20 allowance
 ///      is standing on-chain state that outlives the period and is pulled by a third party this policy never sees. A
@@ -60,7 +65,11 @@ contract SessionPolicy is Policy {
     struct TokenLimit {
         /// @dev ERC-20 token address, or address(0) for native ETH (gated on each call's `value`).
         address token;
-        /// @dev Maximum spend per period (one-time: total cap). Must fit uint160.
+        /// @dev Maximum spend per period (one-time: total cap). Must fit uint160; 0 is rejected ({ZeroLimit}). To
+        ///      express an effectively unlimited budget, set `limit = type(uint160).max` (~1.46e48 wei, far exceeding
+        ///      total ETH supply): spending still accrues to the ledger (telemetry via {getCurrentSpend}) but the cap
+        ///      is never reached. For native ETH this is the *only* way to express "unlimited" — an omitted
+        ///      `address(0)` entry means "no ETH", not "unlimited ETH" (see {NativeValueNotAllowed}).
         uint256 limit;
         /// @dev Recurring period in seconds. 0 = one-time (a single cumulative cap that never resets).
         uint40 period;

--- a/src/policies/SessionPolicy.sol
+++ b/src/policies/SessionPolicy.sol
@@ -66,9 +66,7 @@ contract SessionPolicy is Policy {
         /// @dev ERC-20 token address, or address(0) for native ETH (gated on each call's `value`).
         address token;
         /// @dev Maximum spend per period (one-time: total cap). Must fit uint160; 0 is rejected ({ZeroLimit}). To
-        ///      express an effectively unlimited budget, set `limit = type(uint160).max` (~1.46e48 wei, far exceeding
-        ///      total ETH supply): spending still accrues to the ledger (telemetry via {getCurrentSpend}) but the cap
-        ///      is never reached. For native ETH this is the *only* way to express "unlimited" — an omitted
+        ///      express an effectively unlimited budget, set `limit = type(uint160).max`. For native ETH, an omitted
         ///      `address(0)` entry means "no ETH", not "unlimited ETH" (see {NativeValueNotAllowed}).
         uint256 limit;
         /// @dev Recurring period in seconds. 0 = one-time (a single cumulative cap that never resets).

--- a/src/policies/SessionPolicy.sol
+++ b/src/policies/SessionPolicy.sol
@@ -35,7 +35,10 @@ import {RecurringAllowance} from "./RecurringAllowance.sol";
 ///          ERC-721 `safeTransferFrom`, any ERC-1155 transfer — therefore bypass the spend cap entirely if listed.
 ///          Do NOT allow such selectors on a token you are trying to bound; only `transfer`/`transferFrom`/`approve`
 ///          are tracked.
-///        - Native-ETH limits are consumed from each call's `value`, independent of calldata.
+///        - Native-ETH limits are consumed from each call's `value`, independent of calldata. Native value fails
+///          closed: a call carrying `value` reverts ({NativeValueNotAllowed}) unless the config pins a native
+///          {TokenLimit} (`token == address(0)`). Absence means "no ETH", not "unlimited ETH" — so a grant can call a
+///          value-accepting target while sending it zero ETH, and this does not depend on the target rejecting value.
 ///
 ///      Approvals vs. periods: `approve` is debited from the *current* period at grant time, but an ERC-20 allowance
 ///      is standing on-chain state that outlives the period and is pulled by a third party this policy never sees. A
@@ -44,7 +47,8 @@ import {RecurringAllowance} from "./RecurringAllowance.sol";
 ///      Per-period accounting is exact for the key's own actions; it cannot bound reuse of standing allowances.
 ///
 ///      Calldata length: empty calldata is allowed (a `receive()` / plain value transfer, gated by the target
-///      allowlist and native-ETH cap); calldata of 1–3 bytes is rejected ({MissingSelector}) as it cannot carry a
+///      allowlist and, when it carries `value`, a required native-ETH cap); calldata of 1–3 bytes is rejected
+///      ({MissingSelector}) as it cannot carry a
 ///      4-byte selector; 4+ bytes is treated as a selector (so a fallback reachable via 4+ byte data is gated by the
 ///      selector rules).
 contract SessionPolicy is Policy {
@@ -119,6 +123,11 @@ contract SessionPolicy is Policy {
     error LimitTooLarge(address token, uint256 limit);
     /// @notice A configured spend limit was zero, which would be a no-op cap; reject to fail closed.
     error ZeroLimit(address token);
+    /// @notice The action carried native `value` but the config pins no native-ETH limit (`token == address(0)`).
+    ///         Native value fails closed: unlike an ERC-20 (which requires calling an allowlisted token contract to
+    ///         move), value rides on any call to any allowlisted target, so an absent native limit is treated as "no
+    ///         ETH", not "unlimited ETH". To permit ETH, add a native {TokenLimit} with a positive cap.
+    error NativeValueNotAllowed(uint256 value);
     /// @notice A recipient allowlist was attached to a selector whose recipient argument this policy cannot decode
     ///         (only the standard ERC-20 selectors are supported).
     error RecipientRuleUnsupportedSelector(bytes4 selector);
@@ -295,10 +304,13 @@ contract SessionPolicy is Policy {
             revert MissingSelector();
         }
 
-        // 3b. Native-ETH spend limit: consume from the call value, independent of calldata.
+        // 3b. Native-ETH spend limit: consume from the call value, independent of calldata. Fail closed — value rides
+        // on any call to any allowlisted target (no token contract to allowlist as a gate), so an absent native limit
+        // means "no ETH", not "unlimited ETH". Permitting ETH requires an explicit native {TokenLimit}.
         if (action.value > 0) {
             (bool set, uint160 allowance, uint40 period) = _findTokenLimit(config, address(0));
-            if (set) _consume(commitment, address(0), allowance, period, action.value);
+            if (!set) revert NativeValueNotAllowed(action.value);
+            _consume(commitment, address(0), allowance, period, action.value);
         }
 
         Call[] memory calls = new Call[](1);

--- a/src/policies/SessionPolicy.sol
+++ b/src/policies/SessionPolicy.sol
@@ -66,8 +66,7 @@ contract SessionPolicy is Policy {
         /// @dev ERC-20 token address, or address(0) for native ETH (gated on each call's `value`).
         address token;
         /// @dev Maximum spend per period (one-time: total cap). Must fit uint160; 0 is rejected ({ZeroLimit}). To
-        ///      express an effectively unlimited budget, set `limit = type(uint160).max`. For native ETH, an omitted
-        ///      `address(0)` entry means "no ETH", not "unlimited ETH" (see {NativeValueNotAllowed}).
+        ///      express an effectively unlimited budget, set `limit = type(uint160).max`.
         uint256 limit;
         /// @dev Recurring period in seconds. 0 = one-time (a single cumulative cap that never resets).
         uint40 period;

--- a/test/unit/policies/SessionPolicy.t.sol
+++ b/test/unit/policies/SessionPolicy.t.sol
@@ -282,6 +282,19 @@ contract SessionPolicyTest is KeystoreTest {
         );
     }
 
+    function test_nativeValue_unlimitedIdiomPermitsLargeTransfer() public {
+        // The documented "unlimited ETH" idiom: a uint160.max cap is never reached in practice.
+        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
+        scopes[0] = _anySelectorScope(bob);
+        bytes32 actorId = _install(_config(_limit(address(0), type(uint160).max, WEEK), scopes));
+        _mockActingActor(actorId);
+
+        vm.deal(account, 1_000_000 ether);
+        vm.prank(account);
+        manager.execute(lastBinding, _action(bob, 1_000_000 ether, ""));
+        assertEq(bob.balance, 1_000_000 ether);
+    }
+
     // ── Atomic multi-dimension enforcement on a single call ──
 
     function test_multiDimension_passesAllAtOnce() public {

--- a/test/unit/policies/SessionPolicy.t.sol
+++ b/test/unit/policies/SessionPolicy.t.sol
@@ -257,6 +257,31 @@ contract SessionPolicyTest is KeystoreTest {
         manager.execute(lastBinding, _action(bob, 0.6 ether, ""));
     }
 
+    function test_nativeValue_revertsWhenNoNativeLimit() public {
+        // Fail closed: a call carrying value with no address(0) TokenLimit is rejected, not forwarded unbounded.
+        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
+        scopes[0] = _anySelectorScope(bob);
+        bytes32 actorId = _install(_config(_noLimits(), scopes));
+        _mockActingActor(actorId);
+
+        vm.expectRevert(abi.encodeWithSelector(SessionPolicy.NativeValueNotAllowed.selector, 1 ether));
+        vm.prank(account);
+        manager.execute(lastBinding, _action(bob, 1 ether, ""));
+    }
+
+    function test_nativeValue_erc20LimitDoesNotAuthorizeEth() public {
+        // A token cap (e.g. "USDC 5/month") must not implicitly permit ETH: value to any target still fails closed.
+        bytes32 actorId =
+            _install(_config(_limit(address(token), 5e6, WEEK), _erc20Scope(address(token), _noRecipients())));
+        _mockActingActor(actorId);
+
+        vm.expectRevert(abi.encodeWithSelector(SessionPolicy.NativeValueNotAllowed.selector, 1 ether));
+        vm.prank(account);
+        manager.execute(
+            lastBinding, _action(address(token), 1 ether, abi.encodeCall(SessionMockERC20.transfer, (bob, 0)))
+        );
+    }
+
     // ── Atomic multi-dimension enforcement on a single call ──
 
     function test_multiDimension_passesAllAtOnce() public {


### PR DESCRIPTION
## Summary

Fixes an audit finding: native ETH value was **fail-open** by default.

Native ETH is modeled as a token with address `address(0)`, and like any token a missing `TokenLimit` meant "no cap". But unlike an ERC-20 — which requires calling an allowlisted token contract to move, so the target allowlist doubles as a gate — native value rides on **any** call to **any** allowlisted target. So a config with only target/selector rules placed **no bound on ETH at all**: `value` was forwarded verbatim with no revert and no debit.

Consequences before this change:
- An absent native limit meant "unlimited ETH", not "no ETH".
- "This key may never move ETH" was inexpressible: `_validateConfig` rejects `limit == 0` (`ZeroLimit`), so the tightest bound was 1 wei.
- A token-only cap like "USDC 5/month" gave no ETH bound. It only *appeared* safe because standard ERC-20s are non-payable — an incidental property of the token, not enforced by the policy. A payable or upgradeable-to-payable token would silently reopen an unbounded ETH path.

## Change

Flip the native default to **fail closed** in `_onExecute`: if `action.value > 0` and no `address(0)` `TokenLimit` is set, revert `NativeValueNotAllowed(value)`.

- Absence now means **zero ETH**; permitting ETH requires an explicit native `TokenLimit` with a positive cap.
- "No ETH" is now enforced by the policy itself, independent of whether the target rejects value.
- Deliberate, documented asymmetry with the ERC-20 default (absent = unbounded amount), justified because native has no target-allowlist fallback.

Also adds the `NativeValueNotAllowed` error and updates the contract NatSpec (native-ETH and calldata-length sections) to match.

## Test plan

- [x] `test_nativeValue_revertsWhenNoNativeLimit` — value with no native limit reverts `NativeValueNotAllowed`.
- [x] `test_nativeValue_erc20LimitDoesNotAuthorizeEth` — a token-only cap ("USDC 5/month") does not implicitly permit ETH.
- [x] Existing native tests (`test_nativeLimit_consumesCallValue`) and empty-calldata / zero-value tests unchanged and passing.
- [x] Full `SessionPolicyTest` suite: 40 passed, 0 failed.