### PR TITLE
Keystore: use canonical _isExpired in _applyAuthorize

### DIFF
--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -694,11 +694,12 @@ contract Keystore {
         (bytes32 actorId, ActorConfig memory cfg, bytes memory policyData) =
             abi.decode(payload, (bytes32, ActorConfig, bytes));
 
-        // Unsequenced (JIT) only: silently skip an already-expired grant (non-zero expiry not strictly in the future)
-        // so a lapsed replayable grant can never re-land and clobber its slot — without making the change revert on
-        // onchain time. Sequenced batches are single-consume (no replay) and install an expired grant inert instead —
-        // see the doc above. A zero expiry is the "no expiry" sentinel (unlimited, per {ActorConfig}).
-        if (isUnsequenced && cfg.expiry != 0 && cfg.expiry <= block.timestamp) {
+        // Unsequenced (JIT) only: silently skip an already-expired grant so a lapsed replayable grant can never re-land
+        // and clobber its slot — without making the change revert on onchain time. Sequenced batches are single-consume
+        // (no replay) and install an expired grant inert instead — see the doc above. Use the canonical {_isExpired}
+        // (which folds in the zero = no-expiry sentinel) so the expiry boundary matches authentication exactly: a grant
+        // with `expiry == block.timestamp` is still live for that second and installs, rather than being dropped here.
+        if (isUnsequenced && _isExpired(cfg.expiry)) {
             return;
         }
 

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -20,7 +20,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
 
     function setUp() public override {
         super.setUp();
-        // A non-zero base timestamp so `expiry <= block.timestamp` comparisons are meaningful.
+        // A non-zero base timestamp so strictly-past expiries (block.timestamp - 1) stay non-zero and meaningful.
         vm.warp(1_000_000);
     }
 
@@ -128,9 +128,12 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
 
-        // No revert despite the already-expired grant.
+        // No revert despite the already-expired grant. Use a strictly-past expiry: an actor is expired only once
+        // block.timestamp > expiry (see {_isExpired}), so `expiry == now` is still live and would install.
         _applyUnsequenced(
-            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, uint48(block.timestamp), ""))
+            pk,
+            account,
+            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, uint48(block.timestamp - 1), ""))
         );
 
         // Skipped, not installed inert: the slot was never written, so an explicit revoke finds nothing.
@@ -147,13 +150,27 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
 
         Keystore.AccountChange[] memory changes = new Keystore.AccountChange[](2);
-        changes[0] = _authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, uint48(block.timestamp), ""); // expired
+        changes[0] = _authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, uint48(block.timestamp - 1), ""); // expired
         changes[1] = _authorizeChange(ACTOR_B, address(k1Authenticator), SENDER, _future(1 days), ""); // live
 
         _applyUnsequenced(pk, account, changes);
 
         assertFalse(_isActor(account, ACTOR_A)); // expired -> skipped
         assertTrue(_isActor(account, ACTOR_B)); // live -> applied
+    }
+
+    /// @notice Boundary: a JIT grant whose expiry equals the current timestamp is still live (expired only once
+    ///         block.timestamp > expiry), so it installs rather than being skipped — matching authentication exactly.
+    function test_authorizeUnsequenced_expiryAtNow_installsLive(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+
+        _applyUnsequenced(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, uint48(block.timestamp), ""))
+        );
+
+        assertTrue(_isActor(account, ACTOR_A));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).authenticator, address(k1Authenticator));
     }
 
     /// @notice An unsequenced grant may request the unbounded (max) expiry.


### PR DESCRIPTION
## Summary

Fixes a small boundary inconsistency in how expiry is evaluated.

`_applyAuthorize`'s JIT (unsequenced) skip check hand-rolled its own comparison:

```solidity
if (isUnsequenced && cfg.expiry != 0 && cfg.expiry <= block.timestamp) return;
```

That uses an **inclusive** boundary (`expiry <= now`), while the canonical `_isExpired` uses an **exclusive** one (`block.timestamp > expiry`), which matches the documented rule on the field: `// Actor invalid once block.timestamp > expiry`.

At the exact second `block.timestamp == expiry` the two disagreed:
- `_applyAuthorize` treated the grant as expired and **skipped** installing it.
- `_isExpired` (used at authentication and in `getActorConfig`) treated it as **still live**.

So a JIT grant whose expiry equals the current timestamp — valid for that final second per authentication — was dropped on install. No security impact (it under-installs, never over-installs), but it's exactly the kind of duplicated-definition drift worth removing.

## Change

Route the skip through the canonical helper, which also folds in the `expiry != 0` zero-sentinel check:

```solidity
if (isUnsequenced && _isExpired(cfg.expiry)) return;
```

Both sites now share one definition of "expired" and follow the documented boundary.

## Test plan

- [x] Updated `test_authorizeUnsequenced_pastExpiry_skippedNotApplied` and `test_authorizeUnsequenced_mixedExpiredAndLive_appliesLiveOnly` to use a strictly-past expiry (`block.timestamp - 1`) — they were previously asserting skip at the `expiry == now` boundary, i.e. the old inclusive semantics.
- [x] Added `test_authorizeUnsequenced_expiryAtNow_installsLive` asserting an `expiry == now` JIT grant now installs and is live, consistent with authentication.
- [x] Full Keystore unit suite: 218 passed, 0 failed.