### PR TITLE
DelegateAuthenticator: accept operational actors (Scopes.isOperator)

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -34,7 +34,7 @@ bytes32 constant DELEGATE_SALT = 0x000000000000000000000000000000000000000000000
 /// @dev PolicyManager: 0x8130...0ac1
 bytes32 constant POLICY_MANAGER_SALT = 0x000000000000000000000000000000000000000000000000000000003c1c1ee0;
 /// @dev SessionPolicy: 0x8130...5e55
-bytes32 constant SESSION_POLICY_SALT = 0x00000000000000000000000000000000000000000000000000000001b7622c5c;
+bytes32 constant SESSION_POLICY_SALT = 0x0000000000000000000000000000000000000000000000000000000020ca10ab;
 
 /// @notice Deploys the full EIP-8130 system: Keystore, account implementations, canonical
 ///         authenticators, and the unaudited example policy contracts (PolicyManager, SessionPolicy).

--- a/src/authenticators/DelegateAuthenticator.sol
+++ b/src/authenticators/DelegateAuthenticator.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.36;
 import {Keystore} from "../Keystore.sol";
 import {IAuthenticator} from "../interfaces/IAuthenticator.sol";
 import {ActorId} from "../libraries/ActorId.sol";
+import {Scopes} from "../libraries/Scopes.sol";
 
 /// @notice Delegates authentication to another account's actor configuration; a single hop only.
 ///         actorId = ActorId.fromAddress(delegate_address)
@@ -21,7 +22,7 @@ contract DelegateAuthenticator is IAuthenticator {
     /// @notice The nested authenticator points back to this contract; only one delegation hop is permitted.
     error RecursiveDelegation();
 
-    /// @notice The nested signer is not authorized to sign for the delegate account.
+    /// @notice The nested signer is not an operational actor of the delegate account, so it may not vouch.
     error InvalidNestedSignature();
 
     /// @notice Deploys the authenticator bound to an Keystore instance.
@@ -35,7 +36,8 @@ contract DelegateAuthenticator is IAuthenticator {
     /// @dev Reverts with InvalidDataLength when `data` is shorter than 40 bytes.
     /// @dev Reverts with RecursiveDelegation when the nested authenticator is this contract (recursive delegation
     ///      is not permitted).
-    /// @dev Reverts with InvalidNestedSignature when the delegate account does not validate the nested signature.
+    /// @dev Reverts with InvalidNestedSignature when the nested auth does not resolve to an operational actor
+    ///      (per Scopes.isOperator) on the delegate account.
     ///
     /// @param hash The digest being authenticated.
     /// @param data delegate address (20) then the nested auth blob (nested authenticator address then its data).
@@ -52,9 +54,10 @@ contract DelegateAuthenticator is IAuthenticator {
         address nestedAuthenticator = address(bytes20(nestedAuth[:20]));
         if (nestedAuthenticator == address(this)) revert RecursiveDelegation();
 
-        // The nested actor MUST be the admin (scope == 0x00) of the delegate account.
+        // The nested actor MUST be an operational actor (admin or SENDER without POLICY) of the delegate account,
+        // matching the authority that can drive execution and sign (ERC-1271) as the account.
         try KEYSTORE.authenticateActor(delegate, hash, nestedAuth) returns (bytes32, uint16 nestedScope) {
-            if (nestedScope != 0) revert InvalidNestedSignature();
+            if (!Scopes.isOperator(nestedScope)) revert InvalidNestedSignature();
         } catch {
             revert InvalidNestedSignature();
         }

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -12,14 +12,13 @@ import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 ///         Guards, in source-execution order, each reverting with a custom error:
 ///           1. InvalidDataLength       — data.length < 40
 ///           2. RecursiveDelegation     — nestedAuthenticator == address(this) (blocks 1-hop recursion)
-///           3. InvalidNestedSignature  — the nested auth does not resolve to the admin actor on `delegate`
+///           3. InvalidNestedSignature  — the nested auth does not resolve to an operational actor on `delegate`
 ///         On success returns actorId = bytes32(uint256(uint160(delegate))).
 ///
-///         The delegate vouch requires the nested auth to resolve to the ADMIN actor on `delegate` (scope ==
-///         0x00). This admin-only requirement is enforced independently of the account's ERC-1271 check (via
-///         authenticateActor + an explicit scope == 0 check): a SENDER-without-POLICY key can produce a valid
-///         ERC-1271 signature, but such a key must NOT be able to vouch as a delegate, so a non-admin nested
-///         actor reverts.
+///         The delegate vouch requires the nested auth to resolve to an OPERATIONAL actor on `delegate` (per
+///         Scopes.isOperator: admin scope == 0x00, or SENDER without POLICY). This mirrors the account's ERC-1271
+///         authorization surface: a SENDER-without-POLICY key that can produce a valid ERC-1271 signature can also
+///         vouch as a delegate, while a POLICY-gated or capability-only (non-operational) nested actor reverts.
 contract DelegateAuthenticatorTest is KeystoreTest {
     uint16 constant SCOPE_SENDER = 0x01;
     uint16 constant SCOPE_POLICY = 0x02;
@@ -98,8 +97,9 @@ contract DelegateAuthenticatorTest is KeystoreTest {
         delegateAuthenticator.authenticate(hash, data);
     }
 
-    /// @dev A nested signer that is a live actor on the delegate account but holds any non-zero (non-admin) scope
-    ///      is rejected: the delegate vouch requires admin (scope == 0x00) and guard 3 reverts.
+    /// @dev A nested signer that is a live actor on the delegate account but holds a non-operational scope
+    ///      is rejected: the delegate vouch requires an operational scope (per Scopes.isOperator) and guard 3
+    ///      reverts. Clears SENDER (and POLICY) so the scope carries only non-operational capability bits.
     function test_authenticate_revert_nestedSignerIsScoped(
         uint256 ownerSeed,
         uint256 signerSeed,
@@ -110,9 +110,9 @@ contract DelegateAuthenticatorTest is KeystoreTest {
         uint256 signerPk = _boundK1Pk(signerSeed);
         vm.assume(vm.addr(ownerPk) != vm.addr(signerPk));
 
-        // Any non-zero scope → non-admin → the delegate vouch must revert. Clear POLICY so the scoped actor
-        // needs no policyData at authorization time.
-        uint16 scope = uint16(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_POLICY;
+        // Non-operational scope → the delegate vouch must revert. Clear SENDER and POLICY so the actor holds
+        // only capability bits (NONCE / SELF_PAYER / SPONSOR_PAYER) and needs no policyData at authorization time.
+        uint16 scope = uint16(bound(uint256(scopeSeed), 1, 255)) & ~SCOPE_SENDER & ~SCOPE_POLICY;
         vm.assume(scope != 0);
 
         (address delegateAccount,) = _createK1Account(ownerPk);
@@ -125,10 +125,10 @@ contract DelegateAuthenticatorTest is KeystoreTest {
         delegateAuthenticator.authenticate(hash, data);
     }
 
-    /// @dev Regression guard for the operational/admin decoupling: a SENDER-without-POLICY nested actor on the
-    ///      delegate account CAN satisfy the account's ERC-1271 (it is operational), yet it MUST NOT satisfy the
-    ///      delegate vouch, which stays admin-only. Asserts ERC-1271 validates for the actor, then the vouch reverts.
-    function test_authenticate_revert_operationalSenderCannotVouch(uint256 ownerSeed, uint256 signerSeed, bytes32 hash)
+    /// @dev The operational/signing surfaces are aligned: a SENDER-without-POLICY nested actor on the delegate
+    ///      account is operational, so it CAN satisfy both the account's ERC-1271 AND the delegate vouch. Asserts
+    ///      ERC-1271 validates for the actor, then the vouch succeeds and returns the delegate's actorId.
+    function test_authenticate_success_operationalSenderVouches(uint256 ownerSeed, uint256 signerSeed, bytes32 hash)
         public
     {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
@@ -147,10 +147,10 @@ contract DelegateAuthenticatorTest is KeystoreTest {
             _wrapLocal(_buildK1Auth(signerPk, keystore.replaySafeHash(delegateAccount, block.chainid, hash)));
         assertEq(DefaultAccount(payable(delegateAccount)).isValidSignature(hash, wrappedAuth), bytes4(0x1626ba7e));
 
-        // But it cannot vouch as a delegate — the nested check stays admin-only.
+        // And it can now vouch as a delegate — the nested check accepts any operational actor.
         bytes memory data = abi.encodePacked(delegateAccount, nestedAuth);
-        vm.expectRevert(DelegateAuthenticator.InvalidNestedSignature.selector);
-        delegateAuthenticator.authenticate(hash, data);
+        bytes32 actorId = delegateAuthenticator.authenticate(hash, data);
+        assertEq(actorId, bytes32(uint256(uint160(delegateAccount))));
     }
 
     // ── Happy paths ──


### PR DESCRIPTION
## Summary
- Change `DelegateAuthenticator` so a delegate vouch accepts any **operational** nested actor via `Scopes.isOperator`, instead of requiring admin scope (`scope == 0x00`) only.
- Operational means admin (`scope == 0`) **or** a `SENDER` actor that is not `POLICY`-gated — the same authority that can drive execution and sign (ERC-1271) as the account (see `DefaultAccount`). This aligns delegate vouching with the account's execution/signing authorization surface.
- `POLICY`-gated actors and capability-only actors (e.g. `NONCE` / `SELF_PAYER` / `SPONSOR_PAYER`) remain non-operational and still revert with `InvalidNestedSignature`.

## Changes
- `src/authenticators/DelegateAuthenticator.sol`: import `Scopes`; replace `if (nestedScope != 0)` with `if (!Scopes.isOperator(nestedScope))`; update docs/error comment.
- `test/unit/authenticators/DelegateAuthenticator.t.sol`:
  - Converted the `operationalSenderCannotVouch` regression into `test_authenticate_success_operationalSenderVouches` (SENDER actor now vouches and returns the delegate actorId).
  - Tightened `test_authenticate_revert_nestedSignerIsScoped` to fuzz only non-operational scopes (clears `SENDER` and `POLICY`).
  - Updated the file-level docstring.

## Test plan
- [x] `forge build`
- [x] `forge test --match-path test/unit/authenticators/DelegateAuthenticator.t.sol` (8 passed)
- [x] `forge test` full suite (387 passed, 0 failed)