### PR TITLE
feat(SessionPolicy): make TokenLimit the primary spend grant

### DIFF
--- a/src/policies/README.md
+++ b/src/policies/README.md
@@ -57,18 +57,30 @@ The manager validates exactly **one** binding per `execute` call, so authorizing
 selector **and** recipient **and** spend-limit": each `onExecute` validates config shape then scans the
 authenticated calldata config. Only mutable spend usage lives onchain.
 
-Recipient allowlists and spend-limit accounting require decoding a call's arguments, which is only possible for
-selectors whose ABI is known: `SessionPolicy` hardcodes the standard ERC-20 set (`transfer`, `transferFrom`,
-`approve`). A recipient allowlist may only be attached to one of those (enforced at execute); spend limits are
-consumed for those selectors on a limited token (`approve` included, so an allowance cannot exceed the remaining
-budget), native-ETH limits from each call's `value`, and every other selector is governed by target/selector gating
-alone. `anySelector` on a limited token is rejected at execute — pin an explicit selector allowlist instead.
+A **`TokenLimit` is the primary spend grant**: adding one for a token both caps it and, by itself, authorizes the
+key to move it via the three tracked ERC-20 selectors (`transfer`, `transferFrom`, `approve`). Access resolves per
+call:
+
+- **Case 1 — `TokenLimit` alone** (no `CallScope`): the key may call only those three selectors on the token, each
+  debited from the cap and gated by the limit's `recipients`. Nothing else on the token is callable.
+- **Case 2 — `TokenLimit` + a `CallScope` with an empty selector list** (`anySelector`): the key may call *any*
+  selector. The three tracked selectors stay debited/recipient-gated; every other selector is allowed but **not**
+  debited — an explicit opt-in to untracked, value-moving methods (`increaseAllowance`, ERC-4626 `withdraw`, …).
+- **Case 3 — `TokenLimit` + a `CallScope` with an explicit selector list**: exactly the listed selectors (tracked
+  ones still debited/recipient-gated). An explicit list *replaces* the Case-1 default.
+
+A `CallScope` on a target with **no** `TokenLimit` is a pure call allowlist (no spend semantics). Recipient gating
+lives on the `TokenLimit`: for an ERC-20 it gates the decoded destination of the tracked selectors (`to` for
+transfer/transferFrom, `spender` for approve — a deliberate merge); for native ETH (`token == address(0)`) it gates
+the call `target`. Native value fails closed (a call carrying `value` reverts unless a native `TokenLimit` is set).
+Recipient gating and spend accounting can only decode the hardcoded ERC-20 set, so `safeTransferFrom` and other
+value-moving methods are never tracked — reachable only via the Case-2 / Case-3 opt-in.
 
 #### Worked example
 
 Configure one session key that (1) has full, uncapped access to one ERC-20 (the "MyApp" token), (2) may spend at
 most **$5 of USDC per month**, and (3) may call the MyApp app contract as much as it wants, but only through two
-chosen selectors. Three call scopes + one spend limit:
+chosen selectors. One spend limit + two call scopes:
 
 ```solidity
 address MYAPP_TOKEN; // the "MyApp" ERC-20
@@ -77,25 +89,22 @@ address MYAPP;       // the MyApp app contract
 bytes4  selStake = MyApp.stake.selector;
 bytes4  selClaim = MyApp.claim.selector;
 
-// Spend limits: ONLY USDC ($5/month). MyApp token has no entry, so it is uncapped.
+// Spend limits: ONLY USDC ($5/month) — a Case-1 grant. The limit alone authorizes the three tracked ERC-20
+// selectors and caps every one of them, so the budget can't be sidestepped via approve/transferFrom. The MyApp
+// token has no entry, so it is uncapped.
 SessionPolicy.TokenLimit[] memory limits = new SessionPolicy.TokenLimit[](1);
-limits[0] = SessionPolicy.TokenLimit({token: USDC, limit: 5e6, period: 30 days});
+limits[0] = SessionPolicy.TokenLimit({token: USDC, limit: 5e6, period: 30 days, recipients: new address[](0)});
 
-SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](3);
+SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](2);
 
-// (a) MyApp token: full access — empty rules => any selector; no TokenLimit => no spend cap.
-scopes[0] = SessionPolicy.CallScope({target: MYAPP_TOKEN, selectorRules: new SessionPolicy.SelectorRule[](0)});
+// (a) MyApp token: full access — empty selector list => any selector; no TokenLimit => no spend cap.
+scopes[0] = SessionPolicy.CallScope({target: MYAPP_TOKEN, selectors: new bytes4[](0)});
 
-// (b) USDC: `transfer` only, so the $5/month cap can't be sidestepped by another selector.
-SessionPolicy.SelectorRule[] memory usdcRules = new SessionPolicy.SelectorRule[](1);
-usdcRules[0] = SessionPolicy.SelectorRule({selector: IERC20.transfer.selector, recipients: new address[](0)});
-scopes[1] = SessionPolicy.CallScope({target: USDC, selectorRules: usdcRules});
-
-// (c) MyApp contract: two chosen selectors, unlimited calls.
-SessionPolicy.SelectorRule[] memory appRules = new SessionPolicy.SelectorRule[](2);
-appRules[0] = SessionPolicy.SelectorRule({selector: selStake, recipients: new address[](0)});
-appRules[1] = SessionPolicy.SelectorRule({selector: selClaim, recipients: new address[](0)});
-scopes[2] = SessionPolicy.CallScope({target: MYAPP, selectorRules: appRules});
+// (b) MyApp contract: two chosen selectors, unlimited calls.
+bytes4[] memory appSelectors = new bytes4[](2);
+appSelectors[0] = selStake;
+appSelectors[1] = selClaim;
+scopes[1] = SessionPolicy.CallScope({target: MYAPP, selectors: appSelectors});
 
 bytes memory policyConfig = abi.encode(SessionPolicy.Config({tokenLimits: limits, callScopes: scopes}));
 ```
@@ -103,9 +112,10 @@ bytes memory policyConfig = abi.encode(SessionPolicy.Config({tokenLimits: limits
 With that authorized, the key may transfer any amount of the MyApp token, spend up to $5 of USDC per rolling month
 (refreshing the next month), and call `stake` / `claim` on MyApp without limit — while a USDC transfer over budget
 reverts `ExceededAllowance`, a third MyApp selector reverts `SelectorNotAllowed`, and any other contract reverts
-`TargetNotAllowed`. Two choices to note: modeling "full token access" as *any selector* also permits `approve` /
-`transferFrom` on that token (use a single `transfer` rule to restrict to transfers); and USDC is pinned to
-`transfer` precisely so the cap is airtight. End-to-end test:
+`TargetNotAllowed`. Two choices to note: the USDC cap needs no explicit `CallScope` — the `TokenLimit` alone grants
+and caps the three tracked selectors (add a Case-3 `CallScope` listing `[transfer]` if you also want to forbid
+`approve` / `transferFrom`); and modeling "full token access" as *any selector* also permits `approve` /
+`transferFrom` on the MyApp token. End-to-end test:
 [`test_workedExample_fullTokenAccess_monthlyUsdc_appSelectors`](../../../test/unit/policies/SessionPolicy.t.sol).
 
 ### External callers (subscriptions)

--- a/src/policies/SessionPolicy.sol
+++ b/src/policies/SessionPolicy.sol
@@ -10,28 +10,69 @@ import {RecurringAllowance} from "./RecurringAllowance.sol";
 /// @title SessionPolicy
 ///
 /// @notice Unified EIP-8130 "session key" policy combining, in a single committed binding and a single per-call
-///         check: a call-target allowlist, per-target function-selector rules, optional per-selector recipient
-///         allowlists, and per-token (and native-ETH) recurring/one-time spend limits.
+///         check: a call-target allowlist, per-target function-selector allowlists, per-asset recipient allowlists,
+///         and per-token (and native-ETH) recurring/one-time spend limits.
 ///
-/// @dev Config is never stored: {onExecute} receives the config preimage via calldata, authenticated by the
-///      manager's binding-commitment check, and {_validateConfig} re-checks its shape at execute. The only storage
-///      is {_usage} (spend accounting).
+/// @dev A single policy (rather than several composed) because {PolicyManager} validates one (policy, commitment)
+///      per call; bundling every dimension here lets them all gate the same call atomically.
 ///
-///      Decoding limitation: only the standard ERC-20 selectors (`transfer`, `transferFrom`, `approve`) are decoded
-///      for recipient allowlists and spend accounting. Any other selector on a limited token is gated by the
-///      allowlist but NOT debited from the cap, so do not allowlist value-moving non-ERC-20 methods on a token you
-///      intend to bound; `anySelector` on a limited token is rejected at execute.
+///      Config model: no config storage. Every {onExecute} receives the config preimage via calldata;
+///      {PolicyManager} authenticates it by recomputing the binding commitment against Keystore. Config shape checks
+///      (ZeroLimit, LimitTooLarge, SelfTargetNotAllowed, duplicates) run at execute via {_validateConfig}.
+///      {_findTokenLimit} still defensively re-checks LimitTooLarge before the uint160 cast. The only storage is
+///      {_usage} (mutable spend accounting).
 ///
-///      Native ETH fails closed: a call carrying `value` reverts unless the config pins a native {TokenLimit}
-///      (`token == address(0)`). `approve` is debited at grant time, so a standing allowance pulled later can still
-///      exceed a single period's cap. Empty calldata is allowed; 1-3 bytes revert ({MissingSelector}); 4+ bytes are
-///      treated as a selector.
+///      {TokenLimit} is the primary spend grant. Adding a {TokenLimit} for a token both caps that token and, by
+///      itself, authorizes the key to move it via the three tracked ERC-20 selectors. Access is resolved per call:
+///        - Case 1 — a {TokenLimit} with NO matching {CallScope}: the key may call `transfer`, `transferFrom`,
+///          `approve` on that token (only those three), each debited from the cap and gated by the limit's
+///          `recipients`. Nothing else on the token is callable.
+///        - Case 2 — a {TokenLimit} plus a {CallScope} with an empty selector list (anySelector): the key may call
+///          ANY selector on the token. The three tracked selectors are still debited/recipient-gated; every other
+///          selector is allowed but NOT debited. This is an explicit opt-in to untracked, value-moving methods
+///          (e.g. `increaseAllowance`, ERC-4626 `withdraw`) — use it only when you accept the cap does not bound them.
+///        - Case 3 — a {TokenLimit} plus a {CallScope} with an explicit selector list: the key may call exactly the
+///          listed selectors. Listed tracked selectors are debited/recipient-gated; listed untracked selectors are
+///          allowed but not debited. An explicit list REPLACES the Case-1 default (it does not add to it).
+///      A {CallScope} on a target with no {TokenLimit} is a pure call allowlist (no spend semantics).
+///
+///      Selector awareness (the one inherent limitation): recipient gating and spend accounting require decoding the
+///      call's arguments, which is only possible for selectors whose ABI layout is known. This policy hardcodes the
+///      standard ERC-20 set — `transfer`, `transferFrom`, `approve`. Only those are debited and recipient-gated;
+///      `safeTransferFrom` (ERC-721/1155) and any other value-moving method cannot be decoded (an NFT has no fungible
+///      amount, ERC-1155 adds an `id` dimension {TokenLimit} does not carry) and are therefore never tracked — they
+///      are reachable only via the explicit Case-2/Case-3 opt-in above.
+///
+///      Recipients: the recipient allowlist lives on {TokenLimit} (not per-selector) and is the set of allowed
+///      destinations for that asset's value. For an ERC-20 it gates the decoded destination of the tracked selectors
+///      (`to` for transfer/transferFrom, `spender` for approve — a deliberate merge: an address trusted to receive is
+///      trusted to be approved). For native ETH (`token == address(0)`) it gates the call's `target`. Empty = any
+///      recipient.
+///
+///      Approvals vs. periods: `approve` is debited from the *current* period at grant time, but an ERC-20 allowance
+///      is standing on-chain state that outlives the period and is pulled by a third party this policy never sees. A
+///      grantee can therefore pull a still-live approval from an earlier period in the same wall-clock window as a
+///      fresh-period `transfer`, so real token outflow across a period boundary can exceed a single period's cap.
+///      Per-period accounting is exact for the key's own actions; it cannot bound reuse of standing allowances.
+///
+///      Native value fails closed: a call carrying `value` reverts ({NativeValueNotAllowed}) unless the config pins a
+///      native {TokenLimit} (`token == address(0)`). Absence means "no ETH", not "unlimited ETH" — so a grant can
+///      call a value-accepting target while sending it zero ETH, and this does not depend on the target rejecting
+///      value. The resulting asymmetry with ERC-20 defaults is structural: an ERC-20 must be called at its own
+///      address to move, so the target allowlist already gates it, whereas native value rides on any call. Both share
+///      the same expressible states — forbidden, capped, and unlimited (`limit == type(uint160).max`).
+///
+///      Calldata length: empty calldata is a plain value transfer (a `receive()`), allowed only against a target with
+///      an explicit {CallScope} (a {TokenLimit}-only target is strictly for the three spend selectors, so it cannot
+///      receive a bare value transfer); calldata of 1–3 bytes is rejected ({MissingSelector}) as it cannot carry a
+///      4-byte selector; 4+ bytes is treated as a selector (so a fallback reachable via 4+ byte data is gated by the
+///      selector rules).
 contract SessionPolicy is Policy {
     using RecurringAllowance for RecurringAllowance.State;
 
     // ── Committed configuration (what the account signs; re-supplied at every execute) ──
 
-    /// @notice Per-token (or native-ETH) spend cap.
+    /// @notice Per-token (or native-ETH) spend cap and allowed destinations. The primary spend grant.
     struct TokenLimit {
         /// @dev ERC-20 token address, or address(0) for native ETH (gated on each call's `value`).
         address token;
@@ -40,39 +81,29 @@ contract SessionPolicy is Policy {
         uint256 limit;
         /// @dev Recurring period in seconds. 0 = one-time (a single cumulative cap that never resets).
         uint40 period;
-    }
-
-    /// @notice A function selector and an optional recipient allowlist.
-    struct SelectorRule {
-        /// @dev 4-byte function selector allowed on the parent {CallScope} target.
-        bytes4 selector;
-        /// @dev Allowed recipients (empty = any recipient). Only valid for known ERC-20 selectors.
+        /// @dev Allowed destinations for this asset's value (empty = any). For an ERC-20, gates the decoded recipient
+        ///      of the tracked selectors; for native (token == address(0)), gates the call `target`.
         address[] recipients;
     }
 
-    /// @notice A target contract and its allowed selector rules.
+    /// @notice A target contract and its allowed selectors.
     struct CallScope {
         /// @dev Target contract this binding may call.
         address target;
-        /// @dev Allowed selectors on `target` (empty = any selector allowed, no recipient gating).
-        SelectorRule[] selectorRules;
+        /// @dev Allowed selectors on `target` (empty = any selector allowed).
+        bytes4[] selectors;
     }
 
     /// @notice The full committed configuration for a binding.
     struct Config {
-        /// @dev Per-token (and native-ETH) spend caps.
         TokenLimit[] tokenLimits;
-        /// @dev Allowed call targets and their selector rules.
         CallScope[] callScopes;
     }
 
     /// @notice Per-use action: a single call the session key wants the account to make.
     struct Action {
-        /// @dev Target contract the account will call.
         address target;
-        /// @dev Wei forwarded with the call.
         uint256 value;
-        /// @dev Calldata for the call (empty = plain value transfer).
         bytes data;
     }
 
@@ -91,67 +122,53 @@ contract SessionPolicy is Policy {
     ///      spend never refreshes within representable time.
     uint40 internal constant ONE_TIME_PERIOD = type(uint40).max;
 
-    /// @notice The action's `target` is not in the committed call-target allowlist.
+    /// @notice The action's `target` is neither in the call-target allowlist nor a (non-native) limited token, or a
+    ///         bare value transfer was attempted against a {TokenLimit}-only target (which permits only the three
+    ///         spend selectors, not a plain `receive()`).
     error TargetNotAllowed(address target);
-
-    /// @notice `selector` is not permitted on `target` (the target pins an explicit selector allowlist that omits it).
+    /// @notice `selector` is not permitted on `target` (a {TokenLimit}-only target permits only the tracked ERC-20
+    ///         selectors; an explicit {CallScope} permits only its listed selectors).
     error SelectorNotAllowed(address target, bytes4 selector);
-
-    /// @notice `recipient` (decoded from the ERC-20 call) is not in the selector's committed recipient allowlist.
+    /// @notice `recipient` (decoded ERC-20 destination, or the call `target` for native) is not in the asset's
+    ///         committed recipient allowlist.
     error RecipientNotAllowed(address target, bytes4 selector, address recipient);
-
     /// @notice The action carried 1–3 bytes of calldata: too short to hold a 4-byte selector, so it is rejected rather
     ///         than guessed.
     error MissingSelector();
-
     /// @notice A configured spend `limit` exceeds uint160 and cannot be stored in the normalized allowance field.
     error LimitTooLarge(address token, uint256 limit);
-
     /// @notice A configured spend limit was zero, which would be a no-op cap; reject to fail closed.
     error ZeroLimit(address token);
-
     /// @notice The action carried native `value` but the config pins no native-ETH limit (`token == address(0)`).
+    ///         Native value fails closed: unlike an ERC-20 (which requires calling an allowlisted token contract to
+    ///         move), value rides on any call to any allowlisted target, so an absent native limit is treated as "no
+    ///         ETH", not "unlimited ETH". To permit ETH, add a native {TokenLimit} with a positive cap.
     error NativeValueNotAllowed(uint256 value);
-
-    /// @notice A recipient allowlist was attached to a selector whose recipient argument this policy cannot decode
-    ///         (only the standard ERC-20 selectors are supported).
-    error RecipientRuleUnsupportedSelector(bytes4 selector);
-
     /// @notice A supported ERC-20 call's calldata was too short to decode its (recipient, amount) arguments.
     error MalformedTokenCall(bytes4 selector);
-
-    /// @notice A limited token was configured with `anySelector`, which would let non-ERC-20 methods move value
-    ///         without debiting the spend cap.
-    error AnySelectorOnLimitedToken(address token);
-
-    /// @notice A call scope targeted the account itself, which would let a session key re-enter `executeBatch` and
-    ///         bypass every policy check.
+    /// @notice A call scope targeted the account itself. The account is always an authorized caller of its own
+    ///         `executeBatch`, so allowing a session key to call it would let the key re-enter with an arbitrary
+    ///         batch that bypasses every policy check. Reject to fail closed.
     error SelfTargetNotAllowed();
-
     /// @notice A `transferFrom` moved funds from an address other than the account. A session key may only spend the
     ///         account's own resources, not third-party allowances the account happens to hold.
     error TransferFromNotSelf(address from);
-
     /// @notice Duplicate `TokenLimit.token` in the committed config (would silently widen / ambiguate grants).
     error DuplicateTokenLimit(address token);
-
     /// @notice Duplicate `CallScope.target` in the committed config.
     error DuplicateCallScope(address target);
-
-    /// @notice Duplicate `SelectorRule.selector` within a call scope.
-    error DuplicateSelectorRule(address target, bytes4 selector);
+    /// @notice Duplicate selector within a single call scope.
+    error DuplicateSelector(address target, bytes4 selector);
 
     constructor(address policyManager) Policy(policyManager) {}
 
-    // ── View functions ──
+    // ── Views (pure over supplied config / explicit limit; no config storage to read) ──
 
-    /// @notice Returns whether `target` is allowed by `config`, and whether any selector is permitted on it.
+    /// @notice Returns whether `target` is callable by `config`, and whether any selector is permitted on it.
     ///
-    /// @param config Committed policy configuration.
-    /// @param target Call target to check.
-    ///
-    /// @return allowed     True if `target` is in the call-target allowlist.
-    /// @return anySelector True if the target pins no selector allowlist (any selector permitted).
+    /// @dev A target is callable if it has an explicit {CallScope} or a (non-native) {TokenLimit}. `anySelector` is
+    ///      true only for an explicit {CallScope} with an empty selector list; a {TokenLimit}-only target permits just
+    ///      the three tracked ERC-20 selectors, so it reports `anySelector == false`.
     function isTargetAllowed(Config calldata config, address target)
         external
         pure
@@ -159,77 +176,82 @@ contract SessionPolicy is Policy {
     {
         for (uint256 i; i < config.callScopes.length; i++) {
             if (config.callScopes[i].target == target) {
-                return (true, config.callScopes[i].selectorRules.length == 0);
+                return (true, config.callScopes[i].selectors.length == 0);
+            }
+        }
+        if (target != address(0)) {
+            for (uint256 i; i < config.tokenLimits.length; i++) {
+                if (config.tokenLimits[i].token == target) return (true, false);
             }
         }
         return (false, false);
     }
 
     /// @notice Returns whether `selector` is allowed on `target` by `config`, and whether a recipient allowlist
-    ///         applies.
-    ///
-    /// @param config   Committed policy configuration.
-    /// @param target   Call target the selector is checked against.
-    /// @param selector Function selector to check.
-    ///
-    /// @return allowed        True if `selector` is permitted on `target`.
-    /// @return recipientBound True if a recipient allowlist applies to the selector.
+    ///         applies to it (true only for a tracked ERC-20 selector on a limited token whose limit pins recipients).
     function getSelectorRule(Config calldata config, address target, bytes4 selector)
         external
         pure
         returns (bool allowed, bool recipientBound)
     {
+        bool hasScope;
+        bool anySelector;
+        bool selectorListed;
         for (uint256 i; i < config.callScopes.length; i++) {
             CallScope calldata scope = config.callScopes[i];
             if (scope.target != target) continue;
-            if (scope.selectorRules.length == 0) return (true, false);
-            for (uint256 j; j < scope.selectorRules.length; j++) {
-                if (scope.selectorRules[j].selector == selector) {
-                    return (true, scope.selectorRules[j].recipients.length > 0);
+            hasScope = true;
+            anySelector = scope.selectors.length == 0;
+            for (uint256 j; j < scope.selectors.length; j++) {
+                if (scope.selectors[j] == selector) {
+                    selectorListed = true;
+                    break;
                 }
             }
-            return (false, false);
+            break;
         }
-        return (false, false);
+
+        bool hasLimit;
+        bool hasRecipients;
+        if (target != address(0)) {
+            for (uint256 i; i < config.tokenLimits.length; i++) {
+                if (config.tokenLimits[i].token == target) {
+                    hasLimit = true;
+                    hasRecipients = config.tokenLimits[i].recipients.length > 0;
+                    break;
+                }
+            }
+        }
+
+        if (hasScope) {
+            allowed = anySelector || selectorListed;
+        } else {
+            allowed = hasLimit && _isErc20Selector(selector);
+        }
+        recipientBound = allowed && hasLimit && hasRecipients && _isErc20Selector(selector);
     }
 
-    /// @notice Returns whether `recipient` is in the recipient allowlist for `(target, selector)` in `config`.
-    ///
-    /// @param config    Committed policy configuration.
-    /// @param target    Call target the selector belongs to.
-    /// @param selector  Function selector the recipient allowlist is attached to.
-    /// @param recipient Recipient address to check.
-    ///
-    /// @return True if `recipient` is allowed (or the selector has no recipient allowlist).
+    /// @notice Returns whether `recipient` is allowed for `(target, selector)` in `config`. Untracked selectors and
+    ///         targets without a recipient-bearing limit are unrestricted (returns true).
     function isRecipientAllowed(Config calldata config, address target, bytes4 selector, address recipient)
         external
         pure
         returns (bool)
     {
-        for (uint256 i; i < config.callScopes.length; i++) {
-            CallScope calldata scope = config.callScopes[i];
-            if (scope.target != target) continue;
-            for (uint256 j; j < scope.selectorRules.length; j++) {
-                SelectorRule calldata rule = scope.selectorRules[j];
-                if (rule.selector != selector) continue;
-                if (rule.recipients.length == 0) return true;
-                for (uint256 k; k < rule.recipients.length; k++) {
-                    if (rule.recipients[k] == recipient) return true;
-                }
-                return false;
+        if (!_isErc20Selector(selector)) return true;
+        for (uint256 i; i < config.tokenLimits.length; i++) {
+            TokenLimit calldata tl = config.tokenLimits[i];
+            if (tl.token != target) continue;
+            if (tl.recipients.length == 0) return true;
+            for (uint256 k; k < tl.recipients.length; k++) {
+                if (tl.recipients[k] == recipient) return true;
             }
+            return false;
         }
-        return false;
+        return true;
     }
 
     /// @notice Returns the spend cap for `token` from `config` (normalized period for one-time limits).
-    ///
-    /// @param config Committed policy configuration.
-    /// @param token  Token address to look up (address(0) for native ETH).
-    ///
-    /// @return set       True if `token` has a configured limit.
-    /// @return allowance Spend cap normalized to uint160.
-    /// @return period    Period in seconds ({ONE_TIME_PERIOD} for one-time limits).
     function getTokenLimit(Config calldata config, address token)
         external
         pure
@@ -244,16 +266,23 @@ contract SessionPolicy is Policy {
         return (false, 0, 0);
     }
 
+    /// @notice Returns the committed recipient allowlist for `token` (empty = any recipient / no limit set).
+    function getTokenRecipients(Config calldata config, address token)
+        external
+        pure
+        returns (address[] memory recipients)
+    {
+        for (uint256 i; i < config.tokenLimits.length; i++) {
+            if (config.tokenLimits[i].token == token) return config.tokenLimits[i].recipients;
+        }
+        return new address[](0);
+    }
+
     /// @notice Returns the current-period spend usage for an explicit token limit under a binding.
     ///
-    /// @dev Reverts with LimitTooLarge when `limit.limit` exceeds uint160.
-    /// @dev `limit` is unauthenticated calldata; results are only meaningful when it is the committed {TokenLimit}
-    ///      from the binding's config. A zero `limit.period` is normalized to {ONE_TIME_PERIOD}.
-    ///
-    /// @param commitment Binding commitment the usage is keyed under.
-    /// @param limit      Token limit to report usage for.
-    ///
-    /// @return Current-period usage snapshot (zeroed when `limit.limit` is zero).
+    /// @dev `limit` is unauthenticated calldata — results are only meaningful when `limit` is the committed
+    ///      {TokenLimit} from the binding's config (same token/limit/period the account signed).
+    ///      `limit.period == 0` is normalized to {ONE_TIME_PERIOD} so the accounting library never sees a zero period.
     function getCurrentSpend(bytes32 commitment, TokenLimit calldata limit)
         external
         view
@@ -272,26 +301,9 @@ contract SessionPolicy is Policy {
 
     // ── Hooks ──
 
-    /// @dev Policy execute hook: validates config, gates the decoded {Action} by linear scan, and returns the
-    ///      account call plan (empty postCallData). The manager has already authenticated `policyConfig`.
-    ///
-    /// @dev Reverts via {_validateConfig} when the committed config is malformed.
-    /// @dev Reverts with TargetNotAllowed when `action.target` is not in the call-target allowlist.
-    /// @dev Reverts with SelectorNotAllowed when the call's selector is not permitted on the target.
-    /// @dev Reverts with MalformedTokenCall when an ERC-20 call's calldata is too short to decode.
-    /// @dev Reverts with RecipientNotAllowed when the decoded ERC-20 recipient is not in the selector's allowlist.
-    /// @dev Reverts with TransferFromNotSelf when a `transferFrom` moves funds from an address other than `account`.
-    /// @dev Reverts with ExceededAllowance when a token or native-ETH spend exceeds its remaining cap.
-    /// @dev Reverts with MissingSelector when the action carries 1-3 bytes of calldata.
-    /// @dev Reverts with NativeValueNotAllowed when the action carries `value` but no native-ETH limit is configured.
-    ///
-    /// @param commitment    Binding commitment authorizing this execution.
-    /// @param account       Account the plan will execute against.
-    /// @param policyConfig  ABI-encoded {Config} committed by the account.
-    /// @param executionData ABI-encoded {Action} for this call.
-    ///
-    /// @return accountCallData ABI-encoded {DefaultAccount.executeBatch} plan for the single action.
-    /// @return postCallData    Always empty (no post-call hook).
+    /// @dev Validates config, enforces every configured dimension against a single decoded {Action} by linear scan,
+    ///      then returns the account call plan (and empty postCallData). The manager has already authenticated
+    ///      `policyConfig` via the binding commitment.
     function _onExecute(
         bytes32 commitment,
         address account,
@@ -303,49 +315,56 @@ contract SessionPolicy is Policy {
         _validateConfig(account, config);
         Action memory action = abi.decode(executionData, (Action));
 
-        // 1. Target allowlist + resolve scope.
-        (bool targetAllowed, bool anySelector, CallScope memory scope) = _findScope(config, action.target);
-        if (!targetAllowed) revert TargetNotAllowed(action.target);
+        // 1. Resolve the target. It is callable if it has an explicit {CallScope} or a (non-native) {TokenLimit}.
+        (bool hasScope, bool anySelector, CallScope memory scope) = _findScope(config, action.target);
+        (bool hasLimit, TokenLimit memory limit) = _findTokenLimit(config, action.target);
+        // The native sentinel (address(0)) is a value gate, never a call target.
+        bool hasErc20Limit = action.target != address(0) && hasLimit;
+        if (!hasScope && !hasErc20Limit) revert TargetNotAllowed(action.target);
 
-        // 2. Selector + recipient gating (for calls carrying a selector).
+        // 2. Selector + recipient gating + spend accounting (for calls carrying a selector).
         if (action.data.length >= 4) {
             bytes4 selector = _selectorOf(action.data);
 
-            if (!anySelector) {
-                (bool selAllowed, bool recipientBound, address[] memory recipients) = _findSelectorRule(scope, selector);
-                if (!selAllowed) revert SelectorNotAllowed(action.target, selector);
-                if (recipientBound) {
-                    (address recipient,) = _decodeErc20(selector, action.data);
-                    if (!_recipientIn(recipients, recipient)) {
-                        revert RecipientNotAllowed(action.target, selector, recipient);
-                    }
-                }
-            }
+            // Selector access: an explicit {CallScope} governs (any/listed); otherwise a {TokenLimit}-only target
+            // permits exactly the three tracked ERC-20 selectors.
+            bool selectorAllowed = hasScope ? (anySelector || _selectorIn(scope, selector)) : _isErc20Selector(selector);
+            if (!selectorAllowed) revert SelectorNotAllowed(action.target, selector);
 
-            // transferFrom may only move the account's own funds (from == account), never a third-party allowance.
+            // transferFrom source: a session key spends only the account's own resources, never a third-party
+            // allowance the account holds. Enforce `from == account` regardless of limits or recipient rules.
             if (selector == TRANSFER_FROM) {
                 address from = _decodeTransferFromSender(action.data);
                 if (from != account) revert TransferFromNotSelf(from);
             }
 
-            // ERC-20 spend limit: debit the token's cap for decodable selectors (approve debits at grant time).
-            if (_isErc20Selector(selector)) {
-                (bool set, uint160 allowance, uint40 period) = _findTokenLimit(config, action.target);
-                if (set) {
-                    (, uint256 amount) = _decodeErc20(selector, action.data);
-                    _consume(commitment, action.target, allowance, period, amount);
+            // Recipient gating + spend accounting: only for decodable ERC-20 selectors on a limited token. `approve`
+            // debits at grant time; a standing allowance can still be reused across periods (see contract NatSpec).
+            if (hasErc20Limit && _isErc20Selector(selector)) {
+                (address recipient, uint256 amount) = _decodeErc20(selector, action.data);
+                if (limit.recipients.length > 0 && !_recipientIn(limit.recipients, recipient)) {
+                    revert RecipientNotAllowed(action.target, selector, recipient);
                 }
+                _consume(commitment, action.target, uint160(limit.limit), _period(limit), amount);
             }
         } else if (action.data.length != 0) {
             // 1–3 bytes of data carry no usable selector; reject rather than guess.
             revert MissingSelector();
+        } else if (!hasScope) {
+            // Empty calldata is a plain value transfer; a {TokenLimit}-only target is strictly for the three spend
+            // selectors, so it may not receive a bare value transfer. Require an explicit {CallScope}.
+            revert TargetNotAllowed(action.target);
         }
 
-        // Native-ETH spend limit: debit the call value; fail closed when no native limit is configured.
+        // 3. Native-ETH spend limit: consume from the call value, independent of calldata. Fail closed — value rides
+        // on any call to any allowlisted target, so an absent native limit means "no ETH", not "unlimited ETH".
         if (action.value > 0) {
-            (bool set, uint160 allowance, uint40 period) = _findTokenLimit(config, address(0));
-            if (!set) revert NativeValueNotAllowed(action.value);
-            _consume(commitment, address(0), allowance, period, action.value);
+            (bool nativeSet, TokenLimit memory nativeLimit) = _findTokenLimit(config, address(0));
+            if (!nativeSet) revert NativeValueNotAllowed(action.value);
+            if (nativeLimit.recipients.length > 0 && !_recipientIn(nativeLimit.recipients, action.target)) {
+                revert RecipientNotAllowed(action.target, bytes4(0), action.target);
+            }
+            _consume(commitment, address(0), uint160(nativeLimit.limit), _period(nativeLimit), action.value);
         }
 
         Call[] memory calls = new Call[](1);
@@ -355,19 +374,8 @@ contract SessionPolicy is Policy {
 
     // ── Internal helpers ──
 
-    /// @dev Validates the committed {Config} shape and rejects duplicates.
-    ///
-    /// @dev Reverts with ZeroLimit when a token limit is zero.
-    /// @dev Reverts with LimitTooLarge when a token limit exceeds uint160.
-    /// @dev Reverts with DuplicateTokenLimit when a token appears twice in `tokenLimits`.
-    /// @dev Reverts with DuplicateCallScope when a target appears twice in `callScopes`.
-    /// @dev Reverts with SelfTargetNotAllowed when a call scope targets `account`.
-    /// @dev Reverts with AnySelectorOnLimitedToken when a limited token pins no selector allowlist.
-    /// @dev Reverts with DuplicateSelectorRule when a selector appears twice within a call scope.
-    /// @dev Reverts with RecipientRuleUnsupportedSelector when a recipient allowlist is attached to a non-ERC-20 selector.
-    ///
-    /// @param account Account the config is validated against (used for the self-target check).
-    /// @param config  Committed policy configuration to validate.
+    /// @dev Validates the committed {Config}. Rejects zero/oversized limits, self-targets, and duplicates (token /
+    ///      target / selector).
     function _validateConfig(address account, Config memory config) internal pure {
         for (uint256 i; i < config.tokenLimits.length; i++) {
             TokenLimit memory tl = config.tokenLimits[i];
@@ -383,31 +391,21 @@ contract SessionPolicy is Policy {
             for (uint256 d; d < i; d++) {
                 if (config.callScopes[d].target == scope.target) revert DuplicateCallScope(scope.target);
             }
-            // The account can always call its own executeBatch; allowing it enables policy-bypassing re-entrancy.
+            // Fail closed: the account is always authorized to call its own executeBatch, so a session key allowed to
+            // target the account could re-enter with an arbitrary, unchecked batch and escape every policy dimension.
             if (scope.target == account) revert SelfTargetNotAllowed();
-            bool anySelector = scope.selectorRules.length == 0;
-            // A TokenLimit only tracks ERC-20 transfer/transferFrom/approve; anySelector would move value untracked.
-            if (anySelector && _hasTokenLimit(config, scope.target)) {
-                revert AnySelectorOnLimitedToken(scope.target);
-            }
 
-            for (uint256 j; j < scope.selectorRules.length; j++) {
-                SelectorRule memory rule = scope.selectorRules[j];
+            for (uint256 j; j < scope.selectors.length; j++) {
                 for (uint256 d; d < j; d++) {
-                    if (scope.selectorRules[d].selector == rule.selector) {
-                        revert DuplicateSelectorRule(scope.target, rule.selector);
+                    if (scope.selectors[d] == scope.selectors[j]) {
+                        revert DuplicateSelector(scope.target, scope.selectors[j]);
                     }
-                }
-                // A recipient allowlist is only enforceable for selectors whose recipient argument we can decode.
-                if (rule.recipients.length > 0 && !_isErc20Selector(rule.selector)) {
-                    revert RecipientRuleUnsupportedSelector(rule.selector);
                 }
             }
         }
     }
 
-    /// @dev Consumes `amount` against a token's cap; skips zero amounts. Reverts with ExceededAllowance when the
-    ///      cumulative period spend exceeds the cap.
+    /// @dev Consume `amount` against a token's cap. Skips zero amounts (the library rejects zero-value spends).
     function _consume(bytes32 commitment, address token, uint160 allowance, uint40 period, uint256 amount) internal {
         if (amount == 0) return;
         _usage.useLimit(
@@ -422,33 +420,28 @@ contract SessionPolicy is Policy {
         return keccak256(abi.encode(commitment, token));
     }
 
-    /// @dev True if `config` pins a spend limit for `token`.
-    function _hasTokenLimit(Config memory config, address token) internal pure returns (bool) {
-        for (uint256 i; i < config.tokenLimits.length; i++) {
-            if (config.tokenLimits[i].token == token) return true;
-        }
-        return false;
+    /// @dev Normalizes a {TokenLimit} period: 0 (one-time) maps to the never-resetting {ONE_TIME_PERIOD}.
+    function _period(TokenLimit memory limit) internal pure returns (uint40) {
+        return limit.period == 0 ? ONE_TIME_PERIOD : limit.period;
     }
 
-    /// @dev Finds the spend cap for `token` (period normalized). Reverts with LimitTooLarge if a limit exceeds
-    ///      uint160 (defensive; {_validateConfig} already rejects it).
     function _findTokenLimit(Config memory config, address token)
         internal
         pure
-        returns (bool set, uint160 allowance, uint40 period)
+        returns (bool set, TokenLimit memory limit)
     {
         for (uint256 i; i < config.tokenLimits.length; i++) {
-            TokenLimit memory tl = config.tokenLimits[i];
-            if (tl.token == token) {
-                // Defensive: never truncate a >uint160 limit if {_validateConfig}'s check is ever bypassed.
-                if (tl.limit > type(uint160).max) revert LimitTooLarge(tl.token, tl.limit);
-                return (true, uint160(tl.limit), tl.period == 0 ? ONE_TIME_PERIOD : tl.period);
+            if (config.tokenLimits[i].token == token) {
+                limit = config.tokenLimits[i];
+                // Defensive: {_validateConfig} already rejects LimitTooLarge, but never truncate a >uint160 limit into
+                // a smaller/arbitrary allowance if that invariant is ever bypassed.
+                if (limit.limit > type(uint160).max) revert LimitTooLarge(limit.token, limit.limit);
+                return (true, limit);
             }
         }
-        return (false, 0, 0);
+        return (false, limit);
     }
 
-    /// @dev Finds the {CallScope} for `target`, reporting whether it was found and whether it pins no selectors.
     function _findScope(Config memory config, address target)
         internal
         pure
@@ -457,28 +450,19 @@ contract SessionPolicy is Policy {
         for (uint256 i; i < config.callScopes.length; i++) {
             if (config.callScopes[i].target == target) {
                 scope = config.callScopes[i];
-                return (true, scope.selectorRules.length == 0, scope);
+                return (true, scope.selectors.length == 0, scope);
             }
         }
         return (false, false, scope);
     }
 
-    /// @dev Finds the {SelectorRule} for `selector` within `scope`, returning its recipient allowlist if any.
-    function _findSelectorRule(CallScope memory scope, bytes4 selector)
-        internal
-        pure
-        returns (bool allowed, bool recipientBound, address[] memory recipients)
-    {
-        for (uint256 j; j < scope.selectorRules.length; j++) {
-            SelectorRule memory rule = scope.selectorRules[j];
-            if (rule.selector == selector) {
-                return (true, rule.recipients.length > 0, rule.recipients);
-            }
+    function _selectorIn(CallScope memory scope, bytes4 selector) internal pure returns (bool) {
+        for (uint256 j; j < scope.selectors.length; j++) {
+            if (scope.selectors[j] == selector) return true;
         }
-        return (false, false, recipients);
+        return false;
     }
 
-    /// @dev True if `recipient` is in `recipients`.
     function _recipientIn(address[] memory recipients, address recipient) internal pure returns (bool) {
         for (uint256 i; i < recipients.length; i++) {
             if (recipients[i] == recipient) return true;
@@ -491,15 +475,16 @@ contract SessionPolicy is Policy {
         return selector == TRANSFER || selector == TRANSFER_FROM || selector == APPROVE;
     }
 
-    /// @dev Reads the leading 4-byte selector from `data` (caller guarantees length >= 4), masked to a clean bytes4.
+    /// @dev Reads the leading 4-byte selector from `data` (caller guarantees `data.length >= 4`). Masks to a clean
+    ///      bytes4 so dirty low bytes cannot survive into equality comparisons.
     function _selectorOf(bytes memory data) internal pure returns (bytes4 selector) {
         assembly ("memory-safe") {
             selector := and(mload(add(data, 0x20)), shl(224, 0xffffffff))
         }
     }
 
-    /// @dev Decodes (recipient, amount) from a supported ERC-20 call (`recipient` is `to`, or `spender` for
-    ///      approve). Reverts with MalformedTokenCall when the calldata is too short.
+    /// @dev Decode (recipient, amount) for the supported ERC-20 selectors. `recipient` is `to` for transfer /
+    ///      transferFrom and `spender` for approve.
     function _decodeErc20(bytes4 selector, bytes memory data)
         internal
         pure
@@ -525,8 +510,7 @@ contract SessionPolicy is Policy {
         recipient = address(uint160(recipientWord));
     }
 
-    /// @dev Decodes the `from` (source) address of a `transferFrom` call. Reverts with MalformedTokenCall when the
-    ///      calldata is too short.
+    /// @dev Decode the `from` (source) address of a `transferFrom(address from, address to, uint256 amount)` call.
     function _decodeTransferFromSender(bytes memory data) internal pure returns (address from) {
         if (data.length < 4 + 96) revert MalformedTokenCall(TRANSFER_FROM);
         uint256 fromWord;

--- a/test/unit/policies/ExternalPolicyCaller.t.sol
+++ b/test/unit/policies/ExternalPolicyCaller.t.sol
@@ -232,8 +232,9 @@ contract ExternalPolicyCallerTest is KeystoreTest {
 
         // Nothing moved: the attack reverted, so the victim's shared spend counter and balances are untouched.
         assertEq(token.balanceOf(recipient), 0);
-        SessionPolicy.TokenLimit memory victimLimit =
-            SessionPolicy.TokenLimit({token: address(token), limit: 100e6, period: MONTH});
+        SessionPolicy.TokenLimit memory victimLimit = SessionPolicy.TokenLimit({
+            token: address(token), limit: 100e6, period: MONTH, recipients: new address[](0)
+        });
         assertEq(policy.getCurrentSpend(victimCommitment, victimLimit).spend, 0);
     }
 
@@ -264,16 +265,16 @@ contract ExternalPolicyCallerTest is KeystoreTest {
         );
     }
 
-    /// @dev SessionPolicy config: `transfer` only on `token`, with a USDC-style recurring spend limit.
+    /// @dev SessionPolicy config: a Case-1 USDC-style recurring spend limit on `token` (the limit alone authorizes
+    ///      the tracked ERC-20 selectors, so no CallScope is needed).
     /// @dev `public` and invoked via `this._config(...)` from `_binding` so its nested-struct abi.encode stays in its
     ///      own stack frame; inlining it merges that frame into every test and trips a via_ir stack-too-deep.
     function _config(uint256 limit, uint40 period) public view returns (bytes memory) {
         SessionPolicy.TokenLimit[] memory limits = new SessionPolicy.TokenLimit[](1);
-        limits[0] = SessionPolicy.TokenLimit({token: address(token), limit: limit, period: period});
-        SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
-        rules[0] = SessionPolicy.SelectorRule({selector: ExtMockERC20.transfer.selector, recipients: new address[](0)});
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = SessionPolicy.CallScope({target: address(token), selectorRules: rules});
+        limits[0] = SessionPolicy.TokenLimit({
+            token: address(token), limit: limit, period: period, recipients: new address[](0)
+        });
+        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](0);
         return abi.encode(SessionPolicy.Config({tokenLimits: limits, callScopes: scopes}));
     }
 

--- a/test/unit/policies/PolicyManager.t.sol
+++ b/test/unit/policies/PolicyManager.t.sol
@@ -288,7 +288,7 @@ contract PolicyManagerTest is KeystoreTest {
 
     function _config() internal view returns (bytes memory) {
         SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = SessionPolicy.CallScope({target: target, selectorRules: new SessionPolicy.SelectorRule[](0)});
+        scopes[0] = SessionPolicy.CallScope({target: target, selectors: new bytes4[](0)});
         return abi.encode(SessionPolicy.Config({tokenLimits: new SessionPolicy.TokenLimit[](0), callScopes: scopes}));
     }
 

--- a/test/unit/policies/SessionPolicy.t.sol
+++ b/test/unit/policies/SessionPolicy.t.sol
@@ -54,9 +54,9 @@ contract SessionMockTarget {
     }
 }
 
-/// @notice Exercises the unified {SessionPolicy}: target allowlist, per-target selector rules, recipient
-///         allowlists, per-token recurring/one-time spend limits, native-ETH limits, and the atomic
-///         multi-dimension check on a single call.
+/// @notice Exercises the unified {SessionPolicy}: target allowlist, per-target selector allowlists, per-asset
+///         recipient allowlists, per-token recurring/one-time spend limits (as the primary spend grant), native-ETH
+///         limits, and the atomic multi-dimension check on a single call.
 contract SessionPolicyTest is KeystoreTest {
     PolicyManager internal manager;
     SessionPolicy internal policy;
@@ -73,6 +73,11 @@ contract SessionPolicyTest is KeystoreTest {
     uint8 internal constant SCOPE_POLICY = 0x02;
 
     bytes4 internal constant TRANSFER = bytes4(keccak256("transfer(address,uint256)"));
+    bytes4 internal constant TRANSFER_FROM = bytes4(keccak256("transferFrom(address,address,uint256)"));
+    bytes4 internal constant APPROVE = bytes4(keccak256("approve(address,uint256)"));
+    bytes4 internal constant MINT = bytes4(keccak256("mint(address,uint256)"));
+    bytes4 internal constant OTHER_SELECTOR = bytes4(0x12345678);
+    bytes4 internal constant UNKNOWN_SELECTOR = bytes4(0xaabbccdd);
     uint40 internal constant WEEK = 7 days;
 
     uint256 internal saltNonce;
@@ -95,18 +100,14 @@ contract SessionPolicyTest is KeystoreTest {
     // ── Target gating ──
 
     function test_target_allowsListedTarget() public {
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = _anySelectorScope(address(target));
-        bytes32 actorId = _install(_config(_noLimits(), scopes));
+        bytes32 actorId = _install(_config(_noLimits(), _anySelectorScopes(address(target))));
 
         _execute(actorId, address(target), 0, abi.encodeCall(SessionMockTarget.setValue, (42)));
         assertEq(target.value(), 42);
     }
 
     function test_target_revertsUnlistedTarget() public {
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = _anySelectorScope(address(target));
-        bytes32 actorId = _install(_config(_noLimits(), scopes));
+        bytes32 actorId = _install(_config(_noLimits(), _anySelectorScopes(address(target))));
 
         _mockActingActor(actorId);
         vm.expectRevert(abi.encodeWithSelector(SessionPolicy.TargetNotAllowed.selector, address(token)));
@@ -114,14 +115,10 @@ contract SessionPolicyTest is KeystoreTest {
         manager.execute(lastBinding, _action(address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 1))));
     }
 
-    // ── Selector gating ──
+    // ── Selector gating (explicit CallScope, no spend cap) ──
 
     function test_selector_allowsListedSelector() public {
-        SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
-        rules[0] =
-            SessionPolicy.SelectorRule({selector: SessionMockTarget.setValue.selector, recipients: _noRecipients()});
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = SessionPolicy.CallScope({target: address(target), selectorRules: rules});
+        SessionPolicy.CallScope[] memory scopes = _scope(address(target), _sel1(SessionMockTarget.setValue.selector));
         bytes32 actorId = _install(_config(_noLimits(), scopes));
 
         _execute(actorId, address(target), 0, abi.encodeCall(SessionMockTarget.setValue, (7)));
@@ -129,11 +126,7 @@ contract SessionPolicyTest is KeystoreTest {
     }
 
     function test_selector_revertsUnlistedSelector() public {
-        SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
-        rules[0] =
-            SessionPolicy.SelectorRule({selector: SessionMockTarget.setValue.selector, recipients: _noRecipients()});
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = SessionPolicy.CallScope({target: address(target), selectorRules: rules});
+        SessionPolicy.CallScope[] memory scopes = _scope(address(target), _sel1(SessionMockTarget.setValue.selector));
         bytes32 actorId = _install(_config(_noLimits(), scopes));
 
         _mockActingActor(actorId);
@@ -146,21 +139,93 @@ contract SessionPolicyTest is KeystoreTest {
         manager.execute(lastBinding, _action(address(target), 0, abi.encodeCall(SessionMockTarget.other, (1))));
     }
 
-    // ── Recipient gating ──
+    // ── Case 1: a TokenLimit by itself grants the three tracked selectors ──
+
+    function test_case1_tokenLimitOnly_allowsTransfer() public {
+        bytes32 actorId = _install(_config(_limit(address(token), 500e18, WEEK), _noScopes()));
+
+        _execute(actorId, address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 300e18)));
+        assertEq(token.balanceOf(bob), 300e18);
+    }
+
+    function test_case1_tokenLimitOnly_allowsApprove() public {
+        bytes32 actorId = _install(_config(_limit(address(token), 500e18, WEEK), _noScopes()));
+
+        _execute(actorId, address(token), 0, abi.encodeCall(SessionMockERC20.approve, (bob, 10e18)));
+        assertEq(token.allowance(account, bob), 10e18);
+    }
+
+    function test_case1_tokenLimitOnly_revertsUntrackedSelector() public {
+        // A TokenLimit-only grant permits ONLY transfer/transferFrom/approve — any other selector is rejected.
+        bytes32 actorId = _install(_config(_limit(address(token), 500e18, WEEK), _noScopes()));
+
+        _mockActingActor(actorId);
+        vm.expectRevert(abi.encodeWithSelector(SessionPolicy.SelectorNotAllowed.selector, address(token), MINT));
+        vm.prank(account);
+        manager.execute(lastBinding, _action(address(token), 0, abi.encodeCall(SessionMockERC20.mint, (bob, 1))));
+    }
+
+    function test_case1_tokenLimitOnly_revertsBareValueTransfer() public {
+        // Empty calldata is a plain value transfer; a TokenLimit-only target cannot receive one (needs a CallScope).
+        bytes32 actorId = _install(_config(_limit(address(token), 500e18, WEEK), _noScopes()));
+
+        _mockActingActor(actorId);
+        vm.expectRevert(abi.encodeWithSelector(SessionPolicy.TargetNotAllowed.selector, address(token)));
+        vm.prank(account);
+        manager.execute(lastBinding, _action(address(token), 0, ""));
+    }
+
+    // ── Case 2: TokenLimit + anySelector CallScope opens all selectors (untracked ones uncapped) ──
+
+    function test_case2_anySelectorOnLimitedToken_allowsUntrackedButStillCapsTracked() public {
+        SessionPolicy.TokenLimit[] memory limits = _limit(address(token), 500e18, WEEK);
+        SessionPolicy.CallScope[] memory scopes = _anySelectorScopes(address(token));
+        bytes32 actorId = _install(_config(limits, scopes));
+
+        // Untracked selector is allowed (explicit opt-in) and NOT debited.
+        _execute(actorId, address(token), 0, abi.encodeCall(SessionMockERC20.mint, (bob, 1e18)));
+        assertEq(token.balanceOf(bob), 1e18);
+
+        // Tracked selector is still capped.
+        _execute(actorId, address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 400e18)));
+        _mockActingActor(actorId);
+        vm.expectRevert(abi.encodeWithSelector(RecurringAllowance.ExceededAllowance.selector, 600e18, 500e18));
+        vm.prank(account);
+        manager.execute(
+            lastBinding, _action(address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 200e18)))
+        );
+    }
+
+    // ── Case 3: TokenLimit + explicit selectors (caps tracked, allows listed untracked, rejects unlisted) ──
+
+    function test_case3_explicitSelectors_capsTrackedAllowsListedUntracked() public {
+        SessionPolicy.TokenLimit[] memory limits = _limit(address(token), 500e18, WEEK);
+        SessionPolicy.CallScope[] memory scopes = _scope(address(token), _sel2(TRANSFER, MINT));
+        bytes32 actorId = _install(_config(limits, scopes));
+
+        // Listed untracked selector: allowed, uncapped.
+        _execute(actorId, address(token), 0, abi.encodeCall(SessionMockERC20.mint, (bob, 1e18)));
+        // Listed tracked selector: capped.
+        _execute(actorId, address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 100e18)));
+
+        // Unlisted selector (approve) is rejected — the explicit list replaces the Case-1 default.
+        _mockActingActor(actorId);
+        vm.expectRevert(abi.encodeWithSelector(SessionPolicy.SelectorNotAllowed.selector, address(token), APPROVE));
+        vm.prank(account);
+        manager.execute(lastBinding, _action(address(token), 0, abi.encodeCall(SessionMockERC20.approve, (bob, 1))));
+    }
+
+    // ── Recipient gating (on the TokenLimit) ──
 
     function test_recipient_allowsListedRecipient() public {
-        address[] memory recipients = new address[](1);
-        recipients[0] = bob;
-        bytes32 actorId = _install(_config(_noLimits(), _erc20Scope(address(token), recipients)));
+        bytes32 actorId = _install(_config(_limitTo(address(token), 500e18, WEEK, _addr1(bob)), _noScopes()));
 
         _execute(actorId, address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 100e18)));
         assertEq(token.balanceOf(bob), 100e18);
     }
 
     function test_recipient_revertsUnlistedRecipient() public {
-        address[] memory recipients = new address[](1);
-        recipients[0] = bob;
-        bytes32 actorId = _install(_config(_noLimits(), _erc20Scope(address(token), recipients)));
+        bytes32 actorId = _install(_config(_limitTo(address(token), 500e18, WEEK, _addr1(bob)), _noScopes()));
 
         _mockActingActor(actorId);
         vm.expectRevert(
@@ -172,19 +237,32 @@ contract SessionPolicyTest is KeystoreTest {
         );
     }
 
+    function test_recipient_appliesToApproveSpender() public {
+        // The recipient list is a merged destination set: it also gates approve's spender.
+        bytes32 actorId = _install(_config(_limitTo(address(token), 500e18, WEEK, _addr1(bob)), _noScopes()));
+
+        _execute(actorId, address(token), 0, abi.encodeCall(SessionMockERC20.approve, (bob, 1e18)));
+        assertEq(token.allowance(account, bob), 1e18);
+
+        _mockActingActor(actorId);
+        vm.expectRevert(
+            abi.encodeWithSelector(SessionPolicy.RecipientNotAllowed.selector, address(token), APPROVE, mallory)
+        );
+        vm.prank(account);
+        manager.execute(lastBinding, _action(address(token), 0, abi.encodeCall(SessionMockERC20.approve, (mallory, 1))));
+    }
+
     // ── Recurring spend limit ──
 
     function test_recurringLimit_withinAllowance() public {
-        bytes32 actorId =
-            _install(_config(_limit(address(token), 500e18, WEEK), _erc20Scope(address(token), _noRecipients())));
+        bytes32 actorId = _install(_config(_limit(address(token), 500e18, WEEK), _noScopes()));
 
         _execute(actorId, address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 300e18)));
         assertEq(token.balanceOf(bob), 300e18);
     }
 
     function test_recurringLimit_revertsWhenExceeded() public {
-        bytes32 actorId =
-            _install(_config(_limit(address(token), 500e18, WEEK), _erc20Scope(address(token), _noRecipients())));
+        bytes32 actorId = _install(_config(_limit(address(token), 500e18, WEEK), _noScopes()));
         _mockActingActor(actorId);
 
         vm.prank(account);
@@ -200,8 +278,7 @@ contract SessionPolicyTest is KeystoreTest {
     }
 
     function test_recurringLimit_resetsNextPeriod() public {
-        bytes32 actorId =
-            _install(_config(_limit(address(token), 500e18, WEEK), _erc20Scope(address(token), _noRecipients())));
+        bytes32 actorId = _install(_config(_limit(address(token), 500e18, WEEK), _noScopes()));
         _mockActingActor(actorId);
 
         vm.prank(account);
@@ -222,8 +299,7 @@ contract SessionPolicyTest is KeystoreTest {
     // ── One-time spend limit (period == 0): cumulative, never resets ──
 
     function test_oneTimeLimit_accumulatesAcrossPeriods() public {
-        bytes32 actorId =
-            _install(_config(_limit(address(token), 500e18, 0), _erc20Scope(address(token), _noRecipients())));
+        bytes32 actorId = _install(_config(_limit(address(token), 500e18, 0), _noScopes()));
         _mockActingActor(actorId);
 
         vm.prank(account);
@@ -243,9 +319,7 @@ contract SessionPolicyTest is KeystoreTest {
     // ── Native-ETH spend limit ──
 
     function test_nativeLimit_consumesCallValue() public {
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = _anySelectorScope(bob);
-        bytes32 actorId = _install(_config(_limit(address(0), 1 ether, WEEK), scopes));
+        bytes32 actorId = _install(_config(_limit(address(0), 1 ether, WEEK), _anySelectorScopes(bob)));
         _mockActingActor(actorId);
 
         vm.prank(account);
@@ -259,9 +333,7 @@ contract SessionPolicyTest is KeystoreTest {
 
     function test_nativeValue_revertsWhenNoNativeLimit() public {
         // Fail closed: a call carrying value with no address(0) TokenLimit is rejected, not forwarded unbounded.
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = _anySelectorScope(bob);
-        bytes32 actorId = _install(_config(_noLimits(), scopes));
+        bytes32 actorId = _install(_config(_noLimits(), _anySelectorScopes(bob)));
         _mockActingActor(actorId);
 
         vm.expectRevert(abi.encodeWithSelector(SessionPolicy.NativeValueNotAllowed.selector, 1 ether));
@@ -271,8 +343,7 @@ contract SessionPolicyTest is KeystoreTest {
 
     function test_nativeValue_erc20LimitDoesNotAuthorizeEth() public {
         // A token cap (e.g. "USDC 5/month") must not implicitly permit ETH: value to any target still fails closed.
-        bytes32 actorId =
-            _install(_config(_limit(address(token), 5e6, WEEK), _erc20Scope(address(token), _noRecipients())));
+        bytes32 actorId = _install(_config(_limit(address(token), 5e6, WEEK), _noScopes()));
         _mockActingActor(actorId);
 
         vm.expectRevert(abi.encodeWithSelector(SessionPolicy.NativeValueNotAllowed.selector, 1 ether));
@@ -284,9 +355,7 @@ contract SessionPolicyTest is KeystoreTest {
 
     function test_nativeValue_unlimitedIdiomPermitsLargeTransfer() public {
         // The documented "unlimited ETH" idiom: a uint160.max cap is never reached in practice.
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = _anySelectorScope(bob);
-        bytes32 actorId = _install(_config(_limit(address(0), type(uint160).max, WEEK), scopes));
+        bytes32 actorId = _install(_config(_limit(address(0), type(uint160).max, WEEK), _anySelectorScopes(bob)));
         _mockActingActor(actorId);
 
         vm.deal(account, 1_000_000 ether);
@@ -295,13 +364,29 @@ contract SessionPolicyTest is KeystoreTest {
         assertEq(bob.balance, 1_000_000 ether);
     }
 
+    function test_nativeRecipient_gatesDestination() public {
+        // A native TokenLimit with recipients gates which target may receive ETH.
+        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](2);
+        scopes[0] = _anySelectorScope(bob);
+        scopes[1] = _anySelectorScope(mallory);
+        bytes32 actorId = _install(_config(_limitTo(address(0), 1 ether, WEEK, _addr1(bob)), scopes));
+        _mockActingActor(actorId);
+
+        // Allowed destination.
+        vm.prank(account);
+        manager.execute(lastBinding, _action(bob, 0.3 ether, ""));
+        assertEq(bob.balance, 0.3 ether);
+
+        // Disallowed destination: mallory is a valid target but not an allowed ETH recipient.
+        vm.expectRevert(abi.encodeWithSelector(SessionPolicy.RecipientNotAllowed.selector, mallory, bytes4(0), mallory));
+        vm.prank(account);
+        manager.execute(lastBinding, _action(mallory, 0.1 ether, ""));
+    }
+
     // ── Atomic multi-dimension enforcement on a single call ──
 
     function test_multiDimension_passesAllAtOnce() public {
-        address[] memory recipients = new address[](1);
-        recipients[0] = bob;
-        bytes32 actorId =
-            _install(_config(_limit(address(token), 500e18, WEEK), _erc20Scope(address(token), recipients)));
+        bytes32 actorId = _install(_config(_limitTo(address(token), 500e18, WEEK, _addr1(bob)), _noScopes()));
 
         // target + selector + recipient + within-limit all satisfied in one call.
         _execute(actorId, address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 250e18)));
@@ -309,10 +394,7 @@ contract SessionPolicyTest is KeystoreTest {
     }
 
     function test_multiDimension_recipientFailsEvenWithinLimit() public {
-        address[] memory recipients = new address[](1);
-        recipients[0] = bob;
-        bytes32 actorId =
-            _install(_config(_limit(address(token), 500e18, WEEK), _erc20Scope(address(token), recipients)));
+        bytes32 actorId = _install(_config(_limitTo(address(token), 500e18, WEEK, _addr1(bob)), _noScopes()));
 
         // Amount is within the limit, but mallory isn't an allowed recipient — the whole call is rejected.
         _mockActingActor(actorId);
@@ -328,8 +410,8 @@ contract SessionPolicyTest is KeystoreTest {
     // ── Worked example ──
     //
     // A single session key that: (1) has full, uncapped access to one ERC-20 (the "MyApp" token); (2) may spend at
-    // most $5 of USDC per month; and (3) may call the MyApp app contract as much as it wants, but only through two
-    // chosen selectors. This is the example documented in the policies README.
+    // most $5 of USDC per month (a TokenLimit-only grant); and (3) may call the MyApp app contract as much as it
+    // wants, but only through two chosen selectors.
 
     function test_workedExample_fullTokenAccess_monthlyUsdc_appSelectors() public {
         // A second ERC-20 plays the role of USDC (6 decimals); `token` (minted in setUp) is the MyApp token.
@@ -338,24 +420,15 @@ contract SessionPolicyTest is KeystoreTest {
         uint40 monthPeriod = 30 days;
         uint256 fiveUsdc = 5e6; // $5 at 6 decimals
 
-        // Spend limits: only USDC ($5/month). The MyApp token has no entry, so its transfers are uncapped.
-        SessionPolicy.TokenLimit[] memory limits = new SessionPolicy.TokenLimit[](1);
-        limits[0] = SessionPolicy.TokenLimit({token: address(usdc), limit: fiveUsdc, period: monthPeriod});
+        // Spend limits: only USDC ($5/month), a Case-1 grant (no CallScope needed for the three spend selectors).
+        SessionPolicy.TokenLimit[] memory limits = _limit(address(usdc), fiveUsdc, monthPeriod);
 
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](3);
+        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](2);
         // (a) MyApp token: full access — any selector, and no spend cap (no TokenLimit above).
         scopes[0] = _anySelectorScope(address(token));
-        // (b) USDC: transfer only, so the $5/month cap can't be sidestepped by another selector.
-        SessionPolicy.SelectorRule[] memory usdcRules = new SessionPolicy.SelectorRule[](1);
-        usdcRules[0] = SessionPolicy.SelectorRule({selector: TRANSFER, recipients: _noRecipients()});
-        scopes[1] = SessionPolicy.CallScope({target: address(usdc), selectorRules: usdcRules});
-        // (c) MyApp app contract: two chosen selectors, unlimited calls.
-        SessionPolicy.SelectorRule[] memory appRules = new SessionPolicy.SelectorRule[](2);
-        appRules[0] =
-            SessionPolicy.SelectorRule({selector: SessionMockTarget.setValue.selector, recipients: _noRecipients()});
-        appRules[1] =
-            SessionPolicy.SelectorRule({selector: SessionMockTarget.other.selector, recipients: _noRecipients()});
-        scopes[2] = SessionPolicy.CallScope({target: address(target), selectorRules: appRules});
+        // (b) MyApp app contract: two chosen selectors, unlimited calls.
+        scopes[1] =
+            _scopeOne(address(target), _sel2(SessionMockTarget.setValue.selector, SessionMockTarget.other.selector));
 
         bytes32 actorId = _install(_config(limits, scopes));
 
@@ -363,7 +436,7 @@ contract SessionPolicyTest is KeystoreTest {
         _execute(actorId, address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 750_000e18)));
         assertEq(token.balanceOf(bob), 750_000e18);
 
-        // USDC within the monthly cap.
+        // USDC within the monthly cap (Case 1: transfer permitted by the limit alone).
         _execute(actorId, address(usdc), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 3e6)));
         assertEq(usdc.balanceOf(bob), 3e6);
 
@@ -397,29 +470,8 @@ contract SessionPolicyTest is KeystoreTest {
 
     // ── Config validation (at execute) ──
 
-    function test_execute_revertsRecipientRuleOnUnsupportedSelector() public {
-        address[] memory recipients = new address[](1);
-        recipients[0] = bob;
-        // A recipient allowlist attached to a non-ERC20 selector cannot be enforced → reject at execute.
-        SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
-        rules[0] = SessionPolicy.SelectorRule({selector: SessionMockTarget.setValue.selector, recipients: recipients});
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = SessionPolicy.CallScope({target: address(target), selectorRules: rules});
-
-        bytes32 actorId = _authorize(_config(_noLimits(), scopes));
-        _mockActingActor(actorId);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                SessionPolicy.RecipientRuleUnsupportedSelector.selector, SessionMockTarget.setValue.selector
-            )
-        );
-        vm.prank(account);
-        manager.execute(lastBinding, _action(address(target), 0, abi.encodeCall(SessionMockTarget.setValue, (1))));
-    }
-
     function test_execute_revertsZeroLimit() public {
-        bytes32 actorId =
-            _authorize(_config(_limit(address(token), 0, WEEK), _erc20Scope(address(token), _noRecipients())));
+        bytes32 actorId = _authorize(_config(_limit(address(token), 0, WEEK), _noScopes()));
         _mockActingActor(actorId);
         vm.expectRevert(abi.encodeWithSelector(SessionPolicy.ZeroLimit.selector, address(token)));
         vm.prank(account);
@@ -428,29 +480,15 @@ contract SessionPolicyTest is KeystoreTest {
 
     function test_execute_revertsLimitTooLarge() public {
         uint256 tooLarge = uint256(type(uint160).max) + 1;
-        bytes32 actorId =
-            _authorize(_config(_limit(address(token), tooLarge, WEEK), _erc20Scope(address(token), _noRecipients())));
+        bytes32 actorId = _authorize(_config(_limit(address(token), tooLarge, WEEK), _noScopes()));
         _mockActingActor(actorId);
         vm.expectRevert(abi.encodeWithSelector(SessionPolicy.LimitTooLarge.selector, address(token), tooLarge));
         vm.prank(account);
         manager.execute(lastBinding, _action(address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 1))));
     }
 
-    function test_execute_revertsAnySelectorOnLimitedToken() public {
-        // A TokenLimit only tracks transfer/transferFrom/approve; anySelector would leave other methods untracked.
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = _anySelectorScope(address(token));
-        bytes32 actorId = _authorize(_config(_limit(address(token), 500e18, WEEK), scopes));
-        _mockActingActor(actorId);
-        vm.expectRevert(abi.encodeWithSelector(SessionPolicy.AnySelectorOnLimitedToken.selector, address(token)));
-        vm.prank(account);
-        manager.execute(lastBinding, _action(address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 1))));
-    }
-
     function test_execute_revertsSelfTarget() public {
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = _anySelectorScope(account);
-        bytes32 actorId = _authorize(_config(_noLimits(), scopes));
+        bytes32 actorId = _authorize(_config(_noLimits(), _anySelectorScopes(account)));
         _mockActingActor(actorId);
         vm.expectRevert(SessionPolicy.SelfTargetNotAllowed.selector);
         vm.prank(account);
@@ -459,9 +497,9 @@ contract SessionPolicyTest is KeystoreTest {
 
     function test_execute_revertsDuplicateTokenLimit() public {
         SessionPolicy.TokenLimit[] memory limits = new SessionPolicy.TokenLimit[](2);
-        limits[0] = SessionPolicy.TokenLimit({token: address(token), limit: 100e18, period: WEEK});
-        limits[1] = SessionPolicy.TokenLimit({token: address(token), limit: 200e18, period: WEEK});
-        bytes32 actorId = _authorize(_config(limits, _erc20Scope(address(token), _noRecipients())));
+        limits[0] = _tl(address(token), 100e18, WEEK, _noRecipients());
+        limits[1] = _tl(address(token), 200e18, WEEK, _noRecipients());
+        bytes32 actorId = _authorize(_config(limits, _noScopes()));
         _mockActingActor(actorId);
         vm.expectRevert(abi.encodeWithSelector(SessionPolicy.DuplicateTokenLimit.selector, address(token)));
         vm.prank(account);
@@ -479,15 +517,11 @@ contract SessionPolicyTest is KeystoreTest {
         manager.execute(lastBinding, _action(address(target), 0, ""));
     }
 
-    function test_execute_revertsDuplicateSelectorRule() public {
-        SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](2);
-        rules[0] = SessionPolicy.SelectorRule({selector: TRANSFER, recipients: _noRecipients()});
-        rules[1] = SessionPolicy.SelectorRule({selector: TRANSFER, recipients: _noRecipients()});
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = SessionPolicy.CallScope({target: address(token), selectorRules: rules});
+    function test_execute_revertsDuplicateSelector() public {
+        SessionPolicy.CallScope[] memory scopes = _scope(address(token), _sel2(TRANSFER, TRANSFER));
         bytes32 actorId = _authorize(_config(_noLimits(), scopes));
         _mockActingActor(actorId);
-        vm.expectRevert(abi.encodeWithSelector(SessionPolicy.DuplicateSelectorRule.selector, address(token), TRANSFER));
+        vm.expectRevert(abi.encodeWithSelector(SessionPolicy.DuplicateSelector.selector, address(token), TRANSFER));
         vm.prank(account);
         manager.execute(lastBinding, _action(address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 1))));
     }
@@ -496,9 +530,7 @@ contract SessionPolicyTest is KeystoreTest {
 
     function test_execute_revertsOnPolicyConfigMismatch() public {
         // Execute must re-supply the exact committed binding; the manager recomputes the commitment.
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = _anySelectorScope(address(target));
-        bytes32 actorId = _authorize(_config(_noLimits(), scopes));
+        bytes32 actorId = _authorize(_config(_noLimits(), _anySelectorScopes(address(target))));
         bytes32 commitment = keystore.getPolicyCommitment(account, actorId);
 
         PolicyManager.PolicyBinding memory wrong = lastBinding;
@@ -515,9 +547,7 @@ contract SessionPolicyTest is KeystoreTest {
 
     function test_execute_revertsMissingSelectorForShortData() public {
         // 1–3 bytes of calldata carry no usable selector, so the call is rejected rather than guessed.
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = _anySelectorScope(address(target));
-        bytes32 actorId = _install(_config(_noLimits(), scopes));
+        bytes32 actorId = _install(_config(_noLimits(), _anySelectorScopes(address(target))));
 
         _mockActingActor(actorId);
         vm.expectRevert(SessionPolicy.MissingSelector.selector);
@@ -528,18 +558,13 @@ contract SessionPolicyTest is KeystoreTest {
     function test_execute_acceptsTransferDespiteDirtySelectorWord() public {
         // ABI-encoded `transfer` packs the selector into the high 4 bytes of the first word and the address into
         // the remainder — so a raw mload into bytes4 leaves dirty low bytes. The mask must still match TRANSFER.
-        bytes32 actorId =
-            _install(_config(_limit(address(token), 500e18, WEEK), _erc20Scope(address(token), _noRecipients())));
+        bytes32 actorId = _install(_config(_limit(address(token), 500e18, WEEK), _noScopes()));
         _execute(actorId, address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 1e18)));
         assertEq(token.balanceOf(bob), 1e18);
     }
 
     function test_execute_revertsTransferFromNotSelf() public {
-        SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
-        rules[0] = SessionPolicy.SelectorRule({selector: TRANSFER_FROM, recipients: _noRecipients()});
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = SessionPolicy.CallScope({target: address(token), selectorRules: rules});
-        bytes32 actorId = _install(_config(_limit(address(token), 500e18, WEEK), scopes));
+        bytes32 actorId = _install(_config(_limit(address(token), 500e18, WEEK), _noScopes()));
 
         // Approve the account to pull from mallory so the ERC-20 call would succeed absent the policy check.
         token.mint(mallory, 100e18);
@@ -555,13 +580,8 @@ contract SessionPolicyTest is KeystoreTest {
     }
 
     function test_execute_allowsApproveDecodesSpender() public {
-        // A limited token pinning approve exercises the APPROVE leg of the ERC-20 decoder (`selector == APPROVE`).
-        SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
-        rules[0] =
-            SessionPolicy.SelectorRule({selector: SessionMockERC20.approve.selector, recipients: _noRecipients()});
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = SessionPolicy.CallScope({target: address(token), selectorRules: rules});
-        bytes32 actorId = _install(_config(_limit(address(token), 500e18, WEEK), scopes));
+        // A Case-1 limited token exercises the APPROVE leg of the ERC-20 decoder (`selector == APPROVE`).
+        bytes32 actorId = _install(_config(_limit(address(token), 500e18, WEEK), _noScopes()));
 
         _execute(actorId, address(token), 0, abi.encodeCall(SessionMockERC20.approve, (bob, 1e18)));
         assertEq(token.allowance(account, bob), 1e18);
@@ -570,12 +590,8 @@ contract SessionPolicyTest is KeystoreTest {
     function test_execute_allowsSelfTransferFromDecodesAmount() public {
         // A self-transferFrom (from == account) with a token limit passes the TransferFromNotSelf gate and reaches
         // the ERC-20 amount decode — the else (transferFrom) leg of _decodeErc20 — then consumes the decoded amount.
-        SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
-        rules[0] = SessionPolicy.SelectorRule({selector: TRANSFER_FROM, recipients: _noRecipients()});
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = SessionPolicy.CallScope({target: address(token), selectorRules: rules});
         (bytes32 actorId, bytes32 commitment) =
-            _authorizeWithCommitment(_config(_limit(address(token), 500e18, WEEK), scopes));
+            _authorizeWithCommitment(_config(_limit(address(token), 500e18, WEEK), _noScopes()));
 
         // Fund the account and let it pull from itself so the underlying transferFrom succeeds.
         token.mint(account, 100e18);
@@ -585,13 +601,7 @@ contract SessionPolicyTest is KeystoreTest {
         _execute(actorId, address(token), 0, abi.encodeCall(SessionMockERC20.transferFrom, (account, bob, 10e18)));
 
         // The decoded amount was consumed against the token cap, proving the transferFrom decode leg ran.
-        assertEq(
-            policy.getCurrentSpend(
-                commitment, SessionPolicy.TokenLimit({token: address(token), limit: 500e18, period: WEEK})
-            )
-            .spend,
-            10e18
-        );
+        assertEq(policy.getCurrentSpend(commitment, _tl(address(token), 500e18, WEEK, _noRecipients())).spend, 10e18);
         assertEq(token.balanceOf(bob), 10e18);
     }
 
@@ -602,8 +612,7 @@ contract SessionPolicyTest is KeystoreTest {
         SessionPolicyHarness harness = new SessionPolicyHarness(address(manager));
         uint256 tooLarge = uint256(type(uint160).max) + 1;
 
-        SessionPolicy.TokenLimit[] memory limits = new SessionPolicy.TokenLimit[](1);
-        limits[0] = SessionPolicy.TokenLimit({token: address(token), limit: tooLarge, period: WEEK});
+        SessionPolicy.TokenLimit[] memory limits = _limit(address(token), tooLarge, WEEK);
         SessionPolicy.Config memory cfg =
             SessionPolicy.Config({tokenLimits: limits, callScopes: new SessionPolicy.CallScope[](0)});
 
@@ -612,10 +621,8 @@ contract SessionPolicyTest is KeystoreTest {
     }
 
     function test_execute_allowsEmptyCalldata() public {
-        // 0 bytes of calldata is a plain value call: it skips selector gating entirely.
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = _anySelectorScope(bob);
-        bytes32 actorId = _install(_config(_noLimits(), scopes));
+        // 0 bytes of calldata is a plain value call against a CallScope target: it skips selector gating entirely.
+        bytes32 actorId = _install(_config(_noLimits(), _anySelectorScopes(bob)));
 
         _execute(actorId, bob, 0, "");
     }
@@ -624,25 +631,17 @@ contract SessionPolicyTest is KeystoreTest {
 
     function test_execute_zeroAmountTransferSkipsSpend() public {
         // A zero-value transfer on a limited token must not touch spend accounting (the library rejects zero spends).
-        (bytes32 actorId, bytes32 commitment) = _authorizeWithCommitment(
-            _config(_limit(address(token), 500e18, WEEK), _erc20Scope(address(token), _noRecipients()))
-        );
+        (bytes32 actorId, bytes32 commitment) =
+            _authorizeWithCommitment(_config(_limit(address(token), 500e18, WEEK), _noScopes()));
 
         _execute(actorId, address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 0)));
 
-        assertEq(
-            policy.getCurrentSpend(
-                commitment, SessionPolicy.TokenLimit({token: address(token), limit: 500e18, period: WEEK})
-            )
-            .spend,
-            0
-        );
+        assertEq(policy.getCurrentSpend(commitment, _tl(address(token), 500e18, WEEK, _noRecipients())).spend, 0);
     }
 
     function test_execute_revertsMalformedTransfer() public {
-        // A limited token pins the transfer selector; truncated transfer calldata (< 68 bytes) can't be decoded.
-        bytes32 actorId =
-            _install(_config(_limit(address(token), 500e18, WEEK), _erc20Scope(address(token), _noRecipients())));
+        // A Case-1 limited token; truncated transfer calldata (< 68 bytes) can't be decoded.
+        bytes32 actorId = _install(_config(_limit(address(token), 500e18, WEEK), _noScopes()));
 
         _mockActingActor(actorId);
         bytes memory malformed = abi.encodePacked(TRANSFER, bytes32(uint256(uint160(bob)))); // selector + 32 = 36 bytes
@@ -652,12 +651,8 @@ contract SessionPolicyTest is KeystoreTest {
     }
 
     function test_execute_revertsMalformedTransferFrom() public {
-        // Exercises the transferFrom decode branch: a pinned transferFrom selector with calldata < 100 bytes.
-        SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
-        rules[0] = SessionPolicy.SelectorRule({selector: TRANSFER_FROM, recipients: _noRecipients()});
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = SessionPolicy.CallScope({target: address(token), selectorRules: rules});
-        bytes32 actorId = _install(_config(_limit(address(token), 500e18, WEEK), scopes));
+        // Exercises the transferFrom decode branch: a Case-1 limited token with calldata < 100 bytes.
+        bytes32 actorId = _install(_config(_limit(address(token), 500e18, WEEK), _noScopes()));
 
         _mockActingActor(actorId);
         bytes memory malformed = abi.encodePacked(TRANSFER_FROM, bytes32(0), bytes32(0)); // selector + 64 = 68 < 100
@@ -668,14 +663,12 @@ contract SessionPolicyTest is KeystoreTest {
 
     // ── Views ──
 
-    function test_views_reflectCommittedErc20Scope() public {
-        address[] memory recipients = new address[](1);
-        recipients[0] = bob;
-        (, bytes32 commitment) = _authorizeWithCommitment(
-            _config(_limit(address(token), 500e18, WEEK), _erc20Scope(address(token), recipients))
-        );
+    function test_views_reflectCommittedLimitedToken() public {
+        (, bytes32 commitment) =
+            _authorizeWithCommitment(_config(_limitTo(address(token), 500e18, WEEK, _addr1(bob)), _noScopes()));
         SessionPolicy.Config memory cfg = abi.decode(lastBinding.policyConfig, (SessionPolicy.Config));
 
+        // A TokenLimit-only token is callable (Case 1), reporting anySelector == false.
         (bool allowed, bool anySelector) = policy.isTargetAllowed(cfg, address(token));
         assertTrue(allowed);
         assertFalse(anySelector);
@@ -684,6 +677,10 @@ contract SessionPolicyTest is KeystoreTest {
         assertTrue(selAllowed);
         assertTrue(recipientBound);
 
+        // A non-tracked selector is not allowed on a Case-1 token.
+        (bool mintAllowed,) = policy.getSelectorRule(cfg, address(token), MINT);
+        assertFalse(mintAllowed);
+
         assertTrue(policy.isRecipientAllowed(cfg, address(token), TRANSFER, bob));
         assertFalse(policy.isRecipientAllowed(cfg, address(token), TRANSFER, mallory));
 
@@ -691,6 +688,9 @@ contract SessionPolicyTest is KeystoreTest {
         assertTrue(set);
         assertEq(allowance, 500e18);
         assertEq(period, WEEK);
+
+        assertEq(policy.getTokenRecipients(cfg, address(token)).length, 1);
+        assertEq(policy.getTokenRecipients(cfg, address(token))[0], bob);
 
         assertEq(policy.getCurrentSpend(commitment, cfg.tokenLimits[0]).spend, 0);
     }
@@ -703,7 +703,7 @@ contract SessionPolicyTest is KeystoreTest {
         assertTrue(allowed);
         assertTrue(anySelector);
 
-        // Unlisted target resolves to the zero scope.
+        // Unlisted target (and not a limited token) resolves to not-allowed.
         (bool otherAllowed,) = policy.isTargetAllowed(cfg, address(token));
         assertFalse(otherAllowed);
 
@@ -713,39 +713,38 @@ contract SessionPolicyTest is KeystoreTest {
         assertEq(period, type(uint40).max);
     }
 
-    /// @notice Exercises the mismatch/empty branches of getSelectorRule and isRecipientAllowed: a non-matching
-    ///         target is skipped, an any-selector scope resolves without a recipient binding, an unknown selector
-    ///         resolves to (false,false), a non-matching rule is skipped, and an empty recipient list allows anyone.
+    /// @notice Exercises the mismatch/empty branches of the views: a non-matching target is skipped, an any-selector
+    ///         scope resolves without a recipient binding, an unknown selector on an explicit scope resolves to
+    ///         (false,false), and recipient gating comes from the TokenLimit.
     function test_views_selectorAndRecipientEdges() public view {
-        address[] memory bobOnly = new address[](1);
-        bobOnly[0] = bob;
-
-        // token scope: TRANSFER bound to [bob]; OTHER open to anyone (empty recipient list).
-        SessionPolicy.SelectorRule[] memory tokenRules = new SessionPolicy.SelectorRule[](2);
-        tokenRules[0] = SessionPolicy.SelectorRule({selector: TRANSFER, recipients: bobOnly});
-        tokenRules[1] = SessionPolicy.SelectorRule({selector: OTHER_SELECTOR, recipients: _noRecipients()});
+        SessionPolicy.TokenLimit[] memory limits = _limitTo(address(token), 500e18, WEEK, _addr1(bob));
 
         SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](2);
-        scopes[0] = SessionPolicy.CallScope({target: address(token), selectorRules: tokenRules});
-        scopes[1] = _anySelectorScope(address(target)); // any selector (empty rules)
+        scopes[0] = _scopeOne(address(token), _sel1(TRANSFER)); // Case 3: explicit selectors on the limited token
+        scopes[1] = _anySelectorScope(address(target)); // any selector (empty list), no limit
 
-        SessionPolicy.Config memory cfg = SessionPolicy.Config({tokenLimits: _noLimits(), callScopes: scopes});
+        SessionPolicy.Config memory cfg = SessionPolicy.Config({tokenLimits: limits, callScopes: scopes});
 
-        // getSelectorRule: querying `target` skips scope[0] (target mismatch) and matches the any-selector scope[1].
+        // getSelectorRule: any-selector scope allows any selector, with no recipient binding (no limit on target).
         (bool allowed, bool recipientBound) = policy.getSelectorRule(cfg, address(target), TRANSFER);
         assertTrue(allowed);
         assertFalse(recipientBound);
 
-        // getSelectorRule: matched target, unknown selector → (false, false).
+        // getSelectorRule: explicit scope on token, unknown selector → (false, false).
         (allowed, recipientBound) = policy.getSelectorRule(cfg, address(token), UNKNOWN_SELECTOR);
         assertFalse(allowed);
         assertFalse(recipientBound);
 
-        // isRecipientAllowed: `target` matches the any-selector scope but has no rules → false.
-        assertFalse(policy.isRecipientAllowed(cfg, address(target), TRANSFER, bob));
+        // getSelectorRule: token/TRANSFER is listed and the limit pins recipients → recipientBound true.
+        (allowed, recipientBound) = policy.getSelectorRule(cfg, address(token), TRANSFER);
+        assertTrue(allowed);
+        assertTrue(recipientBound);
 
-        // isRecipientAllowed: token/OTHER skips the TRANSFER rule then hits the empty-recipients rule → anyone allowed.
+        // isRecipientAllowed: untracked selector is unrestricted.
         assertTrue(policy.isRecipientAllowed(cfg, address(token), OTHER_SELECTOR, mallory));
+
+        // isRecipientAllowed: no limit on target → unrestricted.
+        assertTrue(policy.isRecipientAllowed(cfg, address(target), TRANSFER, mallory));
 
         // isRecipientAllowed: token/TRANSFER is bound to bob only.
         assertTrue(policy.isRecipientAllowed(cfg, address(token), TRANSFER, bob));
@@ -754,9 +753,8 @@ contract SessionPolicyTest is KeystoreTest {
 
     /// @notice getCurrentSpend short-circuits to an empty usage when the queried limit is zero.
     function test_getCurrentSpend_zeroLimitReturnsEmpty() public view {
-        RecurringAllowance.PeriodUsage memory u = policy.getCurrentSpend(
-            bytes32(0), SessionPolicy.TokenLimit({token: address(token), limit: 0, period: WEEK})
-        );
+        RecurringAllowance.PeriodUsage memory u =
+            policy.getCurrentSpend(bytes32(0), _tl(address(token), 0, WEEK, _noRecipients()));
         assertEq(u.start, 0);
         assertEq(u.end, 0);
         assertEq(u.spend, 0);
@@ -766,16 +764,10 @@ contract SessionPolicyTest is KeystoreTest {
     function test_getCurrentSpend_revertsLimitTooLarge() public {
         uint256 tooLarge = uint256(type(uint160).max) + 1;
         vm.expectRevert(abi.encodeWithSelector(SessionPolicy.LimitTooLarge.selector, address(token), tooLarge));
-        policy.getCurrentSpend(
-            bytes32(0), SessionPolicy.TokenLimit({token: address(token), limit: tooLarge, period: WEEK})
-        );
+        policy.getCurrentSpend(bytes32(0), _tl(address(token), tooLarge, WEEK, _noRecipients()));
     }
 
     // ── Helpers ──
-
-    bytes4 internal constant TRANSFER_FROM = bytes4(keccak256("transferFrom(address,address,uint256)"));
-    bytes4 internal constant OTHER_SELECTOR = bytes4(0x12345678);
-    bytes4 internal constant UNKNOWN_SELECTOR = bytes4(0xaabbccdd);
 
     function _anySelectorScopes(address t) internal pure returns (SessionPolicy.CallScope[] memory scopes) {
         scopes = new SessionPolicy.CallScope[](1);
@@ -824,33 +816,71 @@ contract SessionPolicyTest is KeystoreTest {
         return new SessionPolicy.TokenLimit[](0);
     }
 
-    function _limit(address tkn, uint256 lim, uint40 period)
-        internal
-        pure
-        returns (SessionPolicy.TokenLimit[] memory limits)
-    {
-        limits = new SessionPolicy.TokenLimit[](1);
-        limits[0] = SessionPolicy.TokenLimit({token: tkn, limit: lim, period: period});
+    function _noScopes() internal pure returns (SessionPolicy.CallScope[] memory) {
+        return new SessionPolicy.CallScope[](0);
     }
 
     function _noRecipients() internal pure returns (address[] memory) {
         return new address[](0);
     }
 
-    function _anySelectorScope(address t) internal pure returns (SessionPolicy.CallScope memory) {
-        return SessionPolicy.CallScope({target: t, selectorRules: new SessionPolicy.SelectorRule[](0)});
+    function _addr1(address a) internal pure returns (address[] memory arr) {
+        arr = new address[](1);
+        arr[0] = a;
     }
 
-    /// @dev A single call scope on `tkn` allowing ERC-20 `transfer` with the given recipient allowlist.
-    function _erc20Scope(address tkn, address[] memory recipients)
+    function _tl(address tkn, uint256 lim, uint40 period, address[] memory recipients)
+        internal
+        pure
+        returns (SessionPolicy.TokenLimit memory)
+    {
+        return SessionPolicy.TokenLimit({token: tkn, limit: lim, period: period, recipients: recipients});
+    }
+
+    function _limit(address tkn, uint256 lim, uint40 period)
+        internal
+        pure
+        returns (SessionPolicy.TokenLimit[] memory limits)
+    {
+        limits = new SessionPolicy.TokenLimit[](1);
+        limits[0] = _tl(tkn, lim, period, _noRecipients());
+    }
+
+    function _limitTo(address tkn, uint256 lim, uint40 period, address[] memory recipients)
+        internal
+        pure
+        returns (SessionPolicy.TokenLimit[] memory limits)
+    {
+        limits = new SessionPolicy.TokenLimit[](1);
+        limits[0] = _tl(tkn, lim, period, recipients);
+    }
+
+    function _sel1(bytes4 a) internal pure returns (bytes4[] memory s) {
+        s = new bytes4[](1);
+        s[0] = a;
+    }
+
+    function _sel2(bytes4 a, bytes4 b) internal pure returns (bytes4[] memory s) {
+        s = new bytes4[](2);
+        s[0] = a;
+        s[1] = b;
+    }
+
+    function _anySelectorScope(address t) internal pure returns (SessionPolicy.CallScope memory) {
+        return SessionPolicy.CallScope({target: t, selectors: new bytes4[](0)});
+    }
+
+    function _scopeOne(address t, bytes4[] memory selectors) internal pure returns (SessionPolicy.CallScope memory) {
+        return SessionPolicy.CallScope({target: t, selectors: selectors});
+    }
+
+    function _scope(address t, bytes4[] memory selectors)
         internal
         pure
         returns (SessionPolicy.CallScope[] memory scopes)
     {
-        SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
-        rules[0] = SessionPolicy.SelectorRule({selector: TRANSFER, recipients: recipients});
         scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = SessionPolicy.CallScope({target: tkn, selectorRules: rules});
+        scopes[0] = _scopeOne(t, selectors);
     }
 
     function _createAccountWithRootAndManager() internal returns (address) {
@@ -931,6 +961,7 @@ contract SessionPolicyHarness is SessionPolicy {
         pure
         returns (bool set, uint160 allowance, uint40 period)
     {
-        return _findTokenLimit(config, token);
+        (bool s, SessionPolicy.TokenLimit memory tl) = _findTokenLimit(config, token);
+        return (s, uint160(tl.limit), tl.period == 0 ? ONE_TIME_PERIOD : tl.period);
     }
 }

--- a/test/unit/policies/SessionPolicyGas.t.sol
+++ b/test/unit/policies/SessionPolicyGas.t.sol
@@ -76,33 +76,18 @@ contract SessionPolicyGasTest is KeystoreTest {
     }
 
     function test_gas_execute_selectorGating() public {
-        SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
-        rules[0] =
-            SessionPolicy.SelectorRule({selector: SessionMockTarget.setValue.selector, recipients: _noRecipients()});
-        SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = SessionPolicy.CallScope({target: address(target), selectorRules: rules});
-        bytes32 actorId = _install(_config(_noLimits(), scopes));
+        bytes32 actorId =
+            _install(_config(_noLimits(), _selScope(address(target), SessionMockTarget.setValue.selector)));
 
         bytes memory ed = _action(address(target), 0, abi.encodeCall(SessionMockTarget.setValue, (7)));
         emit log_named_uint("execute: target + selector gating, cold", _measureCold(actorId, ed));
         emit log_named_uint("execute: target + selector gating, warm", _measure(actorId, ed));
     }
 
-    function test_gas_execute_recipientGating_noLimit() public {
-        address[] memory recipients = new address[](1);
-        recipients[0] = bob;
-        bytes32 actorId = _install(_config(_noLimits(), _erc20Scope(address(token), recipients)));
-
-        bytes memory ed = _action(address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 1e18)));
-        emit log_named_uint("execute: target + selector + recipient gating (no limit), cold", _measureCold(actorId, ed));
-        emit log_named_uint("execute: target + selector + recipient gating (no limit), warm", _measure(actorId, ed));
-    }
-
     // ── Execute: spend-limit accounting (the only path with an SSTORE on the happy path) ──
 
     function test_gas_execute_spendLimitOnly() public {
-        bytes32 actorId =
-            _install(_config(_limit(address(token), 500e18, WEEK), _erc20Scope(address(token), _noRecipients())));
+        bytes32 actorId = _install(_config(_limit(address(token), 500e18, WEEK), _noScopes()));
 
         // Cold: first spend allocates the period-usage slot (zero -> non-zero SSTORE).
         bytes memory ed = _action(address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 1e18)));
@@ -112,10 +97,7 @@ contract SessionPolicyGasTest is KeystoreTest {
     }
 
     function test_gas_execute_spendLimit_plus_recipientGating() public {
-        address[] memory recipients = new address[](1);
-        recipients[0] = bob;
-        bytes32 actorId =
-            _install(_config(_limit(address(token), 500e18, WEEK), _erc20Scope(address(token), recipients)));
+        bytes32 actorId = _install(_config(_limitTo(address(token), 500e18, WEEK, _addr1(bob)), _noScopes()));
 
         bytes memory ed = _action(address(token), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 1e18)));
         emit log_named_uint("execute: spend limit + recipient gating, cold", _measureCold(actorId, ed));
@@ -156,13 +138,7 @@ contract SessionPolicyGasTest is KeystoreTest {
         }
         {
             SessionMockTarget t = new SessionMockTarget();
-            SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
-            rules[0] = SessionPolicy.SelectorRule({
-                selector: SessionMockTarget.setValue.selector, recipients: _noRecipients()
-            });
-            SessionPolicy.CallScope[] memory scopes = new SessionPolicy.CallScope[](1);
-            scopes[0] = SessionPolicy.CallScope({target: address(t), selectorRules: rules});
-            bytes32 a = _install(_config(_noLimits(), scopes));
+            bytes32 a = _install(_config(_noLimits(), _selScope(address(t), SessionMockTarget.setValue.selector)));
             _row(
                 "target + selector gating            ",
                 a,
@@ -170,19 +146,8 @@ contract SessionPolicyGasTest is KeystoreTest {
             );
         }
         {
-            address[] memory recipients = new address[](1);
-            recipients[0] = bob;
             SessionMockERC20 tk = _freshToken();
-            bytes32 a = _install(_config(_noLimits(), _erc20Scope(address(tk), recipients)));
-            _row(
-                "target + selector + recipient       ",
-                a,
-                _action(address(tk), 0, abi.encodeCall(SessionMockERC20.transfer, (bob, 1e18)))
-            );
-        }
-        {
-            SessionMockERC20 tk = _freshToken();
-            bytes32 a = _install(_config(_limit(address(tk), 500e18, WEEK), _erc20Scope(address(tk), _noRecipients())));
+            bytes32 a = _install(_config(_limit(address(tk), 500e18, WEEK), _noScopes()));
             _row(
                 "spend limit only (transfer)         ",
                 a,
@@ -190,10 +155,8 @@ contract SessionPolicyGasTest is KeystoreTest {
             );
         }
         {
-            address[] memory recipients = new address[](1);
-            recipients[0] = bob;
             SessionMockERC20 tk = _freshToken();
-            bytes32 a = _install(_config(_limit(address(tk), 500e18, WEEK), _erc20Scope(address(tk), recipients)));
+            bytes32 a = _install(_config(_limitTo(address(tk), 500e18, WEEK, _addr1(bob)), _noScopes()));
             _row(
                 "spend limit + recipient gating      ",
                 a,
@@ -301,32 +264,46 @@ contract SessionPolicyGasTest is KeystoreTest {
         return new SessionPolicy.TokenLimit[](0);
     }
 
+    function _noScopes() internal pure returns (SessionPolicy.CallScope[] memory) {
+        return new SessionPolicy.CallScope[](0);
+    }
+
     function _limit(address tkn, uint256 lim, uint40 period)
         internal
         pure
         returns (SessionPolicy.TokenLimit[] memory limits)
     {
         limits = new SessionPolicy.TokenLimit[](1);
-        limits[0] = SessionPolicy.TokenLimit({token: tkn, limit: lim, period: period});
+        limits[0] = SessionPolicy.TokenLimit({token: tkn, limit: lim, period: period, recipients: _noRecipients()});
+    }
+
+    function _limitTo(address tkn, uint256 lim, uint40 period, address[] memory recipients)
+        internal
+        pure
+        returns (SessionPolicy.TokenLimit[] memory limits)
+    {
+        limits = new SessionPolicy.TokenLimit[](1);
+        limits[0] = SessionPolicy.TokenLimit({token: tkn, limit: lim, period: period, recipients: recipients});
     }
 
     function _noRecipients() internal pure returns (address[] memory) {
         return new address[](0);
     }
 
-    function _anySelectorScope(address t) internal pure returns (SessionPolicy.CallScope memory) {
-        return SessionPolicy.CallScope({target: t, selectorRules: new SessionPolicy.SelectorRule[](0)});
+    function _addr1(address a) internal pure returns (address[] memory arr) {
+        arr = new address[](1);
+        arr[0] = a;
     }
 
-    function _erc20Scope(address tkn, address[] memory recipients)
-        internal
-        pure
-        returns (SessionPolicy.CallScope[] memory scopes)
-    {
-        SessionPolicy.SelectorRule[] memory rules = new SessionPolicy.SelectorRule[](1);
-        rules[0] = SessionPolicy.SelectorRule({selector: TRANSFER, recipients: recipients});
+    function _anySelectorScope(address t) internal pure returns (SessionPolicy.CallScope memory) {
+        return SessionPolicy.CallScope({target: t, selectors: new bytes4[](0)});
+    }
+
+    function _selScope(address t, bytes4 sel) internal pure returns (SessionPolicy.CallScope[] memory scopes) {
+        bytes4[] memory s = new bytes4[](1);
+        s[0] = sel;
         scopes = new SessionPolicy.CallScope[](1);
-        scopes[0] = SessionPolicy.CallScope({target: tkn, selectorRules: rules});
+        scopes[0] = SessionPolicy.CallScope({target: t, selectors: s});
     }
 
     function _createAccountWithRootAndManager() internal returns (address) {


### PR DESCRIPTION
## Summary

Reworks `SessionPolicy` so a **`TokenLimit` is the primary spend grant** — adding one both caps a token and, on its own, authorizes the key to move it via the three tracked ERC-20 selectors (`transfer`/`transferFrom`/`approve`). Access resolves per call:

- **Case 1 — `TokenLimit` alone** (no `CallScope`): only the three tracked selectors, each debited from the cap and gated by the limit's `recipients`.
- **Case 2 — `TokenLimit` + `CallScope{}` (anySelector)**: any selector; tracked ones stay debited/recipient-gated, untracked ones are allowed but uncapped — an explicit opt-in. This **replaces** the old hard `AnySelectorOnLimitedToken` reject.
- **Case 3 — `TokenLimit` + explicit `CallScope`**: exactly the listed selectors; the explicit list replaces the Case-1 default.

Also **decouples recipient gating from selectors**: the recipient allowlist now lives on `TokenLimit` (`address[] recipients`) and gates the decoded ERC-20 destination (`to`/`spender` — a deliberate merge) or, for native ETH, the call `target`. `CallScope.selectorRules` becomes a plain `bytes4[] selectors` list.

### Behavioral / API changes (breaking config shape)
- `TokenLimit` gains `address[] recipients`; `getCurrentSpend(TokenLimit)` calldata shape changes accordingly.
- `CallScope { address target; bytes4[] selectors; }` (was `SelectorRule[] selectorRules`); `SelectorRule` struct removed.
- Empty calldata (bare value transfer) now requires an explicit `CallScope`; a `TokenLimit`-only target is strictly for the three spend selectors.
- Removed now-unreachable errors `RecipientRuleUnsupportedSelector` and `AnySelectorOnLimitedToken`; renamed `DuplicateSelectorRule` → `DuplicateSelector`; added `getTokenRecipients` view.

Updates unit/gas/external-caller tests, the README worked example, and NatSpec to the new model.

## Test plan
- [x] `forge build`
- [x] `forge test` — 392 passed, 0 failed
- [x] Policy suites (unit/gas/external-caller/manager) green
- [x] `forge fmt` clean
- [ ] Reviewer sanity-check the Case-2 security-posture change (untracked selectors on a limited token now reachable via explicit opt-in) and the approve/transfer recipient merge