### PR TITLE
feat(Keystore): emit ExpiredActorChangeSkipped on JIT expired-grant skip

### DIFF
--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -249,6 +249,19 @@ contract Keystore {
     /// @param actorId The revoked actor's identifier.
     event ActorRevoked(address indexed account, bytes32 indexed actorId);
 
+    /// @notice Emitted when an unsequenced (JIT) AuthorizeActor change is skipped because its grant is already
+    ///         expired, so no write is made.
+    ///
+    /// @dev A JIT batch consumes no sequence counter and stays replayable, so an already-expired grant is skipped
+    ///      rather than written — preventing a lapsed replay from clobbering a since-renewed slot. The skip is
+    ///      per-change: live siblings in the same batch still apply. Sequenced batches never skip (they install an
+    ///      expired grant inert instead), so they never emit this.
+    ///
+    /// @param account The account the change targeted.
+    /// @param actorId The actor whose already-expired grant was skipped.
+    /// @param expiry The skipped grant's expiry timestamp.
+    event ExpiredActorChangeSkipped(address indexed account, bytes32 indexed actorId, uint48 expiry);
+
     /// @notice Emitted when a new account is created.
     ///
     /// @param account The created account address.
@@ -689,9 +702,9 @@ contract Keystore {
     ///      acceptance check — but it does change what the write does, per channel:
     ///
     ///      For an already-expired grant (non-zero `cfg.expiry <= block.timestamp`):
-    ///      - Unsequenced (JIT, `isUnsequenced`): SKIPPED (no write). A JIT batch consumes no counter and stays
-    ///        replayable, so writing a lapsed grant would let an old replay clobber a since-renewed lease. Skip is
-    ///        per-change, so live siblings in the same batch still apply.
+    ///      - Unsequenced (JIT, `isUnsequenced`): SKIPPED (no write; emits {ExpiredActorChangeSkipped}). A JIT batch
+    ///        consumes no counter and stays replayable, so writing a lapsed grant would let an old replay clobber a
+    ///        since-renewed lease. Skip is per-change, so live siblings in the same batch still apply.
     ///      - Sequenced (local or multichain): written anyway but INERT — it authenticates as ActorExpired ({_isExpired})
     ///        so it grants no authority. Sequenced batches are single-consume (not replayable), so there is no clobber
     ///        risk; the write is still made so replayed history stays consistent (a later RevokeActor finds the slot) and
@@ -710,6 +723,7 @@ contract Keystore {
         // (which folds in the zero = no-expiry sentinel) so the expiry boundary matches authentication exactly: a grant
         // with `expiry == block.timestamp` is still live for that second and installs, rather than being dropped here.
         if (isUnsequenced && _isExpired(cfg.expiry)) {
+            emit ExpiredActorChangeSkipped(account, actorId, cfg.expiry);
             return;
         }
 

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -130,11 +130,10 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
 
         // No revert despite the already-expired grant. Use a strictly-past expiry: an actor is expired only once
         // block.timestamp > expiry (see {_isExpired}), so `expiry == now` is still live and would install.
-        _applyUnsequenced(
-            pk,
-            account,
-            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, uint48(block.timestamp - 1), ""))
-        );
+        uint48 expiry = uint48(block.timestamp - 1);
+        vm.expectEmit(true, true, false, true, address(keystore));
+        emit Keystore.ExpiredActorChangeSkipped(account, ACTOR_A, expiry);
+        _applyUnsequenced(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, expiry, "")));
 
         // Skipped, not installed inert: the slot was never written, so an explicit revoke finds nothing.
         assertFalse(_isActor(account, ACTOR_A));
@@ -149,10 +148,14 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
 
+        uint48 expiredAt = uint48(block.timestamp - 1);
         Keystore.AccountChange[] memory changes = new Keystore.AccountChange[](2);
-        changes[0] = _authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, uint48(block.timestamp - 1), ""); // expired
+        changes[0] = _authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, expiredAt, ""); // expired
         changes[1] = _authorizeChange(ACTOR_B, address(k1Authenticator), SENDER, _future(1 days), ""); // live
 
+        // Only the expired change emits the skip event (per-change, not whole-batch).
+        vm.expectEmit(true, true, false, true, address(keystore));
+        emit Keystore.ExpiredActorChangeSkipped(account, ACTOR_A, expiredAt);
         _applyUnsequenced(pk, account, changes);
 
         assertFalse(_isActor(account, ACTOR_A)); // expired -> skipped


### PR DESCRIPTION
## Summary

Emit a new `ExpiredActorChangeSkipped(account, actorId, expiry)` event when an **unsequenced (JIT) `AuthorizeActor`** change is skipped because its grant is already expired.

Today that skip is entirely silent — `_applyAuthorize` returns early with no revert and no write — so there's no on-chain signal that a lapsed, replayable grant was dropped. The event gives indexers/wallets that signal **without changing any control flow**. Sequenced batches (which install an expired grant *inert* rather than skipping) never hit this path and never emit it; the skip remains per-change, so live siblings in the same batch still apply.

## Changes
- New `ExpiredActorChangeSkipped` event (declared next to `ActorRevoked`).
- Emitted in `_applyAuthorize` at the existing `isUnsequenced && _isExpired(cfg.expiry)` skip branch.
- NatSpec on `_applyAuthorize` notes the emit.
- Event assertions added to the existing unsequenced past-expiry and mixed-expired-and-live tests.

## Test plan
- [x] `forge build`
- [x] `forge test` — 394 passed, 0 failed
- [x] `forge fmt` clean
- [x] No control-flow change (event only)