### PR TITLE
feat(Keystore): per-actor two-step revocation, replacing the account-wide lock [STRAWMAN]

### DIFF
--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -6,7 +6,7 @@ import {IAuthenticator} from "./interfaces/IAuthenticator.sol";
 import {Scopes} from "./libraries/Scopes.sol";
 
 /// @notice Keystore system contract for EIP-8130.
-///         Manages actor authorization, account creation, change sequencing, and account lock. This contract is
+///         Manages actor authorization, account creation, and change sequencing. This contract is
 ///         also the canonical reference for the EIP-8130 Keystore ABI: its public structs, events,
 ///         and function signatures are the spec surface, and there is no separate interface file to keep in sync.
 ///
@@ -23,12 +23,16 @@ contract Keystore {
         uint32 localSequence; // current local counter; reset to 0 by IncrementLocalEpoch
     }
 
-    /// @notice An actor's authorization: authenticator, expiry, and scope. Field order matches the normative
-    ///         `actor_config` slot layout: authenticator(20) ‖ expiry(6) ‖ scope(2) ‖ reserved(4).
+    /// @notice An actor's authorization: authenticator, revokeDelayOrExpiry, scope, and pendingRevoke. Field order
+    ///         matches the normative `actor_config` slot layout:
+    ///         authenticator(20) ‖ revokeDelayOrExpiry(6) ‖ scope(2) ‖ pendingRevoke(1) ‖ reserved(3).
     struct ActorConfig {
         address authenticator;
-        uint48 expiry; // Unix seconds; 0 = no expiry. Actor invalid once block.timestamp > expiry
+        // Union selected by `pendingRevoke`: false => revoke delay in seconds (actor live, capped by MAX_REVOKE_DELAY);
+        // true => absolute expiry (actor invalid once block.timestamp > this). Pre-scheduled keys set pendingRevoke.
+        uint48 revokeDelayOrExpiry;
         uint16 scope;
+        bool pendingRevoke;
     }
 
     /// @notice Initial actor for account creation and import. Carries its scope and, when scope & Scopes.POLICY is
@@ -43,25 +47,21 @@ contract Keystore {
 
     /// @notice The operation an {AccountChange} applies within an {applySignedAccountChanges} batch.
     ///
-    /// @dev ABI-encodes as uint8. A locked account freezes every op except Unlock and IncrementLocalEpoch, enforced by
-    ///      the guard in {applySignedAccountChanges} (Unlock additionally self-checks it is hard-locked). Lock and
-    ///      Unlock are Local-only and must each be the batch's only op.
+    /// @dev ABI-encodes as uint8. All ops are admin-only and may share a batch.
     enum ChangeType {
         // Authority ops (mutate who can act).
-        AuthorizeActor, // payload: abi.encode(bytes32 actorId, ActorConfig cfg, bytes policyData); cfg.expiry is the granted expiry
+        AuthorizeActor, // payload: abi.encode(bytes32 actorId, ActorConfig cfg, bytes policyData)
         RevokeActor, // payload: abi.encode(bytes32 actorId)
         // Environment ops (mutate the rules ops are checked against).
-        IncrementLocalEpoch, // Either channel; payload: empty (length == 0 enforced)
-        Lock, // Local only; payload: abi.encode(uint16 unlockDelay)
-        Unlock // Local only; payload: empty (length == 0 enforced)
+        IncrementLocalEpoch // Either channel; payload: empty (length == 0 enforced)
     }
 
     /// @notice The replay domain a {SignedAccountChanges} batch is bound to.
     ///
     /// @dev {AccountChangeChannel.Local} binds `block.chainid` and carries the full local
     ///      epoch machinery (see {SignedAccountChanges.sequence}); {AccountChangeChannel.Multichain} binds chainId 0 and keeps a plain
-    ///      monotonic counter with no epochs and no unsequenced (JIT) mode. {ChangeType.Lock} and {ChangeType.Unlock} are rejected on the
-    ///      Multichain channel; {ChangeType.IncrementLocalEpoch} is allowed on either channel.
+    ///      monotonic counter with no epochs and no unsequenced (JIT) mode. {ChangeType.IncrementLocalEpoch} is allowed
+    ///      on either channel.
     enum AccountChangeChannel {
         Local,
         Multichain
@@ -90,19 +90,18 @@ contract Keystore {
         bytes signature;
     }
 
-    /// @notice Per-account packed state: sequences, lock status, and the inline home for the account's k1 self key.
+    /// @notice Per-account packed state: sequences, flags, and the inline home for the account's k1 self key.
     ///
-    /// @dev Packed into a single storage slot; the field layout is normative (nodes read the raw slot for mempool
-    ///      rate-limit tiering, see the EIP's Account Lock section). Field order and widths match the spec's
-    ///      account-state table: multichainSequence, localSequence, localEpoch, flags, lockUnion, defaultEOAExpiry,
-    ///      defaultEOAScope, then 1 reserved byte that MUST stay zero.
+    /// @dev Packed into a single storage slot; the field layout is normative. Field order and widths match the spec's
+    ///      account-state table: multichainSequence, localSequence, localEpoch, flags, defaultEOAExpiry,
+    ///      defaultEOAScope, then 7 reserved bytes that MUST stay zero.
     ///      The local replay counter is stored as two adjacent uint32 fields — `localSequence` (low) then `localEpoch`
     ///      (high) — which occupy the same 8 bytes as, and read identically to, the single `localEpoch(32)||
     ///      localSequence(32)` word committed in a signed batch's `sequence` (see {getChangeSequences}). Storing
     ///      them split keeps the layout size-neutral (still one slot) while removing pack/unpack math from the hot path.
     ///      The combined local word marks local initialization; the multichain counter covers global-only activity.
     ///      {IncrementLocalEpoch} resets the sequence while keeping the combined local word non-zero.
-    ///      See {FLAG_REVOKE_DEFAULT_EOA}, {FLAG_LOCKED}, and {FLAG_UNLOCK_INITIATED} for `flags` and `lockUnion`.
+    ///      See {FLAG_REVOKE_DEFAULT_EOA} for `flags`.
     ///      The defaultEOA* fields are the inline home for the account's own secp256k1 ("self") key, whose actorId is
     ///      `ActorId.fromAddress(account)`. When FLAG_REVOKE_DEFAULT_EOA is unset, a k1 signature recovering to the
     ///      account authenticates with this inline config (all-zero = full owner; non-zero scope/expiry = a
@@ -114,11 +113,10 @@ contract Keystore {
         uint64 multichainSequence; // 8 bytes
         uint32 localSequence; // 4 bytes – low half of the signed local word
         uint32 localEpoch; // 4 bytes – high half of the signed local word
-        uint8 flags; // 1 byte – bitfield: bit 0 CONTRACT_ESTABLISHED, bit 1 REVOKE_DEFAULT_EOA, bit 2 LOCKED, bit 3 UNLOCK_INITIATED
-        uint48 lockUnion; // 6 bytes – union: unlockDelay while UNLOCK_INITIATED clear, else unlocksAt (timestamp)
+        uint8 flags; // 1 byte – bitfield: bit 0 CONTRACT_ESTABLISHED, bit 1 REVOKE_DEFAULT_EOA
         uint48 defaultEOAExpiry; // 6 bytes – inline self k1 expiry (Unix seconds; 0 = no expiry)
         uint16 defaultEOAScope; // 2 bytes – inline self k1 scope (0 = full owner)
-        // 1 byte reserved (remaining slot byte); MUST stay zero.
+        // 7 bytes reserved (remaining slot bytes); MUST stay zero.
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -136,17 +134,17 @@ contract Keystore {
     ///      against another. `chainId` is either the current chain or 0 for a multichain import. Initial actors are
     ///      hashed structurally below.
     bytes32 public constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
-        "ActorInitialization(bytes32 accountId,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
+        "ActorInitialization(bytes32 accountId,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 revokeDelayOrExpiry,uint16 scope,bool pendingRevoke)"
     );
 
     /// @notice Typehash used to structurally hash each Actor within an ActorInitialization import digest.
     bytes32 public constant ACTOR_TYPEHASH = keccak256(
-        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
+        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 revokeDelayOrExpiry,uint16 scope,bool pendingRevoke)"
     );
 
     /// @notice Typehash used to structurally hash an Actor's ActorConfig within an import digest.
     bytes32 public constant ACTOR_CONFIG_TYPEHASH =
-        keccak256("ActorConfig(address authenticator,uint48 expiry,uint16 scope)");
+        keccak256("ActorConfig(address authenticator,uint48 revokeDelayOrExpiry,uint16 scope,bool pendingRevoke)");
 
     /// @notice Typehash binding a signed account-change batch to its account, chainId, and sequence.
     ///
@@ -216,14 +214,9 @@ contract Keystore {
     ///         clears it (re-enabling the inline self, possibly scoped).
     uint8 public constant FLAG_REVOKE_DEFAULT_EOA = 0x02;
 
-    /// @notice AccountState.flags bit (spec `LOCKED`): identifies a lock record. The account is frozen unless an
-    ///         initiated unlock's timestamp has elapsed; expired lock bits remain until a later Lock overwrites them.
-    uint8 public constant FLAG_LOCKED = 0x04;
-
-    /// @notice AccountState.flags bit (spec `UNLOCK_INITIATED`): selects how the packed `lockUnion` field is read.
-    ///         While clear, `lockUnion` holds the configured unlock delay (seconds); while set, it holds unlocksAt
-    ///         (the timestamp at which the pending unlock takes effect). Only meaningful when FLAG_LOCKED is set.
-    uint8 public constant FLAG_UNLOCK_INITIATED = 0x08;
+    /// @notice Upper bound on a live actor's revoke delay ({ActorConfig.revokeDelayOrExpiry} while pendingRevoke is
+    ///         false), so an actor can never be made effectively unremovable (self-brick). Value is a tunable.
+    uint48 public constant MAX_REVOKE_DELAY = 7 days;
 
     /// @dev secp256k1 half-order (n/2). Per EIP-2, only the lower-half `s` value is accepted to reject signature
     ///      malleability. Equal to (secp256k1n - 1) / 2.
@@ -243,11 +236,18 @@ contract Keystore {
     ///        payload is 32 bytes for an ungated actor and 84 bytes for a policy-gated one.
     event ActorAuthorized(address indexed account, bytes32 indexed actorId, bytes actorData);
 
-    /// @notice Emitted when an actor is revoked from an account.
+    /// @notice Emitted when an actor is revoked from an account (immediate; the inline k1 self key).
     ///
     /// @param account The account whose actor was revoked.
     /// @param actorId The revoked actor's identifier.
     event ActorRevoked(address indexed account, bytes32 indexed actorId);
+
+    /// @notice Emitted when a two-step revocation is initiated for an actor; it stays live until `expiry`.
+    ///
+    /// @param account The account whose actor is being revoked.
+    /// @param actorId The actor being revoked.
+    /// @param expiry The timestamp after which the actor is no longer live.
+    event ActorRevokeInitiated(address indexed account, bytes32 indexed actorId, uint48 expiry);
 
     /// @notice Emitted when a new account is created.
     ///
@@ -267,18 +267,6 @@ contract Keystore {
     /// @param target The delegation target.
     event DelegationApplied(address indexed account, address target);
 
-    /// @notice Emitted when an account is locked.
-    ///
-    /// @param account The locked account.
-    /// @param unlockDelay The configured unlock delay in seconds.
-    event AccountLocked(address indexed account, uint16 unlockDelay);
-
-    /// @notice Emitted when an account's unlock is initiated.
-    ///
-    /// @param account The account whose unlock was initiated.
-    /// @param unlocksAt The timestamp at which the account will unlock.
-    event AccountUnlockInitiated(address indexed account, uint48 unlocksAt);
-
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // ERRORS
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -288,9 +276,6 @@ contract Keystore {
 
     /// @notice The account already has EIP-8130 state, so it cannot be created or imported again.
     error AlreadyInitialized();
-
-    /// @notice The operation is not permitted while the account is locked.
-    error AccountIsLocked();
 
     /// @notice The signed chainId is neither 0 (multichain) nor the current chain.
     error InvalidChainId();
@@ -302,12 +287,11 @@ contract Keystore {
     ///         word.
     error InvalidImportSignature();
 
-    /// @notice A lock op carried a zero unlock delay.
-    error ZeroUnlockDelay();
+    /// @notice An AuthorizeActor set a live actor's revoke delay above {MAX_REVOKE_DELAY}.
+    error RevokeDelayTooLong();
 
-    /// @notice An unlock op was requested when the account was not in the hard-locked state (FLAG_LOCKED set,
-    ///         FLAG_UNLOCK_INITIATED clear) — i.e. never locked, or an unlock was already initiated.
-    error NotLocked();
+    /// @notice A RevokeActor targeted an actor whose two-step revocation is already pending.
+    error AlreadyRevoking();
 
     /// @notice The batch's committed local epoch does not match the account's current local epoch: every unlanded
     ///         local signature at a prior epoch is dead. Applies to sequenced and unsequenced Local batches.
@@ -324,11 +308,8 @@ contract Keystore {
     /// @notice The local epoch is at its terminal value and cannot be incremented.
     error EpochSaturated();
 
-    /// @notice A local-only change (Lock or Unlock) was submitted on the Multichain channel.
-    error ChangeRequiresLocalChannel();
-
     /// @notice A change payload did not match the shape required by its ChangeType (e.g. a non-empty payload on
-    ///         IncrementLocalEpoch / Unlock).
+    ///         IncrementLocalEpoch).
     error InvalidChangePayload();
 
     /// @notice A signed batch carried no changes. An empty batch is rejected so it can neither consume a sequence nor
@@ -337,10 +318,6 @@ contract Keystore {
 
     /// @notice An actor authorization targeted the zero actorId, which is not a usable actor identifier.
     error InvalidActorId();
-
-    /// @notice A Lock or Unlock appeared in a batch alongside other changes. Lock/unlock must be the sole change in
-    ///         their batch, so a lock transition can never interleave with actor changes in the same signed batch.
-    error LockChangeMustBeStandalone();
 
     /// @notice Defensive guard for an unhandled ChangeType in the apply loop. Unreachable in practice — out-of-range
     ///         wire values are rejected by the enum decoder during ABI-decoding — but forces any future ChangeType to
@@ -420,15 +397,6 @@ contract Keystore {
     // MODIFIERS
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice Modifier to check if an account is unlocked.
-    /// @dev Reverts with AccountIsLocked when the account is locked.
-    modifier onlyUnlocked(address account) {
-        if (_isLocked(account)) {
-            revert AccountIsLocked();
-        }
-        _;
-    }
-
     /// @notice Modifier to check if an account is not the zero address.
     /// @dev Reverts with ZeroAccount when the account is the zero address.
     modifier nonZeroAccount(address account) {
@@ -503,7 +471,6 @@ contract Keystore {
     ///         ERC-1271 signature over a typed import digest. The implicit default-EOA key is disabled after import.
     ///
     /// @dev Uses a custom (non-EIP-712) digest to partially mitigate eth_signTypedData phishing.
-    /// @dev Reverts with AccountIsLocked when the account is locked.
     /// @dev Reverts with InvalidChainId when `chainId` is neither 0 (multichain) nor the current chain.
     /// @dev Reverts with AlreadyInitialized when the account already has EIP-8130 state.
     /// @dev Reverts with InvalidImportSignature when the account has no bytecode or its ERC-1271 check does not return
@@ -522,7 +489,7 @@ contract Keystore {
         uint256 chainId,
         InitialActor[] calldata initialActors,
         bytes calldata signature
-    ) external onlyUnlocked(account) {
+    ) external {
         if (chainId != 0 && chainId != block.chainid) {
             revert InvalidChainId();
         }
@@ -553,11 +520,10 @@ contract Keystore {
     }
 
     /// @notice The sole signed-change entry point: applies an ordered, atomic batch of account changes (authorize,
-    ///         revoke, increment-local-epoch, lock, unlock) authenticated by `s.signature`.
+    ///         revoke, increment-local-epoch) authenticated by `s.signature`.
     ///
     /// @dev The governing axiom is Replay: a signed local change is valid only while it could still be validly
-    ///      applied — the committed local epoch must match and grants self-expire (`cfg.expiry > now`, unless
-    ///      `cfg.expiry == 0` which is the never-expiring sentinel).
+    ///      applied — the committed local epoch must match and pre-scheduled grants self-expire.
     ///
     ///      Reduction is NOT contract-enforced. Removing authority durably (revoke, shorter expiry, narrower scope)
     ///      requires retiring the signatures that granted it, which on the local channel means a {IncrementLocalEpoch};
@@ -566,15 +532,12 @@ contract Keystore {
     ///
     ///      Authorization is flat: every signed account change is admin-only, so a single up-front scope check
     ///      (signer scope must be 0) authorizes the whole batch — there is no per-op authorization and no per-op
-    ///      sequencing restriction. Lock and Unlock are Local-only and must also be standalone; IncrementLocalEpoch is
-    ///      allowed on either channel. Other ops may share a non-empty batch.
+    ///      sequencing restriction. IncrementLocalEpoch is allowed on either channel; other ops may share a batch.
     ///
     ///      Pipeline (in order): (1) split the sequence word; (2) reject a stale epoch on Local batches;
     ///      (3) validate/advance the sequence counter BEFORE apply (reentrancy discipline); (4) compute the digest
-    ///      via {_changesDigest}, authenticate, and reject a non-admin signer; (5) iterate
-    ///      changes enforcing channel and lock policy (Lock/Unlock rejected on Multichain; authority ops
-    ///      rejected while the account is locked; Lock/Unlock must be standalone). Anyone may relay — authorization
-    ///      comes entirely from the signature.
+    ///      via {_changesDigest}, authenticate, and reject a non-admin signer; (5) iterate and dispatch changes.
+    ///      Anyone may relay — authorization comes entirely from the signature.
     ///
     /// @param account The account whose configuration is changed.
     /// @param batch The signed batch (channel, ordered changes, sequence word, signature).
@@ -637,28 +600,9 @@ contract Keystore {
             revert UnauthorizedAccountChange();
         }
 
-        // Lock state at batch entry gates every op below. This snapshot is EXACT for the whole batch: the only ops
-        // that mutate lock state (Lock/Unlock) must be standalone, so no op observes a lock state that a peer changed
-        // mid-loop. Relaxing standalone re-opens snapshot staleness — a later authority op could then run against a
-        // lock a Lock earlier in the same batch just set (or a stale-unlocked one).
-        bool locked = _isLocked(account);
-
         uint256 n = batch.changes.length;
         for (uint256 i; i < n; i++) {
             ChangeType t = batch.changes[i].changeType;
-
-            // Preconditions: freeze non-exempt ops on a locked account, and hold Lock/Unlock to a standalone local batch.
-            if (locked && t != ChangeType.Unlock && t != ChangeType.IncrementLocalEpoch) {
-                revert AccountIsLocked();
-            }
-            if (t == ChangeType.Lock || t == ChangeType.Unlock) {
-                if (!isLocal) {
-                    revert ChangeRequiresLocalChannel();
-                }
-                if (n != 1) {
-                    revert LockChangeMustBeStandalone();
-                }
-            }
 
             // Apply: dispatch the op to its handler.
             if (t == ChangeType.AuthorizeActor) {
@@ -667,10 +611,6 @@ contract Keystore {
                 _applyRevoke(account, batch.changes[i].payload);
             } else if (t == ChangeType.IncrementLocalEpoch) {
                 _applyIncrementLocalEpoch(account, batch.changes[i].payload);
-            } else if (t == ChangeType.Lock) {
-                _applyLock(account, batch.changes[i].payload);
-            } else if (t == ChangeType.Unlock) {
-                _applyUnlock(account, batch.changes[i].payload);
             } else {
                 // Unreachable at runtime (the enum decoder rejects out-of-range values). Kept to force any future
                 // ChangeType to be dispatched here rather than silently no-op'ing.
@@ -684,18 +624,20 @@ contract Keystore {
     // ----------------------------------------------------------------------------------------------------------------
 
     /// @dev AuthorizeActor. `payload = abi.encode(bytes32 actorId, ActorConfig cfg, bytes policyData)`. Normally a plain
-    ///      upsert: write `cfg`/`policyData` into the actor's slot, granting authority until `cfg.expiry` (`cfg.expiry
-    ///      == 0` = no expiry). An expired grant never reverts the batch — expiry vs. onchain time is never an
+    ///      upsert: write `cfg`/`policyData` into the actor's slot. A live grant's `cfg.revokeDelayOrExpiry` is a revoke
+    ///      delay bounded by {MAX_REVOKE_DELAY} (else RevokeDelayTooLong); a `pendingRevoke` grant's is an absolute
+    ///      expiry. An expired (pendingRevoke) grant never reverts the batch — expiry vs. onchain time is never an
     ///      acceptance check — but it does change what the write does, per channel:
     ///
-    ///      For an already-expired grant (non-zero `cfg.expiry <= block.timestamp`):
+    ///      For an already-expired pendingRevoke grant (`cfg.revokeDelayOrExpiry <= block.timestamp`):
     ///      - Unsequenced (JIT, `isUnsequenced`): SKIPPED (no write). A JIT batch consumes no counter and stays
     ///        replayable, so writing a lapsed grant would let an old replay clobber a since-renewed lease. Skip is
     ///        per-change, so live siblings in the same batch still apply.
-    ///      - Sequenced (local or multichain): written anyway but INERT — it authenticates as ActorExpired ({_isExpired})
-    ///        so it grants no authority. Sequenced batches are single-consume (not replayable), so there is no clobber
-    ///        risk; the write is still made so replayed history stays consistent (a later RevokeActor finds the slot) and
-    ///        a catching-up chain can step its counter through historical expiring grants to reach the live one.
+    ///      - Sequenced (local or multichain): written anyway but INERT — it authenticates as ActorExpired
+    ///        ({_isActorExpired}) so it grants no authority. Sequenced batches are single-consume (not replayable), so
+    ///        there is no clobber risk; the write is still made so replayed history stays consistent (a later RevokeActor
+    ///        finds the slot) and a catching-up chain can step its counter through historical expiring grants to reach
+    ///        the live one.
     ///
     ///      A JIT grant is last-write-wins on its slot until the epoch is incremented; durable reduction (revoke, shorter
     ///      expiry, narrower scope) is a wallet responsibility — batch it with {IncrementLocalEpoch} to retire outstanding
@@ -704,34 +646,53 @@ contract Keystore {
         (bytes32 actorId, ActorConfig memory cfg, bytes memory policyData) =
             abi.decode(payload, (bytes32, ActorConfig, bytes));
 
+        // Cap a live actor's revoke delay so it can never be made effectively unremovable (self-brick).
+        if (!cfg.pendingRevoke && cfg.revokeDelayOrExpiry > MAX_REVOKE_DELAY) {
+            revert RevokeDelayTooLong();
+        }
+
         // Unsequenced (JIT) only: silently skip an already-expired grant so a lapsed replayable grant can never re-land
         // and clobber its slot — without making the change revert on onchain time. Sequenced batches are single-consume
-        // (no replay) and install an expired grant inert instead — see the doc above. Use the canonical {_isExpired}
-        // (which folds in the zero = no-expiry sentinel) so the expiry boundary matches authentication exactly: a grant
-        // with `expiry == block.timestamp` is still live for that second and installs, rather than being dropped here.
-        if (isUnsequenced && _isExpired(cfg.expiry)) {
+        // (no replay) and install an expired grant inert instead — see the doc above. {_isActorExpired} treats only a
+        // pendingRevoke grant as expired, and a grant with `expiry == block.timestamp` is still live for that second.
+        if (isUnsequenced && _isActorExpired(cfg)) {
             return;
         }
 
         _authorizeActor(account, actorId, cfg, policyData);
     }
 
-    /// @dev RevokeActor. `payload = abi.encode(bytes32 actorId)`. Clears the actor's config and policy slots (and
-    ///      disables the inline k1 self for the self-actorId), emitting ActorRevoked; reverts UnknownActor if the
-    ///      actor is not currently live. Not durable against an outstanding replayable unsequenced grant for the same
-    ///      actorId (which would re-install into the emptied slot); batch a {IncrementLocalEpoch} for durable teardown.
+    /// @dev RevokeActor. `payload = abi.encode(bytes32 actorId)`. Two-step for an explicit actor: instead of clearing
+    ///      the slot it flips `pendingRevoke` and converts the stored revoke delay into an absolute expiry
+    ///      (`revokeDelayOrExpiry += block.timestamp`), so the actor stays live for `delay` more seconds (the front-run
+    ///      window). The inline k1 self has no delay, so it is revoked immediately, emitting ActorRevoked. Reverts
+    ///      UnknownActor if the actor is not authorized, AlreadyRevoking if a revoke is already pending. Not durable
+    ///      against an outstanding replayable unsequenced grant for the same actorId (which would re-install the slot);
+    ///      batch a {IncrementLocalEpoch} for durable teardown.
     function _applyRevoke(address account, bytes calldata payload) private {
         bytes32 actorId = abi.decode(payload, (bytes32));
         if (!_isAuthorized(account, actorId)) {
             revert UnknownActor();
         }
-        delete _actorConfig[actorId][account];
-        delete _policyCommitment[actorId][account];
-        delete _policyManager[actorId][account];
-        if (actorId == _selfActorId(account)) {
+
+        // Inline k1 self (no _actorConfig entry): no revoke-delay concept, so revoke immediately.
+        if (actorId == _selfActorId(account) && _actorConfig[actorId][account].authenticator < K1_AUTHENTICATOR) {
+            delete _policyCommitment[actorId][account];
+            delete _policyManager[actorId][account];
             _disableInlineSelf(_accountState[account]);
+            emit ActorRevoked(account, actorId);
+            return;
         }
-        emit ActorRevoked(account, actorId);
+
+        // Explicit actor: schedule the revoke; reject a second initiation (it would only push the expiry out).
+        ActorConfig storage cfg = _actorConfig[actorId][account];
+        if (cfg.pendingRevoke) {
+            revert AlreadyRevoking();
+        }
+        uint48 expiry = uint48(block.timestamp + cfg.revokeDelayOrExpiry);
+        cfg.pendingRevoke = true;
+        cfg.revokeDelayOrExpiry = expiry;
+        emit ActorRevokeInitiated(account, actorId, expiry);
     }
 
     /// @dev IncrementLocalEpoch. Empty payload. Strict increment of the local epoch, resetting the local sequence to 0
@@ -749,37 +710,6 @@ contract Keystore {
         }
         st.localEpoch += 1;
         st.localSequence = 0;
-    }
-
-    /// @dev Lock. Local-only; `payload = abi.encode(uint16 unlockDelay)`. Must be standalone. The caller
-    ///      ({applySignedAccountChanges}) guarantees the account is unlocked before dispatch, so this overwrites any
-    ///      residue from an elapsed prior lock unconditionally.
-    function _applyLock(address account, bytes calldata payload) private {
-        AccountState storage st = _accountState[account];
-        uint16 unlockDelay = abi.decode(payload, (uint16));
-        if (unlockDelay == 0) {
-            revert ZeroUnlockDelay();
-        }
-        st.flags = (st.flags | FLAG_LOCKED) & ~FLAG_UNLOCK_INITIATED;
-        st.lockUnion = unlockDelay;
-        emit AccountLocked(account, unlockDelay);
-    }
-
-    /// @dev Unlock. Local-only; empty payload. Only from the hard-locked state with no pending unlock; sets the
-    ///      effective unlock timestamp from the stored delay.
-    function _applyUnlock(address account, bytes calldata payload) private {
-        if (payload.length != 0) {
-            revert InvalidChangePayload();
-        }
-        AccountState storage st = _accountState[account];
-        uint8 flags = st.flags;
-        if (flags & FLAG_LOCKED == 0 || flags & FLAG_UNLOCK_INITIATED != 0) {
-            revert NotLocked();
-        }
-        uint48 unlocksAt = uint48(block.timestamp + uint16(st.lockUnion));
-        st.flags = flags | FLAG_UNLOCK_INITIATED;
-        st.lockUnion = unlocksAt;
-        emit AccountUnlockInitiated(account, unlocksAt);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -962,10 +892,13 @@ contract Keystore {
                 if (_isExpired(st.defaultEOAExpiry)) {
                     return _emptyActorConfig();
                 }
-                return
-                    ActorConfig({
-                        authenticator: K1_AUTHENTICATOR, scope: st.defaultEOAScope, expiry: st.defaultEOAExpiry
-                    });
+                // Inline self expiry is a plain absolute value, surfaced as a pendingRevoke config for readers.
+                return ActorConfig({
+                    authenticator: K1_AUTHENTICATOR,
+                    scope: st.defaultEOAScope,
+                    revokeDelayOrExpiry: st.defaultEOAExpiry,
+                    pendingRevoke: st.defaultEOAExpiry != 0
+                });
             }
         }
 
@@ -973,14 +906,14 @@ contract Keystore {
         // (0x1) or a contract, so `>= K1_AUTHENTICATOR` is the "slot populated" test. An expired entry reports empty.
         ActorConfig memory config = _actorConfig[actorId][account];
         if (config.authenticator >= K1_AUTHENTICATOR) {
-            return _isExpired(config.expiry) ? _emptyActorConfig() : config;
+            return _isActorExpired(config) ? _emptyActorConfig() : config;
         }
         return config;
     }
 
     /// @dev The all-zero ActorConfig returned for a non-live actor (unknown, disabled, or expired).
     function _emptyActorConfig() private pure returns (ActorConfig memory) {
-        return ActorConfig({authenticator: address(0), expiry: 0, scope: 0});
+        return ActorConfig({authenticator: address(0), revokeDelayOrExpiry: 0, scope: 0, pendingRevoke: false});
     }
 
     /// @notice The actor's policy commitment, or 0 when the actor is not live. Gating is by liveness (see
@@ -1013,15 +946,6 @@ contract Keystore {
         });
     }
 
-    /// @notice Returns whether the account is currently locked (configuration frozen).
-    ///
-    /// @param account The account to check.
-    ///
-    /// @return True if the account is locked at the current block timestamp.
-    function isLocked(address account) external view returns (bool) {
-        return _isLocked(account);
-    }
-
     /// @notice Whether the account was keystore-established (createAccount or importAccount) rather than backed by a
     ///         proven address key. See {FLAG_CONTRACT_ESTABLISHED}.
     ///
@@ -1032,56 +956,9 @@ contract Keystore {
         return _accountState[account].flags & FLAG_CONTRACT_ESTABLISHED != 0;
     }
 
-    /// @notice Returns the account's full lock status.
-    ///
-    /// @param account The account to read.
-    ///
-    /// @return locked True if the account is locked at the current block timestamp.
-    /// @return hasInitiatedUnlock True if an unlock has been initiated but not yet elapsed.
-    /// @return unlocksAt The timestamp at which the account unlocks (type(uint48).max while hard-locked).
-    /// @return unlockDelay The configured unlock delay in seconds.
-    function getLockStatus(address account)
-        external
-        view
-        returns (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 unlockDelay)
-    {
-        AccountState storage st = _accountState[account];
-        uint8 flags = st.flags;
-        if (flags & FLAG_LOCKED == 0) {
-            // Unlocked: no lock bits set.
-            return (false, false, 0, 0);
-        }
-        if (flags & FLAG_UNLOCK_INITIATED == 0) {
-            // Hard-locked: lockUnion holds the configured delay; synthesize the max sentinel for unlocksAt.
-            return (true, false, type(uint48).max, uint16(st.lockUnion));
-        }
-        // Unlock initiated: lockUnion holds the effective unlock timestamp. Once it has elapsed the account is
-        // effectively unlocked, so report the clean unlocked state instead of surfacing the stale timestamp. Storage is
-        // not canonicalized (lock reads are non-clearing); a later Lock overwrites the residue.
-        uint48 unlockTime = st.lockUnion;
-        if (block.timestamp >= unlockTime) {
-            return (false, false, 0, 0);
-        }
-        return (true, true, unlockTime, 0);
-    }
-
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // INTERNAL FUNCTIONS
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-
-    /// @dev Returns whether the account's configuration is currently frozen.
-    /// @dev An elapsed unlock reads as unlocked; a later {_applyLock} overwrites the stale lock fields.
-    function _isLocked(address account) private view returns (bool) {
-        AccountState storage st = _accountState[account];
-        uint8 flags = st.flags;
-        if (flags & FLAG_LOCKED == 0) {
-            return false;
-        }
-        if (flags & FLAG_UNLOCK_INITIATED == 0) {
-            return true;
-        }
-        return block.timestamp < st.lockUnion; // pending unlock: frozen until the timestamp elapses
-    }
 
     /// @dev True after bootstrap or any successful signed change. The epoch and multichain counter keep initialization
     ///      observable when the current local sequence is zero.
@@ -1119,8 +996,12 @@ contract Keystore {
             // Initial actors carry scope verbatim (0x00 = unrestricted admin) and never an expiry. When
             // scope & Scopes.POLICY is set, policyData is validated by the same frozen rule as authorizeActor
             // (52 bytes). Authorizing the self-actorId as k1 writes its scope into the inline default-EOA fields.
-            ActorConfig memory config =
-                ActorConfig({authenticator: initialActors[i].authenticator, scope: initialActors[i].scope, expiry: 0});
+            ActorConfig memory config = ActorConfig({
+                authenticator: initialActors[i].authenticator,
+                scope: initialActors[i].scope,
+                revokeDelayOrExpiry: 0,
+                pendingRevoke: false
+            });
             _authorizeActor(account, initialActors[i].actorId, config, initialActors[i].policyData);
         }
     }
@@ -1161,7 +1042,8 @@ contract Keystore {
                 // authorize. Re-enabling a previously revoked self is just the flag clear below.
                 delete _actorConfig[actorId][account]; // mutual exclusion: drop any non-k1 self
                 st.defaultEOAScope = config.scope;
-                st.defaultEOAExpiry = config.expiry;
+                // Inline self stores only an absolute expiry (pendingRevoke); a live grant's delay is not an expiry.
+                st.defaultEOAExpiry = config.pendingRevoke ? config.revokeDelayOrExpiry : 0;
                 st.flags &= ~FLAG_REVOKE_DEFAULT_EOA; // enable the inline self
             } else {
                 // Upsert: overwrite any existing non-k1 self in place.
@@ -1198,8 +1080,8 @@ contract Keystore {
     }
 
     /// @dev Emit ActorAuthorized with a tightly packed payload. The base packs to 32 bytes
-    ///      (authenticator(20) || expiry(6) || scope(2) || reserved(4 zero bytes)); the policy gate
-    ///      (manager(20) || commitment(32), 52 bytes) is appended only when scope & Scopes.POLICY != 0.
+    ///      (authenticator(20) || revokeDelayOrExpiry(6) || scope(2) || pendingRevoke(1) || reserved(3 zero bytes)); the
+    ///      policy gate (manager(20) || commitment(32), 52 bytes) is appended only when scope & Scopes.POLICY != 0.
     function _emitActorAuthorized(
         address account,
         bytes32 actorId,
@@ -1207,9 +1089,18 @@ contract Keystore {
         address manager,
         bytes32 commitment
     ) private {
+        bytes1 pendingRevoke = config.pendingRevoke ? bytes1(0x01) : bytes1(0x00);
         bytes memory actorData = (config.scope & Scopes.POLICY != 0)
-            ? abi.encodePacked(config.authenticator, config.expiry, config.scope, bytes4(0), manager, commitment)
-            : abi.encodePacked(config.authenticator, config.expiry, config.scope, bytes4(0));
+            ? abi.encodePacked(
+                config.authenticator,
+                config.revokeDelayOrExpiry,
+                config.scope,
+                pendingRevoke,
+                bytes3(0),
+                manager,
+                commitment
+            )
+            : abi.encodePacked(config.authenticator, config.revokeDelayOrExpiry, config.scope, pendingRevoke, bytes3(0));
         emit ActorAuthorized(account, actorId, actorData);
     }
 
@@ -1348,11 +1239,13 @@ contract Keystore {
     {
         bytes32[] memory actorHashes = new bytes32[](initialActors.length);
         for (uint256 i; i < initialActors.length; i++) {
-            // Expiry is forced to 0 at import — an actor-provided expiry is never accepted here. policyData is
-            // hashed via keccak256 into the Actor struct hash. The typehash structure matches the importAccount
-            // signature payload in EIP-8130.
+            // revokeDelayOrExpiry and pendingRevoke are forced to (0, false) at import — an actor-provided value is
+            // never accepted here. policyData is hashed via keccak256 into the Actor struct hash. The typehash
+            // structure matches the importAccount signature payload in EIP-8130.
             bytes32 configHash = keccak256(
-                abi.encode(ACTOR_CONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), initialActors[i].scope)
+                abi.encode(
+                    ACTOR_CONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), initialActors[i].scope, false
+                )
             );
             actorHashes[i] = keccak256(
                 abi.encode(ACTOR_TYPEHASH, initialActors[i].actorId, configHash, keccak256(initialActors[i].policyData))
@@ -1428,8 +1321,8 @@ contract Keystore {
         if (config.authenticator != expectedAuthenticator) {
             revert AuthenticatorMismatch();
         }
-        // Expiry is read from the same slot; an expired actor fails authentication. 0 = no expiry.
-        if (_isExpired(config.expiry)) {
+        // An expired (pendingRevoke) actor fails authentication; a live actor never fails here on time.
+        if (_isActorExpired(config)) {
             revert ActorExpired();
         }
         scope = config.scope;
@@ -1483,6 +1376,12 @@ contract Keystore {
     /// @dev True when `expiry` is set (non-zero) and has passed. A zero expiry means no expiry.
     function _isExpired(uint48 expiry) private view returns (bool) {
         return expiry != 0 && block.timestamp > expiry;
+    }
+
+    /// @dev Actor-aware liveness: only a pendingRevoke actor expires, once `block.timestamp > revokeDelayOrExpiry` (the
+    ///      boundary second is still live). A live actor's field is a revoke delay, not an expiry.
+    function _isActorExpired(ActorConfig memory config) private view returns (bool) {
+        return config.pendingRevoke && block.timestamp > config.revokeDelayOrExpiry;
     }
 
     /// @dev Recovers the ECDSA signer from a 65-byte r‖s‖v signature over `hash`, enforcing EIP-2 (low-s only,

--- a/src/accounts/CanonicalHighRatePayerAccount.sol
+++ b/src/accounts/CanonicalHighRatePayerAccount.sol
@@ -10,16 +10,138 @@ import {Call, DefaultAccount} from "./DefaultAccount.sol";
 ///         Intended for accounts that pay gas at a high rate — either sponsoring other txs or
 ///         transacting themselves. While locked, outbound ETH value transfers are blocked — the
 ///         account cannot move its own ETH in the transaction — so the only balance decrease is gas
-///         fees. That predictability lets mempools admit higher rate limits.
+///         fees. That predictability lets mempools admit higher payer rate limits.
 ///
 ///         Deployed behind a plain 45-byte ERC-1167 minimal proxy: each account is an ERC-1167 clone that
 ///         delegatecalls this shared implementation. That fixed delegation (hardcoded implementation
 ///         address) is what allows the account to be admitted as a high-rate payer.
+///
+/// @dev STRAWMAN (pre-PPS): the lock that backs payer-tier balance predictability now lives ENTIRELY in this
+///      allowlisted account implementation — it is no longer a Keystore concept. Keystore's account-wide lock was
+///      removed; sender-tier front-run safety is a per-actor {Keystore.ActorConfig} revoke delay. Because nodes
+///      already have to allowlist this bytecode to grant the payer tier, they can read this contract's own lock slot
+///      (layout documented at {getPayerLockStatus}) — enshrining the ETH-movement restriction in the system contract
+///      is unnecessary. This keeps Keystore agnostic to any one account variant's balance-predictability needs.
+///
+/// @author Coinbase
 contract CanonicalHighRatePayerAccount is DefaultAccount {
+    /// @notice Self-contained payer lock. Packs into a single storage slot (slot 0 of the clone): a node that has
+    ///         allowlisted this implementation reads that slot directly for payer-tier admission.
+    ///
+    /// @dev `unlockDelay` is the configured delay (seconds) applied when an unlock is initiated; `unlocksAt` is the
+    ///      timestamp a pending unlock takes effect. While `unlockInitiated` is clear, `unlocksAt` is unused (0).
+    struct PayerLock {
+        bool locked; // the account is in payer-lock (ETH-out blocked) unless a pending unlock has elapsed
+        bool unlockInitiated; // an unlock has been initiated; `unlocksAt` governs
+        uint32 unlockDelay; // configured unlock delay in seconds
+        uint48 unlocksAt; // timestamp at which the pending unlock takes effect
+    }
+
+    /// @notice The account's payer-lock state (slot 0). Read by nodes for payer-tier rate-limit admission.
+    PayerLock internal _payerLock;
+
     /// @notice A value-bearing call was attempted while the account is locked.
     error AccountLocked();
 
+    /// @notice A lock op carried a zero unlock delay.
+    error ZeroUnlockDelay();
+
+    /// @notice A lock op was attempted while the account was already locked.
+    error AccountAlreadyLocked();
+
+    /// @notice An unlock op was attempted when the account was not hard-locked (never locked, or unlock already
+    ///         initiated).
+    error NotLocked();
+
+    /// @notice Emitted when the account is locked.
+    /// @param unlockDelay The configured unlock delay in seconds.
+    event PayerLocked(uint32 unlockDelay);
+
+    /// @notice Emitted when the account's unlock is initiated.
+    /// @param unlocksAt The timestamp at which the account will unlock.
+    event AccountUnlockInitiated(uint48 unlocksAt);
+
     constructor(address keystore) DefaultAccount(keystore) {}
+
+    // ══════════════════════════════════════════════
+    //  PAYER LOCK
+    // ══════════════════════════════════════════════
+
+    /// @notice Locks the account into payer mode: outbound ETH value transfers are blocked until a later unlock
+    ///         delay elapses. Callable by any authorized caller (the account itself or a TRUSTED_EXECUTOR operator).
+    ///
+    /// @dev STRAWMAN (pre-PPS): authorization reuses {_isAuthorizedCaller}. A production design may want to gate the
+    ///      unlock path to the admin (scope 0) specifically, since unlocking removes the balance-predictability
+    ///      guarantee the payer tier relies on.
+    /// @dev Reverts with ZeroUnlockDelay when `unlockDelay` is 0.
+    /// @dev Reverts with AccountAlreadyLocked when the account is already locked.
+    ///
+    /// @param unlockDelay The delay (seconds) that a later {initiateUnlock} must wait out before ETH transfers resume.
+    function lock(uint32 unlockDelay) external {
+        if (!_isAuthorizedCaller(msg.sender)) revert UnauthorizedCaller();
+        if (unlockDelay == 0) revert ZeroUnlockDelay();
+        if (_isLocked()) revert AccountAlreadyLocked();
+        _payerLock = PayerLock({locked: true, unlockInitiated: false, unlockDelay: unlockDelay, unlocksAt: 0});
+        emit PayerLocked(unlockDelay);
+    }
+
+    /// @notice Initiates an unlock: after the configured delay elapses the account leaves payer mode and can move ETH
+    ///         again. Callable by any authorized caller.
+    ///
+    /// @dev Reverts with NotLocked when the account is not hard-locked (never locked, or an unlock is already pending).
+    function initiateUnlock() external {
+        if (!_isAuthorizedCaller(msg.sender)) revert UnauthorizedCaller();
+        PayerLock storage l = _payerLock;
+        if (!l.locked || l.unlockInitiated) revert NotLocked();
+        uint48 unlocksAt = uint48(block.timestamp + l.unlockDelay);
+        l.unlockInitiated = true;
+        l.unlocksAt = unlocksAt;
+        emit AccountUnlockInitiated(unlocksAt);
+    }
+
+    /// @notice Whether the account is currently in payer lock (ETH-out blocked).
+    function isLocked() external view returns (bool) {
+        return _isLocked();
+    }
+
+    /// @notice The account's full payer-lock status, for nodes deciding payer-tier admission.
+    ///
+    /// @dev A node grants the higher payer tier when `locked && !hasInitiatedUnlock && unlockDelay >= threshold`,
+    ///      mirroring the old Keystore Account Lock read but against this account's own slot 0.
+    ///
+    /// @return locked True if the account is locked at the current block timestamp.
+    /// @return hasInitiatedUnlock True if an unlock has been initiated but not yet elapsed.
+    /// @return unlocksAt The timestamp at which the account unlocks (type(uint48).max while hard-locked).
+    /// @return unlockDelay The configured unlock delay in seconds.
+    function getPayerLockStatus()
+        external
+        view
+        returns (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint32 unlockDelay)
+    {
+        PayerLock storage l = _payerLock;
+        if (!l.locked) {
+            return (false, false, 0, 0);
+        }
+        if (!l.unlockInitiated) {
+            return (true, false, type(uint48).max, l.unlockDelay);
+        }
+        if (block.timestamp >= l.unlocksAt) {
+            return (false, false, 0, 0);
+        }
+        return (true, true, l.unlocksAt, 0);
+    }
+
+    /// @dev True while the account's ETH is frozen: locked, unless a pending unlock's timestamp has elapsed.
+    function _isLocked() internal view returns (bool) {
+        PayerLock storage l = _payerLock;
+        if (!l.locked) return false;
+        if (!l.unlockInitiated) return true;
+        return block.timestamp < l.unlocksAt;
+    }
+
+    // ══════════════════════════════════════════════
+    //  EXECUTION
+    // ══════════════════════════════════════════════
 
     /// @notice Executes a batch of calls from the account, blocking outbound value transfers while locked.
     ///
@@ -31,10 +153,7 @@ contract CanonicalHighRatePayerAccount is DefaultAccount {
     function executeBatch(Call[] calldata calls) external override {
         if (!_isAuthorizedCaller(msg.sender)) revert UnauthorizedCaller();
         for (uint256 i; i < calls.length; i++) {
-            if (calls[i].value > 0) {
-                (bool locked,,,) = KEYSTORE.getLockStatus(address(this));
-                if (locked) revert AccountLocked();
-            }
+            if (calls[i].value > 0 && _isLocked()) revert AccountLocked();
             (bool success, bytes memory result) = calls[i].target.call{value: calls[i].value}(calls[i].data);
             if (!success) LibCall.bubbleUpRevert(result);
         }
@@ -52,10 +171,7 @@ contract CanonicalHighRatePayerAccount is DefaultAccount {
     /// @param data Calldata passed to `target`.
     function execute(address target, uint256 value, bytes calldata data) external override {
         if (!_isAuthorizedCaller(msg.sender)) revert UnauthorizedCaller();
-        if (value > 0) {
-            (bool locked,,,) = KEYSTORE.getLockStatus(address(this));
-            if (locked) revert AccountLocked();
-        }
+        if (value > 0 && _isLocked()) revert AccountLocked();
         (bool success, bytes memory result) = target.call{value: value}(data);
         if (!success) LibCall.bubbleUpRevert(result);
     }

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -136,17 +136,20 @@ contract DefaultAccount is Receiver {
     // ══════════════════════════════════════════════
 
     /// @dev Authorized if `caller` is the account itself, or holds the TRUSTED_EXECUTOR authenticator with an
-    ///      unexpired config AND operational authority. Expiry: 0 means none; a non-zero expiry is enforced so a
-    ///      user-set expiry is honored on the execution path. Scope: driving execution requires operational
-    ///      authority ({Scopes.isOperator}) — the unrestricted admin (scope == 0x00) or a SENDER actor not gated
-    ///      by a policy. A POLICY-gated actor must route every call through its manager, so granting it direct
+    ///      operational scope and a still-live config. Liveness is already resolved by {Keystore.getActorConfig}
+    ///      (which returns the all-zero config for an expired actor), so the explicit expiry check below is
+    ///      defense-in-depth against a stale config. STRAWMAN (pre-PPS): the check is actor-aware — a config only
+    ///      "expires" once it is pending-revoke (`pendingRevoke == true`) and its scheduled timestamp has passed; a
+    ///      live actor's `revokeDelayOrExpiry` is a revoke delay, never an expiry. Scope: driving execution requires
+    ///      operational authority ({Scopes.isOperator}) — the unrestricted admin (scope == 0x00) or a SENDER actor not
+    ///      gated by a policy. A POLICY-gated actor must route every call through its manager, so granting it direct
     ///      executeBatch would bypass that gate; fail closed. Sharing {Scopes.isOperator} keeps the execution and
     ///      signing (ERC-1271) authorization surfaces aligned.
     function _isAuthorizedCaller(address caller) internal view virtual returns (bool) {
         if (caller == address(this)) return true;
         Keystore.ActorConfig memory config = KEYSTORE.getActorConfig(address(this), ActorId.fromAddress(caller));
         if (config.authenticator != TRUSTED_EXECUTOR) return false;
-        if (config.expiry != 0 && block.timestamp > config.expiry) return false;
+        if (config.pendingRevoke && block.timestamp > config.revokeDelayOrExpiry) return false;
         return Scopes.isOperator(config.scope);
     }
 }

--- a/test/lib/KeystoreTest.sol
+++ b/test/lib/KeystoreTest.sol
@@ -141,15 +141,54 @@ contract KeystoreTest is Test {
 
     // ── Change builders ──
 
+    /// @dev STRAWMAN (pre-PPS) back-compat shim. The legacy `expiry` arg is mapped onto the new revoke-delay/expiry
+    ///      union so the bulk of the suite ports unchanged:
+    ///        - `expiry == 0` or `expiry == UNBOUNDED`: a live actor (pendingRevoke == false, revoke delay 0) that
+    ///          stays authorized until an explicit revoke — the old "never expires" behavior.
+    ///        - any other value: a pre-scheduled/expiring session key (pendingRevoke == true) whose absolute expiry is
+    ///          `expiry` — the old "expires at T" behavior.
     function _authorizeChange(bytes32 actorId, address auth, uint16 scope, uint48 expiry, bytes memory policyData)
         internal
         pure
         returns (Keystore.AccountChange memory)
     {
+        bool pendingRevoke = expiry != 0 && expiry != UNBOUNDED;
+        uint48 field = pendingRevoke ? expiry : 0;
+        return _authorizeChangeRaw(actorId, auth, scope, field, pendingRevoke, policyData);
+    }
+
+    /// @dev Authorize a live actor with an explicit revoke delay (pendingRevoke == false). Used by tests exercising
+    ///      the new two-step per-actor revocation.
+    function _authorizeChangeWithDelay(
+        bytes32 actorId,
+        address auth,
+        uint16 scope,
+        uint48 revokeDelay,
+        bytes memory policyData
+    ) internal pure returns (Keystore.AccountChange memory) {
+        return _authorizeChangeRaw(actorId, auth, scope, revokeDelay, false, policyData);
+    }
+
+    /// @dev Fully-explicit AuthorizeActor builder over the new {Keystore.ActorConfig} shape.
+    function _authorizeChangeRaw(
+        bytes32 actorId,
+        address auth,
+        uint16 scope,
+        uint48 revokeDelayOrExpiry,
+        bool pendingRevoke,
+        bytes memory policyData
+    ) internal pure returns (Keystore.AccountChange memory) {
         return Keystore.AccountChange({
             changeType: Keystore.ChangeType.AuthorizeActor,
             payload: abi.encode(
-                actorId, Keystore.ActorConfig({authenticator: auth, scope: scope, expiry: expiry}), policyData
+                actorId,
+                Keystore.ActorConfig({
+                    authenticator: auth,
+                    scope: scope,
+                    revokeDelayOrExpiry: revokeDelayOrExpiry,
+                    pendingRevoke: pendingRevoke
+                }),
+                policyData
             )
         });
     }
@@ -160,14 +199,6 @@ contract KeystoreTest is Test {
 
     function _bumpChange() internal pure returns (Keystore.AccountChange memory) {
         return Keystore.AccountChange({changeType: Keystore.ChangeType.IncrementLocalEpoch, payload: ""});
-    }
-
-    function _lockChange(uint16 unlockDelay) internal pure returns (Keystore.AccountChange memory) {
-        return Keystore.AccountChange({changeType: Keystore.ChangeType.Lock, payload: abi.encode(unlockDelay)});
-    }
-
-    function _unlockChange() internal pure returns (Keystore.AccountChange memory) {
-        return Keystore.AccountChange({changeType: Keystore.ChangeType.Unlock, payload: ""});
     }
 
     /// @dev Wrap a single change into a one-element array.
@@ -282,9 +313,13 @@ contract KeystoreTest is Test {
         _applyLocal(pk, account, _one(_authorizeChange(actorId, authenticator, scope, UNBOUNDED, "")));
     }
 
+    /// @dev STRAWMAN (pre-PPS): revocation is now two-step per-actor. Back-compat callers expect the actor to be gone
+    ///      afterward, so this initiates the revoke (delay 0 for helper-authorized actors → expiry == now) and warps one
+    ///      second past the expiry so the actor is durably non-live, preserving the old "revoke ⇒ gone" contract. The
+    ///      inline k1 self is revoked immediately (no delay), so the warp is harmless there too.
     function _revokeActor(address account, uint256 pk, bytes32 actorId) internal {
-        // A bare (sequenced) revoke lands on its own; durable teardown against outstanding grants is a separate bump.
         _applyLocal(pk, account, _one(_revokeChange(actorId)));
+        vm.warp(block.timestamp + 1);
     }
 
     // Implicit-EOA variants are identical here (the same k1 signer path); kept as named aliases for readability.
@@ -300,23 +335,6 @@ contract KeystoreTest is Test {
         uint16 scope
     ) internal {
         _authorizeActorWithScope(account, pk, actorId, authenticator, scope);
-    }
-
-    // ── Signed lock helpers (re-implemented as environment-op batches) ──
-
-    /// @dev Relay a signed Lock (unlockDelay) authorized by `pk` on the local channel.
-    function _signedLock(uint256 pk, address account, uint16 unlockDelay) internal {
-        _applyLocal(pk, account, _one(_lockChange(unlockDelay)));
-    }
-
-    /// @dev Relay a signed Unlock authorized by `pk` on the local channel.
-    function _signedUnlock(uint256 pk, address account) internal {
-        _applyLocal(pk, account, _one(_unlockChange()));
-    }
-
-    /// @dev Hard-lock `account` via the signed lock path, authorized by its admin owner key `pk`.
-    function _lockAccount(uint256 pk, address account) internal {
-        _signedLock(pk, account, 1 hours);
     }
 
     // ── Direct AccountState storage pokes (for saturation edge cases) ──

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -5,9 +5,10 @@ import {Keystore} from "../../../src/Keystore.sol";
 import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
-/// @notice §10 test matrix for the account-environment surface driven through {applySignedAccountChanges}: the lock
-///         / unlock ops (admin-authorized), the Multichain channel (no epochs, no unsequenced mode), and the
-///         split-layout regression checks.
+/// @notice §10 test matrix for the account-environment surface driven through {applySignedAccountChanges}: the
+///         Multichain channel (no epochs, no unsequenced mode) and the split-layout regression checks. STRAWMAN
+///         (pre-PPS): the account-wide lock/unlock ops were removed from Keystore (payer-tier freezing now lives in
+///         the account implementation), so their tests were removed here; see CanonicalHighRatePayerAccount tests.
 contract AccountEnvironmentTest is KeystoreTest {
     bytes32 constant ACTOR_A = bytes32(uint256(0xA1));
     bytes32 constant ACTOR_B = bytes32(uint256(0xB2));
@@ -28,248 +29,6 @@ contract AccountEnvironmentTest is KeystoreTest {
         vm.assume(account != address(keystore));
         vm.assume(account != VM_ADDRESS);
         vm.assume(account != CONSOLE);
-    }
-
-    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // LOCK / UNLOCK
-    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-
-    /// @notice A lock op hard-locks the account (delay stored, isLocked true, max-sentinel unlocksAt).
-    function test_lock_success_setsHardLock(uint256 pkSeed, uint16 delay) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        delay = uint16(bound(delay, 1, type(uint16).max));
-
-        _signedLock(pk, account, delay);
-
-        (bool locked, bool init, uint48 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
-        assertTrue(locked);
-        assertFalse(init);
-        assertEq(unlocksAt, type(uint48).max);
-        assertEq(storedDelay, delay);
-        assertTrue(keystore.isLocked(account));
-    }
-
-    /// @notice A lock op emits AccountLocked(account, delay).
-    function test_lock_success_emitsAccountLocked(uint256 pkSeed, uint16 delay) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        delay = uint16(bound(delay, 1, type(uint16).max));
-
-        vm.expectEmit(true, false, false, true, address(keystore));
-        emit Keystore.AccountLocked(account, delay);
-        _signedLock(pk, account, delay);
-    }
-
-    /// @notice A lock op with a zero unlock delay reverts ZeroUnlockDelay.
-    function test_lock_revert_zeroDelay(uint256 pkSeed) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-
-        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_lockChange(0)));
-        vm.expectRevert(Keystore.ZeroUnlockDelay.selector);
-        keystore.applySignedAccountChanges(account, s);
-    }
-
-    /// @notice A second lock while already hard-locked reverts AccountIsLocked.
-    function test_lock_revert_whenAlreadyLocked(uint256 pkSeed, uint16 d1, uint16 d2) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        d1 = uint16(bound(d1, 1, type(uint16).max));
-        d2 = uint16(bound(d2, 1, type(uint16).max));
-
-        _signedLock(pk, account, d1);
-        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_lockChange(d2)));
-        vm.expectRevert(Keystore.AccountIsLocked.selector);
-        keystore.applySignedAccountChanges(account, s);
-    }
-
-    /// @notice `[Lock, Unlock, Lock]` reverts LockChangeMustBeStandalone: the standalone rule rejects the multi-op
-    ///         batch on its first (Lock) change. Because a lock transition can never interleave with another change
-    ///         in one batch, a lock/unlock desync is structurally impossible.
-    function test_lock_revert_lockUnlockLockSameBatch(uint256 pkSeed, uint16 d1, uint16 d2) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        d1 = uint16(bound(d1, 1, type(uint16).max));
-        d2 = uint16(bound(d2, 1, type(uint16).max));
-
-        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](3);
-        ch[0] = _lockChange(d1);
-        ch[1] = _unlockChange();
-        ch[2] = _lockChange(d2);
-
-        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
-        vm.expectRevert(Keystore.LockChangeMustBeStandalone.selector);
-        keystore.applySignedAccountChanges(account, s);
-    }
-
-    /// @notice An unlock on a never-locked account reverts NotLocked.
-    function test_unlock_revert_whenNeverLocked(uint256 pkSeed) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-
-        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_unlockChange()));
-        vm.expectRevert(Keystore.NotLocked.selector);
-        keystore.applySignedAccountChanges(account, s);
-    }
-
-    /// @notice An unlock op sets unlocksAt = now + delay, zeroes the stored delay, emits AccountUnlockInitiated.
-    function test_unlock_success_initiates(uint256 pkSeed, uint16 delay, uint256 t0) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        delay = uint16(bound(delay, 1, type(uint16).max));
-        t0 = bound(t0, block.timestamp, 1e12);
-
-        _signedLock(pk, account, delay);
-        vm.warp(t0);
-
-        vm.expectEmit(true, false, false, true, address(keystore));
-        emit Keystore.AccountUnlockInitiated(account, uint48(t0 + delay));
-        _signedUnlock(pk, account);
-
-        (bool locked, bool init, uint48 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
-        assertTrue(locked);
-        assertTrue(init);
-        assertEq(unlocksAt, uint48(t0 + delay));
-        assertEq(storedDelay, 0);
-    }
-
-    /// @notice A second unlock after one was already initiated reverts NotLocked.
-    function test_unlock_revert_whenAlreadyInitiated(uint256 pkSeed, uint16 delay, uint256 t0) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        delay = uint16(bound(delay, 1, type(uint16).max));
-        t0 = bound(t0, block.timestamp, 1e9);
-
-        _signedLock(pk, account, delay);
-        vm.warp(t0);
-        _signedUnlock(pk, account);
-
-        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_unlockChange()));
-        vm.expectRevert(Keystore.NotLocked.selector);
-        keystore.applySignedAccountChanges(account, s);
-    }
-
-    /// @notice An account can be re-locked once a prior unlock delay has fully elapsed.
-    function test_lock_success_relockAfterUnlockElapsed(uint256 pkSeed, uint16 d1, uint16 d2, uint256 t0) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        d1 = uint16(bound(d1, 1, type(uint16).max));
-        d2 = uint16(bound(d2, 1, type(uint16).max));
-        t0 = bound(t0, block.timestamp, 1e9);
-
-        _signedLock(pk, account, d1);
-        vm.warp(t0);
-        _signedUnlock(pk, account);
-        vm.warp(t0 + d1); // at unlocksAt: unlocked
-        assertFalse(keystore.isLocked(account));
-
-        _signedLock(pk, account, d2);
-        assertTrue(keystore.isLocked(account));
-    }
-
-    /// @notice While locked, an authority op (authorize) reverts AccountIsLocked but an environment op (bump)
-    ///         succeeds — the lock freezes the actor set, not the epoch.
-    function test_lock_bumpSucceedsAuthorizeFails(uint256 pkSeed) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-
-        _signedLock(pk, account, 1 hours);
-
-        // Bump under lock: allowed.
-        _applyLocal(pk, account, _one(_bumpChange()));
-        (uint32 epoch,) = _localEpochSeq(account);
-        assertEq(epoch, 1);
-
-        // Authorize under lock: rejected.
-        Keystore.SignedAccountChanges memory s = _localBatch(
-            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
-        );
-        vm.expectRevert(Keystore.AccountIsLocked.selector);
-        keystore.applySignedAccountChanges(account, s);
-    }
-
-    /// @notice After a full unlock cycle elapses, an authority op is accepted again (lazy lock clear).
-    function test_lock_success_authorizeAfterFullUnlockCycle(uint256 pkSeed, uint16 delay, uint256 t0) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        (address account,) = _createK1Account(pk);
-        delay = uint16(bound(delay, 1, type(uint16).max));
-        t0 = bound(t0, block.timestamp, 1e9);
-
-        _signedLock(pk, account, delay);
-        vm.warp(t0);
-        _signedUnlock(pk, account);
-        vm.warp(t0 + delay); // unlocked
-        assertFalse(keystore.isLocked(account));
-
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
-        assertTrue(_isActor(account, ACTOR_A));
-    }
-
-    /// @notice Lock-residue overwrite. A full lock -> initiate-unlock -> elapse cycle leaves FLAG_UNLOCK_INITIATED set
-    ///         and a now-elapsed unlocksAt in storage (lock reads never clear them). A fresh Lock over that residue must
-    ///         land a CLEAN hard-lock: FLAG_LOCKED set, FLAG_UNLOCK_INITIATED clear (init == false), and lockUnion
-    ///         holding the NEW delay rather than the stale timestamp. This pins the load-bearing `& ~FLAG_UNLOCK_INITIATED`
-    ///         clear in _applyLock: dropping it would leave a delay-valued union under a set INITIATED flag (the
-    ///         union-corruption bug).
-    function test_lock_success_overwritesElapsedUnlockResidue(uint256 pkSeed, uint16 d1, uint16 d2, uint256 t0) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        address account = vm.addr(pk);
-        _assumeSafeAccount(account);
-        d1 = uint16(bound(d1, 1, type(uint16).max));
-        d2 = uint16(bound(d2, 1, type(uint16).max));
-        t0 = bound(t0, block.timestamp, 1e9);
-
-        // Lock, initiate unlock, and let the delay fully elapse. Storage residue now reads unlocked but still carries
-        // FLAG_LOCKED | FLAG_UNLOCK_INITIATED with an elapsed timestamp in lockUnion.
-        _signedLock(pk, account, d1);
-        vm.warp(t0);
-        _signedUnlock(pk, account);
-        vm.warp(t0 + d1);
-        assertFalse(keystore.isLocked(account));
-
-        // Re-lock over the residue.
-        _signedLock(pk, account, d2);
-
-        // Clean hard-lock: INITIATED cleared and the union holds the new delay (surfaced as storedDelay), not the
-        // stale timestamp.
-        (bool locked, bool init, uint48 unlocksAt, uint16 storedDelay) = keystore.getLockStatus(account);
-        assertTrue(locked);
-        assertFalse(init);
-        assertEq(unlocksAt, type(uint48).max);
-        assertEq(storedDelay, d2);
-    }
-
-    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // ADMIN-ONLY LOCK CHANGES
-    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-
-    /// @notice A scoped (non-admin) actor cannot initiate an Unlock — every signed change is admin-only
-    ///         (UnauthorizedAccountChange).
-    function test_lock_revert_scopedActorCannotUnlock(uint256 ownerSeed, uint256 scopedSeed) public {
-        uint256 ownerPk = _boundK1Pk(ownerSeed);
-        uint256 scopedPk = _boundK1Pk(scopedSeed);
-        vm.assume(vm.addr(ownerPk) != vm.addr(scopedPk));
-        (address account,) = _createK1Account(ownerPk);
-        bytes32 scopedId = bytes32(uint256(uint160(vm.addr(scopedPk))));
-
-        _applyLocal(ownerPk, account, _one(_authorizeChange(scopedId, address(k1Authenticator), SENDER, UNBOUNDED, "")));
-        _signedLock(ownerPk, account, 1 hours);
-        assertTrue(keystore.isLocked(account));
-
-        Keystore.SignedAccountChanges memory s = _localBatch(scopedPk, account, _one(_unlockChange()));
-        vm.expectRevert(Keystore.UnauthorizedAccountChange.selector);
-        keystore.applySignedAccountChanges(account, s);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -313,9 +72,12 @@ contract AccountEnvironmentTest is KeystoreTest {
         assertEq(_multichainSeq(account), mcBefore + 1);
         assertFalse(_isActor(account, ACTOR_A));
 
-        // It is nonetheless present: an explicit revoke succeeds (presence is checked without expiry), proving the
-        // slot was written rather than skipped. Reverts UnknownActor if the slot were empty.
-        _revokeActor(account, pk, ACTOR_A);
+        // It is nonetheless present: STRAWMAN (pre-PPS) an installed-expired grant is stored pending-revoke, so an
+        // explicit revoke reverts AlreadyRevoking (an EMPTY slot would revert UnknownActor) — proving the slot was
+        // written rather than skipped.
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_revokeChange(ACTOR_A)));
+        vm.expectRevert(Keystore.AlreadyRevoking.selector);
+        keystore.applySignedAccountChanges(account, s);
     }
 
     /// @notice New-chain catch-up: a chain onboarded late replays the full multichain history in order. Historical
@@ -342,7 +104,7 @@ contract AccountEnvironmentTest is KeystoreTest {
         _applyMultichain(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, liveNow, "")));
 
         assertTrue(_isActor(account, ACTOR_A));
-        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, liveNow);
+        assertEq(keystore.getActorConfig(account, ACTOR_A).revokeDelayOrExpiry, liveNow);
         assertEq(_multichainSeq(account), 3); // all three slots consumed, gap-free
     }
 
@@ -382,7 +144,11 @@ contract AccountEnvironmentTest is KeystoreTest {
         // Sequence consumed (no revert); the actor is present but not live.
         assertEq(_localSeqWord(account), seqBefore + 1);
         assertFalse(_isActor(account, ACTOR_A));
-        _revokeActor(account, pk, ACTOR_A); // present -> explicit revoke succeeds (reverts UnknownActor if empty)
+        // Present: STRAWMAN (pre-PPS) the installed-expired grant is pending-revoke, so an explicit revoke reverts
+        // AlreadyRevoking (an EMPTY slot would revert UnknownActor).
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_revokeChange(ACTOR_A)));
+        vm.expectRevert(Keystore.AlreadyRevoking.selector);
+        keystore.applySignedAccountChanges(account, s);
     }
 
     /// @notice A Multichain IncrementLocalEpoch bumps the local epoch (resetting the local sequence) and consumes the
@@ -399,27 +165,6 @@ contract AccountEnvironmentTest is KeystoreTest {
         assertEq(epochAfter, epochBefore + 1);
         assertEq(seqAfter, 0); // local sequence reset by the epoch bump
         assertEq(_multichainSeq(account), mcBefore + 1);
-    }
-
-    /// @notice A Lock on the Multichain channel reverts ChangeRequiresLocalChannel.
-    function test_multichain_revert_lockRejected(uint256 pk, uint16 delay) public {
-        pk = _boundK1Pk(pk);
-        (address account,) = _createK1Account(pk);
-        delay = uint16(bound(delay, 1, type(uint16).max));
-
-        Keystore.SignedAccountChanges memory s = _multichainBatch(pk, account, _one(_lockChange(delay)));
-        vm.expectRevert(Keystore.ChangeRequiresLocalChannel.selector);
-        keystore.applySignedAccountChanges(account, s);
-    }
-
-    /// @notice an Unlock on the Multichain channel reverts ChangeRequiresLocalChannel.
-    function test_multichain_revert_unlockRejected(uint256 pk) public {
-        pk = _boundK1Pk(pk);
-        (address account,) = _createK1Account(pk);
-
-        Keystore.SignedAccountChanges memory s = _multichainBatch(pk, account, _one(_unlockChange()));
-        vm.expectRevert(Keystore.ChangeRequiresLocalChannel.selector);
-        keystore.applySignedAccountChanges(account, s);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -7,8 +7,9 @@ import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
 /// @notice §10 test matrix for the authority / environment ops driven through {applySignedAccountChanges}:
 ///         AuthorizeActor (sequenced + unsequenced), RevokeActor, IncrementLocalEpoch, the op-ordering fence,
-///         and the sequenced-channel replay/saturation edges. Lock/unlock (admin-only),
-///         and multichain regression live in applyAccountChange.t.sol.
+///         and the sequenced-channel replay/saturation edges. STRAWMAN (pre-PPS): the account-wide lock is gone;
+///         actor changes are never frozen and front-run safety is the per-actor revoke delay. Multichain regression
+///         lives in applyAccountChange.t.sol.
 contract ApplySignedAccountChangesTest is KeystoreTest {
     // Non-self, non-owner actor ids: small distinct constants that never collide with a real (address-derived) actorId
     // used in these tests.
@@ -45,7 +46,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, ACTOR_A);
         assertEq(cfg.authenticator, address(k1Authenticator));
         assertEq(cfg.scope, SENDER);
-        assertEq(cfg.expiry, _future(1 days));
+        assertEq(cfg.revokeDelayOrExpiry, _future(1 days));
         // Unsequenced batches never consume the counter.
         assertEq(_localSeqWord(account), seqBefore);
     }
@@ -68,7 +69,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
 
         Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, ACTOR_A);
         assertEq(cfg.scope, SENDER);
-        assertEq(cfg.expiry, expiry);
+        assertEq(cfg.revokeDelayOrExpiry, expiry);
     }
 
     /// @notice A stale unsequenced (JIT) grant cannot clobber a renewed slot: once its granted expiry has passed the
@@ -88,7 +89,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
             _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, shortExpiry, ""))
         );
         keystore.applySignedAccountChanges(account, oldLease);
-        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, shortExpiry);
+        assertEq(keystore.getActorConfig(account, ACTOR_A).revokeDelayOrExpiry, shortExpiry);
 
         // Lease lapses, then the actor is renewed with a longer expiry (epoch unchanged).
         vm.warp(uint256(shortExpiry) + 1);
@@ -96,11 +97,11 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         _applyUnsequenced(
             pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, longExpiry, ""))
         );
-        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, longExpiry);
+        assertEq(keystore.getActorConfig(account, ACTOR_A).revokeDelayOrExpiry, longExpiry);
 
         // Replaying the now-expired old lease is skipped: no revert, and the renewal is untouched.
         keystore.applySignedAccountChanges(account, oldLease);
-        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, longExpiry);
+        assertEq(keystore.getActorConfig(account, ACTOR_A).revokeDelayOrExpiry, longExpiry);
     }
 
     /// @notice An unsequenced batch signed at a stale epoch reverts StaleEpoch.
@@ -173,13 +174,18 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         assertEq(keystore.getActorConfig(account, ACTOR_A).authenticator, address(k1Authenticator));
     }
 
-    /// @notice An unsequenced grant may request the unbounded (max) expiry.
+    /// @notice STRAWMAN (pre-PPS): a pre-scheduled (pendingRevoke) unsequenced grant may request the unbounded (max)
+    ///         absolute expiry.
     function test_authorizeUnsequenced_success_unboundedExpiry(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
 
-        _applyUnsequenced(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, UNBOUNDED, "")));
-        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, UNBOUNDED);
+        _applyUnsequenced(
+            pk, account, _one(_authorizeChangeRaw(ACTOR_A, address(k1Authenticator), SENDER, UNBOUNDED, true, ""))
+        );
+        Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, ACTOR_A);
+        assertEq(cfg.revokeDelayOrExpiry, UNBOUNDED);
+        assertTrue(cfg.pendingRevoke);
     }
 
     /// @notice A grant may use expiry 0, the "no expiry" sentinel: it lands and never lapses.
@@ -188,7 +194,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
 
         _applyUnsequenced(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, 0, "")));
-        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, 0);
+        assertEq(keystore.getActorConfig(account, ACTOR_A).revokeDelayOrExpiry, 0);
 
         // Never lapses: still authorized far in the future.
         vm.warp(block.timestamp + 3650 days);
@@ -208,7 +214,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
             pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), NONCE, _future(2 days), ""))
         );
         assertEq(keystore.getActorConfig(account, ACTOR_A).scope, NONCE);
-        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, _future(2 days));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).revokeDelayOrExpiry, _future(2 days));
     }
 
     /// @notice Unsequenced upserts are last-write-wins: the final applied grant's expiry stands, regardless of order.
@@ -221,13 +227,13 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         (address accA,) = _createK1Account(pk);
         _applyUnsequenced(pk, accA, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, t1, "")));
         _applyUnsequenced(pk, accA, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, t2, "")));
-        assertEq(keystore.getActorConfig(accA, ACTOR_A).expiry, t2);
+        assertEq(keystore.getActorConfig(accA, ACTOR_A).revokeDelayOrExpiry, t2);
 
         // Order (T2, T1): ends at T1 (last write wins; a shorter expiry is allowed).
         (address accB,) = _createK1AccountWithSalt(pk, bytes32(uint256(1)));
         _applyUnsequenced(pk, accB, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, t2, "")));
         _applyUnsequenced(pk, accB, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, t1, "")));
-        assertEq(keystore.getActorConfig(accB, ACTOR_A).expiry, t1);
+        assertEq(keystore.getActorConfig(accB, ACTOR_A).revokeDelayOrExpiry, t1);
     }
 
     /// @notice A different authenticator under the same actorId is not possible (id derives from the authenticator);
@@ -290,7 +296,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         uint48 e2 = _future(1 days);
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, e2, "")));
         assertTrue(_isActor(account, ACTOR_A));
-        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, e2);
+        assertEq(keystore.getActorConfig(account, ACTOR_A).revokeDelayOrExpiry, e2);
     }
 
     /// @notice A sequenced scope widen (adding grant bits) is bump-free.
@@ -312,7 +318,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
 
         uint48 higher = _future(5 days);
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, higher, "")));
-        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, higher);
+        assertEq(keystore.getActorConfig(account, ACTOR_A).revokeDelayOrExpiry, higher);
     }
 
     /// @notice A sequenced expiry lowering lands on its own (reduction is not contract-enforced to bump).
@@ -323,7 +329,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
 
         uint48 lower = _future(1 days);
         _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, lower, "")));
-        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, lower);
+        assertEq(keystore.getActorConfig(account, ACTOR_A).revokeDelayOrExpiry, lower);
     }
 
     /// @notice A sequenced scope narrowing lands on its own (reduction is not contract-enforced to bump).
@@ -349,48 +355,168 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         ch[1] = _bumpChange();
         _applyLocal(pk, account, ch);
 
-        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, lower);
+        assertEq(keystore.getActorConfig(account, ACTOR_A).revokeDelayOrExpiry, lower);
         (uint32 epoch,) = _localEpochSeq(account);
         assertEq(epoch, 1);
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+    // KEY ROTATION WITHOUT AN ACCOUNT-WIDE LOCK (STRAWMAN, pre-PPS)
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice The headline scenario (e.g. an x402 facilitator): a high-throughput account adds a new signing key and
+    ///         retires an old one in one batch, with no lock/unlock dance. The retiring key stays live through its
+    ///         revoke delay so its in-flight signatures still settle, while the freshly added key is immediately usable
+    ///         and other keys are untouched.
+    function test_rotation_success_addNewAndRetireOldNoLock(uint256 ownerSeed, uint256 keyASeed, uint256 keyBSeed)
+        public
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 keyAPk = _boundK1Pk(keyASeed);
+        uint256 keyBPk = _boundK1Pk(keyBSeed);
+        vm.assume(ownerPk != keyAPk && ownerPk != keyBPk && keyAPk != keyBPk);
+        (address account,) = _createK1Account(ownerPk);
+
+        bytes32 keyAId = bytes32(uint256(uint160(vm.addr(keyAPk))));
+        bytes32 keyBId = bytes32(uint256(uint160(vm.addr(keyBPk))));
+        uint48 delay = 1 days;
+        bytes32 hash = keccak256("settle payment");
+
+        // Old key A is live with a revoke delay.
+        _applyLocal(
+            ownerPk, account, _one(_authorizeChangeWithDelay(keyAId, address(k1Authenticator), SENDER, delay, ""))
+        );
+
+        // One batch, no lock: add new key B (immediately usable) AND initiate retirement of key A.
+        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
+        ch[0] = _authorizeChangeWithDelay(keyBId, address(k1Authenticator), SENDER, delay, "");
+        ch[1] = _revokeChange(keyAId);
+        _applyLocal(ownerPk, account, ch);
+
+        // Key B is immediately authorized.
+        (bytes32 idB,) = keystore.authenticateActor(account, hash, _buildK1Auth(keyBPk, hash));
+        assertEq(idB, keyBId);
+
+        // Key A is still live during its revoke window, so an in-flight signature still settles.
+        (bytes32 idA,) = keystore.authenticateActor(account, hash, _buildK1Auth(keyAPk, hash));
+        assertEq(idA, keyAId);
+
+        // After the window, key A has lapsed but key B keeps working — no throughput lost during the rotation.
+        vm.warp(block.timestamp + delay + 1);
+        assertFalse(_isActor(account, keyAId));
+        assertTrue(_isActor(account, keyBId));
+    }
+
+    // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
+
+    /// @notice A live actor (pendingRevoke == false) may carry any revoke delay up to MAX_REVOKE_DELAY.
+    function test_authorize_success_liveActorAtMaxRevokeDelay(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        uint48 maxDelay = keystore.MAX_REVOKE_DELAY();
+
+        _applyLocal(
+            pk, account, _one(_authorizeChangeWithDelay(ACTOR_A, address(k1Authenticator), SENDER, maxDelay, ""))
+        );
+        Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, ACTOR_A);
+        assertFalse(cfg.pendingRevoke);
+        assertEq(cfg.revokeDelayOrExpiry, maxDelay);
+        assertTrue(_isActor(account, ACTOR_A)); // live regardless of the delay value
+    }
+
+    /// @notice A live actor whose revoke delay exceeds MAX_REVOKE_DELAY reverts RevokeDelayTooLong, so an admin cannot
+    ///         mint an effectively-unremovable actor.
+    function test_authorize_revert_revokeDelayTooLong(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        uint48 tooLong = keystore.MAX_REVOKE_DELAY() + 1;
+
+        Keystore.SignedAccountChanges memory s = _localBatch(
+            pk, account, _one(_authorizeChangeWithDelay(ACTOR_A, address(k1Authenticator), SENDER, tooLong, ""))
+        );
+        vm.expectRevert(Keystore.RevokeDelayTooLong.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
+    /// @notice The ceiling applies only to the delay interpretation: a pre-scheduled (pendingRevoke) grant may set an
+    ///         absolute expiry far beyond MAX_REVOKE_DELAY, since that field is an expiry, not a delay.
+    function test_authorize_success_pendingRevokeExpiryExceedsCeiling(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        uint48 farExpiry = uint48(block.timestamp) + keystore.MAX_REVOKE_DELAY() + 365 days;
+
+        _applyLocal(
+            pk, account, _one(_authorizeChangeRaw(ACTOR_A, address(k1Authenticator), SENDER, farExpiry, true, ""))
+        );
+        Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, ACTOR_A);
+        assertTrue(cfg.pendingRevoke);
+        assertEq(cfg.revokeDelayOrExpiry, farExpiry);
+        assertTrue(_isActor(account, ACTOR_A));
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // REVOKE
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice A bare revoke of a live actor lands and clears the slot (reduction is not contract-enforced to bump).
-    function test_revoke_success_bareRevokeOfLiveActor(uint256 pk) public {
+    /// @notice STRAWMAN (pre-PPS): a revoke of a live actor is two-step. It keeps the actor live for its configured
+    ///         revoke delay (converting the delay to an absolute expiry), then the actor lapses. This is the per-actor
+    ///         front-run window that replaces the account-wide lock: an in-flight signature still settles inside it.
+    function test_revoke_success_twoStepSchedulesExpiry(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        uint48 delay = 1 days;
+        _applyLocal(pk, account, _one(_authorizeChangeWithDelay(ACTOR_A, address(k1Authenticator), SENDER, delay, "")));
 
+        uint256 t0 = block.timestamp;
         _applyLocal(pk, account, _one(_revokeChange(ACTOR_A)));
+
+        // Still live during the delay window; its config now reads as pending-revoke with the scheduled expiry.
+        Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, ACTOR_A);
+        assertTrue(cfg.pendingRevoke);
+        assertEq(cfg.revokeDelayOrExpiry, uint48(t0 + delay));
+        assertTrue(_isActor(account, ACTOR_A));
+
+        vm.warp(t0 + delay + 1);
         assertFalse(_isActor(account, ACTOR_A));
     }
 
+    /// @notice Re-revoking an actor whose two-step revocation is already pending reverts AlreadyRevoking — a second
+    ///         initiation would only push the expiry further out, weakening the guarantee.
+    function test_revoke_revert_alreadyRevoking(uint256 pk) public {
+        pk = _boundK1Pk(pk);
+        (address account,) = _createK1Account(pk);
+        _applyLocal(pk, account, _one(_authorizeChangeWithDelay(ACTOR_A, address(k1Authenticator), SENDER, 1 days, "")));
+        _applyLocal(pk, account, _one(_revokeChange(ACTOR_A)));
+
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_revokeChange(ACTOR_A)));
+        vm.expectRevert(Keystore.AlreadyRevoking.selector);
+        keystore.applySignedAccountChanges(account, s);
+    }
+
     /// @notice Documents the accepted footgun: a bare revoke is NOT durable while a replayable unsequenced grant for
-    ///         the same actor is outstanding — replaying it re-installs the actor into the emptied slot. Durable
-    ///         teardown requires an IncrementLocalEpoch (see test_revoke_success_revokeBumpThenReplayFails).
+    ///         the same actor is outstanding — replaying it re-installs a fresh live actor over the pending-revoke one.
+    ///         Durable teardown requires an IncrementLocalEpoch (see test_revoke_success_revokeBumpThenReplayFails).
     function test_revoke_bareRevokeNotDurable_replayReinstalls(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
 
-        // An outstanding unsequenced grant for ACTOR_A, captured before it first lands.
+        // An outstanding unsequenced grant for a live ACTOR_A (zero revoke delay), captured before it first lands.
         Keystore.SignedAccountChanges memory grant = _signBatch(
             pk,
             account,
             Keystore.AccountChangeChannel.Local,
             _unseqWord(account),
-            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, UNBOUNDED, ""))
         );
         keystore.applySignedAccountChanges(account, grant);
         assertTrue(_isActor(account, ACTOR_A));
 
-        // Bare revoke lands...
+        // Bare revoke lands (delay 0 → expiry now); step past it so the actor lapses.
         _applyLocal(pk, account, _one(_revokeChange(ACTOR_A)));
+        vm.warp(block.timestamp + 1);
         assertFalse(_isActor(account, ACTOR_A));
 
-        // ...but the epoch never moved, so the original grant replays straight back into the emptied slot.
+        // ...but the epoch never moved, so the original grant replays straight back into the slot as a fresh live actor.
         keystore.applySignedAccountChanges(account, grant);
         assertTrue(_isActor(account, ACTOR_A));
     }
@@ -399,7 +525,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
     function test_revoke_success_revokeBumpThenReplayFails(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, UNBOUNDED, "")));
 
         // A grant signed at the pre-bump epoch (unsequenced), captured before the revoke+bump lands.
         Keystore.SignedAccountChanges memory oldGrant = _signBatch(
@@ -407,29 +533,18 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
             account,
             Keystore.AccountChangeChannel.Local,
             _unseqWord(account),
-            _one(_authorizeChange(ACTOR_B, address(k1Authenticator), SENDER, _future(1 days), ""))
+            _one(_authorizeChange(ACTOR_B, address(k1Authenticator), SENDER, UNBOUNDED, ""))
         );
 
         Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _revokeChange(ACTOR_A);
         ch[1] = _bumpChange();
         _applyLocal(pk, account, ch);
+        vm.warp(block.timestamp + 1); // step past the zero-delay revoke expiry
         assertFalse(_isActor(account, ACTOR_A));
 
         vm.expectRevert(Keystore.StaleEpoch.selector);
         keystore.applySignedAccountChanges(account, oldGrant);
-    }
-
-    /// @notice Revoking an already-lapsed actor is GC-equivalent and lands as a bare single-op batch.
-    function test_revoke_success_lapsedActorNoBump(uint256 pk) public {
-        pk = _boundK1Pk(pk);
-        (address account,) = _createK1Account(pk);
-        uint48 e = _future(1 days);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, e, "")));
-
-        vm.warp(uint256(e) + 1);
-        _applyLocal(pk, account, _one(_revokeChange(ACTOR_A))); // no bump needed
-        assertFalse(_isActor(account, ACTOR_A));
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -548,52 +663,24 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
     // ORDERING / BATCHING
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice `[lock, revoke]` reverts LockChangeMustBeStandalone: a Lock may not share a batch with any other change.
-    function test_ordering_revert_lockNotStandalone(uint256 pk) public {
-        pk = _boundK1Pk(pk);
-        (address account,) = _createK1Account(pk);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
-
-        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
-        ch[0] = _lockChange(1 hours);
-        ch[1] = _revokeChange(ACTOR_A);
-
-        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
-        vm.expectRevert(Keystore.LockChangeMustBeStandalone.selector);
-        keystore.applySignedAccountChanges(account, s);
-    }
-
-    /// @notice `[revoke, bump]` succeeds: an authority op and an environment op (epoch increment) still freely share a
-    ///         batch — only Lock/Unlock are standalone — and the revoke is retired durably by the bump.
+    /// @notice STRAWMAN (pre-PPS): `[revoke, bump]` succeeds. With the account-wide lock removed there are no
+    ///         standalone-op restrictions, so an authority op and an environment op (epoch increment) freely share a
+    ///         batch. The revoke is two-step (delay 0 here → expiry == now), and the bump retires replayable grants;
+    ///         after warping past the expiry the actor is durably gone.
     function test_ordering_success_revokeThenBump(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, UNBOUNDED, "")));
 
         Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _revokeChange(ACTOR_A);
         ch[1] = _bumpChange();
         _applyLocal(pk, account, ch);
 
+        vm.warp(block.timestamp + 1); // step past the (zero-delay) revoke expiry
         assertFalse(_isActor(account, ACTOR_A));
         (uint32 epoch,) = _localEpochSeq(account);
         assertEq(epoch, 1);
-    }
-
-    /// @notice `[unlock, bump]` reverts LockChangeMustBeStandalone: an Unlock may not share a batch with any other
-    ///         change, even an environment op. Unlocking then bumping requires two separate signed batches.
-    function test_unlock_revert_notStandalone(uint256 pk) public {
-        pk = _boundK1Pk(pk);
-        (address account,) = _createK1Account(pk);
-        _signedLock(pk, account, 1 hours);
-
-        Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
-        ch[0] = _unlockChange();
-        ch[1] = _bumpChange();
-
-        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
-        vm.expectRevert(Keystore.LockChangeMustBeStandalone.selector);
-        keystore.applySignedAccountChanges(account, s);
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -674,18 +761,21 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         assertEq(resolvedId, actorId);
     }
 
-    /// @notice A `[revoke, bump]` batch emits ActorRevoked(account, actorId).
-    function test_revoke_success_emitsActorRevoked(uint256 pk) public {
+    /// @notice STRAWMAN (pre-PPS): a `[revoke, bump]` batch for an explicit actor emits
+    ///         ActorRevokeInitiated(account, actorId, expiry) (two-step), not ActorRevoked (which is now reserved for
+    ///         the immediate inline-self revoke).
+    function test_revoke_success_emitsActorRevokeInitiated(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        uint48 delay = 1 days;
+        _applyLocal(pk, account, _one(_authorizeChangeWithDelay(ACTOR_A, address(k1Authenticator), SENDER, delay, "")));
 
         Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _revokeChange(ACTOR_A);
         ch[1] = _bumpChange();
 
         vm.expectEmit(true, true, false, true, address(keystore));
-        emit Keystore.ActorRevoked(account, ACTOR_A);
+        emit Keystore.ActorRevokeInitiated(account, ACTOR_A, uint48(block.timestamp + delay));
         _applyLocal(pk, account, ch);
     }
 }

--- a/test/unit/Keystore/authenticate.t.sol
+++ b/test/unit/Keystore/authenticate.t.sol
@@ -141,13 +141,13 @@ contract AuthenticateTest is KeystoreTest {
         keystore.authenticateActor(account, hash, auth);
     }
 
-    /// @notice After a K1 actor is revoked its config is cleared, so re-presenting its signature mismatches.
-    /// @dev Revoke deletes `_actorConfig[actorId]`, leaving authenticator == 0 != K1 on the non-self K1 path.
-    function test_authenticateActor_revert_authenticatorMismatch_revokedActor(
-        uint256 ownerSeed,
-        uint256 actorSeed,
-        bytes32 hash
-    ) public {
+    /// @notice STRAWMAN (pre-PPS): after a K1 actor's two-step revocation elapses, re-presenting its signature reverts
+    ///         ActorExpired. Revoke no longer clears `_actorConfig[actorId]` — it flips pendingRevoke and schedules an
+    ///         expiry — so the stored authenticator still matches K1 and the failure surfaces at the expiry guard.
+    ///         (`_revokeActor` warps one second past the zero-delay expiry, so the actor has lapsed.)
+    function test_authenticateActor_revert_actorExpired_revokedActor(uint256 ownerSeed, uint256 actorSeed, bytes32 hash)
+        public
+    {
         uint256 ownerPk = _boundK1Pk(ownerSeed);
         uint256 actorPk = _boundK1Pk(actorSeed);
         vm.assume(vm.addr(ownerPk) != vm.addr(actorPk));
@@ -157,7 +157,7 @@ contract AuthenticateTest is KeystoreTest {
         _authorizeActorWithScope(account, ownerPk, actorId, address(k1Authenticator), 0x00);
         _revokeActor(account, ownerPk, actorId);
 
-        vm.expectRevert(Keystore.AuthenticatorMismatch.selector);
+        vm.expectRevert(Keystore.ActorExpired.selector);
         keystore.authenticateActor(account, hash, _buildK1Auth(actorPk, hash));
     }
 
@@ -185,7 +185,7 @@ contract AuthenticateTest is KeystoreTest {
     }
 
     /// @notice A non-self K1 session actor expires and can no longer authenticate.
-    /// @dev _authenticateK1 non-self branch (config.expiry != 0 && block.timestamp > expiry).
+    /// @dev _authenticateK1 non-self branch (config.revokeDelayOrExpiry != 0 && block.timestamp > expiry).
     function test_authenticateActor_revert_actorExpired_nonSelfK1(
         uint256 ownerSeed,
         uint256 sessionSeed,

--- a/test/unit/Keystore/branchCoverage.t.sol
+++ b/test/unit/Keystore/branchCoverage.t.sol
@@ -48,16 +48,6 @@ contract KeystoreBranchCoverageTest is KeystoreTest {
         keystore.applySignedAccountChanges(account, s);
     }
 
-    /// @notice Unlock carries an empty payload; a non-empty one reverts InvalidChangePayload (checked before state).
-    function test_unlock_revert_nonEmptyPayload() public {
-        (address account,) = _createK1Account(OWNER_PK);
-        Keystore.AccountChange memory change =
-            Keystore.AccountChange({changeType: Keystore.ChangeType.Unlock, payload: hex"01"});
-        Keystore.SignedAccountChanges memory s = _localBatch(OWNER_PK, account, _one(change));
-        vm.expectRevert(Keystore.InvalidChangePayload.selector);
-        keystore.applySignedAccountChanges(account, s);
-    }
-
     // ── getActorConfig: expired inline self ──
 
     /// @notice getActorConfig returns the empty config for the inline self once its granted expiry has elapsed.
@@ -76,28 +66,6 @@ contract KeystoreBranchCoverageTest is KeystoreTest {
 
         // Expired: the self path returns the empty config rather than the stale slot.
         assertEq(keystore.getActorConfig(account, selfId).authenticator, address(0));
-    }
-
-    // ── getLockStatus: elapsed pending unlock ──
-
-    /// @notice Once a pending unlock's timestamp has elapsed, getLockStatus reports the clean unlocked state.
-    function test_getLockStatus_success_elapsedUnlockReportsUnlocked() public {
-        (address account,) = _createK1Account(OWNER_PK);
-
-        _signedLock(OWNER_PK, account, 100);
-        _signedUnlock(OWNER_PK, account); // initiates: unlocksAt = now + 100
-
-        (bool lockedBefore, bool initiatedBefore,,) = keystore.getLockStatus(account);
-        assertTrue(lockedBefore);
-        assertTrue(initiatedBefore);
-
-        vm.warp(block.timestamp + 101);
-
-        (bool locked, bool initiated, uint48 unlocksAt, uint16 delay) = keystore.getLockStatus(account);
-        assertFalse(locked);
-        assertFalse(initiated);
-        assertEq(unlocksAt, 0);
-        assertEq(delay, 0);
     }
 
     // ── Multichain sequence saturation ──

--- a/test/unit/Keystore/createAccount.t.sol
+++ b/test/unit/Keystore/createAccount.t.sol
@@ -274,7 +274,7 @@ contract CreateAccountTest is KeystoreTest {
         Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, actorId);
         assertEq(cfg.authenticator, authenticator);
         assertEq(cfg.scope, 0x00);
-        assertEq(cfg.expiry, 0);
+        assertEq(cfg.revokeDelayOrExpiry, 0);
         assertTrue(_isActor(account, actorId));
     }
 
@@ -293,16 +293,10 @@ contract CreateAccountTest is KeystoreTest {
         Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, actorId);
         assertEq(cfg.authenticator, address(k1Authenticator));
         assertEq(cfg.scope, 0x00);
-        assertEq(cfg.expiry, 0);
+        assertEq(cfg.revokeDelayOrExpiry, 0);
 
         assertEq(keystore.getChangeSequences(account).localSequence, 1);
         assertEq(keystore.getChangeSequences(account).multichain, 0);
-
-        (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 unlockDelay) = keystore.getLockStatus(account);
-        assertFalse(locked);
-        assertFalse(hasInitiatedUnlock);
-        assertEq(unlocksAt, 0);
-        assertEq(unlockDelay, 0);
     }
 
     /// @notice Verifies createAccount marks the account's implicit secp256k1 self key revoked by default

--- a/test/unit/Keystore/importAccount.t.sol
+++ b/test/unit/Keystore/importAccount.t.sol
@@ -60,12 +60,13 @@ contract ImportAccountTest is KeystoreTest {
     // retains the full Actor/ActorConfig typehash structure; for imported (always unrestricted) actors the config
     // fields are zero and policyData is empty.
     bytes32 constant ACTOR_INITIALIZATION_TYPEHASH = keccak256(
-        "ActorInitialization(bytes32 accountId,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
+        "ActorInitialization(bytes32 accountId,uint256 chainId,Actor[] initialActors)Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 revokeDelayOrExpiry,uint16 scope,bool pendingRevoke)"
     );
     bytes32 constant ACTOR_TYPEHASH = keccak256(
-        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 expiry,uint16 scope)"
+        "Actor(bytes32 actorId,ActorConfig config,bytes policyData)ActorConfig(address authenticator,uint48 revokeDelayOrExpiry,uint16 scope,bool pendingRevoke)"
     );
-    bytes32 constant ACTOR_CONFIG_TYPEHASH = keccak256("ActorConfig(address authenticator,uint48 expiry,uint16 scope)");
+    bytes32 constant ACTOR_CONFIG_TYPEHASH =
+        keccak256("ActorConfig(address authenticator,uint48 revokeDelayOrExpiry,uint16 scope,bool pendingRevoke)");
 
     // ── digest helpers ──
 
@@ -85,9 +86,12 @@ contract ImportAccountTest is KeystoreTest {
     {
         bytes32[] memory actorHashes = new bytes32[](initialActors.length);
         for (uint256 i; i < initialActors.length; i++) {
-            // Hash the actor's real scope; expiry is always 0 at import. policyData is hashed into the Actor hash.
+            // Hash the actor's real scope; revokeDelayOrExpiry and pendingRevoke are (0, false) at import. policyData
+            // is hashed into the Actor hash.
             bytes32 configHash = keccak256(
-                abi.encode(ACTOR_CONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), initialActors[i].scope)
+                abi.encode(
+                    ACTOR_CONFIG_TYPEHASH, initialActors[i].authenticator, uint48(0), initialActors[i].scope, false
+                )
             );
             actorHashes[i] = keccak256(
                 abi.encode(ACTOR_TYPEHASH, initialActors[i].actorId, configHash, keccak256(initialActors[i].policyData))
@@ -152,25 +156,6 @@ contract ImportAccountTest is KeystoreTest {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // REVERTS (source-execution order)
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-
-    /// @notice Verifies importAccount reverts when the account is hard-locked (onlyUnlocked runs before all else).
-    /// @dev A lock op sets unlocksAt = type(uint48).max, so the account stays locked regardless of warp; any non-zero
-    ///      unlock delay locks it. The onlyUnlocked modifier trips before the chainId/sequence/signature checks, so
-    ///      the account is a controllable EOA (its inline default-EOA self signs the lock) and the actors/sig are
-    ///      never reached.
-    function test_importAccount_revert_accountIsLocked(uint256 ownerSeed, uint16 delay, bool multichain) public {
-        uint256 ownerPk = _boundK1Pk(ownerSeed);
-        vm.assume(delay != 0);
-        address account = vm.addr(ownerPk);
-
-        Keystore.InitialActor[] memory actors = _singleUnrestrictedActor(account);
-        uint256 chainId = _acceptedChainId(multichain);
-
-        _signedLock(ownerPk, account, delay);
-
-        vm.expectRevert(Keystore.AccountIsLocked.selector);
-        keystore.importAccount(account, chainId, actors, "");
-    }
 
     /// @notice Verifies importAccount reverts for a chainId that is neither 0 (multichain) nor the current chain.
     /// @dev Exercises the `chainId != 0 && chainId != block.chainid` guard, which runs before any signature work.
@@ -506,7 +491,7 @@ contract ImportAccountTest is KeystoreTest {
             Keystore.ActorConfig memory config = keystore.getActorConfig(address(wallet), actorId);
             assertEq(config.authenticator, address(k1Authenticator));
             assertEq(config.scope, 0);
-            assertEq(config.expiry, 0);
+            assertEq(config.revokeDelayOrExpiry, 0);
         }
     }
 

--- a/test/unit/Keystore/policyAccessors.t.sol
+++ b/test/unit/Keystore/policyAccessors.t.sol
@@ -606,7 +606,7 @@ contract PolicyAccessorsTest is KeystoreTest {
             keystore.getActorWithPolicy(account, actorId);
         assertEq(config.authenticator, address(0));
         assertEq(config.scope, uint16(0));
-        assertEq(config.expiry, uint48(0));
+        assertEq(config.revokeDelayOrExpiry, uint48(0));
         assertEq(outManager, address(0));
         assertEq(outCommitment, bytes32(0));
     }

--- a/test/unit/accounts/CanonicalHighRatePayerAccount.t.sol
+++ b/test/unit/accounts/CanonicalHighRatePayerAccount.t.sol
@@ -43,9 +43,12 @@ contract CanonicalHighRatePayerAccountTest is KeystoreTest {
         account = keystore.createAccount(bytes32(uint256(0xbeef)), bytecode, actors);
     }
 
-    /// @dev Hard-lock `account` via the signed lock path, authorized by its admin owner key `pk`.
-    function _lockAccount(uint256 pk, address account, uint16 unlockDelay) internal {
-        _signedLock(pk, account, unlockDelay);
+    /// @dev STRAWMAN (pre-PPS): hard-lock `account` via its own self-contained lock (no longer a Keystore op). The
+    ///      `pk` arg is unused — the account authorizes lock/unlock by caller identity ({_isAuthorizedCaller}), so a
+    ///      self-call (prank as the account) is sufficient.
+    function _lockAccount(uint256, address account, uint32 unlockDelay) internal {
+        vm.prank(account);
+        CanonicalHighRatePayerAccount(payable(account)).lock(unlockDelay);
     }
 
     function _singleCall(address t, uint256 v, bytes memory d) internal pure returns (Call[] memory calls) {
@@ -213,6 +216,96 @@ contract CanonicalHighRatePayerAccountTest is KeystoreTest {
             .execute(address(target), 0, abi.encodeCall(HighRatePayerMockTarget.setValue, (99)));
 
         assertEq(target.value(), 99);
+    }
+
+    // ── self-contained payer lock (STRAWMAN, pre-PPS) ──
+
+    function test_lock_success_setsLockedAndStatus() public {
+        (address account,) = _createHighRatePayerK1Account(ACTOR_PK);
+
+        _lockAccount(ACTOR_PK, account, 1 hours);
+
+        assertTrue(CanonicalHighRatePayerAccount(payable(account)).isLocked());
+        (bool locked, bool initiated, uint48 unlocksAt, uint32 delay) =
+            CanonicalHighRatePayerAccount(payable(account)).getPayerLockStatus();
+        assertTrue(locked);
+        assertFalse(initiated);
+        assertEq(unlocksAt, type(uint48).max);
+        assertEq(delay, 1 hours);
+    }
+
+    function test_lock_revert_zeroDelay() public {
+        (address account,) = _createHighRatePayerK1Account(ACTOR_PK);
+
+        vm.prank(account);
+        vm.expectRevert(CanonicalHighRatePayerAccount.ZeroUnlockDelay.selector);
+        CanonicalHighRatePayerAccount(payable(account)).lock(0);
+    }
+
+    function test_lock_revert_whenAlreadyLocked() public {
+        (address account,) = _createHighRatePayerK1Account(ACTOR_PK);
+        _lockAccount(ACTOR_PK, account, 1 hours);
+
+        vm.prank(account);
+        vm.expectRevert(CanonicalHighRatePayerAccount.AccountAlreadyLocked.selector);
+        CanonicalHighRatePayerAccount(payable(account)).lock(1 hours);
+    }
+
+    function test_lock_revert_unauthorizedCaller() public {
+        (address account,) = _createHighRatePayerK1Account(ACTOR_PK);
+
+        vm.prank(address(0xdead));
+        vm.expectRevert(DefaultAccount.UnauthorizedCaller.selector);
+        CanonicalHighRatePayerAccount(payable(account)).lock(1 hours);
+    }
+
+    function test_initiateUnlock_success_thenElapsesToUnlocked() public {
+        (address account,) = _createHighRatePayerK1Account(ACTOR_PK);
+        vm.deal(account, 1 ether);
+        _lockAccount(ACTOR_PK, account, 100);
+
+        vm.prank(account);
+        CanonicalHighRatePayerAccount(payable(account)).initiateUnlock();
+
+        // Still locked (ETH blocked) until the delay elapses.
+        (bool locked, bool initiated, uint48 unlocksAt,) =
+            CanonicalHighRatePayerAccount(payable(account)).getPayerLockStatus();
+        assertTrue(locked);
+        assertTrue(initiated);
+        assertEq(unlocksAt, uint48(block.timestamp + 100));
+        assertTrue(CanonicalHighRatePayerAccount(payable(account)).isLocked());
+
+        vm.warp(block.timestamp + 101);
+
+        // Elapsed: reports clean unlocked and ETH moves again.
+        assertFalse(CanonicalHighRatePayerAccount(payable(account)).isLocked());
+        (bool locked2,,,) = CanonicalHighRatePayerAccount(payable(account)).getPayerLockStatus();
+        assertFalse(locked2);
+
+        vm.prank(account);
+        CanonicalHighRatePayerAccount(payable(account))
+            .execute(address(target), 0.5 ether, abi.encodeCall(HighRatePayerMockTarget.setValue, (7)));
+        assertEq(address(target).balance, 0.5 ether);
+    }
+
+    function test_initiateUnlock_revert_whenNeverLocked() public {
+        (address account,) = _createHighRatePayerK1Account(ACTOR_PK);
+
+        vm.prank(account);
+        vm.expectRevert(CanonicalHighRatePayerAccount.NotLocked.selector);
+        CanonicalHighRatePayerAccount(payable(account)).initiateUnlock();
+    }
+
+    function test_initiateUnlock_revert_whenAlreadyInitiated() public {
+        (address account,) = _createHighRatePayerK1Account(ACTOR_PK);
+        _lockAccount(ACTOR_PK, account, 100);
+
+        vm.prank(account);
+        CanonicalHighRatePayerAccount(payable(account)).initiateUnlock();
+
+        vm.prank(account);
+        vm.expectRevert(CanonicalHighRatePayerAccount.NotLocked.selector);
+        CanonicalHighRatePayerAccount(payable(account)).initiateUnlock();
     }
 
     // ── isValidSignature ──

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -257,7 +257,7 @@ contract DefaultAccountTest is KeystoreTest {
     }
 
     /// @notice A TRUSTED_EXECUTOR actor with an unbounded (expiry == 0) grant may drive execution.
-    /// @dev Covers the `config.expiry != 0` false leg of the expiry guard (the && short-circuits before the
+    /// @dev Covers the `config.revokeDelayOrExpiry != 0` false leg of the expiry guard (the && short-circuits before the
     ///      timestamp comparison), which the UNBOUNDED-expiry executor helper never exercises.
     function test_executeBatch_success_trustedExecutorZeroExpiry(uint256 execSeed, uint256 v) public {
         (address account,) = _createK1Account(ACTOR_PK);
@@ -287,8 +287,10 @@ contract DefaultAccountTest is KeystoreTest {
         vm.assume(executor != account && executor != vm.addr(ACTOR_PK));
 
         vm.warp(1000);
-        Keystore.ActorConfig memory stale =
-            Keystore.ActorConfig({authenticator: TRUSTED_EXECUTOR, expiry: 500, scope: 0}); // expiry < now
+        // pendingRevoke == true with a scheduled expiry < now: a stale, expired executor config.
+        Keystore.ActorConfig memory stale = Keystore.ActorConfig({
+            authenticator: TRUSTED_EXECUTOR, revokeDelayOrExpiry: 500, scope: 0, pendingRevoke: true
+        });
         vm.mockCall(
             address(keystore),
             abi.encodeWithSelector(Keystore.getActorConfig.selector, account, bytes32(uint256(uint160(executor)))),


### PR DESCRIPTION
> **STRAWMAN / pre-PPS — do not merge.** This is a concrete strawman to make the [proposal](https://coinbase.slack.com/archives/C09JS807HCG/p1787302527416189) tangible for discussion and a PPS. Every changed symbol carries a `STRAWMAN (pre-PPS)` marker. Full test suite passes (385) and `forge fmt` is clean, but the design surface (spec, node behavior, storage layout) is deliberately up for debate.

## Problem

A high-throughput account (canonically an x402 facilitator with many load-balanced signing keys) cannot add or rotate a key without leaving high-throughput mode. The account-wide lock freezes *all* actor changes, so key rotation means unlock → wait out the delay → rotate → re-lock, dropping the tier for the whole window. For a *permissioned* high-throughput account (Shopify Operator, the Cloudflare equivalent) the "run two accounts and reroute traffic" workaround doesn't apply.

## Insight

The lock was doing two unrelated jobs. Splitting them removes the coupling:

| Job | Before | After |
|-----|--------|-------|
| **Sender-tier** front-run/DOS safety (an in-flight signature can't be revoke-front-run) | account-wide config freeze | **per-actor revoke delay** in Keystore |
| **Payer-tier** balance predictability (ETH-out blocked so balance is mempool-predictable) | lock-gated ETH block, lock state read from Keystore | **self-contained lock** inside the allowlisted `CanonicalHighRatePayerAccount` |

Adding a key never invalidates a peer's in-flight tx, so **adds are immediate**. Removing a key only needs to protect *that key's* in-flight signatures, so **revokes are two-step per-actor**. Neither needs an account-wide freeze.

## Keystore changes

- `ActorConfig`: add `bool pendingRevoke`; rename `expiry` → `revokeDelayOrExpiry` (union).
  - `pendingRevoke == false`: actor live; field is a **revoke delay** (seconds), bounded by `MAX_REVOKE_DELAY`. This value is the per-actor guarantee a node reads for the sender tier ("this signer can't be pulled faster than N seconds").
  - `pendingRevoke == true`: field is an **absolute expiry**. Pre-scheduled session keys / policy leases authorize directly with `pendingRevoke = true`.
- `RevokeActor`: two-step. Flips `pendingRevoke` and converts the stored delay into an absolute expiry (`revokeDelayOrExpiry += block.timestamp`); the actor stays live through the window. `AlreadyRevoking` guards re-initiation. Emits `ActorRevokeInitiated`.
- **Removed**: `Lock`/`Unlock` change types, `AccountState.lockUnion`, `FLAG_LOCKED`, `FLAG_UNLOCK_INITIATED`, `isLocked`/`getLockStatus`, `onlyUnlocked`, and the lock events/errors. `applySignedAccountChanges` has no lock gate or standalone-op rule anymore.
- Typehashes / import digest / `ActorAuthorized` packing updated for the new field. Inline k1 self revocation stays immediate (flag flip) — delayed revoke for the self key is a noted follow-up.

## Account change (`CanonicalHighRatePayerAccount`)

Absorbs the payer freeze in its **own storage** (slot 0, packed): `lock(unlockDelay)`, `initiateUnlock()`, `isLocked()`, `getPayerLockStatus()`. Outbound ETH is blocked while locked, exactly as before — but with no `KEYSTORE` dependency. Since nodes already allowlist this bytecode to grant the payer tier, they read this contract's slot directly. This keeps Keystore agnostic to any one account variant's balance-predictability needs.

## Safeguards & known trade-offs

- **Self-brick bound**: `MAX_REVOKE_DELAY` (strawman: 7 days) caps a live actor's revoke delay so an admin can't mint an effectively-unremovable actor.
- **Durability**: a bare revoke is still not durable while a replayable JIT authorize is outstanding — durable teardown requires an `IncrementLocalEpoch` pairing (same reduction axiom as today; documented + tested).
- **Normative surface**: this changes the `actor_config` / `AccountState` layouts and the node's rate-limit tiering read (from an account slot to the signing actor's config slot). That's the real reason it would push Cobalt, and why it wants a PPS + a call.

## Open questions for the PPS

1. `MAX_REVOKE_DELAY` value.
2. Should the payer account's `unlock` be admin-only (scope 0) rather than any authorized caller?
3. Delayed revocation for the inline k1 self key (kept immediate here).
4. Node tiering: confirm reading the per-actor slot for the sender tier is acceptable to the EL/node team.

## Testing

`forge test` → 385 passing; `forge fmt --check` clean. New coverage: two-step revoke lifecycle, `AlreadyRevoking`, `RevokeDelayTooLong` ceiling, pre-scheduled expiry beyond the ceiling, the end-to-end key-rotation-without-lock scenario, and the account's self-contained lock/unlock lifecycle.