### PR TITLE
Allow AuthorizeActor while locked when expiry outlives unlock

### DIFF
--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -44,9 +44,9 @@ contract Keystore {
     /// @notice The operation an {AccountChange} applies within an {applySignedAccountChanges} batch.
     ///
     /// @dev ABI-encodes as uint8. A locked account freezes every op except Unlock, IncrementLocalEpoch, and
-    ///      AuthorizeActor (the last only when the granted expiry outlives the unlock floor; see {_applyAuthorize}).
-    ///      Unlock additionally self-checks it is hard-locked. Lock and Unlock are Local-only and must each be the
-    ///      batch's only op.
+    ///      AuthorizeActor (the last only as an add or expiry-only re-lease that outlives the unlock floor; see
+    ///      {_applyAuthorize}). Unlock additionally self-checks it is hard-locked. Lock and Unlock are Local-only
+    ///      and must each be the batch's only op.
     enum ChangeType {
         // Authority ops (mutate who can act).
         AuthorizeActor, // payload: abi.encode(bytes32 actorId, ActorConfig cfg, bytes policyData); cfg.expiry is the granted expiry
@@ -218,8 +218,9 @@ contract Keystore {
     uint8 public constant FLAG_REVOKE_DEFAULT_EOA = 0x02;
 
     /// @notice AccountState.flags bit (spec `LOCKED`): identifies a lock record. Revoke and lock-delay changes are
-    ///         frozen unless an initiated unlock's timestamp has elapsed; AuthorizeActor may still land when the
-    ///         granted expiry outlives the unlock floor. Expired lock bits remain until a later Lock overwrites them.
+    ///         frozen unless an initiated unlock's timestamp has elapsed; AuthorizeActor may still add a new actor or
+    ///         re-lease a live one (expiry only) when the granted expiry outlives the unlock floor. Expired lock bits
+    ///         remain until a later Lock overwrites them.
     uint8 public constant FLAG_LOCKED = 0x04;
 
     /// @notice AccountState.flags bit (spec `UNLOCK_INITIATED`): selects how the packed `lockUnion` field is read.
@@ -580,9 +581,9 @@ contract Keystore {
     ///      (3) validate/advance the sequence counter BEFORE apply (reentrancy discipline); (4) compute the digest
     ///      via {_changesDigest}, authenticate, and reject a non-admin signer; (5) iterate
     ///      changes enforcing channel and lock policy (Lock/Unlock rejected on Multichain; RevokeActor and Lock
-    ///      rejected while the account is locked; AuthorizeActor while locked only when the granted expiry outlives
-    ///      the unlock floor; Lock/Unlock must be standalone). Anyone may relay — authorization comes entirely from
-    ///      the signature.
+    ///      rejected while the account is locked; AuthorizeActor while locked only as an add or expiry-only re-lease
+    ///      that outlives the unlock floor; Lock/Unlock must be standalone). Anyone may relay — authorization comes
+    ///      entirely from the signature.
     ///
     /// @param account The account whose configuration is changed.
     /// @param batch The signed batch (channel, ordered changes, sequence word, signature).
@@ -713,9 +714,12 @@ contract Keystore {
     ///      expiry, narrower scope) is a wallet responsibility — batch it with {IncrementLocalEpoch} to retire outstanding
     ///      grants.
     ///
-    ///      While the account is locked, the grant must outlive the unlock floor (`now + delay` while hard-locked,
-    ///      `unlocksAt` while pending). A shorter expiry would be dead by the time the account can unlock — the same
-    ///      end state as a revoke, which stays frozen. `expiry == 0` (no expiry) always outlives the floor.
+    ///      While the account is locked, a grant must outlive the unlock floor (`now + delay` while hard-locked,
+    ///      `unlocksAt` while pending) and, if the actor is already live, may change only expiry — authenticator,
+    ///      scope, and policy stay frozen (changing them is a revoke-shaped rewrite). A shorter expiry would be dead
+    ///      by the time the account can unlock — the same end state as a revoke, which stays frozen. `expiry == 0`
+    ///      (no expiry) always outlives the floor. A new or already-expired actorId is a fresh add and is not
+    ///      identity-frozen.
     function _applyAuthorize(address account, bytes calldata payload, bool isUnsequenced, bool locked) private {
         (bytes32 actorId, ActorConfig memory cfg, bytes memory policyData) =
             abi.decode(payload, (bytes32, ActorConfig, bytes));
@@ -729,13 +733,39 @@ contract Keystore {
             return;
         }
 
-        // Locked: reject a grant that does not outlive the soonest the account can unlock. Checked after the JIT skip
-        // so a lapsed replayable grant stays a no-op rather than reverting on the floor.
-        if (locked && cfg.expiry != 0 && cfg.expiry <= _unlockFloor(account)) {
-            revert ExpiryDoesNotOutliveUnlock();
+        // Locked: reject a grant that does not outlive the soonest the account can unlock, and reject a rewrite of a
+        // live actor's authenticator / scope / policy. Checked after the JIT skip so a lapsed replayable grant stays
+        // a no-op rather than reverting on the floor.
+        if (locked) {
+            if (cfg.expiry != 0 && cfg.expiry <= _unlockFloor(account)) {
+                revert ExpiryDoesNotOutliveUnlock();
+            }
+            _requireLockedAuthorizePreservesIdentity(account, actorId, cfg, policyData);
         }
 
         _authorizeActor(account, actorId, cfg, policyData);
+    }
+
+    /// @dev While locked, a live actor may only have its expiry rewritten. Authenticator, scope, and policy
+    ///      (manager + commitment) must match the current live config; anything else is a revoke-shaped mutation.
+    ///      Unknown or expired actorIds have no live identity and are treated as a new add.
+    function _requireLockedAuthorizePreservesIdentity(
+        address account,
+        bytes32 actorId,
+        ActorConfig memory cfg,
+        bytes memory policyData
+    ) private view {
+        ActorConfig memory current = _resolveActorConfig(account, actorId);
+        if (current.authenticator == address(0)) {
+            return;
+        }
+        if (cfg.authenticator != current.authenticator || cfg.scope != current.scope) {
+            revert AccountIsLocked();
+        }
+        (address manager, bytes32 commitment) = _slicePolicy(cfg.scope, policyData);
+        if (manager != _policyManager[actorId][account] || commitment != _policyCommitment[actorId][account]) {
+            revert AccountIsLocked();
+        }
     }
 
     /// @dev RevokeActor. `payload = abi.encode(bytes32 actorId)`. Clears the actor's config and policy slots (and
@@ -1035,8 +1065,8 @@ contract Keystore {
         });
     }
 
-    /// @notice Returns whether the account is currently locked (revoke/lock frozen; authorize only above the unlock
-    ///         floor).
+    /// @notice Returns whether the account is currently locked (revoke/lock frozen; authorize is add or expiry-only
+    ///         re-lease above the unlock floor).
     ///
     /// @param account The account to check.
     ///

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -43,9 +43,10 @@ contract Keystore {
 
     /// @notice The operation an {AccountChange} applies within an {applySignedAccountChanges} batch.
     ///
-    /// @dev ABI-encodes as uint8. A locked account freezes every op except Unlock and IncrementLocalEpoch, enforced by
-    ///      the guard in {applySignedAccountChanges} (Unlock additionally self-checks it is hard-locked). Lock and
-    ///      Unlock are Local-only and must each be the batch's only op.
+    /// @dev ABI-encodes as uint8. A locked account freezes every op except Unlock, IncrementLocalEpoch, and
+    ///      AuthorizeActor (the last only when the granted expiry outlives the unlock floor; see {_applyAuthorize}).
+    ///      Unlock additionally self-checks it is hard-locked. Lock and Unlock are Local-only and must each be the
+    ///      batch's only op.
     enum ChangeType {
         // Authority ops (mutate who can act).
         AuthorizeActor, // payload: abi.encode(bytes32 actorId, ActorConfig cfg, bytes policyData); cfg.expiry is the granted expiry
@@ -216,8 +217,9 @@ contract Keystore {
     ///         clears it (re-enabling the inline self, possibly scoped).
     uint8 public constant FLAG_REVOKE_DEFAULT_EOA = 0x02;
 
-    /// @notice AccountState.flags bit (spec `LOCKED`): identifies a lock record. The account is frozen unless an
-    ///         initiated unlock's timestamp has elapsed; expired lock bits remain until a later Lock overwrites them.
+    /// @notice AccountState.flags bit (spec `LOCKED`): identifies a lock record. Revoke and lock-delay changes are
+    ///         frozen unless an initiated unlock's timestamp has elapsed; AuthorizeActor may still land when the
+    ///         granted expiry outlives the unlock floor. Expired lock bits remain until a later Lock overwrites them.
     uint8 public constant FLAG_LOCKED = 0x04;
 
     /// @notice AccountState.flags bit (spec `UNLOCK_INITIATED`): selects how the packed `lockUnion` field is read.
@@ -291,6 +293,11 @@ contract Keystore {
 
     /// @notice The operation is not permitted while the account is locked.
     error AccountIsLocked();
+
+    /// @notice An AuthorizeActor while locked carried an expiry that does not outlive the unlock floor: `now + delay`
+    ///         while hard-locked, `unlocksAt` while a pending unlock is in flight. `expiry == 0` (no expiry) always
+    ///         outlives the floor and is accepted.
+    error ExpiryDoesNotOutliveUnlock();
 
     /// @notice The signed chainId is neither 0 (multichain) nor the current chain.
     error InvalidChainId();
@@ -572,9 +579,10 @@ contract Keystore {
     ///      Pipeline (in order): (1) split the sequence word; (2) reject a stale epoch on Local batches;
     ///      (3) validate/advance the sequence counter BEFORE apply (reentrancy discipline); (4) compute the digest
     ///      via {_changesDigest}, authenticate, and reject a non-admin signer; (5) iterate
-    ///      changes enforcing channel and lock policy (Lock/Unlock rejected on Multichain; authority ops
-    ///      rejected while the account is locked; Lock/Unlock must be standalone). Anyone may relay — authorization
-    ///      comes entirely from the signature.
+    ///      changes enforcing channel and lock policy (Lock/Unlock rejected on Multichain; RevokeActor and Lock
+    ///      rejected while the account is locked; AuthorizeActor while locked only when the granted expiry outlives
+    ///      the unlock floor; Lock/Unlock must be standalone). Anyone may relay — authorization comes entirely from
+    ///      the signature.
     ///
     /// @param account The account whose configuration is changed.
     /// @param batch The signed batch (channel, ordered changes, sequence word, signature).
@@ -648,7 +656,11 @@ contract Keystore {
             ChangeType t = batch.changes[i].changeType;
 
             // Preconditions: freeze non-exempt ops on a locked account, and hold Lock/Unlock to a standalone local batch.
-            if (locked && t != ChangeType.Unlock && t != ChangeType.IncrementLocalEpoch) {
+            // AuthorizeActor is exempt here; {_applyAuthorize} still requires the granted expiry to outlive unlock.
+            if (
+                locked && t != ChangeType.Unlock && t != ChangeType.IncrementLocalEpoch
+                    && t != ChangeType.AuthorizeActor
+            ) {
                 revert AccountIsLocked();
             }
             if (t == ChangeType.Lock || t == ChangeType.Unlock) {
@@ -662,7 +674,7 @@ contract Keystore {
 
             // Apply: dispatch the op to its handler.
             if (t == ChangeType.AuthorizeActor) {
-                _applyAuthorize(account, batch.changes[i].payload, isUnsequenced);
+                _applyAuthorize(account, batch.changes[i].payload, isUnsequenced, locked);
             } else if (t == ChangeType.RevokeActor) {
                 _applyRevoke(account, batch.changes[i].payload);
             } else if (t == ChangeType.IncrementLocalEpoch) {
@@ -700,7 +712,11 @@ contract Keystore {
     ///      A JIT grant is last-write-wins on its slot until the epoch is incremented; durable reduction (revoke, shorter
     ///      expiry, narrower scope) is a wallet responsibility — batch it with {IncrementLocalEpoch} to retire outstanding
     ///      grants.
-    function _applyAuthorize(address account, bytes calldata payload, bool isUnsequenced) private {
+    ///
+    ///      While the account is locked, the grant must outlive the unlock floor (`now + delay` while hard-locked,
+    ///      `unlocksAt` while pending). A shorter expiry would be dead by the time the account can unlock — the same
+    ///      end state as a revoke, which stays frozen. `expiry == 0` (no expiry) always outlives the floor.
+    function _applyAuthorize(address account, bytes calldata payload, bool isUnsequenced, bool locked) private {
         (bytes32 actorId, ActorConfig memory cfg, bytes memory policyData) =
             abi.decode(payload, (bytes32, ActorConfig, bytes));
 
@@ -711,6 +727,12 @@ contract Keystore {
         // with `expiry == block.timestamp` is still live for that second and installs, rather than being dropped here.
         if (isUnsequenced && _isExpired(cfg.expiry)) {
             return;
+        }
+
+        // Locked: reject a grant that does not outlive the soonest the account can unlock. Checked after the JIT skip
+        // so a lapsed replayable grant stays a no-op rather than reverting on the floor.
+        if (locked && cfg.expiry != 0 && cfg.expiry <= _unlockFloor(account)) {
+            revert ExpiryDoesNotOutliveUnlock();
         }
 
         _authorizeActor(account, actorId, cfg, policyData);
@@ -1013,7 +1035,8 @@ contract Keystore {
         });
     }
 
-    /// @notice Returns whether the account is currently locked (configuration frozen).
+    /// @notice Returns whether the account is currently locked (revoke/lock frozen; authorize only above the unlock
+    ///         floor).
     ///
     /// @param account The account to check.
     ///
@@ -1081,6 +1104,16 @@ contract Keystore {
             return true;
         }
         return block.timestamp < st.lockUnion; // pending unlock: frozen until the timestamp elapses
+    }
+
+    /// @dev Soonest timestamp the account can be unlocked. Caller must only use this when {_isLocked} is true.
+    ///      Hard-locked: `now +` stored delay. Pending unlock: the stored `unlocksAt`.
+    function _unlockFloor(address account) private view returns (uint48) {
+        AccountState storage st = _accountState[account];
+        if (st.flags & FLAG_UNLOCK_INITIATED != 0) {
+            return st.lockUnion;
+        }
+        return uint48(block.timestamp + uint16(st.lockUnion));
     }
 
     /// @dev True after bootstrap or any successful signed change. The epoch and multichain counter keep initialization

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -657,7 +657,7 @@ contract Keystore {
             ChangeType t = batch.changes[i].changeType;
 
             // Preconditions: freeze non-exempt ops on a locked account, and hold Lock/Unlock to a standalone local batch.
-            // AuthorizeActor is exempt here; {_applyAuthorize} still requires the granted expiry to outlive unlock.
+            // AuthorizeActor is exempt here; {_applyAuthorize} still applies the locked add / expiry-only rule.
             if (
                 locked && t != ChangeType.Unlock && t != ChangeType.IncrementLocalEpoch
                     && t != ChangeType.AuthorizeActor
@@ -714,12 +714,9 @@ contract Keystore {
     ///      expiry, narrower scope) is a wallet responsibility — batch it with {IncrementLocalEpoch} to retire outstanding
     ///      grants.
     ///
-    ///      While the account is locked, a grant must outlive the unlock floor (`now + delay` while hard-locked,
-    ///      `unlocksAt` while pending) and, if the actor is already live, may change only expiry — authenticator,
-    ///      scope, and policy stay frozen (changing them is a revoke-shaped rewrite). A shorter expiry would be dead
-    ///      by the time the account can unlock — the same end state as a revoke, which stays frozen. `expiry == 0`
-    ///      (no expiry) always outlives the floor. A new or already-expired actorId is a fresh add and is not
-    ///      identity-frozen.
+    ///      Locked rule: the grant must outlive the unlock floor (`now + delay` / `unlocksAt`; `expiry == 0` always
+    ///      does). If a live entry exists, only expiry may change — authenticator, scope, and policy stay as they are.
+    ///      No live entry (unknown or expired) is a new add. After the account unlocks, this guard is off.
     function _applyAuthorize(address account, bytes calldata payload, bool isUnsequenced, bool locked) private {
         (bytes32 actorId, ActorConfig memory cfg, bytes memory policyData) =
             abi.decode(payload, (bytes32, ActorConfig, bytes));
@@ -733,39 +730,25 @@ contract Keystore {
             return;
         }
 
-        // Locked: reject a grant that does not outlive the soonest the account can unlock, and reject a rewrite of a
-        // live actor's authenticator / scope / policy. Checked after the JIT skip so a lapsed replayable grant stays
-        // a no-op rather than reverting on the floor.
         if (locked) {
             if (cfg.expiry != 0 && cfg.expiry <= _unlockFloor(account)) {
                 revert ExpiryDoesNotOutliveUnlock();
             }
-            _requireLockedAuthorizePreservesIdentity(account, actorId, cfg, policyData);
+            // Live entry: expiry-only. Expired reads as empty ({_resolveActorConfig}), so that id is a new add.
+            ActorConfig memory current = _resolveActorConfig(account, actorId);
+            if (current.authenticator != address(0)) {
+                (address manager, bytes32 commitment) = _slicePolicy(cfg.scope, policyData);
+                if (
+                    cfg.authenticator != current.authenticator || cfg.scope != current.scope
+                        || manager != _policyManager[actorId][account]
+                        || commitment != _policyCommitment[actorId][account]
+                ) {
+                    revert AccountIsLocked();
+                }
+            }
         }
 
         _authorizeActor(account, actorId, cfg, policyData);
-    }
-
-    /// @dev While locked, a live actor may only have its expiry rewritten. Authenticator, scope, and policy
-    ///      (manager + commitment) must match the current live config; anything else is a revoke-shaped mutation.
-    ///      Unknown or expired actorIds have no live identity and are treated as a new add.
-    function _requireLockedAuthorizePreservesIdentity(
-        address account,
-        bytes32 actorId,
-        ActorConfig memory cfg,
-        bytes memory policyData
-    ) private view {
-        ActorConfig memory current = _resolveActorConfig(account, actorId);
-        if (current.authenticator == address(0)) {
-            return;
-        }
-        if (cfg.authenticator != current.authenticator || cfg.scope != current.scope) {
-            revert AccountIsLocked();
-        }
-        (address manager, bytes32 commitment) = _slicePolicy(cfg.scope, policyData);
-        if (manager != _policyManager[actorId][account] || commitment != _policyCommitment[actorId][account]) {
-            revert AccountIsLocked();
-        }
     }
 
     /// @dev RevokeActor. `payload = abi.encode(bytes32 actorId)`. Clears the actor's config and policy slots (and

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -329,6 +329,29 @@ contract AccountEnvironmentTest is KeystoreTest {
         assertEq(commitment, bytes32(uint256(1)));
     }
 
+    /// @notice An expired actor has no live entry, so while the account stays locked that actorId is a new add:
+    ///         authenticator and scope may change, subject only to the unlock floor.
+    function test_lock_authorize_success_expiredActorIsNewAdd(uint256 pkSeed) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+
+        uint48 shortExpiry = _future(10);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, shortExpiry, "")));
+        _signedLock(pk, account, 1 hours);
+
+        vm.warp(uint256(shortExpiry) + 1);
+        assertFalse(_isActor(account, ACTOR_A));
+        assertTrue(keystore.isLocked(account));
+
+        uint48 newExpiry = uint48(block.timestamp + 1 hours + 1);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(p256Authenticator), 0, newExpiry, "")));
+        Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, ACTOR_A);
+        assertEq(cfg.authenticator, address(p256Authenticator));
+        assertEq(cfg.scope, 0);
+        assertEq(cfg.expiry, newExpiry);
+    }
+
     /// @notice Pending unlock: AuthorizeActor with expiry == unlocksAt reverts ExpiryDoesNotOutliveUnlock.
     function test_lock_authorize_revert_expiryAtPendingUnlocksAt(uint256 pkSeed, uint16 delay, uint256 t0) public {
         uint256 pk = _boundK1Pk(pkSeed);

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -177,9 +177,9 @@ contract AccountEnvironmentTest is KeystoreTest {
         assertTrue(keystore.isLocked(account));
     }
 
-    /// @notice While locked, an authority op (authorize) reverts AccountIsLocked but an environment op (bump)
-    ///         succeeds — the lock freezes the actor set, not the epoch.
-    function test_lock_bumpSucceedsAuthorizeFails(uint256 pkSeed) public {
+    /// @notice While locked, an environment op (bump) and an AuthorizeActor whose expiry outlives `now + delay`
+    ///         succeed; RevokeActor stays frozen.
+    function test_lock_bumpAndAuthorizeSucceedRevokeFails(uint256 pkSeed) public {
         uint256 pk = _boundK1Pk(pkSeed);
         address account = vm.addr(pk);
         _assumeSafeAccount(account);
@@ -191,12 +191,132 @@ contract AccountEnvironmentTest is KeystoreTest {
         (uint32 epoch,) = _localEpochSeq(account);
         assertEq(epoch, 1);
 
-        // Authorize under lock: rejected.
-        Keystore.SignedAccountChanges memory s = _localBatch(
-            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
-        );
+        // Authorize under lock with expiry > now + delay: allowed.
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        assertTrue(_isActor(account, ACTOR_A));
+
+        // Revoke under lock: still rejected.
+        Keystore.SignedAccountChanges memory s = _localBatch(pk, account, _one(_revokeChange(ACTOR_A)));
         vm.expectRevert(Keystore.AccountIsLocked.selector);
         keystore.applySignedAccountChanges(account, s);
+        assertTrue(_isActor(account, ACTOR_A));
+    }
+
+    /// @notice Hard-locked AuthorizeActor: expiry must be strictly greater than `now + delay`. Equal is a
+    ///         revoke-shaped grant (dead by the soonest unlock) and reverts ExpiryDoesNotOutliveUnlock.
+    function test_lock_authorize_revert_expiryAtHardLockFloor(uint256 pkSeed, uint16 delay) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+
+        _signedLock(pk, account, delay);
+        uint48 floor = uint48(block.timestamp + delay);
+
+        Keystore.SignedAccountChanges memory s =
+            _localBatch(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, floor, "")));
+        vm.expectRevert(Keystore.ExpiryDoesNotOutliveUnlock.selector);
+        keystore.applySignedAccountChanges(account, s);
+        assertFalse(_isActor(account, ACTOR_A));
+    }
+
+    /// @notice Hard-locked AuthorizeActor: expiry == `now + delay + 1` (just above the floor) lands.
+    function test_lock_authorize_success_expiryJustAboveHardLockFloor(uint256 pkSeed, uint16 delay) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+
+        _signedLock(pk, account, delay);
+        uint48 expiry = uint48(block.timestamp + delay + 1);
+
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, expiry, "")));
+        assertTrue(_isActor(account, ACTOR_A));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, expiry);
+    }
+
+    /// @notice Hard-locked AuthorizeActor: `expiry == 0` (no expiry) always outlives the floor.
+    function test_lock_authorize_success_unboundedExpiry(uint256 pkSeed, uint16 delay) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+
+        _signedLock(pk, account, delay);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, 0, "")));
+        assertTrue(_isActor(account, ACTOR_A));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, 0);
+    }
+
+    /// @notice Hard-locked re-lease: an existing actor may be rewritten with a new expiry above the floor, including
+    ///         a shorten, as long as the new expiry still outlives `now + delay`.
+    function test_lock_authorize_success_releaseAboveFloor(uint256 pkSeed, uint16 delay) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+
+        uint48 longExpiry = _future(2 days);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, longExpiry, "")));
+        _signedLock(pk, account, delay);
+
+        uint48 shorterButAboveFloor = uint48(block.timestamp + delay + 1);
+        _applyLocal(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, shorterButAboveFloor, ""))
+        );
+        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, shorterButAboveFloor);
+    }
+
+    /// @notice Pending unlock: AuthorizeActor with expiry == unlocksAt reverts ExpiryDoesNotOutliveUnlock.
+    function test_lock_authorize_revert_expiryAtPendingUnlocksAt(uint256 pkSeed, uint16 delay, uint256 t0) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+        t0 = bound(t0, block.timestamp, 1e9);
+
+        _signedLock(pk, account, delay);
+        vm.warp(t0);
+        _signedUnlock(pk, account);
+        uint48 unlocksAt = uint48(t0 + delay);
+
+        Keystore.SignedAccountChanges memory s =
+            _localBatch(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, unlocksAt, "")));
+        vm.expectRevert(Keystore.ExpiryDoesNotOutliveUnlock.selector);
+        keystore.applySignedAccountChanges(account, s);
+        assertFalse(_isActor(account, ACTOR_A));
+    }
+
+    /// @notice Pending unlock: AuthorizeActor with expiry == unlocksAt + 1 lands; the grant outlives the unlock.
+    function test_lock_authorize_success_expiryJustAbovePendingUnlocksAt(uint256 pkSeed, uint16 delay, uint256 t0)
+        public
+    {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+        delay = uint16(bound(delay, 1, type(uint16).max));
+        t0 = bound(t0, block.timestamp, 1e9);
+
+        _signedLock(pk, account, delay);
+        vm.warp(t0);
+        _signedUnlock(pk, account);
+        uint48 expiry = uint48(t0 + delay + 1);
+
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, expiry, "")));
+        assertTrue(_isActor(account, ACTOR_A));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, expiry);
+    }
+
+    /// @notice A lapsed JIT grant under lock is still skipped (no-op), not rejected as ExpiryDoesNotOutliveUnlock.
+    function test_lock_authorizeUnsequenced_expiredSkips(uint256 pkSeed) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+
+        _signedLock(pk, account, 1 hours);
+        uint48 past = uint48(block.timestamp - 1);
+        _applyUnsequenced(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, past, "")));
+        assertFalse(_isActor(account, ACTOR_A));
     }
 
     /// @notice After a full unlock cycle elapses, an authority op is accepted again (lazy lock clear).

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -265,6 +265,68 @@ contract AccountEnvironmentTest is KeystoreTest {
             pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, shorterButAboveFloor, ""))
         );
         assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, shorterButAboveFloor);
+        assertEq(keystore.getActorConfig(account, ACTOR_A).authenticator, address(k1Authenticator));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).scope, SENDER);
+    }
+
+    /// @notice Hard-locked re-lease cannot widen or swap a live actor's scope.
+    function test_lock_authorize_revert_scopeChange(uint256 pkSeed) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(2 days), "")));
+        _signedLock(pk, account, 1 hours);
+
+        Keystore.SignedAccountChanges memory s =
+            _localBatch(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), 0, _future(2 days), "")));
+        vm.expectRevert(Keystore.AccountIsLocked.selector);
+        keystore.applySignedAccountChanges(account, s);
+        assertEq(keystore.getActorConfig(account, ACTOR_A).scope, SENDER);
+    }
+
+    /// @notice Hard-locked re-lease cannot replace a live actor's authenticator.
+    function test_lock_authorize_revert_authenticatorChange(uint256 pkSeed) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(2 days), "")));
+        _signedLock(pk, account, 1 hours);
+
+        Keystore.SignedAccountChanges memory s = _localBatch(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(p256Authenticator), SENDER, _future(2 days), ""))
+        );
+        vm.expectRevert(Keystore.AccountIsLocked.selector);
+        keystore.applySignedAccountChanges(account, s);
+        assertEq(keystore.getActorConfig(account, ACTOR_A).authenticator, address(k1Authenticator));
+    }
+
+    /// @notice Hard-locked re-lease cannot rewrite a live actor's policy commitment.
+    function test_lock_authorize_revert_policyChange(uint256 pkSeed) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        address account = vm.addr(pk);
+        _assumeSafeAccount(account);
+
+        bytes memory policyData = abi.encodePacked(address(0xBEEF), bytes32(uint256(1)));
+        _applyLocal(
+            pk,
+            account,
+            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), Scopes.POLICY, _future(2 days), policyData))
+        );
+        _signedLock(pk, account, 1 hours);
+
+        bytes memory otherPolicy = abi.encodePacked(address(0xBEEF), bytes32(uint256(2)));
+        Keystore.SignedAccountChanges memory s = _localBatch(
+            pk,
+            account,
+            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), Scopes.POLICY, _future(2 days), otherPolicy))
+        );
+        vm.expectRevert(Keystore.AccountIsLocked.selector);
+        keystore.applySignedAccountChanges(account, s);
+        (, address manager, bytes32 commitment) = keystore.getActorWithPolicy(account, ACTOR_A);
+        assertEq(manager, address(0xBEEF));
+        assertEq(commitment, bytes32(uint256(1)));
     }
 
     /// @notice Pending unlock: AuthorizeActor with expiry == unlocksAt reverts ExpiryDoesNotOutliveUnlock.


### PR DESCRIPTION
## Summary
- While locked, `AuthorizeActor` is now permitted if the granted expiry outlives the unlock floor: `now + delay` when hard-locked, `unlocksAt` when a pending unlock is in flight. `expiry == 0` (no expiry) always passes.
- A live actor may only have its expiry rewritten. Authenticator, scope, and policy (manager + commitment) stay frozen; changing them reverts `AccountIsLocked`. A new or already-expired actorId is a fresh add.
- Revoke, re-lock, and other authority changes stay frozen. A grant that would be dead by the soonest unlock is revoke-shaped and reverts `ExpiryDoesNotOutliveUnlock`.
- Lets high-rate payer accounts stay locked (mempool tier) while adding new keys or re-leasing existing 24h leases; rotation is add-new and let the old expiry elapse.

This is a spec change relative to the current EIP-8130 Account Lock section (authorize is listed as rejected while locked). Follow-up needed on the EIP text.

## Test plan
- [x] Hard-locked: expiry `== now + delay` reverts; `== now + delay + 1` lands; `expiry == 0` lands
- [x] Pending unlock: expiry `== unlocksAt` reverts; `== unlocksAt + 1` lands
- [x] Re-lease / shorten of an existing actor is allowed if the new expiry is still above the floor
- [x] Live-actor scope, authenticator, or policy rewrite while locked reverts `AccountIsLocked`
- [x] Revoke while locked still reverts `AccountIsLocked`; epoch bump still succeeds
- [x] Expired JIT authorize under lock is still a skip, not an `ExpiryDoesNotOutliveUnlock` revert
- [ ] Confirm EIP-8130 Account Lock wording is updated to match