### PR TITLE
Co-locate Keystore actor records for garbage collection

### DIFF
--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.36;
 
 import {ActorId} from "./libraries/ActorId.sol";
 import {IAuthenticator} from "./interfaces/IAuthenticator.sol";
+import {KeystoreLayout} from "./libraries/KeystoreLayout.sol";
 import {Scopes} from "./libraries/Scopes.sol";
 
 /// @notice Keystore system contract for EIP-8130.
@@ -25,6 +26,8 @@ contract Keystore {
 
     /// @notice An actor's authorization: authenticator, expiry, and scope. Field order matches the normative
     ///         `actor_config` slot layout: authenticator(20) ‖ expiry(6) ‖ scope(2) ‖ reserved(4).
+    ///         Storage word0 additionally sets {KeystoreLayout.CLEANABLE} in the reserved region; that bit is
+    ///         storage-only and is not part of this ABI struct or the ActorAuthorized payload.
     struct ActorConfig {
         address authenticator;
         uint48 expiry; // Unix seconds; 0 = no expiry. Actor invalid once block.timestamp > expiry
@@ -106,10 +109,11 @@ contract Keystore {
     ///      The defaultEOA* fields are the inline home for the account's own secp256k1 ("self") key, whose actorId is
     ///      `ActorId.fromAddress(account)`. When FLAG_REVOKE_DEFAULT_EOA is unset, a k1 signature recovering to the
     ///      account authenticates with this inline config (all-zero = full owner; non-zero scope/expiry = a
-    ///      scoped self key), resolved in a single SLOAD. Policy gating (when scope & Scopes.POLICY != 0) is still keyed
-    ///      by actorId in the shared _policyManager/_policyCommitment keyspace. The separate _actorConfig[self][account]
-    ///      slot is reserved for a *non-k1* self authenticator (e.g. a post-quantum verifier returning the
-    ///      self-actorId); the two homes are mutually exclusive (see _authorizeActor).
+    ///      scoped self key), resolved in a single SLOAD. Policy gating (when scope & Scopes.POLICY != 0) is still
+    ///      keyed by actorId in the co-located actor record (word1/word2). A *non-k1* self authenticator (e.g. a
+    ///      post-quantum verifier returning the self-actorId) lives in that record's word0; the two homes are
+    ///      mutually exclusive (see _authorizeActor). The reserved byte of this slot MUST stay zero so a reaper
+    ///      can distinguish it from a CLEANABLE actor record.
     struct AccountState {
         uint64 multichainSequence; // 8 bytes
         uint32 localSequence; // 4 bytes – low half of the signed local word
@@ -402,18 +406,9 @@ contract Keystore {
     // STORAGE
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice Per-actor configuration
-    /// @dev Account must be inner-most mapping key to pass ERC-7562 storage access rules for ERC-4337 compatibility.
-    mapping(bytes32 actorId => mapping(address account => ActorConfig)) internal _actorConfig;
-
-    /// @notice Per-actor signed policy commitment. Set when the actor's scope carries Scopes.POLICY.
-    /// @dev Read only during execution (via getPolicyCommitment / getActorWithPolicy), never during signature validity checks.
-    mapping(bytes32 actorId => mapping(address account => bytes32)) internal _policyCommitment;
-
-    /// @notice Per-actor policy manager address. Set when the actor's scope carries Scopes.POLICY.
-    mapping(bytes32 actorId => mapping(address account => address)) internal _policyManager;
-
-    /// @notice Per-account state: sequences, lock status (single slot per account)
+    /// @notice Per-account state: sequences, lock status, inline k1 self (single slot per account).
+    /// @dev The only Solidity mapping. Actor config, policy manager, and policy commitment are co-located at
+    ///      {KeystoreLayout.recordBase} as a 3-word record so a later stem walk can reap expired leaves.
     mapping(address account => AccountState) internal _accountState;
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -725,9 +720,7 @@ contract Keystore {
         if (!_isAuthorized(account, actorId)) {
             revert UnknownActor();
         }
-        delete _actorConfig[actorId][account];
-        delete _policyCommitment[actorId][account];
-        delete _policyManager[actorId][account];
+        _clearActorRecord(account, actorId);
         if (actorId == _selfActorId(account)) {
             _disableInlineSelf(_accountState[account]);
         }
@@ -941,13 +934,12 @@ contract Keystore {
         config = _resolveActorConfig(account, actorId);
         // Gating is by the scope bit, matching {_emitActorAuthorized}; a non-live or ungated actor has a zero gate.
         if (config.authenticator != address(0) && config.scope & Scopes.POLICY != 0) {
-            policyManager = _policyManager[actorId][account];
-            policyCommitment = _policyCommitment[actorId][account];
+            (policyManager, policyCommitment) = _loadPolicySlots(account, actorId);
         }
     }
 
     /// @dev The single liveness resolver behind every read surface ({getActorConfig}, {getActorWithPolicy},
-    ///      {getPolicyCommitment}, {getPolicyManager}). A populated _actorConfig entry returns verbatim unless expired;
+    ///      {getPolicyCommitment}, {getPolicyManager}). A populated actor-record word0 returns verbatim unless expired;
     ///      the k1 self (inline in AccountState) resolves to a native ecrecover owner unless disabled or expired;
     ///      anything unknown/revoked/disabled/expired resolves to the all-zero (empty) config. Centralizing this is
     ///      what makes "expired" read identically to "revoked" on every surface — the invariant that lets a node
@@ -955,7 +947,7 @@ contract Keystore {
     function _resolveActorConfig(address account, bytes32 actorId) private view returns (ActorConfig memory) {
         // Common path first: the inline k1 self. A clear FLAG_REVOKE_DEFAULT_EOA means the inline self is live, so
         // resolve it from AccountState alone (all-zero = full owner). When the flag is set the inline self is off —
-        // either a non-k1 self lives in _actorConfig, or the self was revoked — so fall through to the shared home.
+        // either a non-k1 self lives in the actor record, or the self was revoked — so fall through to the shared home.
         if (actorId == _selfActorId(account)) {
             AccountState storage st = _accountState[account];
             if (st.flags & FLAG_REVOKE_DEFAULT_EOA == 0) {
@@ -969,9 +961,9 @@ contract Keystore {
             }
         }
 
-        // Explicit actor (or a non-k1 self): the single _actorConfig home. A stored authenticator is K1_AUTHENTICATOR
+        // Explicit actor (or a non-k1 self): the co-located actor record. A stored authenticator is K1_AUTHENTICATOR
         // (0x1) or a contract, so `>= K1_AUTHENTICATOR` is the "slot populated" test. An expired entry reports empty.
-        ActorConfig memory config = _actorConfig[actorId][account];
+        ActorConfig memory config = _loadActorConfig(account, actorId);
         if (config.authenticator >= K1_AUTHENTICATOR) {
             return _isExpired(config.expiry) ? _emptyActorConfig() : config;
         }
@@ -989,7 +981,8 @@ contract Keystore {
         if (_resolveActorConfig(account, actorId).authenticator == address(0)) {
             return bytes32(0);
         }
-        return _policyCommitment[actorId][account];
+        (, bytes32 commitment) = _loadPolicySlots(account, actorId);
+        return commitment;
     }
 
     /// @notice The actor's policy manager, or 0 when the actor is not live. See {_resolveActorConfig}.
@@ -997,7 +990,8 @@ contract Keystore {
         if (_resolveActorConfig(account, actorId).authenticator == address(0)) {
             return address(0);
         }
-        return _policyManager[actorId][account];
+        (address manager,) = _loadPolicySlots(account, actorId);
+        return manager;
     }
 
     /// @notice Returns the account's replay counters: the multichain counter and the local channel's epoch and
@@ -1127,8 +1121,8 @@ contract Keystore {
 
     /// @dev Authorizes (upserts) `actorId` with `config` and optional `policyData`, emitting ActorAuthorized. Rejects
     ///      a sub-K1 authenticator. The self-actorId is routed by authenticator type (a k1 self inline in
-    ///      AccountState, a non-k1 self in _actorConfig) and the two are kept mutually exclusive; every other actor
-    ///      lives in _actorConfig. Reverts with InvalidActorId, InvalidAuthenticator, or InvalidPolicyData.
+    ///      AccountState, a non-k1 self in the actor record) and the two are kept mutually exclusive; every other actor
+    ///      lives in the actor record. Reverts with InvalidActorId, InvalidAuthenticator, or InvalidPolicyData.
     function _authorizeActor(address account, bytes32 actorId, ActorConfig memory config, bytes memory policyData)
         private
         nonZeroAccount(account)
@@ -1151,42 +1145,104 @@ contract Keystore {
         // Scopes.POLICY and the account's other capabilities is protocol-side, not enforced here.
         (address manager, bytes32 commitment) = _slicePolicy(config.scope, policyData);
 
+        uint256 w0;
         if (actorId == _selfActorId(account)) {
             // Self-actorId is routed by authenticator type and the two homes are mutually exclusive: the k1 self
-            // lives inline in AccountState; a non-k1 self lives in _actorConfig. Authorizing one clears the
+            // lives inline in AccountState; a non-k1 self lives in the actor record. Authorizing one clears the
             // other so a k1 and a non-k1 self are never simultaneously live.
             AccountState storage st = _accountState[account];
             if (config.authenticator == K1_AUTHENTICATOR) {
                 // Upsert: overwrite a live self in place (no re-auth guard); the end state equals revoke-then-
                 // authorize. Re-enabling a previously revoked self is just the flag clear below.
-                delete _actorConfig[actorId][account]; // mutual exclusion: drop any non-k1 self
+                // word0 stays 0 (not CLEANABLE): config is inline, so a reaper must not treat this as an actor record.
                 st.defaultEOAScope = config.scope;
                 st.defaultEOAExpiry = config.expiry;
                 st.flags &= ~FLAG_REVOKE_DEFAULT_EOA; // enable the inline self
             } else {
                 // Upsert: overwrite any existing non-k1 self in place.
-                _actorConfig[actorId][account] = config;
+                w0 = KeystoreLayout.packWord0(config.authenticator, config.expiry, config.scope);
                 // Mutual exclusion: disable and clear the inline k1 self.
                 _disableInlineSelf(st);
             }
-            // Policy slots are keyed by actorId (shared keyspace across both self homes).
-            _writePolicySlots(actorId, account, manager, commitment);
-
-            _emitActorAuthorized(account, actorId, config, manager, commitment);
-            return;
+        } else {
+            // Non-self actor: single co-located record. Upsert: overwrite in place.
+            w0 = KeystoreLayout.packWord0(config.authenticator, config.expiry, config.scope);
         }
-
-        // Non-self actor: single _actorConfig home. Upsert: overwrite in place.
-        _actorConfig[actorId][account] = config;
-        _writePolicySlots(actorId, account, manager, commitment);
+        // Policy occupies word1/word2 of the same record (shared keyspace across both self homes).
+        _storeActorRecord(account, actorId, w0, manager, commitment);
 
         _emitActorAuthorized(account, actorId, config, manager, commitment);
     }
 
-    /// @dev Writes the current policy values and clears stale values when an actor becomes ungated.
-    function _writePolicySlots(bytes32 actorId, address account, address manager, bytes32 commitment) private {
-        _policyCommitment[actorId][account] = commitment;
-        _policyManager[actorId][account] = manager;
+    /// @dev Writes the 3-word actor record at {KeystoreLayout.recordBase}. `w0 == 0` clears the CLEANABLE
+    ///      marker (k1 self: config lives in AccountState); non-zero `w0` is a packWord0'd reap-eligible actor.
+    function _storeActorRecord(address account, bytes32 actorId, uint256 w0, address manager, bytes32 commitment)
+        private
+    {
+        bytes32 base = KeystoreLayout.recordBase(account, actorId);
+        uint256 w1 = uint256(uint160(manager));
+        uint256 w2 = uint256(commitment);
+        assembly ("memory-safe") {
+            sstore(base, w0)
+            sstore(add(base, 1), w1)
+            sstore(add(base, 2), w2)
+        }
+    }
+
+    /// @dev Clears the whole actor record (config + policy). Unchanged revoke semantics; emits nothing here.
+    function _clearActorRecord(address account, bytes32 actorId) private {
+        _storeActorRecord(account, actorId, 0, address(0), bytes32(0));
+    }
+
+    /// @dev word0 of the co-located record, unpacked as ActorConfig. CLEANABLE occupies reserved bits and is
+    ///      dropped by these shifts, so callers see the ABI struct unchanged.
+    function _loadActorConfig(address account, bytes32 actorId) private view returns (ActorConfig memory config) {
+        bytes32 base = KeystoreLayout.recordBase(account, actorId);
+        uint256 w0;
+        assembly ("memory-safe") {
+            w0 := sload(base)
+        }
+        config.authenticator = address(uint160(w0));
+        config.expiry = uint48(w0 >> 160);
+        config.scope = uint16(w0 >> 208);
+    }
+
+    /// @dev word1/word2 of the co-located record. Read only at execution (policy enforcement), never on the
+    ///      signature-validity hot path — matching the previous split mappings.
+    function _loadPolicySlots(address account, bytes32 actorId)
+        private
+        view
+        returns (address manager, bytes32 commitment)
+    {
+        bytes32 base = KeystoreLayout.recordBase(account, actorId);
+        uint256 w1;
+        uint256 w2;
+        assembly ("memory-safe") {
+            w1 := sload(add(base, 1))
+            w2 := sload(add(base, 2))
+        }
+        manager = address(uint160(w1));
+        commitment = bytes32(w2);
+    }
+
+    /// @dev Protocol-driven reaper. Operates on a record base discovered by a seeded stem walk; needs no
+    ///      (account, actorId) preimage and emits nothing (pruning stays invisible). On MPT this is unused;
+    ///      a later slot-grouping tree can random-scan expired leaves.
+    function _reapRecord(bytes32 base, uint256 nowTs) internal returns (bool cleared) {
+        uint256 w0;
+        assembly ("memory-safe") {
+            w0 := sload(base)
+        }
+        // Not a cleanable actor record (account-state has CLEANABLE == 0) -> skip.
+        if (w0 & KeystoreLayout.CLEANABLE == 0) return false;
+        uint48 expiry = uint48(w0 >> 160);
+        if (expiry == 0 || nowTs <= expiry) return false; // no expiry, or still live
+        assembly ("memory-safe") {
+            sstore(base, 0)
+            sstore(add(base, 1), 0)
+            sstore(add(base, 2), 0)
+        }
+        return true;
     }
 
     /// @dev Disables the inline k1 ("self") key: sets FLAG_REVOKE_DEFAULT_EOA so the inline full-owner path stays off
@@ -1243,10 +1299,10 @@ contract Keystore {
     /// @dev Checks authorization presence without expiry so expired actors can still be explicitly revoked.
     function _isAuthorized(address account, bytes32 actorId) private view returns (bool) {
         // A populated entry represents any non-self actor or a non-k1 self authenticator.
-        if (_actorConfig[actorId][account].authenticator >= K1_AUTHENTICATOR) {
+        if (_loadActorConfig(account, actorId).authenticator >= K1_AUTHENTICATOR) {
             return true;
         }
-        // No _actorConfig entry: the self-actorId's k1 key lives inline in AccountState, live unless the flag is set.
+        // No actor-record word0: the self-actorId's k1 key lives inline in AccountState, live unless the flag is set.
         if (actorId == _selfActorId(account)) {
             return !_isDefaultEoaRevoked(account);
         }
@@ -1397,7 +1453,7 @@ contract Keystore {
 
     /// @dev Resolves and authenticates the actor behind `authenticator`/`data`, returning its
     ///      (actorId, scope). Routes the K1 sentinel to _authenticateK1; otherwise calls the
-    ///      IAuthenticator and requires the resolved actorId to carry a matching, unexpired _actorConfig entry.
+    ///      IAuthenticator and requires the resolved actorId to carry a matching, unexpired actor-record entry.
     ///      Reverts with AuthenticationFailed, AuthenticatorMismatch, or ActorExpired.
     function _authenticate(address account, bytes32 hash, address authenticator, bytes calldata data)
         private
@@ -1416,7 +1472,7 @@ contract Keystore {
         return (actorId, _resolveExplicitActor(account, actorId, authenticator));
     }
 
-    /// @dev Resolves an explicit _actorConfig-homed actor: requires a matching authenticator and an unexpired entry,
+    /// @dev Resolves an explicit actor-record-homed actor: requires a matching authenticator and an unexpired entry,
     ///      returning its scope. Shared by the non-k1 (_authenticate) and k1 other-actor (_authenticateK1) paths.
     ///      Reverts with AuthenticatorMismatch or ActorExpired.
     function _resolveExplicitActor(address account, bytes32 actorId, address expectedAuthenticator)
@@ -1424,7 +1480,7 @@ contract Keystore {
         view
         returns (uint16 scope)
     {
-        ActorConfig memory config = _actorConfig[actorId][account];
+        ActorConfig memory config = _loadActorConfig(account, actorId);
         if (config.authenticator != expectedAuthenticator) {
             revert AuthenticatorMismatch();
         }
@@ -1440,7 +1496,7 @@ contract Keystore {
     ///          key (set => revert), and when live the scope/expiry come from the inline fields (all-zero = full
     ///          owner; non-zero = a scoped self). A non-k1 self is unreachable here by construction (it requires
     ///          its own authenticator), and mutual exclusion keeps the flag set whenever one is live.
-    ///        - otherwise the signer's actorId must carry an explicit K1 config in _actorConfig (any other k1 actor).
+    ///        - otherwise the signer's actorId must carry an explicit K1 config in the actor record (any other k1 actor).
     ///      Both the common self and other-actor paths cost a single SLOAD.
     function _authenticateK1(address account, bytes32 hash, bytes calldata data)
         private

--- a/src/libraries/KeystoreLayout.sol
+++ b/src/libraries/KeystoreLayout.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.36;
+
+/// @notice EIP-8130 Keystore actor-record layout (GC-ready).
+///
+///         Each actor occupies a contiguous 3-word record: `{base, base+1, base+2}`.
+///         word0 keeps the existing `actor_config` Solidity packing (authenticator, expiry, scope);
+///         the CLEANABLE marker in the reserved region tags a reap-eligible actor record and
+///         distinguishes it from the (never-reaped) account-state record.
+///
+///         word0 packing (low bytes first, matching the `ActorConfig` storage layout):
+///           authenticator : bits 0..159
+///           expiry        : bits 160..207 (uint48)
+///           scope         : bits 208..223 (uint16)
+///           reserved      : bits 224..255   <-- CLEANABLE lives here
+///
+///         CLEANABLE is the low bit of the last byte of word0 (bit 248). That byte is reserved
+///         on both the actor record and AccountState (which MUST keep it zero), so a stem-walk
+///         reaper can skip account-state without an `(account, actorId)` preimage.
+library KeystoreLayout {
+    /// @dev Low bit of the last byte of word0. Set on every reap-eligible actor record; never set
+    ///      on AccountState (its reserved byte stays zero).
+    uint256 internal constant CLEANABLE = uint256(1) << 248;
+
+    /// @dev Base slot salt for the actor-record region. `record(account, actorId) -> {base, base+1, base+2}`.
+    bytes32 internal constant ACTOR_RECORD_BASE = keccak256("eip8130.actor.record.v1");
+
+    /// @dev First slot of the 3-word record. The words are contiguous and 4-aligned so a record never
+    ///      straddles a 256-slot group, which lets a slot-grouping tree place the whole record in one stem.
+    ///      `account` is the first `abi.encode` word so the unaligned hash is `keccak256(account || x)`
+    ///      (ERC-7562 associated storage). Ceiling-aligning (not flooring) keeps `{base, base+1, base+2}`
+    ///      at `keccak256(account || x) + n` for `n < 4`.
+    function recordBase(address account, bytes32 actorId) internal pure returns (bytes32 base) {
+        bytes32 h = keccak256(abi.encode(account, actorId, ACTOR_RECORD_BASE));
+        base = bytes32((uint256(h) + 3) & ~uint256(3));
+    }
+
+    /// @dev Pack word0: existing `ActorConfig` fields plus the CLEANABLE marker.
+    function packWord0(address authenticator, uint48 expiry, uint16 scope) internal pure returns (uint256 w0) {
+        w0 = uint256(uint160(authenticator)) | (uint256(expiry) << 160) | (uint256(scope) << 208) | CLEANABLE;
+    }
+}

--- a/test/lib/KeystoreTest.sol
+++ b/test/lib/KeystoreTest.sol
@@ -321,12 +321,12 @@ contract KeystoreTest is Test {
 
     // ── Direct AccountState storage pokes (for saturation edge cases) ──
     //
-    // AccountState packs into one slot at base-slot 3 (declaration order: _actorConfig, _policyCommitment,
-    // _policyManager, _accountState). multichainSequence occupies bytes[0:8] and localSequence bytes[8:16] of that
+    // AccountState packs into one slot at base-slot 0 (the only remaining Solidity mapping; actor records live at
+    // {KeystoreLayout.recordBase}). multichainSequence occupies bytes[0:8] and localSequence bytes[8:16] of that
     // slot; localSequence's high 32 bits are the epoch, its low 32 bits the sequence.
 
     function _accountStateSlot(address account) internal pure returns (bytes32) {
-        return keccak256(abi.encode(account, uint256(3)));
+        return keccak256(abi.encode(account, uint256(0)));
     }
 
     /// @dev Overwrite the packed localSequence word (epoch<<32 | seq), preserving every other field in the slot.

--- a/test/unit/Keystore/branchCoverage.t.sol
+++ b/test/unit/Keystore/branchCoverage.t.sol
@@ -106,8 +106,8 @@ contract KeystoreBranchCoverageTest is KeystoreTest {
     function test_multichain_revert_sequenceSaturated() public {
         (address account,) = _createK1Account(OWNER_PK);
 
-        // Force the multichain counter (low 64 bits of the packed AccountState slot at base-slot 3) to its max.
-        bytes32 slot = keccak256(abi.encode(account, uint256(3)));
+        // Force the multichain counter (low 64 bits of the packed AccountState slot at base-slot 0) to its max.
+        bytes32 slot = keccak256(abi.encode(account, uint256(0)));
         uint256 cur = uint256(vm.load(address(keystore), slot));
         uint256 updated = (cur & ~uint256(type(uint64).max)) | uint256(type(uint64).max);
         vm.store(address(keystore), slot, bytes32(updated));

--- a/test/unit/Keystore/cleanableLayout.t.sol
+++ b/test/unit/Keystore/cleanableLayout.t.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DefaultAccount} from "../../../src/accounts/DefaultAccount.sol";
+import {Keystore} from "../../../src/Keystore.sol";
+import {KeystoreLayout} from "../../../src/libraries/KeystoreLayout.sol";
+import {Scopes} from "../../../src/libraries/Scopes.sol";
+import {KeystoreTest} from "../../lib/KeystoreTest.sol";
+
+/// @dev Exposes {_reapRecord} so tests can drive the protocol reaper without adding it to the Keystore ABI.
+contract KeystoreReapHarness is Keystore {
+    function reapRecord(bytes32 base, uint256 nowTs) external returns (bool) {
+        return _reapRecord(base, nowTs);
+    }
+}
+
+/// @notice Layout and reaper tests for the co-located 3-word actor record.
+contract CleanableLayoutTest is KeystoreTest {
+    uint256 constant OWNER_PK = 0xA11CE;
+
+    KeystoreReapHarness internal reapable;
+
+    function setUp() public override {
+        reapable = new KeystoreReapHarness();
+        keystore = reapable;
+        k1Authenticator = keystore.K1_AUTHENTICATOR();
+        defaultAccountImplementation = address(new DefaultAccount(address(keystore)));
+    }
+
+    function test_recordBase_ceilingAlignedToFour(address account, bytes32 actorId) public pure {
+        bytes32 h = keccak256(abi.encode(account, actorId, KeystoreLayout.ACTOR_RECORD_BASE));
+        bytes32 base = KeystoreLayout.recordBase(account, actorId);
+        uint256 delta = uint256(base) - uint256(h);
+        assertEq(uint256(base) % 4, 0, "base must be 4-aligned");
+        assertLe(delta, 3, "ceiling-align stays at keccak256(account||x)+n for n<4");
+    }
+
+    function test_authorize_writesColocatedCleanableRecord() public {
+        (address account,) = _createK1Account(OWNER_PK);
+        bytes32 actorId = bytes32(uint256(0xB0B));
+        uint48 expiry = uint48(block.timestamp + 100);
+        address manager = address(0xCAFE);
+        bytes32 commitment = bytes32(uint256(0xC0FFEE));
+
+        _applyLocal(
+            OWNER_PK,
+            account,
+            _one(
+                _authorizeChange(actorId, k1Authenticator, Scopes.POLICY, expiry, abi.encodePacked(manager, commitment))
+            )
+        );
+
+        bytes32 base = KeystoreLayout.recordBase(account, actorId);
+        uint256 w0 = uint256(vm.load(address(keystore), base));
+        uint256 w1 = uint256(vm.load(address(keystore), bytes32(uint256(base) + 1)));
+        uint256 w2 = uint256(vm.load(address(keystore), bytes32(uint256(base) + 2)));
+
+        assertEq(w0 & KeystoreLayout.CLEANABLE, KeystoreLayout.CLEANABLE, "actor record is CLEANABLE");
+        assertEq(address(uint160(w0)), k1Authenticator);
+        assertEq(uint48(w0 >> 160), expiry);
+        assertEq(uint16(w0 >> 208), Scopes.POLICY);
+        assertEq(address(uint160(w1)), manager);
+        assertEq(bytes32(w2), commitment);
+
+        Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, actorId);
+        assertEq(cfg.authenticator, k1Authenticator);
+        assertEq(cfg.expiry, expiry);
+        assertEq(cfg.scope, Scopes.POLICY);
+        assertEq(keystore.getPolicyManager(account, actorId), manager);
+        assertEq(keystore.getPolicyCommitment(account, actorId), commitment);
+    }
+
+    function test_k1Self_word0NotCleanable() public {
+        (address account,) = _createK1Account(OWNER_PK);
+        bytes32 selfId = bytes32(uint256(uint160(account)));
+        bytes32 base = KeystoreLayout.recordBase(account, selfId);
+        uint256 w0 = uint256(vm.load(address(keystore), base));
+        assertEq(w0, 0, "k1 self config is inline; actor-record word0 stays empty");
+        assertEq(w0 & KeystoreLayout.CLEANABLE, 0);
+    }
+
+    function test_accountState_notCleanableAndReaperSkips() public {
+        (address account,) = _createK1Account(OWNER_PK);
+        bytes32 slot = _accountStateSlot(account);
+        uint256 before = uint256(vm.load(address(keystore), slot));
+        assertEq(before & KeystoreLayout.CLEANABLE, 0, "AccountState reserved byte stays zero");
+
+        assertFalse(reapable.reapRecord(slot, type(uint256).max));
+        assertEq(uint256(vm.load(address(keystore), slot)), before);
+    }
+
+    function test_revoke_clearsWholeRecord() public {
+        (address account,) = _createK1Account(OWNER_PK);
+        bytes32 actorId = bytes32(uint256(0xB0B));
+        _applyLocal(OWNER_PK, account, _one(_authorizeChange(actorId, k1Authenticator, 0, UNBOUNDED, "")));
+        _applyLocal(OWNER_PK, account, _one(_revokeChange(actorId)));
+
+        bytes32 base = KeystoreLayout.recordBase(account, actorId);
+        assertEq(uint256(vm.load(address(keystore), base)), 0);
+        assertEq(uint256(vm.load(address(keystore), bytes32(uint256(base) + 1))), 0);
+        assertEq(uint256(vm.load(address(keystore), bytes32(uint256(base) + 2))), 0);
+    }
+
+    function test_reapRecord_clearsExpiredAndSkipsLive() public {
+        (address account,) = _createK1Account(OWNER_PK);
+        bytes32 actorId = bytes32(uint256(0xB0B));
+        uint48 expiry = uint48(block.timestamp + 50);
+        address manager = address(0xCAFE);
+        bytes32 commitment = bytes32(uint256(0xC0FFEE));
+        _applyLocal(
+            OWNER_PK,
+            account,
+            _one(
+                _authorizeChange(actorId, k1Authenticator, Scopes.POLICY, expiry, abi.encodePacked(manager, commitment))
+            )
+        );
+
+        bytes32 base = KeystoreLayout.recordBase(account, actorId);
+
+        assertFalse(reapable.reapRecord(base, expiry), "still live at expiry");
+        assertTrue(keystore.getActorConfig(account, actorId).authenticator != address(0));
+
+        vm.warp(uint256(expiry) + 1);
+        assertEq(keystore.getActorConfig(account, actorId).authenticator, address(0), "expired reads empty");
+        assertTrue(reapable.reapRecord(base, block.timestamp), "expired CLEANABLE record is reaped");
+
+        assertEq(uint256(vm.load(address(keystore), base)), 0);
+        assertEq(uint256(vm.load(address(keystore), bytes32(uint256(base) + 1))), 0);
+        assertEq(uint256(vm.load(address(keystore), bytes32(uint256(base) + 2))), 0);
+        assertFalse(reapable.reapRecord(base, block.timestamp), "already empty");
+    }
+
+    function test_reapRecord_skipsNoExpiry() public {
+        (address account,) = _createK1Account(OWNER_PK);
+        bytes32 actorId = bytes32(uint256(0xB0B));
+        _applyLocal(OWNER_PK, account, _one(_authorizeChange(actorId, k1Authenticator, 0, 0, "")));
+
+        bytes32 base = KeystoreLayout.recordBase(account, actorId);
+        assertTrue(uint256(vm.load(address(keystore), base)) & KeystoreLayout.CLEANABLE != 0);
+        assertFalse(reapable.reapRecord(base, type(uint256).max));
+        assertEq(keystore.getActorConfig(account, actorId).authenticator, k1Authenticator);
+    }
+}

--- a/test/unit/Keystore/policyAccessors.t.sol
+++ b/test/unit/Keystore/policyAccessors.t.sol
@@ -754,7 +754,7 @@ contract PolicyAccessorsTest is KeystoreTest {
 
     /// @dev Authorize the EOA's self-actorId as a scoped k1 actor carrying a gated policy. The EOA is not
     ///      createAccount'd, so the implicit default-EOA owner signs the change; the authorization lives in the
-    ///      inline-k1 self home (`_accountState`) with (manager, commitment) in the shared actorId-keyed keyspace.
+    ///      inline-k1 self home (`_accountState`) with (manager, commitment) in the co-located actor record.
     function _authorizeInlineSelfWithPolicy(
         address eoa,
         uint256 eoaPk,


### PR DESCRIPTION
## Summary
- Pack actor config, policy manager, and policy commitment into one 4-aligned 3-word record (`word0`/`word1`/`word2`) so a later slot-grouping stem walk can reap expired leaves without an `(account, actorId)` preimage.
- Tag reap-eligible records with `CLEANABLE` (bit 248 of word0, last byte of the reserved region). Account-state keeps that byte zero, so a reaper can skip it. k1 self config stays inline and is not tagged.
- `_reapRecord` is internal and silent (no `ActorPruned`); it is not on the ABI yet. A random scan can be wired later.

## Test plan
- [ ] `forge test` (401 passing locally, including `CleanableLayoutTest`)
- [ ] Confirm authorize still writes authenticator/expiry/scope on word0 and policy on word1/word2
- [ ] Confirm revoke zeros the whole record
- [ ] Confirm expired `CLEANABLE` records reap; live, no-expiry, and AccountState do not
- [ ] Confirm `ActorConfig` ABI / `ActorAuthorized` payload still omit the storage-only `CLEANABLE` bit