### PR TITLE
Reorder scopes, co-locate policy with actor config, decouple policy/nonce

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           submodules: recursive
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1.7.0
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
 
       - name: Show Forge version
         run: forge --version

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -190,9 +190,9 @@ contract Keystore {
 
     // This contract is deliberately scope-agnostic. `scope == 0` is the admin predicate (the only scope value it
     // acts on for config/lock changes). Named grants (OPERATOR, SELF_PAYER, SPONSOR_PAYER, and the optional POLICY
-    // and NONCE bits) are stored verbatim and never read here; a chain may omit POLICY and NONCE entirely. Policy
-    // attachment is a length check on the authorize payload (empty vs 52 bytes), not a scope-bit test. The full
-    // uint16 grant vocabulary lives in {Scopes} for consumers. This contract does not reject scope combinations.
+    // and NONCE bits) are stored verbatim and never read here. Policy attachment is a length check on the authorize
+    // payload (empty vs 52 bytes), not a scope-bit test. The full uint16 grant vocabulary lives in {Scopes} for
+    // consumers. This contract does not reject scope combinations.
 
     /// @notice The single secp256k1 authenticator. The default EOA and every k1 actor share this one identity; the
     ///         actor config alone distinguishes a full-owner EOA from a scoped key. Signed with a K1_AUTHENTICATOR

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -190,9 +190,10 @@ contract Keystore {
 
     // This contract is deliberately scope-agnostic. `scope == 0` is the admin predicate (the only scope value it
     // acts on for config/lock changes). Named grants (OPERATOR, SELF_PAYER, SPONSOR_PAYER, and the optional POLICY
-    // and NONCE bits) are stored verbatim and never read here. Policy attachment is a length check on the authorize
-    // payload (empty vs 52 bytes), not a scope-bit test. The full uint16 grant vocabulary lives in {Scopes} for
-    // consumers. This contract does not reject scope combinations.
+    // and NONCE bits) are stored verbatim and never read here. Length decides what gets stored; POLICY decides
+    // whether the sender is gated; OPERATOR overrides POLICY. Policy attachment is a length check on the authorize
+    // payload (empty vs 52 bytes), not a scope-bit test — the protocol node, not this contract, gates `sender_auth`
+    // on POLICY. The full uint16 grant vocabulary lives in {Scopes}. This contract does not reject scope combinations.
 
     /// @notice The single secp256k1 authenticator. The default EOA and every k1 actor share this one identity; the
     ///         actor config alone distinguishes a full-owner EOA from a scoped key. Signed with a K1_AUTHENTICATOR
@@ -911,9 +912,10 @@ contract Keystore {
     ///      precompile. It lets an off-8130 consumer read `getPolicyManager` / `getPolicyCommitment(account, actorId)`
     ///      (execution-time reads) for a policy-gated actor, reaching parity with the native hot path.
     /// @dev `scope` is the actor's capability set, stored verbatim and never interpreted by this contract.
-    ///      Protocol-side semantics for bits like OPERATOR / POLICY / NONCE live outside this contract. Consumers
-    ///      that implement a policy gate look at whether policy bytes were attached (via {getPolicyManager})
-    ///      independently of the stored scope bits.
+    ///      Protocol-side semantics for bits like OPERATOR / POLICY / NONCE live outside this contract. Length
+    ///      decides what gets stored; POLICY decides whether the sender is gated; OPERATOR overrides POLICY. An
+    ///      off-8130 consumer that implements a policy gate should follow that same split — gate on the POLICY
+    ///      bit, not on whether policy bytes were attached.
     /// @dev Reverts with InvalidAuthLength when `auth` is shorter than 20 bytes.
     /// @dev Reverts with AuthenticationFailed, AuthenticatorMismatch, ActorExpired, DefaultEoaRevoked, or
     ///      InvalidSignature when the actor cannot be authenticated.
@@ -1257,7 +1259,8 @@ contract Keystore {
     ///      Empty → (0, 0). Exactly 52 bytes manager[20] || commitment[32] → (manager, commitment), written
     ///      verbatim. Neither field need be non-zero: a zero commitment is a valid "no params" and a zero
     ///      manager gates the actor to address(0). Only a length that is neither 0 nor 52 reverts. Scope bits
-    ///      are not consulted. The protocol does not interpret the commitment value.
+    ///      are not consulted here: length decides what gets stored; the protocol node gates the sender on POLICY.
+    ///      The protocol does not interpret the commitment value.
     function _slicePolicy(bytes memory policyData) private pure returns (address manager, bytes32 commitment) {
         if (policyData.length == 0) {
             return (address(0), bytes32(0));

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -665,22 +665,31 @@ contract Keystore {
                 }
             }
 
-            // Apply: dispatch the op to its handler.
+            // Apply: dispatch the op to its handler. Independent `if ... continue` arms (not an if/else-if chain) so
+            // each op's match/no-match paths are exercised and instrumented in isolation.
             if (t == ChangeType.AuthorizeActor) {
                 _applyAuthorize(account, batch.changes[i].payload, isUnsequenced, locked);
-            } else if (t == ChangeType.RevokeActor) {
-                _applyRevoke(account, batch.changes[i].payload);
-            } else if (t == ChangeType.IncrementLocalEpoch) {
-                _applyIncrementLocalEpoch(account, batch.changes[i].payload);
-            } else if (t == ChangeType.Lock) {
-                _applyLock(account, batch.changes[i].payload);
-            } else if (t == ChangeType.Unlock) {
-                _applyUnlock(account, batch.changes[i].payload);
-            } else {
-                // Unreachable at runtime (the enum decoder rejects out-of-range values). Kept to force any future
-                // ChangeType to be dispatched here rather than silently no-op'ing.
-                revert UnknownChangeType();
+                continue;
             }
+            if (t == ChangeType.RevokeActor) {
+                _applyRevoke(account, batch.changes[i].payload);
+                continue;
+            }
+            if (t == ChangeType.IncrementLocalEpoch) {
+                _applyIncrementLocalEpoch(account, batch.changes[i].payload);
+                continue;
+            }
+            if (t == ChangeType.Lock) {
+                _applyLock(account, batch.changes[i].payload);
+                continue;
+            }
+            if (t == ChangeType.Unlock) {
+                _applyUnlock(account, batch.changes[i].payload);
+                continue;
+            }
+            // Unreachable at runtime (the enum decoder rejects out-of-range values). Kept to force any future
+            // ChangeType to be dispatched here rather than silently no-op'ing.
+            revert UnknownChangeType();
         }
     }
 

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -665,8 +665,10 @@ contract Keystore {
                 }
             }
 
-            // Apply: dispatch the op to its handler. Independent `if ... continue` arms (not an if/else-if chain) so
-            // each op's match/no-match paths are exercised and instrumented in isolation.
+            // Apply: dispatch the op to its handler. Written as independent `if ... continue` arms rather than an
+            // if/else-if chain: under `forge coverage --ir-minimum` (forced by a stack-too-deep dep) the chain form
+            // leaves each arm's false edge as an unreachable coverage dash; the flat form instruments cleanly. Purely
+            // a coverage-shape choice — behavior is identical (same handlers, order, and UnknownChangeType fallback).
             if (t == ChangeType.AuthorizeActor) {
                 _applyAuthorize(account, batch.changes[i].payload, isUnsequenced, locked);
                 continue;

--- a/src/Keystore.sol
+++ b/src/Keystore.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.36;
 
 import {ActorId} from "./libraries/ActorId.sol";
 import {IAuthenticator} from "./interfaces/IAuthenticator.sol";
-import {Scopes} from "./libraries/Scopes.sol";
 
 /// @notice Keystore system contract for EIP-8130.
 ///         Manages actor authorization, account creation, change sequencing, and account lock. This contract is
@@ -24,21 +23,32 @@ contract Keystore {
     }
 
     /// @notice An actor's authorization: authenticator, expiry, and scope. Field order matches the normative
-    ///         `actor_config` slot layout: authenticator(20) ‖ expiry(6) ‖ scope(2) ‖ reserved(4).
+    ///         packed actor-config layout: authenticator(20) ‖ expiry(6) ‖ scope(2) ‖ reserved(4) = 32 bytes.
     struct ActorConfig {
         address authenticator;
         uint48 expiry; // Unix seconds; 0 = no expiry. Actor invalid once block.timestamp > expiry
         uint16 scope;
     }
 
-    /// @notice Initial actor for account creation and import. Carries its scope and, when scope & Scopes.POLICY is
-    ///         set, its policy data; expiry is always 0 for initial actors (scoped-with-expiry keys are added later
-    ///         via applySignedAccountChanges).
+    /// @notice Co-located actor record: the 32-byte config followed by optional policy (manager ‖ commitment).
+    ///         Consecutive slots so a Verkle witness can cover config and policy together. Policy is present iff
+    ///         the authorize payload carried the extra 52 bytes (84-byte packed record); Keystore does not read
+    ///         scope bits to decide this.
+    struct ActorRecord {
+        ActorConfig config; // slot 0: authenticator ‖ expiry ‖ scope ‖ reserved
+        address policyManager; // slot 1
+        bytes32 policyCommitment; // slot 2
+    }
+
+    /// @notice Initial actor for account creation and import. Carries its scope and optional policy data; expiry is
+    ///         always 0 for initial actors (scoped-with-expiry keys are added later via applySignedAccountChanges).
+    ///         `policyData` is empty (32-byte config only) or exactly 52 bytes manager(20) ‖ commitment(32),
+    ///         independent of `scope`.
     struct InitialActor {
         bytes32 actorId;
         address authenticator;
         uint16 scope; // 0x00 = unrestricted admin
-        bytes policyData; // empty unless scope & Scopes.POLICY; then manager(20) || commitment(32)
+        bytes policyData; // empty, or manager(20) || commitment(32)
     }
 
     /// @notice The operation an {AccountChange} applies within an {applySignedAccountChanges} batch.
@@ -49,7 +59,7 @@ contract Keystore {
     ///      and must each be the batch's only op.
     enum ChangeType {
         // Authority ops (mutate who can act).
-        AuthorizeActor, // payload: abi.encode(bytes32 actorId, ActorConfig cfg, bytes policyData); cfg.expiry is the granted expiry
+        AuthorizeActor, // payload: abi.encode(bytes32 actorId, ActorConfig cfg, bytes policyData); policyData empty or 52 bytes; cfg.expiry is the granted expiry
         RevokeActor, // payload: abi.encode(bytes32 actorId)
         // Environment ops (mutate the rules ops are checked against).
         IncrementLocalEpoch, // Either channel; payload: empty (length == 0 enforced)
@@ -107,10 +117,10 @@ contract Keystore {
     ///      The defaultEOA* fields are the inline home for the account's own secp256k1 ("self") key, whose actorId is
     ///      `ActorId.fromAddress(account)`. When FLAG_REVOKE_DEFAULT_EOA is unset, a k1 signature recovering to the
     ///      account authenticates with this inline config (all-zero = full owner; non-zero scope/expiry = a
-    ///      scoped self key), resolved in a single SLOAD. Policy gating (when scope & Scopes.POLICY != 0) is still keyed
-    ///      by actorId in the shared _policyManager/_policyCommitment keyspace. The separate _actorConfig[self][account]
-    ///      slot is reserved for a *non-k1* self authenticator (e.g. a post-quantum verifier returning the
-    ///      self-actorId); the two homes are mutually exclusive (see _authorizeActor).
+    ///      scoped self key), resolved in a single SLOAD. Optional policy (manager, commitment) lives in the co-located
+    ///      {ActorRecord} keyed by actorId. The separate _actors[self][account].config slot is reserved for a *non-k1*
+    ///      self authenticator (e.g. a post-quantum verifier returning the self-actorId); the two homes are mutually
+    ///      exclusive (see _authorizeActor).
     struct AccountState {
         uint64 multichainSequence; // 8 bytes
         uint32 localSequence; // 4 bytes – low half of the signed local word
@@ -179,11 +189,10 @@ contract Keystore {
     // ----------------------------------------------------------------------------------------------------------------
 
     // This contract is deliberately scope-agnostic. `scope == 0` is the admin predicate (the only scope value it
-    // acts on for config/lock changes), and it interprets exactly one grant bit — Scopes.POLICY — to slice and
-    // store an actor's policy data. Every other named grant (SENDER, NONCE, SELF_PAYER, SPONSOR_PAYER, and future
-    // bits) is stored verbatim and never read here; its meaning is enforced by whoever consumes it (protocol nodes,
-    // account contracts, policy managers). The full uint16 grant vocabulary lives in {Scopes}. This contract does
-    // not reject scope combinations — any use-time exclusivity is protocol-side.
+    // acts on for config/lock changes). Named grants (OPERATOR, SELF_PAYER, SPONSOR_PAYER, and the optional POLICY
+    // and NONCE bits) are stored verbatim and never read here; a chain may omit POLICY and NONCE entirely. Policy
+    // attachment is a length check on the authorize payload (empty vs 52 bytes), not a scope-bit test. The full
+    // uint16 grant vocabulary lives in {Scopes} for consumers. This contract does not reject scope combinations.
 
     /// @notice The single secp256k1 authenticator. The default EOA and every k1 actor share this one identity; the
     ///         actor config alone distinguishes a full-owner EOA from a scoped key. Signed with a K1_AUTHENTICATOR
@@ -232,9 +241,9 @@ contract Keystore {
     /// @param account The account whose actor was authorized.
     /// @param actorId The authorized actor's identifier.
     /// @param actorData Tightly packed authorization surface, mirroring the wire packing:
-    ///        authenticator(20) || expiry(6) || scope(2) || reserved(4 zero bytes) = 32 bytes, and, only when
-    ///        scope & Scopes.POLICY != 0, followed by the resolved policy gate manager(20) || commitment(32). So the
-    ///        payload is 32 bytes for an ungated actor and 84 bytes for a policy-gated one.
+    ///        authenticator(20) || expiry(6) || scope(2) || reserved(4 zero bytes) = 32 bytes, and, when policy
+    ///        bytes were attached, followed by manager(20) || commitment(32). So the payload is 32 bytes (config
+    ///        only) or 84 bytes (config + policy). Attachment is by length, not by any scope bit.
     event ActorAuthorized(address indexed account, bytes32 indexed actorId, bytes actorData);
 
     /// @notice Emitted when an actor is revoked from an account.
@@ -358,7 +367,8 @@ contract Keystore {
     /// @notice An actor config named an authenticator below the K1 sentinel (i.e. address(0)).
     error InvalidAuthenticator();
 
-    /// @notice The policyData length did not match `scope & Scopes.POLICY` (52 bytes when set, empty when unset).
+    /// @notice The attached policy bytes were neither empty (32-byte config only) nor exactly 52 bytes
+    ///         (manager(20) || commitment(32), making an 84-byte packed record).
     error InvalidPolicyData();
 
     /// @notice The referenced actor is not currently authorized on the account.
@@ -401,16 +411,9 @@ contract Keystore {
     // STORAGE
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
-    /// @notice Per-actor configuration
+    /// @notice Per-actor record: 32-byte config plus optional co-located policy (manager, commitment).
     /// @dev Account must be inner-most mapping key to pass ERC-7562 storage access rules for ERC-4337 compatibility.
-    mapping(bytes32 actorId => mapping(address account => ActorConfig)) internal _actorConfig;
-
-    /// @notice Per-actor signed policy commitment. Set when the actor's scope carries Scopes.POLICY.
-    /// @dev Read only during execution (via getPolicyCommitment / getActorWithPolicy), never during signature validity checks.
-    mapping(bytes32 actorId => mapping(address account => bytes32)) internal _policyCommitment;
-
-    /// @notice Per-actor policy manager address. Set when the actor's scope carries Scopes.POLICY.
-    mapping(bytes32 actorId => mapping(address account => address)) internal _policyManager;
+    mapping(bytes32 actorId => mapping(address account => ActorRecord)) internal _actors;
 
     /// @notice Per-account state: sequences, lock status (single slot per account)
     mapping(address account => AccountState) internal _accountState;
@@ -442,10 +445,10 @@ contract Keystore {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     /// @notice Deploys a new account with its initial actors. Each initial actor is registered with its declared
-    ///         `scope` and, when `scope & Scopes.POLICY` is set, its `policyData` (an external `manager` is expressible
-    ///         at create; `manager = account` is not, as the address is unknown at commitment time). `expiry` is
-    ///         always 0 at create — scoped-with-expiry keys are added afterwards via applySignedAccountChanges. The
-    ///         implicit default-EOA key is disabled on creation.
+    ///         `scope` and optional `policyData` (empty, or manager(20) ‖ commitment(32); an external `manager` is
+    ///         expressible at create; `manager = account` is not, as the address is unknown at commitment time).
+    ///         `expiry` is always 0 at create — scoped-with-expiry keys are added afterwards via
+    ///         applySignedAccountChanges. The implicit default-EOA key is disabled on creation.
     ///
     /// @dev Reverts with EmptyBytecode when `bytecode` is empty.
     /// @dev Reverts with BytecodeTooLarge when `bytecode` exceeds the maximum encodable length.
@@ -453,7 +456,7 @@ contract Keystore {
     /// @dev Reverts with NoInitialActors when `initialActors` is empty.
     /// @dev Reverts with ActorsNotSortedOrDuplicate when `initialActors` is not strictly ascending by actorId.
     /// @dev Reverts with InvalidAuthenticator when an initial actor names a zero authenticator.
-    /// @dev Reverts with InvalidPolicyData when an initial actor's policyData length does not match its scope.
+    /// @dev Reverts with InvalidPolicyData when an initial actor's policyData is neither empty nor 52 bytes.
     /// @dev Reverts with AccountDeploymentFailed when CREATE2 does not deploy code at the expected address.
     ///
     /// @param userSalt Caller-chosen salt mixed into the CREATE2 address derivation.
@@ -726,11 +729,11 @@ contract Keystore {
             // Live entry: expiry-only. Expired reads as empty ({_resolveActorConfig}), so that id is a new add.
             ActorConfig memory current = _resolveActorConfig(account, actorId);
             if (current.authenticator != address(0)) {
-                (address manager, bytes32 commitment) = _slicePolicy(cfg.scope, policyData);
+                (address manager, bytes32 commitment) = _slicePolicy(policyData);
+                ActorRecord storage rec = _actors[actorId][account];
                 if (
                     cfg.authenticator != current.authenticator || cfg.scope != current.scope
-                        || manager != _policyManager[actorId][account]
-                        || commitment != _policyCommitment[actorId][account]
+                        || manager != rec.policyManager || commitment != rec.policyCommitment
                 ) {
                     revert AccountIsLocked();
                 }
@@ -749,9 +752,7 @@ contract Keystore {
         if (!_isAuthorized(account, actorId)) {
             revert UnknownActor();
         }
-        delete _actorConfig[actorId][account];
-        delete _policyCommitment[actorId][account];
-        delete _policyManager[actorId][account];
+        delete _actors[actorId][account];
         if (actorId == _selfActorId(account)) {
             _disableInlineSelf(_accountState[account]);
         }
@@ -898,9 +899,10 @@ contract Keystore {
     /// @dev `actorId` is the resolved actor identifier — the same value an 8130 chain surfaces via the tx-context
     ///      precompile. It lets an off-8130 consumer read `getPolicyManager` / `getPolicyCommitment(account, actorId)`
     ///      (execution-time reads) for a policy-gated actor, reaching parity with the native hot path.
-    /// @dev `scope` is the actor's capability set, stored verbatim and never interpreted by this contract —
-    ///      protocol-side semantics for bits like Scopes.NONCE live outside this contract. Consumers decide policy
-    ///      gating via `scope & Scopes.POLICY`, then resolve the gate target separately via {getPolicyManager}.
+    /// @dev `scope` is the actor's capability set, stored verbatim and never interpreted by this contract.
+    ///      Protocol-side semantics for bits like OPERATOR / POLICY / NONCE live outside this contract. Consumers
+    ///      that implement a policy gate look at whether policy bytes were attached (via {getPolicyManager})
+    ///      independently of the stored scope bits.
     /// @dev Reverts with InvalidAuthLength when `auth` is shorter than 20 bytes.
     /// @dev Reverts with AuthenticationFailed, AuthenticatorMismatch, ActorExpired, DefaultEoaRevoked, or
     ///      InvalidSignature when the actor cannot be authenticated.
@@ -955,23 +957,23 @@ contract Keystore {
     }
 
     /// @notice Returns an actor's config, policy manager, and policy commitment in one read. The manager and
-    ///         commitment are non-zero only for a live actor with scope & Scopes.POLICY set; a non-live actor
-    ///         returns the empty config and a zero manager/commitment.
+    ///         commitment are the co-located values stored when 52 policy bytes were attached; a non-live actor
+    ///         returns the empty config and a zero manager/commitment. Attachment is by length, not by any scope bit.
     function getActorWithPolicy(address account, bytes32 actorId)
         external
         view
         returns (ActorConfig memory config, address policyManager, bytes32 policyCommitment)
     {
         config = _resolveActorConfig(account, actorId);
-        // Gating is by the scope bit, matching {_emitActorAuthorized}; a non-live or ungated actor has a zero gate.
-        if (config.authenticator != address(0) && config.scope & Scopes.POLICY != 0) {
-            policyManager = _policyManager[actorId][account];
-            policyCommitment = _policyCommitment[actorId][account];
+        if (config.authenticator != address(0)) {
+            ActorRecord storage rec = _actors[actorId][account];
+            policyManager = rec.policyManager;
+            policyCommitment = rec.policyCommitment;
         }
     }
 
     /// @dev The single liveness resolver behind every read surface ({getActorConfig}, {getActorWithPolicy},
-    ///      {getPolicyCommitment}, {getPolicyManager}). A populated _actorConfig entry returns verbatim unless expired;
+    ///      {getPolicyCommitment}, {getPolicyManager}). A populated _actors[].config entry returns verbatim unless expired;
     ///      the k1 self (inline in AccountState) resolves to a native ecrecover owner unless disabled or expired;
     ///      anything unknown/revoked/disabled/expired resolves to the all-zero (empty) config. Centralizing this is
     ///      what makes "expired" read identically to "revoked" on every surface — the invariant that lets a node
@@ -979,7 +981,7 @@ contract Keystore {
     function _resolveActorConfig(address account, bytes32 actorId) private view returns (ActorConfig memory) {
         // Common path first: the inline k1 self. A clear FLAG_REVOKE_DEFAULT_EOA means the inline self is live, so
         // resolve it from AccountState alone (all-zero = full owner). When the flag is set the inline self is off —
-        // either a non-k1 self lives in _actorConfig, or the self was revoked — so fall through to the shared home.
+        // either a non-k1 self lives in _actors[].config, or the self was revoked — so fall through to the shared home.
         if (actorId == _selfActorId(account)) {
             AccountState storage st = _accountState[account];
             if (st.flags & FLAG_REVOKE_DEFAULT_EOA == 0) {
@@ -993,9 +995,9 @@ contract Keystore {
             }
         }
 
-        // Explicit actor (or a non-k1 self): the single _actorConfig home. A stored authenticator is K1_AUTHENTICATOR
+        // Explicit actor (or a non-k1 self): the single _actors home. A stored authenticator is K1_AUTHENTICATOR
         // (0x1) or a contract, so `>= K1_AUTHENTICATOR` is the "slot populated" test. An expired entry reports empty.
-        ActorConfig memory config = _actorConfig[actorId][account];
+        ActorConfig memory config = _actors[actorId][account].config;
         if (config.authenticator >= K1_AUTHENTICATOR) {
             return _isExpired(config.expiry) ? _emptyActorConfig() : config;
         }
@@ -1013,7 +1015,7 @@ contract Keystore {
         if (_resolveActorConfig(account, actorId).authenticator == address(0)) {
             return bytes32(0);
         }
-        return _policyCommitment[actorId][account];
+        return _actors[actorId][account].policyCommitment;
     }
 
     /// @notice The actor's policy manager, or 0 when the actor is not live. See {_resolveActorConfig}.
@@ -1021,7 +1023,7 @@ contract Keystore {
         if (_resolveActorConfig(account, actorId).authenticator == address(0)) {
             return address(0);
         }
-        return _policyManager[actorId][account];
+        return _actors[actorId][account].policyManager;
     }
 
     /// @notice Returns the account's replay counters: the multichain counter and the local channel's epoch and
@@ -1121,7 +1123,7 @@ contract Keystore {
 
     /// @dev Registers the bootstrap actor set shared by createAccount and importAccount: requires a non-empty,
     ///      strictly ascending-by-actorId list (rejecting unsorted or duplicate entries) and authorizes each entry
-    ///      with its declared scope and (when scope & Scopes.POLICY is set) policyData. Expiry is always 0 for
+    ///      with its declared scope and optional policyData (empty or 52 bytes). Expiry is always 0 for
     ///      initial actors; scoped-with-expiry keys are added later via applySignedAccountChanges. Reverts with
     ///      NoInitialActors or ActorsNotSortedOrDuplicate.
     function _initializeAccount(address account, InitialActor[] calldata initialActors)
@@ -1141,9 +1143,9 @@ contract Keystore {
             }
             previousActorId = initialActors[i].actorId;
 
-            // Initial actors carry scope verbatim (0x00 = unrestricted admin) and never an expiry. When
-            // scope & Scopes.POLICY is set, policyData is validated by the same frozen rule as authorizeActor
-            // (52 bytes). Authorizing the self-actorId as k1 writes its scope into the inline default-EOA fields.
+            // Initial actors carry scope verbatim (0x00 = unrestricted admin) and never an expiry. policyData is
+            // validated by the same length rule as authorizeActor (empty or 52 bytes). Authorizing the
+            // self-actorId as k1 writes its scope into the inline default-EOA fields.
             ActorConfig memory config =
                 ActorConfig({authenticator: initialActors[i].authenticator, scope: initialActors[i].scope, expiry: 0});
             _authorizeActor(account, initialActors[i].actorId, config, initialActors[i].policyData);
@@ -1152,8 +1154,8 @@ contract Keystore {
 
     /// @dev Authorizes (upserts) `actorId` with `config` and optional `policyData`, emitting ActorAuthorized. Rejects
     ///      a sub-K1 authenticator. The self-actorId is routed by authenticator type (a k1 self inline in
-    ///      AccountState, a non-k1 self in _actorConfig) and the two are kept mutually exclusive; every other actor
-    ///      lives in _actorConfig. Reverts with InvalidActorId, InvalidAuthenticator, or InvalidPolicyData.
+    ///      AccountState, a non-k1 self in _actors[].config) and the two are kept mutually exclusive; every other actor
+    ///      lives in _actors. Reverts with InvalidActorId, InvalidAuthenticator, or InvalidPolicyData.
     function _authorizeActor(address account, bytes32 actorId, ActorConfig memory config, bytes memory policyData)
         private
         nonZeroAccount(account)
@@ -1171,47 +1173,47 @@ contract Keystore {
             revert InvalidAuthenticator();
         }
 
-        // Slice the signed policy by scope & Scopes.POLICY. The commitment is opaque to the protocol. This contract
-        // does not reject scope combinations (e.g. Scopes.POLICY | Scopes.SELF_PAYER) — any use-time exclusivity between
-        // Scopes.POLICY and the account's other capabilities is protocol-side, not enforced here.
-        (address manager, bytes32 commitment) = _slicePolicy(config.scope, policyData);
+        // Slice optional policy by length: empty → (0, 0); 52 bytes → (manager, commitment); anything else reverts.
+        // Scope bits are not consulted. The commitment is opaque to this contract.
+        (address manager, bytes32 commitment) = _slicePolicy(policyData);
 
         if (actorId == _selfActorId(account)) {
             // Self-actorId is routed by authenticator type and the two homes are mutually exclusive: the k1 self
-            // lives inline in AccountState; a non-k1 self lives in _actorConfig. Authorizing one clears the
+            // lives inline in AccountState; a non-k1 self lives in _actors[].config. Authorizing one clears the
             // other so a k1 and a non-k1 self are never simultaneously live.
             AccountState storage st = _accountState[account];
             if (config.authenticator == K1_AUTHENTICATOR) {
                 // Upsert: overwrite a live self in place (no re-auth guard); the end state equals revoke-then-
                 // authorize. Re-enabling a previously revoked self is just the flag clear below.
-                delete _actorConfig[actorId][account]; // mutual exclusion: drop any non-k1 self
+                delete _actors[actorId][account].config; // mutual exclusion: drop any non-k1 self
                 st.defaultEOAScope = config.scope;
                 st.defaultEOAExpiry = config.expiry;
                 st.flags &= ~FLAG_REVOKE_DEFAULT_EOA; // enable the inline self
             } else {
                 // Upsert: overwrite any existing non-k1 self in place.
-                _actorConfig[actorId][account] = config;
+                _actors[actorId][account].config = config;
                 // Mutual exclusion: disable and clear the inline k1 self.
                 _disableInlineSelf(st);
             }
-            // Policy slots are keyed by actorId (shared keyspace across both self homes).
+            // Policy is co-located on the same ActorRecord, including for the inline k1 self.
             _writePolicySlots(actorId, account, manager, commitment);
 
-            _emitActorAuthorized(account, actorId, config, manager, commitment);
+            _emitActorAuthorized(account, actorId, config, manager, commitment, policyData.length == 52);
             return;
         }
 
-        // Non-self actor: single _actorConfig home. Upsert: overwrite in place.
-        _actorConfig[actorId][account] = config;
+        // Non-self actor: single _actors home. Upsert: overwrite in place.
+        _actors[actorId][account].config = config;
         _writePolicySlots(actorId, account, manager, commitment);
 
-        _emitActorAuthorized(account, actorId, config, manager, commitment);
+        _emitActorAuthorized(account, actorId, config, manager, commitment, policyData.length == 52);
     }
 
-    /// @dev Writes the current policy values and clears stale values when an actor becomes ungated.
+    /// @dev Writes the current policy values (zeroing them when no 52-byte policy was attached).
     function _writePolicySlots(bytes32 actorId, address account, address manager, bytes32 commitment) private {
-        _policyCommitment[actorId][account] = commitment;
-        _policyManager[actorId][account] = manager;
+        ActorRecord storage rec = _actors[actorId][account];
+        rec.policyManager = manager;
+        rec.policyCommitment = commitment;
     }
 
     /// @dev Disables the inline k1 ("self") key: sets FLAG_REVOKE_DEFAULT_EOA so the inline full-owner path stays off
@@ -1224,34 +1226,29 @@ contract Keystore {
 
     /// @dev Emit ActorAuthorized with a tightly packed payload. The base packs to 32 bytes
     ///      (authenticator(20) || expiry(6) || scope(2) || reserved(4 zero bytes)); the policy gate
-    ///      (manager(20) || commitment(32), 52 bytes) is appended only when scope & Scopes.POLICY != 0.
+    ///      (manager(20) || commitment(32), 52 bytes) is appended when 52 policy bytes were attached,
+    ///      producing an 84-byte record. Attachment is by length, not by any scope bit.
     function _emitActorAuthorized(
         address account,
         bytes32 actorId,
         ActorConfig memory config,
         address manager,
-        bytes32 commitment
+        bytes32 commitment,
+        bool policyAttached
     ) private {
-        bytes memory actorData = (config.scope & Scopes.POLICY != 0)
+        bytes memory actorData = policyAttached
             ? abi.encodePacked(config.authenticator, config.expiry, config.scope, bytes4(0), manager, commitment)
             : abi.encodePacked(config.authenticator, config.expiry, config.scope, bytes4(0));
         emit ActorAuthorized(account, actorId, actorData);
     }
 
-    /// @dev Validates `policyData` against `scope & Scopes.POLICY` and returns (manager, commitment).
-    ///      Unset: empty data -> (0, 0). Set: exactly 52 bytes manager[20] || commitment[32] -> (manager,
-    ///      commitment), written verbatim. Neither field need be non-zero: a zero commitment is a valid "no
-    ///      params" and a zero manager gates the actor to address(0). Only a length mismatch reverts. The protocol
-    ///      does not interpret the commitment value; self-enforcement is expressed as manager == account.
-    function _slicePolicy(uint16 scope, bytes memory policyData)
-        private
-        pure
-        returns (address manager, bytes32 commitment)
-    {
-        if (scope & Scopes.POLICY == 0) {
-            if (policyData.length != 0) {
-                revert InvalidPolicyData();
-            }
+    /// @dev Validates attached policy bytes by length and returns (manager, commitment).
+    ///      Empty → (0, 0). Exactly 52 bytes manager[20] || commitment[32] → (manager, commitment), written
+    ///      verbatim. Neither field need be non-zero: a zero commitment is a valid "no params" and a zero
+    ///      manager gates the actor to address(0). Only a length that is neither 0 nor 52 reverts. Scope bits
+    ///      are not consulted. The protocol does not interpret the commitment value.
+    function _slicePolicy(bytes memory policyData) private pure returns (address manager, bytes32 commitment) {
+        if (policyData.length == 0) {
             return (address(0), bytes32(0));
         }
         if (policyData.length != 52) {
@@ -1268,10 +1265,10 @@ contract Keystore {
     /// @dev Checks authorization presence without expiry so expired actors can still be explicitly revoked.
     function _isAuthorized(address account, bytes32 actorId) private view returns (bool) {
         // A populated entry represents any non-self actor or a non-k1 self authenticator.
-        if (_actorConfig[actorId][account].authenticator >= K1_AUTHENTICATOR) {
+        if (_actors[actorId][account].config.authenticator >= K1_AUTHENTICATOR) {
             return true;
         }
-        // No _actorConfig entry: the self-actorId's k1 key lives inline in AccountState, live unless the flag is set.
+        // No _actors[].config entry: the self-actorId's k1 key lives inline in AccountState, live unless the flag is set.
         if (actorId == _selfActorId(account)) {
             return !_isDefaultEoaRevoked(account);
         }
@@ -1281,11 +1278,11 @@ contract Keystore {
     /// @dev The shared, read-only static gate on a bootstrap actor set, applying the exact rules that
     ///      _initializeAccount/_authorizeActor enforce at write time: non-empty, strictly ascending by actorId (which
     ///      also rejects duplicates and the zero actorId), a K1-or-above authenticator, and a policyData length that
-    ///      matches scope & Scopes.POLICY (52 bytes when set, empty when clear). Running it inside {_prepareDeployment}
-    ///      gives {computeAddress} the same validity as {createAccount}, so a predicted address is never returned for
-    ///      an actor set a later createAccount would reject (which would otherwise let a client prefund and strand
-    ///      funds at an undeployable address). Reverts with NoInitialActors, ActorsNotSortedOrDuplicate,
-    ///      InvalidAuthenticator, or InvalidPolicyData.
+    ///      is empty or exactly 52 bytes. Running it inside {_prepareDeployment} gives {computeAddress} the same
+    ///      validity as {createAccount}, so a predicted address is never returned for an actor set a later
+    ///      createAccount would reject (which would otherwise let a client prefund and strand funds at an
+    ///      undeployable address). Reverts with NoInitialActors, ActorsNotSortedOrDuplicate, InvalidAuthenticator, or
+    ///      InvalidPolicyData.
     function _validateInitialActors(InitialActor[] calldata initialActors) private pure {
         if (initialActors.length == 0) {
             revert NoInitialActors();
@@ -1302,8 +1299,8 @@ contract Keystore {
             if (actor.authenticator < K1_AUTHENTICATOR) {
                 revert InvalidAuthenticator();
             }
-            // Same frozen rule as _slicePolicy: 52 bytes when POLICY-scoped, empty otherwise.
-            if (actor.policyData.length != (actor.scope & Scopes.POLICY != 0 ? 52 : 0)) {
+            // Same length rule as _slicePolicy: empty (config only) or exactly 52 bytes (config + policy).
+            if (actor.policyData.length != 0 && actor.policyData.length != 52) {
                 revert InvalidPolicyData();
             }
 
@@ -1342,8 +1339,8 @@ contract Keystore {
 
     /// @dev Commitment over the initial actor set, using the same hash-the-leaves-then-hash-the-list scheme as the
     ///      signed digests ({_computeImportDigest}, {_changesDigest}). Each actor hashes to a fixed-width leaf over
-    ///      actorId (32) || authenticator (20) || scope (2) || policyData, where policyData is empty (POLICY unset)
-    ///      or exactly 52 bytes (POLICY set); expiry does not participate (always 0 for initial actors). The
+    ///      actorId (32) || authenticator (20) || scope (2) || policyData, where policyData is empty or exactly 52
+    ///      bytes (manager ‖ commitment); expiry does not participate (always 0 for initial actors). The
     ///      commitment is keccak256 over the tightly packed 32-byte leaves, so it is unambiguous by construction and
     ///      linear in the actor count. Protocol clients reproduce it as leaf_i = keccak256(actorId || authenticator ||
     ///      scope || policyData); commitment = keccak256(leaf_0 || ... || leaf_{n-1}).
@@ -1422,7 +1419,7 @@ contract Keystore {
 
     /// @dev Resolves and authenticates the actor behind `authenticator`/`data`, returning its
     ///      (actorId, scope). Routes the K1 sentinel to _authenticateK1; otherwise calls the
-    ///      IAuthenticator and requires the resolved actorId to carry a matching, unexpired _actorConfig entry.
+    ///      IAuthenticator and requires the resolved actorId to carry a matching, unexpired _actors[].config entry.
     ///      Reverts with AuthenticationFailed, AuthenticatorMismatch, or ActorExpired.
     function _authenticate(address account, bytes32 hash, address authenticator, bytes calldata data)
         private
@@ -1441,7 +1438,7 @@ contract Keystore {
         return (actorId, _resolveExplicitActor(account, actorId, authenticator));
     }
 
-    /// @dev Resolves an explicit _actorConfig-homed actor: requires a matching authenticator and an unexpired entry,
+    /// @dev Resolves an explicit _actors-homed actor: requires a matching authenticator and an unexpired entry,
     ///      returning its scope. Shared by the non-k1 (_authenticate) and k1 other-actor (_authenticateK1) paths.
     ///      Reverts with AuthenticatorMismatch or ActorExpired.
     function _resolveExplicitActor(address account, bytes32 actorId, address expectedAuthenticator)
@@ -1449,7 +1446,7 @@ contract Keystore {
         view
         returns (uint16 scope)
     {
-        ActorConfig memory config = _actorConfig[actorId][account];
+        ActorConfig memory config = _actors[actorId][account].config;
         if (config.authenticator != expectedAuthenticator) {
             revert AuthenticatorMismatch();
         }
@@ -1465,7 +1462,7 @@ contract Keystore {
     ///          key (set => revert), and when live the scope/expiry come from the inline fields (all-zero = full
     ///          owner; non-zero = a scoped self). A non-k1 self is unreachable here by construction (it requires
     ///          its own authenticator), and mutual exclusion keeps the flag set whenever one is live.
-    ///        - otherwise the signer's actorId must carry an explicit K1 config in _actorConfig (any other k1 actor).
+    ///        - otherwise the signer's actorId must carry an explicit K1 config in _actors (any other k1 actor).
     ///      Both the common self and other-actor paths cost a single SLOAD.
     function _authenticateK1(address account, bytes32 hash, bytes calldata data)
         private

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -99,7 +99,7 @@ contract DefaultAccount is Receiver {
     // ══════════════════════════════════════════════
 
     /// @notice Validates an ERC-1271 signature via Keystore; requires the verified actor to be operational (the
-    ///         unrestricted admin, scope == 0x00, or a SENDER actor without POLICY). Never reverts.
+    ///         unrestricted admin, scope == 0x00, or an OPERATOR actor). Never reverts.
     ///
     /// @dev {Keystore.validateSignature} resolves the typed envelope and reverts on any authentication failure; the
     ///      revert is caught and reported as the ERC-1271 failure value. Operational gating lives here (not in the
@@ -138,10 +138,10 @@ contract DefaultAccount is Receiver {
     /// @dev Authorized if `caller` is the account itself, or holds the TRUSTED_EXECUTOR authenticator with an
     ///      unexpired config AND operational authority. Expiry: 0 means none; a non-zero expiry is enforced so a
     ///      user-set expiry is honored on the execution path. Scope: driving execution requires operational
-    ///      authority ({Scopes.isOperator}) — the unrestricted admin (scope == 0x00) or a SENDER actor not gated
-    ///      by a policy. A POLICY-gated actor must route every call through its manager, so granting it direct
-    ///      executeBatch would bypass that gate; fail closed. Sharing {Scopes.isOperator} keeps the execution and
-    ///      signing (ERC-1271) authorization surfaces aligned.
+    ///      authority ({Scopes.isOperator}) — the unrestricted admin (scope == 0x00) or an OPERATOR actor.
+    ///      OPERATOR is more permissive than POLICY and the two do not combine: a POLICY-only actor must route
+    ///      every call through its manager, so granting it direct executeBatch would bypass that gate; fail closed.
+    ///      Sharing {Scopes.isOperator} keeps the execution and signing (ERC-1271) authorization surfaces aligned.
     function _isAuthorizedCaller(address caller) internal view virtual returns (bool) {
         if (caller == address(this)) return true;
         Keystore.ActorConfig memory config = KEYSTORE.getActorConfig(address(this), ActorId.fromAddress(caller));

--- a/src/libraries/Scopes.sol
+++ b/src/libraries/Scopes.sol
@@ -3,39 +3,43 @@ pragma solidity 0.8.36;
 
 /// @notice Canonical EIP-8130 actor scope grants.
 /// @dev Scope assignments are append-only; unknown bits are stored verbatim and grant no authority.
-///      Keystore treats `scope == 0` as admin and interprets only {POLICY}; consumers enforce all other grants.
+///      Core grants occupy bits 0–2 so a chain can omit POLICY and NONCE without renumbering anything else.
+///      Keystore stores `scope` verbatim and never interprets these bits; consumers enforce meaning at use time.
+///      OPERATOR and POLICY do not combine: OPERATOR may originate to any `call.to`; POLICY-only is gated to the
+///      actor's policy manager. A chain that drops POLICY/NONCE simply never sets those bits.
 library Scopes {
     /// @notice Ungated initiation (`sender_auth`): may originate transactions to any `call.to`.
-    uint16 internal constant SENDER = 0x0001;
-
-    /// @notice Gated initiation (`sender_auth`): may originate transactions only to the actor's `policy_manager`.
-    ///         The one bit Keystore itself interprets, to slice and store the actor's policy data.
-    uint16 internal constant POLICY = 0x0002;
-
-    /// @notice Permits a restricted actor to use sequenced `nonce_key`s for sender-context transactions.
-    uint16 internal constant NONCE = 0x0004;
+    uint16 internal constant OPERATOR = 0x0001;
 
     /// @notice Self-pay gas: authorizes paying the account's own gas when `payer == sender`.
-    uint16 internal constant SELF_PAYER = 0x0008;
+    uint16 internal constant SELF_PAYER = 0x0002;
 
     /// @notice Sponsor gas: authorizes acting as `payer_auth` for a different sender (`payer != sender`).
-    uint16 internal constant SPONSOR_PAYER = 0x0010;
+    uint16 internal constant SPONSOR_PAYER = 0x0004;
+
+    /// @notice Gated initiation (`sender_auth`): may originate transactions only to the actor's policy manager.
+    ///         Optional: a chain that has no policy system leaves this bit unused.
+    uint16 internal constant POLICY = 0x0008;
+
+    /// @notice Permits a restricted actor to use sequenced `nonce_key`s for sender-context transactions.
+    ///         Optional: a chain that has no extra nonce lanes leaves this bit unused.
+    uint16 internal constant NONCE = 0x0010;
 
     // 0x0020..0x8000 (bits 5–15) are spare, reserved for future pure grants.
 
     /// @notice Whether `scope` grants operational authority — the authority to drive execution and to sign
     ///         (ERC-1271) as the account.
     ///
-    /// @dev Operational means either the unrestricted admin (`scope == 0`) or a {SENDER} actor that is not gated by
-    ///      a policy ({POLICY} unset). A POLICY-gated actor is deliberately not operational: it must route every
-    ///      call through its policy manager, so letting it drive execution or vouch a signature would act outside
-    ///      that gate. This is the single shared definition consumers use to keep the execution and signing
+    /// @dev Operational means the unrestricted admin (`scope == 0`) or an {OPERATOR} actor. POLICY does not
+    ///      suppress OPERATOR: the two grants do not combine, and OPERATOR is the more permissive of the two.
+    ///      A POLICY-only actor is deliberately not operational — it must route every call through its policy
+    ///      manager. This is the single shared definition consumers use to keep the execution and signing
     ///      authorization surfaces aligned (see DefaultAccount).
     ///
     /// @param scope The actor scope bitmask to test.
     ///
     /// @return True iff `scope` carries operational authority.
     function isOperator(uint16 scope) internal pure returns (bool) {
-        return scope == 0 || ((scope & SENDER != 0) && (scope & POLICY == 0));
+        return scope == 0 || (scope & OPERATOR != 0);
     }
 }

--- a/src/libraries/Scopes.sol
+++ b/src/libraries/Scopes.sol
@@ -4,9 +4,10 @@ pragma solidity 0.8.36;
 /// @notice Canonical EIP-8130 actor scope grants.
 /// @dev Scope assignments are append-only; unknown bits are stored verbatim and grant no authority.
 ///      Core grants occupy bits 0–2; the optional POLICY and NONCE grants trail them.
-///      Keystore stores `scope` verbatim and never interprets these bits; consumers enforce meaning at use time.
-///      OPERATOR and POLICY do not combine: OPERATOR may originate to any `call.to`; POLICY-only is gated to the
-///      actor's policy manager.
+///      Length decides what gets stored; POLICY decides whether the sender is gated; OPERATOR overrides POLICY.
+///      Keystore attaches policy by payload length (empty vs 52 bytes) and stores `scope` verbatim. The protocol
+///      node gates `sender_auth` on the POLICY bit; OPERATOR is the more permissive initiation grant and is not
+///      suppressed by POLICY.
 library Scopes {
     /// @notice Ungated initiation (`sender_auth`): may originate transactions to any `call.to`.
     uint16 internal constant OPERATOR = 0x0001;

--- a/src/libraries/Scopes.sol
+++ b/src/libraries/Scopes.sol
@@ -3,10 +3,10 @@ pragma solidity 0.8.36;
 
 /// @notice Canonical EIP-8130 actor scope grants.
 /// @dev Scope assignments are append-only; unknown bits are stored verbatim and grant no authority.
-///      Core grants occupy bits 0–2 so a chain can omit POLICY and NONCE without renumbering anything else.
+///      Core grants occupy bits 0–2; the optional POLICY and NONCE grants trail them.
 ///      Keystore stores `scope` verbatim and never interprets these bits; consumers enforce meaning at use time.
 ///      OPERATOR and POLICY do not combine: OPERATOR may originate to any `call.to`; POLICY-only is gated to the
-///      actor's policy manager. A chain that drops POLICY/NONCE simply never sets those bits.
+///      actor's policy manager.
 library Scopes {
     /// @notice Ungated initiation (`sender_auth`): may originate transactions to any `call.to`.
     uint16 internal constant OPERATOR = 0x0001;
@@ -18,11 +18,11 @@ library Scopes {
     uint16 internal constant SPONSOR_PAYER = 0x0004;
 
     /// @notice Gated initiation (`sender_auth`): may originate transactions only to the actor's policy manager.
-    ///         Optional: a chain that has no policy system leaves this bit unused.
+    ///         Optional grant.
     uint16 internal constant POLICY = 0x0008;
 
     /// @notice Permits a restricted actor to use sequenced `nonce_key`s for sender-context transactions.
-    ///         Optional: a chain that has no extra nonce lanes leaves this bit unused.
+    ///         Optional grant.
     uint16 internal constant NONCE = 0x0010;
 
     // 0x0020..0x8000 (bits 5–15) are spare, reserved for future pure grants.

--- a/src/policies/PolicyManager.sol
+++ b/src/policies/PolicyManager.sol
@@ -22,7 +22,7 @@ address constant EXTERNAL_POLICY_AUTHENTICATOR = address(uint160(uint256(keccak2
 ///         paths derive identity from `msg.sender` and work on any chain.
 ///
 /// @dev The account registers this manager as an execution-enabled actor and gates a restricted session key with
-///      `scope & Scopes.POLICY != 0` and `policy_manager = address(this)`, so the protocol routes that key's calls
+///      `scope & Scopes.POLICY != 0` (optional) and `policy_manager = address(this)`, so the protocol routes that key's calls
 ///      here. Authorization is the account's signed commitment: the keccak256 of a {PolicyBinding}, stored in
 ///      Keystore. Every entrypoint recomputes the commitment from the supplied binding and requires it to match, so
 ///      config, validity window, and owning account are authenticated in one check with no config stored here.

--- a/src/policies/README.md
+++ b/src/policies/README.md
@@ -6,10 +6,10 @@ In EIP-8130, a restricted actor (e.g. a session key) is configured with optional
 (`manager(20) || commitment(32)`) stored co-located with the 32-byte actor config, making an 84-byte packed
 record. The protocol gate typically also sets `scope & Scopes.POLICY != 0` and forces every call that actor
 makes to land on that single manager. These contracts are one realization of that manager: it enforces
-application-specific limits and then drives the account. `Scopes.POLICY` (`0x08`) is optional — a chain
-that has no policy system never sets the bit and never attaches the extra 52 bytes. `Keystore` does not
-import or interpret scope bits; attachment is a length check (empty vs 52). OPERATOR and POLICY do not
-combine: OPERATOR may originate to any `call.to`, POLICY-only is gated to the manager.
+application-specific limits and then drives the account. `Scopes.POLICY` (`0x08`) is an optional grant.
+`Keystore` does not import or interpret scope bits; policy attachment is a length check (empty vs 52).
+OPERATOR and POLICY do not combine: OPERATOR may originate to any `call.to`, POLICY-only is gated to the
+manager.
 
 ## Flow
 

--- a/src/policies/README.md
+++ b/src/policies/README.md
@@ -2,13 +2,14 @@
 
 A policy manager for EIP-8130 restricted actors.
 
-In EIP-8130, a restricted actor (e.g. a session key) is configured with `scope & Scopes.POLICY != 0`, which stores a
-`policy_manager` address and an opaque `policy_commitment` in the Keystore contract. The protocol
-gate forces every call that actor makes to land on that single manager. These contracts are one realization of
-that manager: it enforces application-specific limits and then drives the account. `Scopes.POLICY`
-(`0x02`) may be combined with other scope bits (e.g. `Scopes.POLICY | Scopes.SELF_PAYER`) — `Keystore` does
-not reject scope combinations; use-time exclusivity between policy gating and an actor's other capabilities is
-protocol-side, not enforced by this contract.
+In EIP-8130, a restricted actor (e.g. a session key) is configured with optional 52-byte policy data
+(`manager(20) || commitment(32)`) stored co-located with the 32-byte actor config, making an 84-byte packed
+record. The protocol gate typically also sets `scope & Scopes.POLICY != 0` and forces every call that actor
+makes to land on that single manager. These contracts are one realization of that manager: it enforces
+application-specific limits and then drives the account. `Scopes.POLICY` (`0x08`) is optional — a chain
+that has no policy system never sets the bit and never attaches the extra 52 bytes. `Keystore` does not
+import or interpret scope bits; attachment is a length check (empty vs 52). OPERATOR and POLICY do not
+combine: OPERATOR may originate to any `call.to`, POLICY-only is gated to the manager.
 
 ## Flow
 
@@ -146,14 +147,14 @@ then `executeFor` — so the account never needs to send a transaction. The acco
 // actorId = ActorId.fromAddress(provider). The provider never signs an 8130 tx; it acts by being msg.sender.
 Keystore.ActorConfig({
     authenticator: EXTERNAL_POLICY_AUTHENTICATOR, // recognized actor; NO direct executeBatch; not 8130-usable
-    scope:         0x02,                          // Scopes.POLICY — gated initiation only (MAY also OR Scopes.SELF_PAYER
-                                                  //   for self-pay; SHOULD NOT combine with SENDER — POLICY gates
-                                                  //   regardless, so SENDER adds no authority the protocol will honor)
+    scope:         0x08,                          // Scopes.POLICY — gated initiation only (MAY also OR Scopes.SELF_PAYER
+                                                  //   for self-pay). OPERATOR and POLICY do not combine: OPERATOR may
+                                                  //   originate to any call.to; POLICY-only is gated to the manager.
     expiry:        0
 });
 ```
 
-`Scopes.NONCE` (`0x04`) is a separate, orthogonal scope bit: it permits a restricted actor to use sequenced
+`Scopes.NONCE` (`0x10`) is a separate, orthogonal scope bit: it permits a restricted actor to use sequenced
 `nonce_key`s. This contract stores the bit verbatim and never interprets it — nonce semantics are entirely
 protocol-side — so it isn't part of the policy flow above and is only mentioned here for completeness.
 

--- a/src/policies/README.md
+++ b/src/policies/README.md
@@ -4,12 +4,11 @@ A policy manager for EIP-8130 restricted actors.
 
 In EIP-8130, a restricted actor (e.g. a session key) is configured with optional 52-byte policy data
 (`manager(20) || commitment(32)`) stored co-located with the 32-byte actor config, making an 84-byte packed
-record. The protocol gate typically also sets `scope & Scopes.POLICY != 0` and forces every call that actor
-makes to land on that single manager. These contracts are one realization of that manager: it enforces
-application-specific limits and then drives the account. `Scopes.POLICY` (`0x08`) is an optional grant.
-`Keystore` does not import or interpret scope bits; policy attachment is a length check (empty vs 52).
-OPERATOR and POLICY do not combine: OPERATOR may originate to any `call.to`, POLICY-only is gated to the
-manager.
+record. Length decides what gets stored; POLICY decides whether the sender is gated; OPERATOR overrides POLICY.
+The protocol node gates on `scope & Scopes.POLICY != 0` and forces every call that actor makes to land on that
+single manager. These contracts are one realization of that manager: it enforces application-specific limits
+and then drives the account. `Scopes.POLICY` (`0x08`) is an optional grant. `Keystore` does not import or
+interpret scope bits; policy attachment is a length check (empty vs 52).
 
 ## Flow
 

--- a/test/lib/KeystoreTest.sol
+++ b/test/lib/KeystoreTest.sol
@@ -321,12 +321,12 @@ contract KeystoreTest is Test {
 
     // ── Direct AccountState storage pokes (for saturation edge cases) ──
     //
-    // AccountState packs into one slot at base-slot 3 (declaration order: _actorConfig, _policyCommitment,
-    // _policyManager, _accountState). multichainSequence occupies bytes[0:8] and localSequence bytes[8:16] of that
-    // slot; localSequence's high 32 bits are the epoch, its low 32 bits the sequence.
+    // AccountState packs into one slot at base-slot 1 (declaration order: _actors, _accountState).
+    // multichainSequence occupies bytes[0:8] and localSequence bytes[8:16] of that slot; localSequence's high
+    // 32 bits are the epoch, its low 32 bits the sequence.
 
     function _accountStateSlot(address account) internal pure returns (bytes32) {
-        return keccak256(abi.encode(account, uint256(3)));
+        return keccak256(abi.encode(account, uint256(1)));
     }
 
     /// @dev Overwrite the packed localSequence word (epoch<<32 | seq), preserving every other field in the slot.

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -12,7 +12,7 @@ contract AccountEnvironmentTest is KeystoreTest {
     bytes32 constant ACTOR_A = bytes32(uint256(0xA1));
     bytes32 constant ACTOR_B = bytes32(uint256(0xB2));
 
-    uint16 constant SENDER = Scopes.SENDER;
+    uint16 constant SENDER = Scopes.OPERATOR;
 
     function setUp() public override {
         super.setUp();

--- a/test/unit/Keystore/applyAccountChange.t.sol
+++ b/test/unit/Keystore/applyAccountChange.t.sol
@@ -12,7 +12,7 @@ contract AccountEnvironmentTest is KeystoreTest {
     bytes32 constant ACTOR_A = bytes32(uint256(0xA1));
     bytes32 constant ACTOR_B = bytes32(uint256(0xB2));
 
-    uint16 constant SENDER = Scopes.OPERATOR;
+    uint16 constant OPERATOR = Scopes.OPERATOR;
 
     function setUp() public override {
         super.setUp();
@@ -192,7 +192,9 @@ contract AccountEnvironmentTest is KeystoreTest {
         assertEq(epoch, 1);
 
         // Authorize under lock with expiry > now + delay: allowed.
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        _applyLocal(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
+        );
         assertTrue(_isActor(account, ACTOR_A));
 
         // Revoke under lock: still rejected.
@@ -214,7 +216,7 @@ contract AccountEnvironmentTest is KeystoreTest {
         uint48 floor = uint48(block.timestamp + delay);
 
         Keystore.SignedAccountChanges memory s =
-            _localBatch(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, floor, "")));
+            _localBatch(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, floor, "")));
         vm.expectRevert(Keystore.ExpiryDoesNotOutliveUnlock.selector);
         keystore.applySignedAccountChanges(account, s);
         assertFalse(_isActor(account, ACTOR_A));
@@ -230,7 +232,7 @@ contract AccountEnvironmentTest is KeystoreTest {
         _signedLock(pk, account, delay);
         uint48 expiry = uint48(block.timestamp + delay + 1);
 
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, expiry, "")));
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, expiry, "")));
         assertTrue(_isActor(account, ACTOR_A));
         assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, expiry);
     }
@@ -243,7 +245,7 @@ contract AccountEnvironmentTest is KeystoreTest {
         delay = uint16(bound(delay, 1, type(uint16).max));
 
         _signedLock(pk, account, delay);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, 0, "")));
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, 0, "")));
         assertTrue(_isActor(account, ACTOR_A));
         assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, 0);
     }
@@ -257,16 +259,16 @@ contract AccountEnvironmentTest is KeystoreTest {
         delay = uint16(bound(delay, 1, type(uint16).max));
 
         uint48 longExpiry = _future(2 days);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, longExpiry, "")));
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, longExpiry, "")));
         _signedLock(pk, account, delay);
 
         uint48 shorterButAboveFloor = uint48(block.timestamp + delay + 1);
         _applyLocal(
-            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, shorterButAboveFloor, ""))
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, shorterButAboveFloor, ""))
         );
         assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, shorterButAboveFloor);
         assertEq(keystore.getActorConfig(account, ACTOR_A).authenticator, address(k1Authenticator));
-        assertEq(keystore.getActorConfig(account, ACTOR_A).scope, SENDER);
+        assertEq(keystore.getActorConfig(account, ACTOR_A).scope, OPERATOR);
     }
 
     /// @notice Hard-locked re-lease cannot widen or swap a live actor's scope.
@@ -275,14 +277,16 @@ contract AccountEnvironmentTest is KeystoreTest {
         address account = vm.addr(pk);
         _assumeSafeAccount(account);
 
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(2 days), "")));
+        _applyLocal(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(2 days), ""))
+        );
         _signedLock(pk, account, 1 hours);
 
         Keystore.SignedAccountChanges memory s =
             _localBatch(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), 0, _future(2 days), "")));
         vm.expectRevert(Keystore.AccountIsLocked.selector);
         keystore.applySignedAccountChanges(account, s);
-        assertEq(keystore.getActorConfig(account, ACTOR_A).scope, SENDER);
+        assertEq(keystore.getActorConfig(account, ACTOR_A).scope, OPERATOR);
     }
 
     /// @notice Hard-locked re-lease cannot replace a live actor's authenticator.
@@ -291,11 +295,13 @@ contract AccountEnvironmentTest is KeystoreTest {
         address account = vm.addr(pk);
         _assumeSafeAccount(account);
 
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(2 days), "")));
+        _applyLocal(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(2 days), ""))
+        );
         _signedLock(pk, account, 1 hours);
 
         Keystore.SignedAccountChanges memory s = _localBatch(
-            pk, account, _one(_authorizeChange(ACTOR_A, address(p256Authenticator), SENDER, _future(2 days), ""))
+            pk, account, _one(_authorizeChange(ACTOR_A, address(p256Authenticator), OPERATOR, _future(2 days), ""))
         );
         vm.expectRevert(Keystore.AccountIsLocked.selector);
         keystore.applySignedAccountChanges(account, s);
@@ -337,7 +343,7 @@ contract AccountEnvironmentTest is KeystoreTest {
         _assumeSafeAccount(account);
 
         uint48 shortExpiry = _future(10);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, shortExpiry, "")));
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, shortExpiry, "")));
         _signedLock(pk, account, 1 hours);
 
         vm.warp(uint256(shortExpiry) + 1);
@@ -365,8 +371,9 @@ contract AccountEnvironmentTest is KeystoreTest {
         _signedUnlock(pk, account);
         uint48 unlocksAt = uint48(t0 + delay);
 
-        Keystore.SignedAccountChanges memory s =
-            _localBatch(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, unlocksAt, "")));
+        Keystore.SignedAccountChanges memory s = _localBatch(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, unlocksAt, ""))
+        );
         vm.expectRevert(Keystore.ExpiryDoesNotOutliveUnlock.selector);
         keystore.applySignedAccountChanges(account, s);
         assertFalse(_isActor(account, ACTOR_A));
@@ -387,7 +394,7 @@ contract AccountEnvironmentTest is KeystoreTest {
         _signedUnlock(pk, account);
         uint48 expiry = uint48(t0 + delay + 1);
 
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, expiry, "")));
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, expiry, "")));
         assertTrue(_isActor(account, ACTOR_A));
         assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, expiry);
     }
@@ -400,7 +407,7 @@ contract AccountEnvironmentTest is KeystoreTest {
 
         _signedLock(pk, account, 1 hours);
         uint48 past = uint48(block.timestamp - 1);
-        _applyUnsequenced(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, past, "")));
+        _applyUnsequenced(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, past, "")));
         assertFalse(_isActor(account, ACTOR_A));
     }
 
@@ -417,7 +424,9 @@ contract AccountEnvironmentTest is KeystoreTest {
         vm.warp(t0 + delay); // unlocked
         assertFalse(keystore.isLocked(account));
 
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        _applyLocal(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
+        );
         assertTrue(_isActor(account, ACTOR_A));
     }
 
@@ -468,7 +477,9 @@ contract AccountEnvironmentTest is KeystoreTest {
         (address account,) = _createK1Account(ownerPk);
         bytes32 scopedId = bytes32(uint256(uint160(vm.addr(scopedPk))));
 
-        _applyLocal(ownerPk, account, _one(_authorizeChange(scopedId, address(k1Authenticator), SENDER, UNBOUNDED, "")));
+        _applyLocal(
+            ownerPk, account, _one(_authorizeChange(scopedId, address(k1Authenticator), OPERATOR, UNBOUNDED, ""))
+        );
         _signedLock(ownerPk, account, 1 hours);
         assertTrue(keystore.isLocked(account));
 
@@ -489,7 +500,7 @@ contract AccountEnvironmentTest is KeystoreTest {
         uint64 mcBefore = _multichainSeq(account);
 
         _applyMultichain(
-            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
         );
 
         assertTrue(_isActor(account, ACTOR_A));
@@ -512,7 +523,9 @@ contract AccountEnvironmentTest is KeystoreTest {
         // Strictly-past expiry: an unsequenced (JIT) batch would skip this, but a sequenced batch (Local or
         // Multichain) installs it inert.
         uint48 pastExpiry = uint48(block.timestamp - 1);
-        _applyMultichain(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, pastExpiry, "")));
+        _applyMultichain(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, pastExpiry, ""))
+        );
 
         // Sequence consumed (no revert), yet the actor is not live (getActorConfig is expiry-aware).
         assertEq(_multichainSeq(account), mcBefore + 1);
@@ -537,14 +550,18 @@ contract AccountEnvironmentTest is KeystoreTest {
         uint48 liveNow = _future(365 days);
 
         // seq 0 and seq 1: historical (expired) operator grants — inert, but each consumes its slot.
-        _applyMultichain(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, expiredOld, "")));
+        _applyMultichain(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, expiredOld, ""))
+        );
         assertFalse(_isActor(account, ACTOR_A));
-        _applyMultichain(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, expiredMid, "")));
+        _applyMultichain(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, expiredMid, ""))
+        );
         assertFalse(_isActor(account, ACTOR_A));
 
         // seq 2: the current renewal is still live -> the operator is now authorized, converged with chains that
         // applied the same history earlier.
-        _applyMultichain(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, liveNow, "")));
+        _applyMultichain(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, liveNow, "")));
 
         assertTrue(_isActor(account, ACTOR_A));
         assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, liveNow);
@@ -564,7 +581,7 @@ contract AccountEnvironmentTest is KeystoreTest {
         // Signed by the (still-live at auth time) k1 self; installs an already-expired non-k1 self.
         uint48 pastExpiry = uint48(block.timestamp - 1);
         _applyMultichain(
-            pk, account, _one(_authorizeChange(selfActorId, address(p256Authenticator), SENDER, pastExpiry, ""))
+            pk, account, _one(_authorizeChange(selfActorId, address(p256Authenticator), OPERATOR, pastExpiry, ""))
         );
 
         // No revert; slot consumed. The non-k1 self is present but not live (expired).
@@ -582,7 +599,7 @@ contract AccountEnvironmentTest is KeystoreTest {
         uint64 seqBefore = _localSeqWord(account);
 
         uint48 pastExpiry = uint48(block.timestamp - 1);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, pastExpiry, "")));
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, pastExpiry, "")));
 
         // Sequence consumed (no revert); the actor is present but not live.
         assertEq(_localSeqWord(account), seqBefore + 1);
@@ -727,7 +744,7 @@ contract AccountEnvironmentTest is KeystoreTest {
         assertEq(seq0, 0);
 
         _applyUnsequenced(
-            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
         );
 
         // Sequence 0 burned -> reads initialized; the actor landed.
@@ -755,12 +772,12 @@ contract AccountEnvironmentTest is KeystoreTest {
 
         // A sequenced local batch at seq 0, captured while the account is still fresh (epoch 0, seq 0).
         Keystore.SignedAccountChanges memory seqZero = _localBatch(
-            pk, account, _one(_authorizeChange(ACTOR_B, address(k1Authenticator), SENDER, _future(1 days), ""))
+            pk, account, _one(_authorizeChange(ACTOR_B, address(k1Authenticator), OPERATOR, _future(1 days), ""))
         );
 
         // First act is an unsequenced batch: burns local sequence 0 -> 1 (marks initialized).
         _applyUnsequenced(
-            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
         );
         (, uint32 seq1) = _localEpochSeq(account);
         assertEq(seq1, 1);
@@ -782,7 +799,7 @@ contract AccountEnvironmentTest is KeystoreTest {
         // Bootstrap via multichain: multichain counter 0 -> 1, local word stays 0/0 (initialized via the multichain
         // term of _isInitialized).
         _applyMultichain(
-            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
         );
         (uint32 epoch0, uint32 seq0) = _localEpochSeq(account);
         assertEq(epoch0, 0);
@@ -791,14 +808,14 @@ contract AccountEnvironmentTest is KeystoreTest {
         // A local unsequenced batch: the unsequenced-init write is skipped (already initialized), so localSequence
         // stays 0.
         _applyUnsequenced(
-            pk, account, _one(_authorizeChange(ACTOR_B, address(k1Authenticator), SENDER, _future(1 days), ""))
+            pk, account, _one(_authorizeChange(ACTOR_B, address(k1Authenticator), OPERATOR, _future(1 days), ""))
         );
         (, uint32 seq1) = _localEpochSeq(account);
         assertEq(seq1, 0);
 
         // A local sequenced batch at seq 0 therefore still lands (seq 0 == localSequence 0), consuming 0 -> 1.
         bytes32 idC = bytes32(uint256(0xC3));
-        _applyLocal(pk, account, _one(_authorizeChange(idC, address(k1Authenticator), SENDER, _future(1 days), "")));
+        _applyLocal(pk, account, _one(_authorizeChange(idC, address(k1Authenticator), OPERATOR, _future(1 days), "")));
         assertTrue(_isActor(account, idC));
         (, uint32 seq2) = _localEpochSeq(account);
         assertEq(seq2, 1);

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -15,7 +15,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
     bytes32 constant ACTOR_A = bytes32(uint256(0xA1));
     bytes32 constant ACTOR_B = bytes32(uint256(0xB2));
 
-    uint16 constant SENDER = Scopes.OPERATOR;
+    uint16 constant OPERATOR = Scopes.OPERATOR;
     uint16 constant NONCE = Scopes.NONCE;
 
     function setUp() public override {
@@ -39,12 +39,12 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         uint64 seqBefore = _localSeqWord(account);
 
         _applyUnsequenced(
-            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
         );
 
         Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, ACTOR_A);
         assertEq(cfg.authenticator, address(k1Authenticator));
-        assertEq(cfg.scope, SENDER);
+        assertEq(cfg.scope, OPERATOR);
         assertEq(cfg.expiry, _future(1 days));
         // Unsequenced batches never consume the counter.
         assertEq(_localSeqWord(account), seqBefore);
@@ -61,13 +61,13 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
             account,
             Keystore.AccountChangeChannel.Local,
             _unseqWord(account),
-            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, expiry, ""))
+            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, expiry, ""))
         );
         keystore.applySignedAccountChanges(account, s);
         keystore.applySignedAccountChanges(account, s);
 
         Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, ACTOR_A);
-        assertEq(cfg.scope, SENDER);
+        assertEq(cfg.scope, OPERATOR);
         assertEq(cfg.expiry, expiry);
     }
 
@@ -85,7 +85,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
             account,
             Keystore.AccountChangeChannel.Local,
             _unseqWord(account),
-            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, shortExpiry, ""))
+            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, shortExpiry, ""))
         );
         keystore.applySignedAccountChanges(account, oldLease);
         assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, shortExpiry);
@@ -94,7 +94,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         vm.warp(uint256(shortExpiry) + 1);
         uint48 longExpiry = _future(365 days);
         _applyUnsequenced(
-            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, longExpiry, ""))
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, longExpiry, ""))
         );
         assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, longExpiry);
 
@@ -113,7 +113,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
             account,
             Keystore.AccountChangeChannel.Local,
             _unseqWord(account),
-            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
         );
         _applyUnsequenced(pk, account, _one(_bumpChange())); // epoch 0 -> 1
 
@@ -133,7 +133,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         _applyUnsequenced(
             pk,
             account,
-            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, uint48(block.timestamp - 1), ""))
+            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, uint48(block.timestamp - 1), ""))
         );
 
         // Skipped, not installed inert: the slot was never written, so an explicit revoke finds nothing.
@@ -150,8 +150,8 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
 
         Keystore.AccountChange[] memory changes = new Keystore.AccountChange[](2);
-        changes[0] = _authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, uint48(block.timestamp - 1), ""); // expired
-        changes[1] = _authorizeChange(ACTOR_B, address(k1Authenticator), SENDER, _future(1 days), ""); // live
+        changes[0] = _authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, uint48(block.timestamp - 1), ""); // expired
+        changes[1] = _authorizeChange(ACTOR_B, address(k1Authenticator), OPERATOR, _future(1 days), ""); // live
 
         _applyUnsequenced(pk, account, changes);
 
@@ -166,7 +166,9 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
 
         _applyUnsequenced(
-            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, uint48(block.timestamp), ""))
+            pk,
+            account,
+            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, uint48(block.timestamp), ""))
         );
 
         assertTrue(_isActor(account, ACTOR_A));
@@ -178,7 +180,9 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
 
-        _applyUnsequenced(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, UNBOUNDED, "")));
+        _applyUnsequenced(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, UNBOUNDED, ""))
+        );
         assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, UNBOUNDED);
     }
 
@@ -187,7 +191,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
 
-        _applyUnsequenced(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, 0, "")));
+        _applyUnsequenced(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, 0, "")));
         assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, 0);
 
         // Never lapses: still authorized far in the future.
@@ -201,7 +205,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         _applyUnsequenced(
-            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
         );
 
         _applyUnsequenced(
@@ -219,14 +223,14 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
 
         // Order (T1, T2): ends at T2.
         (address accA,) = _createK1Account(pk);
-        _applyUnsequenced(pk, accA, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, t1, "")));
-        _applyUnsequenced(pk, accA, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, t2, "")));
+        _applyUnsequenced(pk, accA, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, t1, "")));
+        _applyUnsequenced(pk, accA, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, t2, "")));
         assertEq(keystore.getActorConfig(accA, ACTOR_A).expiry, t2);
 
         // Order (T2, T1): ends at T1 (last write wins; a shorter expiry is allowed).
         (address accB,) = _createK1AccountWithSalt(pk, bytes32(uint256(1)));
-        _applyUnsequenced(pk, accB, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, t2, "")));
-        _applyUnsequenced(pk, accB, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, t1, "")));
+        _applyUnsequenced(pk, accB, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, t2, "")));
+        _applyUnsequenced(pk, accB, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, t1, "")));
         assertEq(keystore.getActorConfig(accB, ACTOR_A).expiry, t1);
     }
 
@@ -237,10 +241,10 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
 
         _applyUnsequenced(
-            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
         );
         _applyUnsequenced(
-            pk, account, _one(_authorizeChange(ACTOR_B, address(p256Authenticator), SENDER, _future(1 days), ""))
+            pk, account, _one(_authorizeChange(ACTOR_B, address(p256Authenticator), OPERATOR, _future(1 days), ""))
         );
 
         assertEq(keystore.getActorConfig(account, ACTOR_A).authenticator, address(k1Authenticator));
@@ -254,7 +258,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
 
         Keystore.SignedAccountChanges memory s = _localBatch(
-            pk, account, _one(_authorizeChange(bytes32(0), address(k1Authenticator), SENDER, _future(1 days), ""))
+            pk, account, _one(_authorizeChange(bytes32(0), address(k1Authenticator), OPERATOR, _future(1 days), ""))
         );
         vm.expectRevert(Keystore.InvalidActorId.selector);
         keystore.applySignedAccountChanges(account, s);
@@ -270,7 +274,9 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
         (uint32 epoch0, uint32 seq0) = _localEpochSeq(account);
 
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        _applyLocal(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
+        );
 
         (uint32 epoch1, uint32 seq1) = _localEpochSeq(account);
         assertEq(epoch1, epoch0);
@@ -282,13 +288,13 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         uint48 e1 = _future(1 days);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, e1, "")));
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, e1, "")));
 
         vm.warp(uint256(e1) + 1);
         assertFalse(_isActor(account, ACTOR_A)); // lapsed
 
         uint48 e2 = _future(1 days);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, e2, "")));
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, e2, "")));
         assertTrue(_isActor(account, ACTOR_A));
         assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, e2);
     }
@@ -298,20 +304,22 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         uint48 e = _future(10 days);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, e, "")));
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, e, "")));
 
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER | NONCE, e, "")));
-        assertEq(keystore.getActorConfig(account, ACTOR_A).scope, SENDER | NONCE);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR | NONCE, e, "")));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).scope, OPERATOR | NONCE);
     }
 
     /// @notice A sequenced expiry raise is bump-free.
     function test_authorizeSequenced_success_expiryRaiseBumpFree(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        _applyLocal(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
+        );
 
         uint48 higher = _future(5 days);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, higher, "")));
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, higher, "")));
         assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, higher);
     }
 
@@ -319,10 +327,12 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
     function test_authorizeSequenced_success_expiryLower(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(5 days), "")));
+        _applyLocal(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(5 days), ""))
+        );
 
         uint48 lower = _future(1 days);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, lower, "")));
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, lower, "")));
         assertEq(keystore.getActorConfig(account, ACTOR_A).expiry, lower);
     }
 
@@ -331,21 +341,23 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         uint48 e = _future(10 days);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER | NONCE, e, "")));
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR | NONCE, e, "")));
 
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, e, "")));
-        assertEq(keystore.getActorConfig(account, ACTOR_A).scope, SENDER);
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, e, "")));
+        assertEq(keystore.getActorConfig(account, ACTOR_A).scope, OPERATOR);
     }
 
     /// @notice A sequenced expiry lowering may still be batched with an IncrementLocalEpoch (the durable teardown form).
     function test_authorizeSequenced_success_lowerPlusBump(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(5 days), "")));
+        _applyLocal(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(5 days), ""))
+        );
 
         uint48 lower = _future(1 days);
         Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
-        ch[0] = _authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, lower, "");
+        ch[0] = _authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, lower, "");
         ch[1] = _bumpChange();
         _applyLocal(pk, account, ch);
 
@@ -362,7 +374,9 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
     function test_revoke_success_bareRevokeOfLiveActor(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        _applyLocal(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
+        );
 
         _applyLocal(pk, account, _one(_revokeChange(ACTOR_A)));
         assertFalse(_isActor(account, ACTOR_A));
@@ -381,7 +395,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
             account,
             Keystore.AccountChangeChannel.Local,
             _unseqWord(account),
-            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
         );
         keystore.applySignedAccountChanges(account, grant);
         assertTrue(_isActor(account, ACTOR_A));
@@ -399,7 +413,9 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
     function test_revoke_success_revokeBumpThenReplayFails(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        _applyLocal(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
+        );
 
         // A grant signed at the pre-bump epoch (unsequenced), captured before the revoke+bump lands.
         Keystore.SignedAccountChanges memory oldGrant = _signBatch(
@@ -407,7 +423,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
             account,
             Keystore.AccountChangeChannel.Local,
             _unseqWord(account),
-            _one(_authorizeChange(ACTOR_B, address(k1Authenticator), SENDER, _future(1 days), ""))
+            _one(_authorizeChange(ACTOR_B, address(k1Authenticator), OPERATOR, _future(1 days), ""))
         );
 
         Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
@@ -425,7 +441,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         uint48 e = _future(1 days);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, e, "")));
+        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, e, "")));
 
         vm.warp(uint256(e) + 1);
         _applyLocal(pk, account, _one(_revokeChange(ACTOR_A))); // no bump needed
@@ -441,7 +457,9 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         // Consume a sequence first so we can observe the reset.
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        _applyLocal(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
+        );
         (uint32 epoch0,) = _localEpochSeq(account);
 
         _applyUnsequenced(pk, account, _one(_bumpChange()));
@@ -456,7 +474,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
         Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
-        ch[0] = _authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "");
+        ch[0] = _authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), "");
         ch[1] = _bumpChange();
 
         _applyUnsequenced(pk, account, ch);
@@ -491,7 +509,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         (address account,) = _createK1Account(pk);
         Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _bumpChange();
-        ch[1] = _authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "");
+        ch[1] = _authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), "");
 
         Keystore.SignedAccountChanges memory s = _localBatch(pk, account, ch);
         keystore.applySignedAccountChanges(account, s);
@@ -500,7 +518,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         assertEq(epoch, 1);
         assertEq(seq, 0);
         assertTrue(_isActor(account, ACTOR_A));
-        assertEq(keystore.getActorConfig(account, ACTOR_A).scope, SENDER);
+        assertEq(keystore.getActorConfig(account, ACTOR_A).scope, OPERATOR);
     }
 
     /// @notice A bump at the terminal epoch (the full uint32 max — the epoch half reserves no sentinel) reverts
@@ -519,12 +537,14 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
     function test_bump_success_landedActorsUnaffected(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        _applyLocal(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
+        );
 
         _applyUnsequenced(pk, account, _one(_bumpChange()));
 
         assertTrue(_isActor(account, ACTOR_A));
-        assertEq(keystore.getActorConfig(account, ACTOR_A).scope, SENDER);
+        assertEq(keystore.getActorConfig(account, ACTOR_A).scope, OPERATOR);
     }
 
     /// @notice Post-bump, an old unsequenced signature on the local channel is invalid (StaleEpoch).
@@ -536,7 +556,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
             account,
             Keystore.AccountChangeChannel.Local,
             _unseqWord(account),
-            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
         );
         _applyUnsequenced(pk, account, _one(_bumpChange()));
 
@@ -552,7 +572,9 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
     function test_ordering_revert_lockNotStandalone(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        _applyLocal(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
+        );
 
         Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _lockChange(1 hours);
@@ -568,7 +590,9 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
     function test_ordering_success_revokeThenBump(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        _applyLocal(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
+        );
 
         Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _revokeChange(ACTOR_A);
@@ -607,7 +631,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
         _forceLocalSequence(account, keystore.UNSEQUENCED() - 1);
 
         Keystore.SignedAccountChanges memory s = _localBatch(
-            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
         );
         vm.expectRevert(Keystore.SequenceSaturated.selector);
         keystore.applySignedAccountChanges(account, s);
@@ -622,7 +646,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
             account,
             Keystore.AccountChangeChannel.Local,
             _localSeqWord(account),
-            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), ""))
+            _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
         );
 
         (, uint32 seqSigned) = _localEpochSeq(account);
@@ -643,7 +667,9 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
 
         vm.expectEmit(true, true, false, false, address(keystore));
         emit Keystore.ActorAuthorized(account, ACTOR_A, "");
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        _applyLocal(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
+        );
     }
 
     /// @notice Right-aligned actorId round-trip. An address-derived actor's id is the address right-aligned
@@ -678,7 +704,9 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
     function test_revoke_success_emitsActorRevoked(uint256 pk) public {
         pk = _boundK1Pk(pk);
         (address account,) = _createK1Account(pk);
-        _applyLocal(pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), SENDER, _future(1 days), "")));
+        _applyLocal(
+            pk, account, _one(_authorizeChange(ACTOR_A, address(k1Authenticator), OPERATOR, _future(1 days), ""))
+        );
 
         Keystore.AccountChange[] memory ch = new Keystore.AccountChange[](2);
         ch[0] = _revokeChange(ACTOR_A);

--- a/test/unit/Keystore/applyKeyChange.t.sol
+++ b/test/unit/Keystore/applyKeyChange.t.sol
@@ -15,7 +15,7 @@ contract ApplySignedAccountChangesTest is KeystoreTest {
     bytes32 constant ACTOR_A = bytes32(uint256(0xA1));
     bytes32 constant ACTOR_B = bytes32(uint256(0xB2));
 
-    uint16 constant SENDER = Scopes.SENDER;
+    uint16 constant SENDER = Scopes.OPERATOR;
     uint16 constant NONCE = Scopes.NONCE;
 
     function setUp() public override {

--- a/test/unit/Keystore/authenticate.t.sol
+++ b/test/unit/Keystore/authenticate.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {Keystore} from "../../../src/Keystore.sol";
+import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
 /// @notice Fuzzed, branch-complete suite for the authentication paths of Keystore:
@@ -20,11 +21,11 @@ import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 ///         The authentication functions are `view` and emit no events, so there are no event assertions here;
 ///         events (ActorAuthorized / ActorRevoked) belong to the applyKeyChange suite that drives the config writes.
 contract AuthenticateTest is KeystoreTest {
-    uint16 constant SCOPE_SENDER = 0x01;
-    uint16 constant SCOPE_POLICY = 0x02;
-    uint16 constant SCOPE_NONCE = 0x04;
-    uint16 constant SCOPE_SELF_PAYER = 0x08;
-    uint16 constant SCOPE_SPONSOR_PAYER = 0x10;
+    uint16 constant SCOPE_SENDER = Scopes.OPERATOR;
+    uint16 constant SCOPE_POLICY = Scopes.POLICY;
+    uint16 constant SCOPE_NONCE = Scopes.NONCE;
+    uint16 constant SCOPE_SELF_PAYER = Scopes.SELF_PAYER;
+    uint16 constant SCOPE_SPONSOR_PAYER = Scopes.SPONSOR_PAYER;
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // REVERTS (source order)
@@ -381,7 +382,7 @@ contract AuthenticateTest is KeystoreTest {
 
     /// @notice A registered P-256 actor authenticates via the non-K1 authenticator path.
     /// @dev _authenticate (non-K1) success: IAuthenticator resolves actorId, config.authenticator == p256. The
-    ///      SCOPE_POLICY bit is cleared so no policyData is required at authorize time.
+    ///      Empty policyData is accepted regardless of scope bits.
     function test_authenticateActor_success_p256Actor(uint256 ownerSeed, uint256 pkSeed, uint8 scopeSeed, bytes32 hash)
         public
     {

--- a/test/unit/Keystore/authenticate.t.sol
+++ b/test/unit/Keystore/authenticate.t.sol
@@ -21,7 +21,7 @@ import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 ///         The authentication functions are `view` and emit no events, so there are no event assertions here;
 ///         events (ActorAuthorized / ActorRevoked) belong to the applyKeyChange suite that drives the config writes.
 contract AuthenticateTest is KeystoreTest {
-    uint16 constant SCOPE_SENDER = Scopes.OPERATOR;
+    uint16 constant SCOPE_OPERATOR = Scopes.OPERATOR;
     uint16 constant SCOPE_POLICY = Scopes.POLICY;
     uint16 constant SCOPE_NONCE = Scopes.NONCE;
     uint16 constant SCOPE_SELF_PAYER = Scopes.SELF_PAYER;
@@ -752,12 +752,12 @@ contract AuthenticateTest is KeystoreTest {
         (address account,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(sessionPk) != account);
         bytes32 sessionActorId = bytes32(uint256(uint160(vm.addr(sessionPk))));
-        _authorizeGatedActor(account, ownerPk, sessionActorId, SCOPE_SENDER | SCOPE_POLICY, manager, commitment);
+        _authorizeGatedActor(account, ownerPk, sessionActorId, SCOPE_OPERATOR | SCOPE_POLICY, manager, commitment);
 
         bytes memory auth = _wrapLocal(_buildK1Auth(sessionPk, keystore.replaySafeHash(account, block.chainid, hash)));
         (bytes32 outActorId, uint16 outScope) = keystore.validateSignature(account, hash, auth);
         assertEq(outActorId, sessionActorId);
-        assertEq(outScope, SCOPE_SENDER | SCOPE_POLICY);
+        assertEq(outScope, SCOPE_OPERATOR | SCOPE_POLICY);
     }
 
     /// @notice A multichain envelope (SignatureType.Multichain) validates against the chainId = 0 digest.

--- a/test/unit/Keystore/branchCoverage.t.sol
+++ b/test/unit/Keystore/branchCoverage.t.sol
@@ -154,4 +154,17 @@ contract KeystoreBranchCoverageTest is KeystoreTest {
         assertEq(keystore.getPolicyManager(account, actorId), policyManager);
         assertEq(keystore.getPolicyCommitment(account, actorId), commitment);
     }
+
+    // ── _resolveActorConfig: unknown non-self actor ──
+
+    /// @notice Resolving an unknown, non-self actorId returns the all-zero config (empty _actors[].config slot,
+    ///         distinct from the inline-self and populated-entry paths).
+    function test_getActorConfig_unknownNonSelfActor_returnsEmpty() public {
+        (address account,) = _createK1Account(OWNER_PK);
+        bytes32 ghost = bytes32(uint256(0xDEAD)); // never authorized, not the self actorId
+        Keystore.ActorConfig memory config = keystore.getActorConfig(account, ghost);
+        assertEq(config.authenticator, address(0));
+        assertEq(config.expiry, 0);
+        assertEq(config.scope, 0);
+    }
 }

--- a/test/unit/Keystore/branchCoverage.t.sol
+++ b/test/unit/Keystore/branchCoverage.t.sol
@@ -106,8 +106,8 @@ contract KeystoreBranchCoverageTest is KeystoreTest {
     function test_multichain_revert_sequenceSaturated() public {
         (address account,) = _createK1Account(OWNER_PK);
 
-        // Force the multichain counter (low 64 bits of the packed AccountState slot at base-slot 3) to its max.
-        bytes32 slot = keccak256(abi.encode(account, uint256(3)));
+        // Force the multichain counter (low 64 bits of the packed AccountState slot at base-slot 1) to its max.
+        bytes32 slot = keccak256(abi.encode(account, uint256(1)));
         uint256 cur = uint256(vm.load(address(keystore), slot));
         uint256 updated = (cur & ~uint256(type(uint64).max)) | uint256(type(uint64).max);
         vm.store(address(keystore), slot, bytes32(updated));
@@ -120,8 +120,8 @@ contract KeystoreBranchCoverageTest is KeystoreTest {
 
     // ── _slicePolicy length guards ──
 
-    /// @notice An ungated actor (scope without POLICY) must carry no policy data.
-    function test_authorize_revert_ungatedActorWithPolicyData() public {
+    /// @notice Attached policy bytes must be empty or exactly 52 bytes (manager(20) || commitment(32)).
+    function test_authorize_revert_malformedPolicyLength() public {
         (address account,) = _createK1Account(OWNER_PK);
         bytes32 actorId = bytes32(uint256(0xA11CE));
         Keystore.AccountChange memory change = _authorizeChange(actorId, k1Authenticator, 0, UNBOUNDED, hex"01");
@@ -130,26 +130,25 @@ contract KeystoreBranchCoverageTest is KeystoreTest {
         keystore.applySignedAccountChanges(account, s);
     }
 
-    /// @notice A policy-gated actor must carry exactly 52 bytes (manager(20) || commitment(32)) of policy data.
+    /// @notice A 5-byte policy blob is neither empty nor the required 52.
     function test_authorize_revert_policyActorWrongLengthData() public {
         (address account,) = _createK1Account(OWNER_PK);
         bytes32 actorId = bytes32(uint256(0xA11CE));
-        // Scopes.POLICY == 0x02; 5 bytes is neither empty nor the required 52.
-        Keystore.AccountChange memory change =
-            _authorizeChange(actorId, k1Authenticator, 0x02, UNBOUNDED, hex"0102030405");
+        Keystore.AccountChange memory change = _authorizeChange(actorId, k1Authenticator, 0, UNBOUNDED, hex"0102030405");
         Keystore.SignedAccountChanges memory s = _localBatch(OWNER_PK, account, _one(change));
         vm.expectRevert(Keystore.InvalidPolicyData.selector);
         keystore.applySignedAccountChanges(account, s);
     }
 
-    /// @notice A policy-gated actor with the exact 52-byte policy data authorizes successfully.
-    function test_authorize_success_policyActorValidData() public {
+    /// @notice Attachment is by length, not by any scope bit: 52-byte policy data stores manager/commitment
+    ///         even when POLICY is unset.
+    function test_authorize_success_policyAttachedWithoutPolicyBit() public {
         (address account,) = _createK1Account(OWNER_PK);
         bytes32 actorId = bytes32(uint256(0xA11CE));
         address policyManager = address(0xCAFE);
         bytes32 commitment = keccak256("commitment");
         bytes memory policyData = abi.encodePacked(policyManager, commitment); // 20 + 32 = 52 bytes
-        _applyLocal(OWNER_PK, account, _one(_authorizeChange(actorId, k1Authenticator, 0x02, UNBOUNDED, policyData)));
+        _applyLocal(OWNER_PK, account, _one(_authorizeChange(actorId, k1Authenticator, 0, UNBOUNDED, policyData)));
 
         assertEq(keystore.getActorConfig(account, actorId).authenticator, k1Authenticator);
         assertEq(keystore.getPolicyManager(account, actorId), policyManager);

--- a/test/unit/Keystore/createAccount.t.sol
+++ b/test/unit/Keystore/createAccount.t.sol
@@ -462,8 +462,8 @@ contract CreateAccountTest is KeystoreTest {
     }
 
     /// @notice Verifies computeAddress rejects malformed policyData, matching createAccount (M-02 parity)
-    /// @dev Scope carries Scopes.POLICY (0x02) but policyData is not the required 52 bytes, so _validateInitialActors
-    ///      reverts InvalidPolicyData before an address is predicted.
+    /// @dev policyData is neither empty nor 52 bytes, so _validateInitialActors reverts InvalidPolicyData
+    ///      before an address is predicted. Scope bits are not consulted.
     function test_computeAddress_revert_invalidPolicyData(bytes32 actorId, bytes32 salt) public {
         vm.assume(actorId != 0);
 
@@ -478,8 +478,8 @@ contract CreateAccountTest is KeystoreTest {
     }
 
     /// @notice Verifies createAccount rejects malformed policyData up front via the shared validator
-    /// @dev Complements the existing sorted/duplicate/authenticator revert tests: scope has Scopes.POLICY set but
-    ///      policyData is not 52 bytes, so _prepareDeployment -> _validateInitialActors reverts InvalidPolicyData.
+    /// @dev Complements the existing sorted/duplicate/authenticator revert tests: policyData is neither empty nor
+    ///      52 bytes, so _prepareDeployment -> _validateInitialActors reverts InvalidPolicyData.
     function test_createAccount_revert_invalidPolicyData(bytes32 actorId, bytes32 salt) public {
         vm.assume(actorId != 0);
 

--- a/test/unit/Keystore/policyAccessors.t.sol
+++ b/test/unit/Keystore/policyAccessors.t.sol
@@ -11,10 +11,10 @@ import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 ///           - `getActorWithPolicy(account, actorId)`  — one-shot liveness-gated aggregate (config + manager + commitment)
 ///
 ///         All are `view`; there are no events to assert. Every test fuzzes its inputs (managers, commitments,
-///         actorIds, keys, scopes). Gating is determined by the SCOPE_POLICY bit, never by "slot non-zero": a
-///         policy-bearing actor's policyData is exactly 52 bytes (manager(20) || commitment(32)) and is written
-///         verbatim, even when a field is zero. Tests bound manager/commitment to non-zero only so the written
-///         value is distinguishable from the ungated (unwritten, zero) case.
+///         actorIds, keys, scopes). Policy attachment is by length (empty vs 52 bytes), never by a scope bit:
+///         a 52-byte policyData is manager(20) || commitment(32) and is written verbatim, even when a field is
+///         zero. Tests bound manager/commitment to non-zero only so the written value is distinguishable from
+///         the unattached (unwritten, zero) case.
 contract PolicyAccessorsTest is KeystoreTest {
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
     // getPolicyManager / getPolicyCommitment — liveness-gated granular reads
@@ -94,8 +94,8 @@ contract PolicyAccessorsTest is KeystoreTest {
         assertEq(keystore.getPolicyCommitment(eoa, selfActorId), commitment);
     }
 
-    /// @notice An ungated actor never has manager/commitment written (per `_authorizeActor`'s SCOPE_POLICY-gated
-    ///         writes), so both granular accessors return zero.
+    /// @notice An actor authorized with empty policyData never has manager/commitment written, so both granular
+    ///         accessors return zero.
     function test_getPolicyManager_success_ungatedActor_returnsZero(uint256 rootSeed, bytes32 actorId) public {
         uint256 rootPk = _boundK1Pk(rootSeed);
         (address account,) = _createK1Account(rootPk);
@@ -126,7 +126,7 @@ contract PolicyAccessorsTest is KeystoreTest {
     }
 
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-    // Lifecycle — invariant: policy slots written iff scope & SCOPE_POLICY
+    // Lifecycle — invariant: policy slots written iff 52-byte policyData was attached
     // ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 
     /// @notice Revoking an explicit gated actor clears both policy slots (`_revokeActor` deletes them).
@@ -199,7 +199,7 @@ contract PolicyAccessorsTest is KeystoreTest {
             _boundNonZeroWord(commitmentSeed)
         );
 
-        // Overwrite the same actor as ungated (scope & SCOPE_POLICY == 0).
+        // Overwrite the same actor with empty policyData (32-byte config only).
         _authorizeUngatedActor(account, rootPk, actorId, address(k1Authenticator));
 
         assertEq(keystore.getPolicyManager(account, actorId), address(0));
@@ -238,8 +238,8 @@ contract PolicyAccessorsTest is KeystoreTest {
         assertEq(keystore.getPolicyCommitment(account, actorId), newCommitment);
     }
 
-    /// @notice A gated actor may legitimately carry a zero manager and/or zero commitment: the relaxed policyData
-    ///         rule writes both slots verbatim. Gating is by the SCOPE_POLICY bit, not slot non-zero.
+    /// @notice A 52-byte policy attachment may legitimately carry a zero manager and/or zero commitment: the
+    ///         length rule writes both slots verbatim. Attachment is by length, not slot non-zero.
     function test_getPolicyAccessors_success_gatedWithZeroManagerAndCommitment(uint256 rootSeed, bytes32 actorId)
         public
     {
@@ -249,7 +249,7 @@ contract PolicyAccessorsTest is KeystoreTest {
 
         _authorizePolicyActor(account, rootPk, actorId, Scopes.POLICY, address(0), bytes32(0));
 
-        // Slots are zero, yet the actor is gated by the SCOPE_POLICY bit.
+        // Slots are zero, yet 52 policy bytes were attached (and the POLICY bit is set in this test).
         assertEq(keystore.getPolicyManager(account, actorId), address(0));
         assertEq(keystore.getPolicyCommitment(account, actorId), bytes32(0));
         Keystore.ActorConfig memory cfg = keystore.getActorConfig(account, actorId);

--- a/test/unit/Keystore/sloadCounts.t.sol
+++ b/test/unit/Keystore/sloadCounts.t.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Keystore} from "../../../src/Keystore.sol";
+import {Scopes} from "../../../src/libraries/Scopes.sol";
+import {KeystoreTest} from "../../lib/KeystoreTest.sol";
+
+/// @notice SLOAD-count guards for the hot read paths after policy co-location. Measured with vm.record /
+///         vm.accesses against the keystore address, so a future layout change that splits the packed config or
+///         spreads policy across extra slots fails loudly:
+///           - keystore-side authentication ({_resolveExplicitActor}) is a single SLOAD (the packed 32-byte config)
+///           - each policy getter is exactly two SLOADs: one liveness read of the co-located config, one for the
+///             policy value (manager or commitment)
+contract KeystoreSloadCountTest is KeystoreTest {
+    /// @dev Total keystore SLOADs recorded since the preceding vm.record() (duplicates included, so a slot read
+    ///      twice counts twice — this is the true SLOAD opcode count, not a distinct-slot count).
+    function _keystoreSloads() internal returns (uint256) {
+        (bytes32[] memory reads,) = vm.accesses(address(keystore));
+        return reads.length;
+    }
+
+    /// @dev Authenticating an explicit k1 actor resolves it from the single packed config slot: one SLOAD.
+    function test_sload_authExplicitK1Actor_isSingleSload(uint256 ownerSeed, bytes32 hash) public {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        (address account,) = _createK1Account(ownerPk);
+        // The owner is an explicit actor (its address != the account clone), so this exercises _resolveExplicitActor
+        // rather than the inline-self path.
+        vm.assume(vm.addr(ownerPk) != account);
+
+        bytes memory auth = _buildK1Auth(ownerPk, hash);
+
+        vm.record();
+        keystore.authenticateActor(account, hash, auth);
+        assertEq(_keystoreSloads(), 1, "auth must be a single SLOAD");
+    }
+
+    /// @dev getPolicyCommitment is one liveness SLOAD (config) plus one for the commitment: two total.
+    function test_sload_getPolicyCommitment_isTwoSloads(uint256 ownerSeed, uint256 actorSeed) public {
+        (address account, bytes32 actorId) = _accountWithPolicyActor(ownerSeed, actorSeed);
+
+        vm.record();
+        keystore.getPolicyCommitment(account, actorId);
+        assertEq(_keystoreSloads(), 2, "getPolicyCommitment must be two SLOADs");
+    }
+
+    /// @dev getPolicyManager mirrors getPolicyCommitment: one liveness SLOAD (config) plus one for the manager.
+    function test_sload_getPolicyManager_isTwoSloads(uint256 ownerSeed, uint256 actorSeed) public {
+        (address account, bytes32 actorId) = _accountWithPolicyActor(ownerSeed, actorSeed);
+
+        vm.record();
+        keystore.getPolicyManager(account, actorId);
+        assertEq(_keystoreSloads(), 2, "getPolicyManager must be two SLOADs");
+    }
+
+    /// @dev Creates an account and authorizes a distinct k1 actor carrying 52-byte co-located policy data.
+    function _accountWithPolicyActor(uint256 ownerSeed, uint256 actorSeed)
+        internal
+        returns (address account, bytes32 actorId)
+    {
+        uint256 ownerPk = _boundK1Pk(ownerSeed);
+        uint256 actorPk = _boundK1Pk(actorSeed);
+        vm.assume(vm.addr(ownerPk) != vm.addr(actorPk));
+
+        (account,) = _createK1Account(ownerPk);
+        address actor = vm.addr(actorPk);
+        vm.assume(actor != account);
+        actorId = bytes32(uint256(uint160(actor)));
+
+        bytes memory policyData = abi.encodePacked(address(0xCAFE), keccak256("commitment")); // 20 + 32 = 52 bytes
+        _applyLocal(
+            ownerPk,
+            account,
+            _one(_authorizeChange(actorId, address(k1Authenticator), Scopes.POLICY, UNBOUNDED, policyData))
+        );
+    }
+}

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -42,7 +42,7 @@ contract DefaultAccountTest is KeystoreTest {
 
     // Scope bits: ERC-1271 signing is operational (admin scope == 0x00, or OPERATOR). SELF_PAYER and
     // SPONSOR_PAYER are non-OPERATOR capability scopes that are not operational on their own.
-    uint16 constant SCOPE_SENDER = Scopes.OPERATOR;
+    uint16 constant SCOPE_OPERATOR = Scopes.OPERATOR;
     uint16 constant SCOPE_SELF_PAYER = Scopes.SELF_PAYER;
     uint16 constant SCOPE_SPONSOR_PAYER = Scopes.SPONSOR_PAYER;
 
@@ -407,7 +407,7 @@ contract DefaultAccountTest is KeystoreTest {
         assertEq(result, ERC1271_FAIL);
     }
 
-    /// @notice A valid signature from a payer-only (non-SENDER, non-admin) actor returns the failure magic value.
+    /// @notice A valid signature from a payer-only (non-OPERATOR, non-admin) actor returns the failure magic value.
     /// @dev isValidSignature gates on Scopes.isOperator; here SCOPE_SELF_PAYER (no OPERATOR, no admin) is not
     ///      operational, so an otherwise-valid signature is rejected.
     function test_isValidSignature_success_returnsFailureForNonOperationalScope(
@@ -433,7 +433,7 @@ contract DefaultAccountTest is KeystoreTest {
     }
 
     /// @notice A valid signature from an operational OPERATOR actor returns the ERC-1271 magic value.
-    /// @dev An operational actor validates: signing encodes authority a SENDER key already holds via calls, so it
+    /// @dev An operational actor validates: signing encodes authority an OPERATOR key already holds via calls, so it
     ///      does not require the admin scope.
     function test_isValidSignature_success_operationalSenderSigns(uint256 ownerSeed, uint256 actorSeed, bytes32 hash)
         public
@@ -445,8 +445,8 @@ contract DefaultAccountTest is KeystoreTest {
         address actor = vm.addr(actorPk);
         vm.assume(actor != vm.addr(ownerPk) && actor != account);
 
-        // Authorize the actor with SENDER scope only (no POLICY) — it is operational and can validate signatures.
-        _authorizeActorWithScope(account, ownerPk, bytes32(uint256(uint160(actor))), k1Authenticator, SCOPE_SENDER);
+        // Authorize the actor with OPERATOR scope only (no POLICY) — it is operational and can validate signatures.
+        _authorizeActorWithScope(account, ownerPk, bytes32(uint256(uint160(actor))), k1Authenticator, SCOPE_OPERATOR);
 
         // Chain-local envelope over the account-scoped replaySafeHash digest.
         bytes memory authData = _wrapLocal(_buildK1Auth(actorPk, keystore.replaySafeHash(account, block.chainid, hash)));

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.30;
 
 import {DefaultAccount, Call} from "../../../src/accounts/DefaultAccount.sol";
 import {Keystore} from "../../../src/Keystore.sol";
+import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
 /// @dev Minimal call target: a payable state setter plus reverters that fail with a string reason, a custom error, or
@@ -39,11 +40,11 @@ contract DefaultAccountTest is KeystoreTest {
     bytes4 constant ERC1271_MAGIC = 0x1626ba7e;
     bytes4 constant ERC1271_FAIL = 0xFFFFFFFF;
 
-    // Scope bits: ERC-1271 signing is operational (admin scope == 0x00, or SENDER without POLICY). SELF_PAYER and
-    // SPONSOR_PAYER are non-SENDER capability scopes that are not operational on their own.
-    uint16 constant SCOPE_SENDER = 0x01;
-    uint16 constant SCOPE_SELF_PAYER = 0x08;
-    uint16 constant SCOPE_SPONSOR_PAYER = 0x10;
+    // Scope bits: ERC-1271 signing is operational (admin scope == 0x00, or OPERATOR). SELF_PAYER and
+    // SPONSOR_PAYER are non-OPERATOR capability scopes that are not operational on their own.
+    uint16 constant SCOPE_SENDER = Scopes.OPERATOR;
+    uint16 constant SCOPE_SELF_PAYER = Scopes.SELF_PAYER;
+    uint16 constant SCOPE_SPONSOR_PAYER = Scopes.SPONSOR_PAYER;
 
     // TRUSTED_EXECUTOR sentinel: the authenticator value that marks an actor as a direct-execution caller.
     address constant TRUSTED_EXECUTOR = address(uint160(uint256(keccak256("trustedExecutor"))));
@@ -407,7 +408,7 @@ contract DefaultAccountTest is KeystoreTest {
     }
 
     /// @notice A valid signature from a payer-only (non-SENDER, non-admin) actor returns the failure magic value.
-    /// @dev isValidSignature gates on Scopes.isOperator; here SCOPE_SELF_PAYER (no SENDER, no admin) is not
+    /// @dev isValidSignature gates on Scopes.isOperator; here SCOPE_SELF_PAYER (no OPERATOR, no admin) is not
     ///      operational, so an otherwise-valid signature is rejected.
     function test_isValidSignature_success_returnsFailureForNonOperationalScope(
         uint256 ownerSeed,
@@ -431,7 +432,7 @@ contract DefaultAccountTest is KeystoreTest {
         assertEq(result, ERC1271_FAIL);
     }
 
-    /// @notice A valid signature from an operational SENDER-without-POLICY actor returns the ERC-1271 magic value.
+    /// @notice A valid signature from an operational OPERATOR actor returns the ERC-1271 magic value.
     /// @dev An operational actor validates: signing encodes authority a SENDER key already holds via calls, so it
     ///      does not require the admin scope.
     function test_isValidSignature_success_operationalSenderSigns(uint256 ownerSeed, uint256 actorSeed, bytes32 hash)
@@ -490,8 +491,8 @@ contract DefaultAccountTest is KeystoreTest {
         assertEq(result, ERC1271_MAGIC);
     }
 
-    /// @notice A non-operational scoped actor never validates, even for the former SIGNER bit (0x10, now
-    ///         SCOPE_SPONSOR_PAYER). Only an operational actor (admin, or SENDER-without-POLICY) returns the magic.
+    /// @notice A non-operational scoped actor never validates. Only an operational actor (admin, or OPERATOR)
+    ///         returns the magic.
     /// @dev There is no SIGNER grant anymore; a sponsor-payer actor's valid signature returns the failure magic value.
     function test_isValidSignature_success_scopedActorCannotSign(uint256 ownerSeed, uint256 actorSeed, bytes32 hash)
         public

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -22,7 +22,7 @@ import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 ///         ERC-1271 signature, but such a key must NOT be able to vouch as a delegate, so a non-admin nested
 ///         actor reverts.
 contract DelegateAuthenticatorTest is KeystoreTest {
-    uint16 constant SCOPE_SENDER = Scopes.OPERATOR;
+    uint16 constant SCOPE_OPERATOR = Scopes.OPERATOR;
     uint16 constant SCOPE_POLICY = Scopes.POLICY;
     uint16 constant SCOPE_NONCE = Scopes.NONCE;
     uint16 constant SCOPE_SELF_PAYER = Scopes.SELF_PAYER;
@@ -138,7 +138,7 @@ contract DelegateAuthenticatorTest is KeystoreTest {
 
         (address delegateAccount,) = _createK1Account(ownerPk);
         vm.assume(vm.addr(signerPk) != delegateAccount);
-        _authorizeScopedK1Actor(delegateAccount, ownerPk, signerPk, SCOPE_SENDER);
+        _authorizeScopedK1Actor(delegateAccount, ownerPk, signerPk, SCOPE_OPERATOR);
 
         bytes memory nestedAuth = abi.encodePacked(k1Authenticator, _signDigest(signerPk, hash));
 

--- a/test/unit/authenticators/DelegateAuthenticator.t.sol
+++ b/test/unit/authenticators/DelegateAuthenticator.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.30;
 import {Keystore} from "../../../src/Keystore.sol";
 import {DelegateAuthenticator} from "../../../src/authenticators/DelegateAuthenticator.sol";
 import {DefaultAccount} from "../../../src/accounts/DefaultAccount.sol";
+import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
 /// @notice Fuzzed, branch-complete test suite for DelegateAuthenticator.authenticate.
@@ -17,15 +18,15 @@ import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 ///
 ///         The delegate vouch requires the nested auth to resolve to the ADMIN actor on `delegate` (scope ==
 ///         0x00). This admin-only requirement is enforced independently of the account's ERC-1271 check (via
-///         authenticateActor + an explicit scope == 0 check): a SENDER-without-POLICY key can produce a valid
+///         authenticateActor + an explicit scope == 0 check): an OPERATOR key can produce a valid
 ///         ERC-1271 signature, but such a key must NOT be able to vouch as a delegate, so a non-admin nested
 ///         actor reverts.
 contract DelegateAuthenticatorTest is KeystoreTest {
-    uint16 constant SCOPE_SENDER = 0x01;
-    uint16 constant SCOPE_POLICY = 0x02;
-    uint16 constant SCOPE_NONCE = 0x04;
-    uint16 constant SCOPE_SELF_PAYER = 0x08;
-    uint16 constant SCOPE_SPONSOR_PAYER = 0x10;
+    uint16 constant SCOPE_SENDER = Scopes.OPERATOR;
+    uint16 constant SCOPE_POLICY = Scopes.POLICY;
+    uint16 constant SCOPE_NONCE = Scopes.NONCE;
+    uint16 constant SCOPE_SELF_PAYER = Scopes.SELF_PAYER;
+    uint16 constant SCOPE_SPONSOR_PAYER = Scopes.SPONSOR_PAYER;
 
     // ── Guard 1: require(data.length >= 40) ──
 
@@ -125,7 +126,7 @@ contract DelegateAuthenticatorTest is KeystoreTest {
         delegateAuthenticator.authenticate(hash, data);
     }
 
-    /// @dev Regression guard for the operational/admin decoupling: a SENDER-without-POLICY nested actor on the
+    /// @dev Regression guard for the operational/admin decoupling: an OPERATOR nested actor on the
     ///      delegate account CAN satisfy the account's ERC-1271 (it is operational), yet it MUST NOT satisfy the
     ///      delegate vouch, which stays admin-only. Asserts ERC-1271 validates for the actor, then the vouch reverts.
     function test_authenticate_revert_operationalSenderCannotVouch(uint256 ownerSeed, uint256 signerSeed, bytes32 hash)

--- a/test/unit/libraries/Scopes.t.sol
+++ b/test/unit/libraries/Scopes.t.sol
@@ -5,36 +5,47 @@ import {Test} from "forge-std/Test.sol";
 import {Scopes} from "../../../src/libraries/Scopes.sol";
 
 /// @notice Unit tests for the Scopes.isOperator predicate — the single shared definition of ERC-1271 signing and
-///         execution authority (admin, or a SENDER actor without POLICY) consumed by DefaultAccount.
+///         execution authority (admin, or an OPERATOR actor) consumed by DefaultAccount.
 contract ScopesTest is Test {
     /// @notice Admin (scope == 0) is operational.
     function test_isOperator_true_admin() public pure {
         assertTrue(Scopes.isOperator(0));
     }
 
-    /// @notice A SENDER actor without POLICY is operational, including when combined with non-POLICY capability bits.
-    function test_isOperator_true_senderWithoutPolicy() public pure {
-        assertTrue(Scopes.isOperator(Scopes.SENDER));
-        assertTrue(Scopes.isOperator(Scopes.SENDER | Scopes.SELF_PAYER));
-        assertTrue(Scopes.isOperator(Scopes.SENDER | Scopes.NONCE | Scopes.SPONSOR_PAYER));
+    /// @notice An OPERATOR actor is operational, including when combined with other capability bits.
+    function test_isOperator_true_operator() public pure {
+        assertTrue(Scopes.isOperator(Scopes.OPERATOR));
+        assertTrue(Scopes.isOperator(Scopes.OPERATOR | Scopes.SELF_PAYER));
+        assertTrue(Scopes.isOperator(Scopes.OPERATOR | Scopes.NONCE | Scopes.SPONSOR_PAYER));
+        // OPERATOR is more permissive than POLICY; the bits do not combine to suppress OPERATOR.
+        assertTrue(Scopes.isOperator(Scopes.OPERATOR | Scopes.POLICY));
     }
 
-    /// @notice Any POLICY-bearing scope is NOT operational, even with SENDER set.
-    function test_isOperator_false_policy() public pure {
+    /// @notice A POLICY-only scope is NOT operational.
+    function test_isOperator_false_policyOnly() public pure {
         assertFalse(Scopes.isOperator(Scopes.POLICY));
-        assertFalse(Scopes.isOperator(Scopes.SENDER | Scopes.POLICY));
+        assertFalse(Scopes.isOperator(Scopes.POLICY | Scopes.SELF_PAYER));
     }
 
-    /// @notice A non-SENDER capability-only scope (no admin, no SENDER) is NOT operational.
-    function test_isOperator_false_nonSenderCapabilities() public pure {
+    /// @notice A non-OPERATOR capability-only scope (no admin, no OPERATOR) is NOT operational.
+    function test_isOperator_false_nonOperatorCapabilities() public pure {
         assertFalse(Scopes.isOperator(Scopes.SELF_PAYER));
         assertFalse(Scopes.isOperator(Scopes.SPONSOR_PAYER));
         assertFalse(Scopes.isOperator(Scopes.NONCE));
     }
 
-    /// @notice Fuzz: isOperator exactly equals `scope == 0 || (SENDER set && POLICY unset)` across the space.
+    /// @notice Fuzz: isOperator exactly equals `scope == 0 || OPERATOR set` across the space.
     function test_isOperator_matchesPredicate(uint16 scope) public pure {
-        bool expected = scope == 0 || ((scope & Scopes.SENDER != 0) && (scope & Scopes.POLICY == 0));
+        bool expected = scope == 0 || (scope & Scopes.OPERATOR != 0);
         assertEq(Scopes.isOperator(scope), expected);
+    }
+
+    /// @notice Core grants occupy bits 0–2 so POLICY/NONCE can be omitted without renumbering.
+    function test_bitLayout_coreThenOptional() public pure {
+        assertEq(Scopes.OPERATOR, uint16(0x0001));
+        assertEq(Scopes.SELF_PAYER, uint16(0x0002));
+        assertEq(Scopes.SPONSOR_PAYER, uint16(0x0004));
+        assertEq(Scopes.POLICY, uint16(0x0008));
+        assertEq(Scopes.NONCE, uint16(0x0010));
     }
 }

--- a/test/unit/policies/ExternalPolicyCaller.t.sol
+++ b/test/unit/policies/ExternalPolicyCaller.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {Keystore} from "../../../src/Keystore.sol";
+import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {TRUSTED_EXECUTOR} from "../../../src/accounts/DefaultAccount.sol";
 
 import {PolicyManager, EXTERNAL_POLICY_AUTHENTICATOR} from "../../../src/policies/PolicyManager.sol";
@@ -38,8 +39,8 @@ contract ExternalPolicyCallerTest is KeystoreTest {
     address internal recipient = address(0x5EE);
 
     uint256 internal constant ROOT_PK = 0xA11CE;
-    uint8 internal constant SCOPE_OPERATOR = 0x01;
-    uint8 internal constant SCOPE_POLICY = 0x08;
+    uint16 internal constant SCOPE_OPERATOR = Scopes.OPERATOR;
+    uint16 internal constant SCOPE_POLICY = Scopes.POLICY;
 
     bytes4 internal constant TRANSFER = bytes4(keccak256("transfer(address,uint256)"));
     uint40 internal constant MONTH = 30 days;

--- a/test/unit/policies/ExternalPolicyCaller.t.sol
+++ b/test/unit/policies/ExternalPolicyCaller.t.sol
@@ -38,7 +38,7 @@ contract ExternalPolicyCallerTest is KeystoreTest {
     address internal recipient = address(0x5EE);
 
     uint256 internal constant ROOT_PK = 0xA11CE;
-    uint8 internal constant SCOPE_SENDER = 0x01;
+    uint8 internal constant SCOPE_OPERATOR = 0x01;
     uint8 internal constant SCOPE_POLICY = 0x08;
 
     bytes4 internal constant TRANSFER = bytes4(keccak256("transfer(address,uint256)"));

--- a/test/unit/policies/ExternalPolicyCaller.t.sol
+++ b/test/unit/policies/ExternalPolicyCaller.t.sol
@@ -39,7 +39,7 @@ contract ExternalPolicyCallerTest is KeystoreTest {
 
     uint256 internal constant ROOT_PK = 0xA11CE;
     uint8 internal constant SCOPE_SENDER = 0x01;
-    uint8 internal constant SCOPE_POLICY = 0x02;
+    uint8 internal constant SCOPE_POLICY = 0x08;
 
     bytes4 internal constant TRANSFER = bytes4(keccak256("transfer(address,uint256)"));
     uint40 internal constant MONTH = 30 days;

--- a/test/unit/policies/PolicyManager.t.sol
+++ b/test/unit/policies/PolicyManager.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.30;
 import {ReentrancyGuard} from "openzeppelin/utils/ReentrancyGuard.sol";
 
 import {Keystore} from "../../../src/Keystore.sol";
+import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {ITransactionContext, TX_CONTEXT_ADDRESS} from "../../../src/interfaces/ITransactionContext.sol";
 import {Call, DefaultAccount, TRUSTED_EXECUTOR} from "../../../src/accounts/DefaultAccount.sol";
 
@@ -89,7 +90,7 @@ contract PolicyManagerTest is KeystoreTest {
 
     uint256 internal constant ROOT_PK = 0xA11CE;
 
-    uint8 internal constant SCOPE_POLICY = 0x08;
+    uint16 internal constant SCOPE_POLICY = Scopes.POLICY;
 
     function setUp() public override {
         super.setUp();

--- a/test/unit/policies/PolicyManager.t.sol
+++ b/test/unit/policies/PolicyManager.t.sol
@@ -89,7 +89,7 @@ contract PolicyManagerTest is KeystoreTest {
 
     uint256 internal constant ROOT_PK = 0xA11CE;
 
-    uint8 internal constant SCOPE_POLICY = 0x02;
+    uint8 internal constant SCOPE_POLICY = 0x08;
 
     function setUp() public override {
         super.setUp();

--- a/test/unit/policies/SessionPolicy.t.sol
+++ b/test/unit/policies/SessionPolicy.t.sol
@@ -69,7 +69,7 @@ contract SessionPolicyTest is KeystoreTest {
     address internal mallory = address(0xBAD);
 
     uint256 internal constant ROOT_PK = 0xA11CE;
-    uint8 internal constant SCOPE_SENDER = 0x01;
+    uint8 internal constant SCOPE_OPERATOR = 0x01;
     uint8 internal constant SCOPE_POLICY = 0x08;
 
     bytes4 internal constant TRANSFER = bytes4(keccak256("transfer(address,uint256)"));

--- a/test/unit/policies/SessionPolicy.t.sol
+++ b/test/unit/policies/SessionPolicy.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {Keystore} from "../../../src/Keystore.sol";
+import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {ITransactionContext, TX_CONTEXT_ADDRESS} from "../../../src/interfaces/ITransactionContext.sol";
 import {TRUSTED_EXECUTOR} from "../../../src/accounts/DefaultAccount.sol";
 
@@ -69,8 +70,8 @@ contract SessionPolicyTest is KeystoreTest {
     address internal mallory = address(0xBAD);
 
     uint256 internal constant ROOT_PK = 0xA11CE;
-    uint8 internal constant SCOPE_OPERATOR = 0x01;
-    uint8 internal constant SCOPE_POLICY = 0x08;
+    uint16 internal constant SCOPE_OPERATOR = Scopes.OPERATOR;
+    uint16 internal constant SCOPE_POLICY = Scopes.POLICY;
 
     bytes4 internal constant TRANSFER = bytes4(keccak256("transfer(address,uint256)"));
     bytes4 internal constant TRANSFER_FROM = bytes4(keccak256("transferFrom(address,address,uint256)"));

--- a/test/unit/policies/SessionPolicy.t.sol
+++ b/test/unit/policies/SessionPolicy.t.sol
@@ -70,7 +70,7 @@ contract SessionPolicyTest is KeystoreTest {
 
     uint256 internal constant ROOT_PK = 0xA11CE;
     uint8 internal constant SCOPE_SENDER = 0x01;
-    uint8 internal constant SCOPE_POLICY = 0x02;
+    uint8 internal constant SCOPE_POLICY = 0x08;
 
     bytes4 internal constant TRANSFER = bytes4(keccak256("transfer(address,uint256)"));
     bytes4 internal constant TRANSFER_FROM = bytes4(keccak256("transferFrom(address,address,uint256)"));

--- a/test/unit/policies/SessionPolicyGas.t.sol
+++ b/test/unit/policies/SessionPolicyGas.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.30;
 import {console} from "forge-std/Test.sol";
 
 import {Keystore} from "../../../src/Keystore.sol";
+import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {ITransactionContext, TX_CONTEXT_ADDRESS} from "../../../src/interfaces/ITransactionContext.sol";
 import {TRUSTED_EXECUTOR} from "../../../src/accounts/DefaultAccount.sol";
 
@@ -41,7 +42,7 @@ contract SessionPolicyGasTest is KeystoreTest {
     address internal bob = address(0xB0B);
 
     uint256 internal constant ROOT_PK = 0xA11CE;
-    uint8 internal constant SCOPE_POLICY = 0x08;
+    uint16 internal constant SCOPE_POLICY = Scopes.POLICY;
 
     bytes4 internal constant TRANSFER = bytes4(keccak256("transfer(address,uint256)"));
     uint40 internal constant WEEK = 7 days;

--- a/test/unit/policies/SessionPolicyGas.t.sol
+++ b/test/unit/policies/SessionPolicyGas.t.sol
@@ -41,7 +41,7 @@ contract SessionPolicyGasTest is KeystoreTest {
     address internal bob = address(0xB0B);
 
     uint256 internal constant ROOT_PK = 0xA11CE;
-    uint8 internal constant SCOPE_POLICY = 0x02;
+    uint8 internal constant SCOPE_POLICY = 0x08;
 
     bytes4 internal constant TRANSFER = bytes4(keccak256("transfer(address,uint256)"));
     uint40 internal constant WEEK = 7 days;


### PR DESCRIPTION
## Summary
- **Reorder scope bits** so always-present grants lead and optional ones trail: `OPERATOR` (0x01), `SELF_PAYER` (0x02), `SPONSOR_PAYER` (0x04), `POLICY` (0x08), `NONCE` (0x10).
- **Rename `SENDER` → `OPERATOR`** to reflect that it is the more permissive grant. `OPERATOR` and `POLICY` do not combine: `OPERATOR` may originate to any `call.to`; a `POLICY`-only actor is gated to its manager. `isOperator` is now `scope == 0 || OPERATOR set`.
- **Co-locate policy with actor config.** The three per-actor mappings (`_actorConfig`, `_policyManager`, `_policyCommitment`) become one `ActorRecord` (config slot, then manager, then commitment) under a single `_actors` mapping, so a Verkle witness can cover an actor's config and policy together.
- **Length stores; POLICY gates; OPERATOR overrides.** Keystore no longer imports `Scopes` and never reads a scope bit to decide policy. Policy attachment is a **length check** on the authorize payload — empty (32-byte config only) or exactly 52 bytes `manager(20) ‖ commitment(32)` (84-byte packed record). The protocol node gates `sender_auth` on the `POLICY` bit; `OPERATOR` is the more permissive initiation grant and is not suppressed by `POLICY`.

## Notes
- Storage layout of `_actors` changed (base slot moved); no live deployments to migrate.
- Spec (`eip-8130.md`) matching update for this split: [chunter-cb/EIPs `eip-8130-length-policy-operator-split`](https://github.com/chunter-cb/EIPs/tree/eip-8130-length-policy-operator-split). Full scope-order + co-location still pending.

## Test plan
- [x] `forge test` — 401 passing
- [x] `forge fmt`
- [ ] Confirm scope-bit ordering with spec / other implementations before un-drafting