### PR TITLE
Drop the TRUSTED_EXECUTOR sentinel; gate execution on operational scope

### DIFF
--- a/src/accounts/CanonicalHighRatePayerAccount.sol
+++ b/src/accounts/CanonicalHighRatePayerAccount.sol
@@ -23,7 +23,7 @@ contract CanonicalHighRatePayerAccount is DefaultAccount {
 
     /// @notice Executes a batch of calls from the account, blocking outbound value transfers while locked.
     ///
-    /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a TRUSTED_EXECUTOR actor.
+    /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a live operational actor.
     /// @dev Reverts with AccountLocked when a call carries non-zero value and the account is locked.
     /// @dev Bubbles up the inner call's revert reason verbatim (a reason-less revert propagates as an empty revert).
     ///
@@ -43,7 +43,7 @@ contract CanonicalHighRatePayerAccount is DefaultAccount {
     /// @notice Executes a single call from the account, blocking an outbound value transfer while locked.
     ///
     /// @dev Equivalent to a one-element {executeBatch}. Included for selector-compatibility with common existing wallet implementations.
-    /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a TRUSTED_EXECUTOR actor.
+    /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a live operational actor.
     /// @dev Reverts with AccountLocked when the call carries non-zero value and the account is locked.
     /// @dev Bubbles up the inner call's revert reason verbatim (a reason-less revert propagates as an empty revert).
     ///

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -18,20 +18,15 @@ struct Call {
     bytes data;
 }
 
-/// @dev Sentinel `authenticator` value marking an actor as a trusted executor: an address (e.g. a PolicyManager,
-///      EntryPoint, or relayer) authorized to drive execution on the account by matching `msg.sender` rather than
-///      by verifying a signature. No contract exists at this address; it is hash-derived and deterministic across
-///      all chains, so if the protocol ever calls authenticate() on it the call naturally fails.
-address constant TRUSTED_EXECUTOR = address(uint160(uint256(keccak256("trustedExecutor"))));
-
 /// @notice Canonical model of the EIP-8130 default account: the behavior every EOA exhibits by default on an
 ///         EIP-8130 chain, expressed in Solidity. It handles batched execution and ERC-1271 signature validation,
 ///         and defers all authorization to the Keystore system contract.
 ///
 ///         Caller authorization:
 ///           - address(this) is always authorized (hardcoded), covering 8130 self-call batches
-///           - Trusted executors (PolicyManagers, relayers, EntryPoints) are registered as actors with
-///             TRUSTED_EXECUTOR as the authenticator in Keystore
+///           - any live, operational Keystore actor (admin scope 0x00, or an OPERATOR actor) may drive execution
+///             directly by matching `msg.sender`: an owner EOA, or a contract such as a PolicyManager, relayer,
+///             or EntryPoint registered as an operational actor
 ///
 /// @dev Not a deployment target. This describes the default EOA behavior applied natively on an EIP-8130 chain; it
 ///      is intentionally minimal and is NOT ERC-4337 compatible. An account that wants smart-account features (for
@@ -51,7 +46,7 @@ contract DefaultAccount is Receiver {
     /// @notice ERC-1271 sentinel returned for an invalid signature.
     bytes4 internal constant ERC1271_INVALID = 0xffffffff;
 
-    /// @notice The caller is neither the account itself nor a registered TRUSTED_EXECUTOR actor.
+    /// @notice The caller is neither the account itself nor a live, operational Keystore actor.
     error UnauthorizedCaller();
 
     /// @notice Deploys the account implementation bound to an Keystore instance.
@@ -66,7 +61,7 @@ contract DefaultAccount is Receiver {
 
     /// @notice Executes a batch of calls from the account; reverts the entire batch if any call fails.
     ///
-    /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a TRUSTED_EXECUTOR actor.
+    /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a live operational actor.
     /// @dev Bubbles up the inner call's revert reason verbatim (a reason-less revert propagates as an empty revert).
     ///
     /// @param calls Ordered calls to execute, each as (target, value, data).
@@ -82,7 +77,7 @@ contract DefaultAccount is Receiver {
     /// @notice Executes a single call from the account.
     ///
     /// @dev Equivalent to a one-element {executeBatch}. Included for selector-compatibility with common existing wallet implementations.
-    /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a TRUSTED_EXECUTOR actor.
+    /// @dev Reverts with UnauthorizedCaller when the caller is neither the account nor a live operational actor.
     /// @dev Bubbles up the inner call's revert reason verbatim (a reason-less revert propagates as an empty revert).
     ///
     /// @param target Address the account calls.
@@ -126,7 +121,7 @@ contract DefaultAccount is Receiver {
     ///
     /// @param caller Address to check.
     ///
-    /// @return True if `caller` is the account itself or a registered TRUSTED_EXECUTOR actor.
+    /// @return True if `caller` is the account itself or a live, operational Keystore actor.
     function isAuthorizedCaller(address caller) external view returns (bool) {
         return _isAuthorizedCaller(caller);
     }
@@ -135,17 +130,19 @@ contract DefaultAccount is Receiver {
     //  INTERNALS
     // ══════════════════════════════════════════════
 
-    /// @dev Authorized if `caller` is the account itself, or holds the TRUSTED_EXECUTOR authenticator with an
-    ///      unexpired config AND operational authority. Expiry: 0 means none; a non-zero expiry is enforced so a
-    ///      user-set expiry is honored on the execution path. Scope: driving execution requires operational
-    ///      authority ({Scopes.isOperator}) — the unrestricted admin (scope == 0x00) or an OPERATOR actor.
-    ///      OPERATOR is more permissive than POLICY and the two do not combine: a POLICY-only actor must route
-    ///      every call through its manager, so granting it direct executeBatch would bypass that gate; fail closed.
-    ///      Sharing {Scopes.isOperator} keeps the execution and signing (ERC-1271) authorization surfaces aligned.
+    /// @dev Authorized if `caller` is the account itself, or is a live actor with an unexpired config AND
+    ///      operational authority. The `authenticator != address(0)` liveness check must run before the scope check:
+    ///      {Keystore.getActorConfig} zeroes any unknown/revoked/expired actor, and {Scopes.isOperator} treats
+    ///      scope 0 as the unrestricted admin, so gating on scope alone would authorize every unregistered caller.
+    ///      Expiry: 0 means none; a non-zero elapsed expiry fails closed (defense in depth over getActorConfig's own
+    ///      zeroing). Scope: driving execution requires operational authority ({Scopes.isOperator}), i.e. the
+    ///      unrestricted admin (scope == 0x00) or an OPERATOR actor; a POLICY-only actor is not operational and must
+    ///      route every call through its manager. Sharing {Scopes.isOperator} keeps the execution and signing
+    ///      (ERC-1271) authorization surfaces aligned.
     function _isAuthorizedCaller(address caller) internal view virtual returns (bool) {
         if (caller == address(this)) return true;
         Keystore.ActorConfig memory config = KEYSTORE.getActorConfig(address(this), ActorId.fromAddress(caller));
-        if (config.authenticator != TRUSTED_EXECUTOR) return false;
+        if (config.authenticator == address(0)) return false;
         if (config.expiry != 0 && block.timestamp > config.expiry) return false;
         return Scopes.isOperator(config.scope);
     }

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -130,12 +130,11 @@ contract DefaultAccount is Receiver {
     //  INTERNALS
     // ══════════════════════════════════════════════
 
-    /// @dev Authorized if `caller` is the account itself, or is a live actor with an unexpired config AND
-    ///      operational authority. The `authenticator != address(0)` liveness check must run before the scope check:
-    ///      {Keystore.getActorConfig} zeroes any unknown/revoked/expired actor, and {Scopes.isOperator} treats
-    ///      scope 0 as the unrestricted admin, so gating on scope alone would authorize every unregistered caller.
-    ///      Expiry: 0 means none; a non-zero elapsed expiry fails closed (defense in depth over getActorConfig's own
-    ///      zeroing). Scope: driving execution requires operational authority ({Scopes.isOperator}), i.e. the
+    /// @dev Authorized if `caller` is the account itself, or is a live actor with operational authority. The
+    ///      `authenticator != address(0)` liveness check must run before the scope check: {Keystore.getActorConfig}
+    ///      zeroes any unknown/revoked/expired actor (so expiry is already enforced there), and {Scopes.isOperator}
+    ///      treats scope 0 as the unrestricted admin, so gating on scope alone would authorize every unregistered
+    ///      caller. Scope: driving execution requires operational authority ({Scopes.isOperator}), i.e. the
     ///      unrestricted admin (scope == 0x00) or an OPERATOR actor; a POLICY-only actor is not operational and must
     ///      route every call through its manager. Sharing {Scopes.isOperator} keeps the execution and signing
     ///      (ERC-1271) authorization surfaces aligned.
@@ -143,7 +142,6 @@ contract DefaultAccount is Receiver {
         if (caller == address(this)) return true;
         Keystore.ActorConfig memory config = KEYSTORE.getActorConfig(address(this), ActorId.fromAddress(caller));
         if (config.authenticator == address(0)) return false;
-        if (config.expiry != 0 && block.timestamp > config.expiry) return false;
         return Scopes.isOperator(config.scope);
     }
 }

--- a/src/policies/README.md
+++ b/src/policies/README.md
@@ -157,11 +157,12 @@ Keystore.ActorConfig({
 `nonce_key`s. This contract stores the bit verbatim and never interprets it — nonce semantics are entirely
 protocol-side — so it isn't part of the policy flow above and is only mentioned here for completeness.
 
-Critically, the provider must **not** be registered with `TRUSTED_EXECUTOR` — that sentinel grants
-*direct, unrestricted* `executeBatch` and would let the provider bypass the policy entirely. `EXTERNAL_POLICY_AUTHENTICATOR`
-is a no-code sentinel: the actor is recognized (non-zero authenticator) but can neither drive the account directly
-nor authenticate an 8130 transaction. Give the provider its **own salt** so its commitment — and therefore its
-spend budget — is isolated from any session keys on the account. End-to-end tests:
+Critically, the provider must **not** be registered as an *operational* actor (admin scope `0x00` or `OPERATOR`) —
+operational scope grants *direct, unrestricted* `executeBatch` and would let the provider bypass the policy
+entirely. `EXTERNAL_POLICY_AUTHENTICATOR` is a no-code sentinel: the actor is recognized (non-zero authenticator)
+but can neither drive the account directly nor authenticate an 8130 transaction. Give the provider its **own salt**
+so its commitment — and therefore its spend budget — is isolated from any session keys on the account. End-to-end
+tests:
 [`ExternalPolicyCaller.t.sol`](../../../test/unit/policies/ExternalPolicyCaller.t.sol).
 
 > Out of scope for this reference: signature-based replacement and uninstall. See

--- a/test/lib/KeystoreTest.sol
+++ b/test/lib/KeystoreTest.sol
@@ -25,7 +25,7 @@ contract KeystoreTest is Test {
     IAuthenticator public delegateAuthenticator;
     address public defaultAccountImplementation;
 
-    /// @dev Test EntryPoint address; tests register it as a TRUSTED_EXECUTOR actor in the initial actor set.
+    /// @dev Test EntryPoint address; tests register it as an operational actor in the initial actor set.
     address public constant ENTRY_POINT = address(0xEEEE);
 
     // SECP256K1_ORDER (curve order n) is inherited from forge-std; _boundK1Pk bounds fuzzed keys to [1, n-1].

--- a/test/unit/Keystore/importAccount.t.sol
+++ b/test/unit/Keystore/importAccount.t.sol
@@ -261,8 +261,6 @@ contract StorageReconstructedWallet {
     address public immutable PASSKEY_AUTHENTICATOR;
     address public immutable ENTRY_POINT;
 
-    address constant TRUSTED_EXECUTOR = address(uint160(uint256(keccak256("trustedExecutor"))));
-
     error OnlySelf();
     error NotOwner();
 
@@ -291,7 +289,10 @@ contract StorageReconstructedWallet {
             actors[i] = _storedOwners[i];
         }
         actors[_storedOwners.length] = Keystore.InitialActor({
-            actorId: bytes32(uint256(uint160(ENTRY_POINT))), authenticator: TRUSTED_EXECUTOR, scope: 0, policyData: ""
+            actorId: bytes32(uint256(uint160(ENTRY_POINT))),
+            authenticator: KEYSTORE.K1_AUTHENTICATOR(),
+            scope: 0,
+            policyData: ""
         });
         _sortByActorId(actors);
     }
@@ -926,7 +927,7 @@ contract ImportAccountTest is KeystoreTest {
         assertTrue(_isActor(address(wallet), bytes32(uint256(uint160(entryPoint)))));
         assertEq(
             keystore.getActorConfig(address(wallet), bytes32(uint256(uint160(entryPoint)))).authenticator,
-            address(uint160(uint256(keccak256("trustedExecutor"))))
+            k1Authenticator
         );
     }
 

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.30;
 
 import {DefaultAccount, Call} from "../../../src/accounts/DefaultAccount.sol";
-import {Keystore} from "../../../src/Keystore.sol";
 import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {KeystoreTest} from "../../lib/KeystoreTest.sol";
 
@@ -238,51 +237,6 @@ contract DefaultAccountTest is KeystoreTest {
             .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (v))));
 
         assertEq(target.value(), v);
-    }
-
-    /// @notice An operational actor with an unbounded (expiry == 0) grant may drive execution.
-    /// @dev Covers the `config.expiry != 0` false leg of the expiry guard (the && short-circuits before the
-    ///      timestamp comparison), which the UNBOUNDED-expiry helper never exercises.
-    function test_executeBatch_success_operationalActorZeroExpiry(uint256 execSeed, uint256 v) public {
-        (address account,) = _createK1Account(ACTOR_PK);
-
-        address executor = address(uint160(bound(execSeed, 10, type(uint160).max)));
-        vm.assume(executor != account && executor != vm.addr(ACTOR_PK));
-
-        // Operational admin scope, expiry == 0 (unlimited).
-        _applyLocal(
-            ACTOR_PK, account, _one(_authorizeChange(bytes32(uint256(uint160(executor))), k1Authenticator, 0, 0, ""))
-        );
-
-        vm.prank(executor);
-        DefaultAccount(payable(account))
-            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (v))));
-
-        assertEq(target.value(), v);
-    }
-
-    /// @notice An actor config whose non-zero expiry has elapsed is rejected.
-    /// @dev getActorConfig already zeroes expired configs, so the elapsed-expiry leg of _isAuthorizedCaller is
-    ///      defense-in-depth; mock the keystore to return a stale (expired) config and prove it fails closed.
-    function test_executeBatch_revert_expiredActor(uint256 execSeed) public {
-        (address account,) = _createK1Account(ACTOR_PK);
-
-        address executor = address(uint160(bound(execSeed, 10, type(uint160).max)));
-        vm.assume(executor != account && executor != vm.addr(ACTOR_PK));
-
-        vm.warp(1000);
-        Keystore.ActorConfig memory stale =
-            Keystore.ActorConfig({authenticator: k1Authenticator, expiry: 500, scope: 0}); // expiry < now
-        vm.mockCall(
-            address(keystore),
-            abi.encodeWithSelector(Keystore.getActorConfig.selector, account, bytes32(uint256(uint160(executor)))),
-            abi.encode(stale)
-        );
-
-        vm.prank(executor);
-        vm.expectRevert(DefaultAccount.UnauthorizedCaller.selector);
-        DefaultAccount(payable(account))
-            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (1))));
     }
 
     /// @notice A call to a target with no code succeeds (the low-level call returns success).

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -46,9 +46,6 @@ contract DefaultAccountTest is KeystoreTest {
     uint16 constant SCOPE_SELF_PAYER = Scopes.SELF_PAYER;
     uint16 constant SCOPE_SPONSOR_PAYER = Scopes.SPONSOR_PAYER;
 
-    // TRUSTED_EXECUTOR sentinel: the authenticator value that marks an actor as a direct-execution caller.
-    address constant TRUSTED_EXECUTOR = address(uint160(uint256(keccak256("trustedExecutor"))));
-
     MockTarget public target;
 
     function setUp() public override {
@@ -62,8 +59,8 @@ contract DefaultAccountTest is KeystoreTest {
     }
 
     // _authorizeActor and _authorizeActorWithScope are provided by the KeystoreTest harness (re-implemented on
-    // applySignedAccountChanges, granting UNBOUNDED on a sequenced local batch). TRUSTED_EXECUTOR and scoped k1
-    // actors are registered through those helpers.
+    // applySignedAccountChanges, granting UNBOUNDED on a sequenced local batch). Operational and scoped actors are
+    // registered through those helpers.
 
     // ══════════════════════════════════════════════
     //  executeBatch — reverts (source order)
@@ -73,7 +70,8 @@ contract DefaultAccountTest is KeystoreTest {
     /// @dev Exercises the false leg of `require(_isAuthorizedCaller(msg.sender))`; fuzzes caller/value/data.
     function test_executeBatch_revert_unauthorizedCaller(address caller, uint256 value, bytes calldata data) public {
         (address account,) = _createK1Account(ACTOR_PK);
-        vm.assume(caller != account);
+        // The owner is now an operational (admin-scope) actor and therefore an authorized caller, so exclude it.
+        vm.assume(caller != account && caller != vm.addr(ACTOR_PK));
         value = bound(value, 0, type(uint128).max);
 
         vm.prank(caller);
@@ -81,31 +79,17 @@ contract DefaultAccountTest is KeystoreTest {
         DefaultAccount(payable(account)).executeBatch(_singleCall(address(target), value, data));
     }
 
-    /// @notice The account owner's own EOA key holder cannot drive executeBatch directly.
-    /// @dev The owner is a k1 actor (authenticator == K1), not TRUSTED_EXECUTOR, so _isAuthorizedCaller is false.
-    function test_executeBatch_revert_ownerEoaCallerUnauthorized(uint256 pkSeed) public {
-        uint256 pk = _boundK1Pk(pkSeed);
-        (address account,) = _createK1Account(pk);
-        address owner = vm.addr(pk);
-        vm.assume(owner != account);
-
-        vm.prank(owner);
-        vm.expectRevert(DefaultAccount.UnauthorizedCaller.selector);
-        DefaultAccount(payable(account))
-            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (1))));
-    }
-
-    /// @notice A registered actor whose authenticator is K1 (not the TRUSTED_EXECUTOR sentinel) cannot call.
-    /// @dev Only the TRUSTED_EXECUTOR sentinel authorizes calls; an ordinary k1 actor does not.
-    function test_executeBatch_revert_nonExecutorActorCaller(uint256 actorSeed) public {
+    /// @notice A registered actor with a non-operational (capability-only) scope cannot drive executeBatch.
+    /// @dev A live actor is authorized only when operational; a SELF_PAYER-only k1 actor fails the isOperator leg.
+    function test_executeBatch_revert_nonOperationalActorCaller(uint256 actorSeed) public {
         (address account,) = _createK1Account(ACTOR_PK);
 
         uint256 actorPk = _boundK1Pk(actorSeed);
         address actor = vm.addr(actorPk);
         vm.assume(actor != account && actor != vm.addr(ACTOR_PK));
 
-        // Register `actor` as an ordinary k1 actor (authenticator == K1_AUTHENTICATOR), NOT a trusted executor.
-        _authorizeActor(account, ACTOR_PK, bytes32(uint256(uint160(actor))), k1Authenticator);
+        // Registered, but with a non-operational (capability-only) scope.
+        _authorizeActorWithScope(account, ACTOR_PK, bytes32(uint256(uint160(actor))), k1Authenticator, SCOPE_SELF_PAYER);
 
         vm.prank(actor);
         vm.expectRevert(DefaultAccount.UnauthorizedCaller.selector);
@@ -220,16 +204,18 @@ contract DefaultAccountTest is KeystoreTest {
         assertEq(address(target2).balance, b);
     }
 
-    /// @notice A registered TRUSTED_EXECUTOR actor may drive execution directly by matching msg.sender.
-    /// @dev Covers the config-driven authorization branch: getActorConfig(...).authenticator == TRUSTED_EXECUTOR.
-    function test_executeBatch_success_trustedExecutor(uint256 execSeed, uint256 v) public {
+    /// @notice A registered operational actor may drive execution directly by matching msg.sender.
+    /// @dev Covers the config-driven authorization branch: a live actor (here an admin-scope k1 actor) with
+    ///      operational authority. Authorization is authenticator-agnostic; a contract executor is registered the
+    ///      same way (an operational actor whose address is msg.sender).
+    function test_executeBatch_success_operationalActor(uint256 execSeed, uint256 v) public {
         (address account,) = _createK1Account(ACTOR_PK);
 
         address executor = address(uint160(bound(execSeed, 10, type(uint160).max)));
         vm.assume(executor != account && executor != vm.addr(ACTOR_PK));
 
-        // The owner signs an actor change registering `executor` with the TRUSTED_EXECUTOR authenticator.
-        _authorizeActor(account, ACTOR_PK, bytes32(uint256(uint160(executor))), TRUSTED_EXECUTOR);
+        // The owner signs an actor change registering `executor` as an operational (admin-scope) actor.
+        _authorizeActor(account, ACTOR_PK, bytes32(uint256(uint160(executor))), k1Authenticator);
 
         vm.prank(executor);
         DefaultAccount(payable(account))
@@ -238,29 +224,26 @@ contract DefaultAccountTest is KeystoreTest {
         assertEq(target.value(), v);
     }
 
-    /// @notice A TRUSTED_EXECUTOR actor whose scope is not operational (a capability-only scope, e.g. SELF_PAYER)
-    ///         cannot drive execution: _isAuthorizedCaller returns false via the isOperator(scope) == false leg.
-    function test_executeBatch_revert_trustedExecutorNonOperationalScope(uint256 execSeed) public {
-        (address account,) = _createK1Account(ACTOR_PK);
+    /// @notice The account owner's own EOA key holder (an operational admin actor) may drive executeBatch directly.
+    /// @dev The owner registered by _createK1Account has admin scope 0, which is operational, so it authorizes as a
+    ///      direct caller by matching msg.sender.
+    function test_executeBatch_success_ownerEoaCaller(uint256 pkSeed, uint256 v) public {
+        uint256 pk = _boundK1Pk(pkSeed);
+        (address account,) = _createK1Account(pk);
+        address owner = vm.addr(pk);
+        vm.assume(owner != account);
 
-        address executor = address(uint160(bound(execSeed, 10, type(uint160).max)));
-        vm.assume(executor != account && executor != vm.addr(ACTOR_PK));
-
-        // Registered as a trusted executor, but with a non-operational (capability-only) scope.
-        _authorizeActorWithScope(
-            account, ACTOR_PK, bytes32(uint256(uint160(executor))), TRUSTED_EXECUTOR, SCOPE_SELF_PAYER
-        );
-
-        vm.prank(executor);
-        vm.expectRevert(DefaultAccount.UnauthorizedCaller.selector);
+        vm.prank(owner);
         DefaultAccount(payable(account))
-            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (1))));
+            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (v))));
+
+        assertEq(target.value(), v);
     }
 
-    /// @notice A TRUSTED_EXECUTOR actor with an unbounded (expiry == 0) grant may drive execution.
+    /// @notice An operational actor with an unbounded (expiry == 0) grant may drive execution.
     /// @dev Covers the `config.expiry != 0` false leg of the expiry guard (the && short-circuits before the
-    ///      timestamp comparison), which the UNBOUNDED-expiry executor helper never exercises.
-    function test_executeBatch_success_trustedExecutorZeroExpiry(uint256 execSeed, uint256 v) public {
+    ///      timestamp comparison), which the UNBOUNDED-expiry helper never exercises.
+    function test_executeBatch_success_operationalActorZeroExpiry(uint256 execSeed, uint256 v) public {
         (address account,) = _createK1Account(ACTOR_PK);
 
         address executor = address(uint160(bound(execSeed, 10, type(uint160).max)));
@@ -268,7 +251,7 @@ contract DefaultAccountTest is KeystoreTest {
 
         // Operational admin scope, expiry == 0 (unlimited).
         _applyLocal(
-            ACTOR_PK, account, _one(_authorizeChange(bytes32(uint256(uint160(executor))), TRUSTED_EXECUTOR, 0, 0, ""))
+            ACTOR_PK, account, _one(_authorizeChange(bytes32(uint256(uint160(executor))), k1Authenticator, 0, 0, ""))
         );
 
         vm.prank(executor);
@@ -278,10 +261,10 @@ contract DefaultAccountTest is KeystoreTest {
         assertEq(target.value(), v);
     }
 
-    /// @notice A TRUSTED_EXECUTOR config whose non-zero expiry has elapsed is rejected.
+    /// @notice An actor config whose non-zero expiry has elapsed is rejected.
     /// @dev getActorConfig already zeroes expired configs, so the elapsed-expiry leg of _isAuthorizedCaller is
-    ///      defense-in-depth; mock the keystore to return a stale (expired) executor config and prove it fails closed.
-    function test_executeBatch_revert_trustedExecutorExpired(uint256 execSeed) public {
+    ///      defense-in-depth; mock the keystore to return a stale (expired) config and prove it fails closed.
+    function test_executeBatch_revert_expiredActor(uint256 execSeed) public {
         (address account,) = _createK1Account(ACTOR_PK);
 
         address executor = address(uint160(bound(execSeed, 10, type(uint160).max)));
@@ -289,7 +272,7 @@ contract DefaultAccountTest is KeystoreTest {
 
         vm.warp(1000);
         Keystore.ActorConfig memory stale =
-            Keystore.ActorConfig({authenticator: TRUSTED_EXECUTOR, expiry: 500, scope: 0}); // expiry < now
+            Keystore.ActorConfig({authenticator: k1Authenticator, expiry: 500, scope: 0}); // expiry < now
         vm.mockCall(
             address(keystore),
             abi.encodeWithSelector(Keystore.getActorConfig.selector, account, bytes32(uint256(uint160(executor)))),
@@ -323,7 +306,8 @@ contract DefaultAccountTest is KeystoreTest {
     /// @dev Exercises the false leg of `_isAuthorizedCaller(msg.sender)`; fuzzes the caller.
     function test_execute_revert_unauthorizedCaller(address caller) public {
         (address account,) = _createK1Account(ACTOR_PK);
-        vm.assume(caller != account);
+        // The owner is now an operational (admin-scope) actor and therefore an authorized caller, so exclude it.
+        vm.assume(caller != account && caller != vm.addr(ACTOR_PK));
 
         vm.prank(caller);
         vm.expectRevert(DefaultAccount.UnauthorizedCaller.selector);
@@ -528,29 +512,29 @@ contract DefaultAccountTest is KeystoreTest {
         assertTrue(DefaultAccount(payable(account)).isAuthorizedCaller(account));
     }
 
-    /// @notice A registered TRUSTED_EXECUTOR actor is reported as authorized.
-    /// @dev Covers the config-driven true branch: getActorConfig(...).authenticator == TRUSTED_EXECUTOR.
-    function test_isAuthorizedCaller_success_trustedExecutor(uint256 execSeed) public {
+    /// @notice A registered operational actor is reported as authorized.
+    /// @dev Covers the config-driven true branch: a live actor with operational scope, regardless of authenticator.
+    function test_isAuthorizedCaller_success_operationalActor(uint256 execSeed) public {
         (address account,) = _createK1Account(ACTOR_PK);
 
         address executor = address(uint160(bound(execSeed, 10, type(uint160).max)));
         vm.assume(executor != account && executor != vm.addr(ACTOR_PK));
 
-        _authorizeActor(account, ACTOR_PK, bytes32(uint256(uint160(executor))), TRUSTED_EXECUTOR);
+        _authorizeActor(account, ACTOR_PK, bytes32(uint256(uint160(executor))), k1Authenticator);
 
         assertTrue(DefaultAccount(payable(account)).isAuthorizedCaller(executor));
     }
 
-    /// @notice A registered k1 actor (authenticator != TRUSTED_EXECUTOR) is not an authorized caller.
-    /// @dev Covers the config-driven false branch: a configured actor whose authenticator is the K1 sentinel.
-    function test_isAuthorizedCaller_success_k1ActorNotAuthorized(uint256 actorSeed) public {
+    /// @notice A registered but non-operational actor is not an authorized caller.
+    /// @dev Covers the config-driven false branch: a live actor whose scope (SELF_PAYER only) is not operational.
+    function test_isAuthorizedCaller_success_nonOperationalActorNotAuthorized(uint256 actorSeed) public {
         (address account,) = _createK1Account(ACTOR_PK);
 
         uint256 actorPk = _boundK1Pk(actorSeed);
         address actor = vm.addr(actorPk);
         vm.assume(actor != account && actor != vm.addr(ACTOR_PK));
 
-        _authorizeActor(account, ACTOR_PK, bytes32(uint256(uint160(actor))), k1Authenticator);
+        _authorizeActorWithScope(account, ACTOR_PK, bytes32(uint256(uint160(actor))), k1Authenticator, SCOPE_SELF_PAYER);
 
         assertFalse(DefaultAccount(payable(account)).isAuthorizedCaller(actor));
     }
@@ -559,7 +543,8 @@ contract DefaultAccountTest is KeystoreTest {
     /// @dev Covers the config-driven false branch for an empty config (authenticator == address(0)). Fuzzes caller.
     function test_isAuthorizedCaller_success_randomCallerNotAuthorized(address caller) public {
         (address account,) = _createK1Account(ACTOR_PK);
-        vm.assume(caller != account);
+        // Exclude the owner, which is now an operational (admin-scope) actor and therefore authorized.
+        vm.assume(caller != account && caller != vm.addr(ACTOR_PK));
 
         assertFalse(DefaultAccount(payable(account)).isAuthorizedCaller(caller));
     }

--- a/test/unit/policies/ExternalPolicyCaller.t.sol
+++ b/test/unit/policies/ExternalPolicyCaller.t.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.30;
 
 import {Keystore} from "../../../src/Keystore.sol";
 import {Scopes} from "../../../src/libraries/Scopes.sol";
-import {TRUSTED_EXECUTOR} from "../../../src/accounts/DefaultAccount.sol";
 
 import {PolicyManager, EXTERNAL_POLICY_AUTHENTICATOR} from "../../../src/policies/PolicyManager.sol";
 import {SessionPolicy} from "../../../src/policies/SessionPolicy.sol";
@@ -321,7 +320,7 @@ contract ExternalPolicyCallerTest is KeystoreTest {
         });
         Keystore.InitialActor memory mgr = Keystore.InitialActor({
             actorId: bytes32(uint256(uint160(address(manager)))),
-            authenticator: TRUSTED_EXECUTOR,
+            authenticator: k1Authenticator,
             scope: 0,
             policyData: ""
         });

--- a/test/unit/policies/PolicyManager.t.sol
+++ b/test/unit/policies/PolicyManager.t.sol
@@ -6,7 +6,7 @@ import {ReentrancyGuard} from "openzeppelin/utils/ReentrancyGuard.sol";
 import {Keystore} from "../../../src/Keystore.sol";
 import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {ITransactionContext, TX_CONTEXT_ADDRESS} from "../../../src/interfaces/ITransactionContext.sol";
-import {Call, DefaultAccount, TRUSTED_EXECUTOR} from "../../../src/accounts/DefaultAccount.sol";
+import {Call, DefaultAccount} from "../../../src/accounts/DefaultAccount.sol";
 
 import {PolicyManager} from "../../../src/policies/PolicyManager.sol";
 import {Policy} from "../../../src/policies/Policy.sol";
@@ -342,7 +342,7 @@ contract PolicyManagerTest is KeystoreTest {
         });
         Keystore.InitialActor memory mgr = Keystore.InitialActor({
             actorId: bytes32(uint256(uint160(address(manager)))),
-            authenticator: TRUSTED_EXECUTOR,
+            authenticator: k1Authenticator,
             scope: 0,
             policyData: ""
         });
@@ -386,7 +386,7 @@ contract PolicyManagerTest is KeystoreTest {
         });
         Keystore.InitialActor memory mgr = Keystore.InitialActor({
             actorId: bytes32(uint256(uint160(address(manager)))),
-            authenticator: TRUSTED_EXECUTOR,
+            authenticator: k1Authenticator,
             scope: 0,
             policyData: ""
         });

--- a/test/unit/policies/SessionPolicy.t.sol
+++ b/test/unit/policies/SessionPolicy.t.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.30;
 import {Keystore} from "../../../src/Keystore.sol";
 import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {ITransactionContext, TX_CONTEXT_ADDRESS} from "../../../src/interfaces/ITransactionContext.sol";
-import {TRUSTED_EXECUTOR} from "../../../src/accounts/DefaultAccount.sol";
 
 import {PolicyManager} from "../../../src/policies/PolicyManager.sol";
 import {SessionPolicy} from "../../../src/policies/SessionPolicy.sol";
@@ -893,7 +892,7 @@ contract SessionPolicyTest is KeystoreTest {
         });
         Keystore.InitialActor memory mgr = Keystore.InitialActor({
             actorId: bytes32(uint256(uint160(address(manager)))),
-            authenticator: TRUSTED_EXECUTOR,
+            authenticator: k1Authenticator,
             scope: 0,
             policyData: ""
         });

--- a/test/unit/policies/SessionPolicyGas.t.sol
+++ b/test/unit/policies/SessionPolicyGas.t.sol
@@ -6,7 +6,6 @@ import {console} from "forge-std/Test.sol";
 import {Keystore} from "../../../src/Keystore.sol";
 import {Scopes} from "../../../src/libraries/Scopes.sol";
 import {ITransactionContext, TX_CONTEXT_ADDRESS} from "../../../src/interfaces/ITransactionContext.sol";
-import {TRUSTED_EXECUTOR} from "../../../src/accounts/DefaultAccount.sol";
 
 import {PolicyManager} from "../../../src/policies/PolicyManager.sol";
 import {SessionPolicy} from "../../../src/policies/SessionPolicy.sol";
@@ -316,7 +315,7 @@ contract SessionPolicyGasTest is KeystoreTest {
         });
         Keystore.InitialActor memory mgr = Keystore.InitialActor({
             actorId: bytes32(uint256(uint160(address(manager)))),
-            authenticator: TRUSTED_EXECUTOR,
+            authenticator: k1Authenticator,
             scope: 0,
             policyData: ""
         });


### PR DESCRIPTION
## Summary

`DefaultAccount` authorized a direct caller only when it was registered under the
`TRUSTED_EXECUTOR` sentinel authenticator. This replaces that with a scope-based rule: any
live, operational Keystore actor (the account itself, or an actor with a non-zero
authenticator and operational scope) may drive execution. This makes `DefaultAccount`
consistent with `CoinbaseSmartWalletV2`, which already dropped the sentinel in favor of the
same `isOperator` rule.

## Core change

`_isAuthorizedCaller`'s gate changes from:
```solidity
if (config.authenticator != TRUSTED_EXECUTOR) return false;
```
to a liveness guard:
```solidity
if (config.authenticator == address(0)) return false;
```
This guard **must** precede the scope check: `getActorConfig` zeroes any unknown/revoked/
expired actor, and `Scopes.isOperator` treats scope `0` as the unrestricted admin, so gating
on scope alone would authorize every unregistered caller. `CanonicalHighRatePayerAccount`
inherits `_isAuthorizedCaller`, so it picks up the new behavior with no code change.

## Behavioral effects

- An **owner EOA** and any **operational actor** (including a contract registered as an
  operational actor, e.g. a PolicyManager/EntryPoint/relayer) can now drive `executeBatch` /
  `execute` directly by matching `msg.sender`.
- **Passkeys** are unaffected (a passkey actorId is never an address, so it can't be
  `msg.sender`).
- **POLICY-only** actors remain non-operational and still cannot direct-call.

The trust boundary is unchanged: an operational actor already holds execution authority
(direct-call is that actor acting as its own identity, paying its own gas). The rule is a
superset of the old sentinel gate — a contract that was a `TRUSTED_EXECUTOR` is now simply
registered as an operational actor.

## Removal + consumer migration

The `TRUSTED_EXECUTOR` constant is deleted, and every consumer is migrated:
- `src/policies/README.md`: the warning now reads "a policy provider must **not** be
  registered as an *operational* actor" (operational scope is what grants direct
  `executeBatch`); `EXTERNAL_POLICY_AUTHENTICATOR` is unchanged.
- Policy tests (`PolicyManager`, `ExternalPolicyCaller`, `SessionPolicy`, `SessionPolicyGas`)
  and the `importAccount` mock wallet: register drive-only contracts (PolicyManager,
  EntryPoint) as operational actors instead of `TRUSTED_EXECUTOR`.
- `DefaultAccount.t.sol`: rewrote the tests whose k1-vs-sentinel premise inverts — an owner
  EOA and an operational k1 actor now *succeed* at driving execution; the "not authorized"
  cases now cover an unregistered caller and a registered-but-non-operational actor.

## Testing

`forge test`: **418 passed / 0 failed**. `forge fmt` clean.
