### PR TITLE
Restrict DefaultAccount direct execution to k1 actors (close delegate-authenticator bypass)

### DIFF
--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -24,9 +24,10 @@ struct Call {
 ///
 ///         Caller authorization:
 ///           - address(this) is always authorized (hardcoded), covering 8130 self-call batches
-///           - any live, operational Keystore actor (admin scope 0x00, or an OPERATOR actor) may drive execution
-///             directly by matching `msg.sender`: an owner EOA, or a contract such as a PolicyManager, relayer,
-///             or EntryPoint registered as an operational actor
+///           - a live, operational k1 actor (admin scope 0x00, or an OPERATOR actor) may drive execution directly
+///             by matching `msg.sender`: an owner EOA, or a contract such as a PolicyManager, relayer, or EntryPoint
+///             registered as an operational k1 actor. Non-k1 actors (e.g. delegate, passkey) must use their
+///             signature path and cannot drive execution merely by being `msg.sender`
 ///
 /// @dev Not a deployment target. This describes the default EOA behavior applied natively on an EIP-8130 chain; it
 ///      is intentionally minimal and is NOT ERC-4337 compatible. An account that wants smart-account features (for
@@ -46,7 +47,7 @@ contract DefaultAccount is Receiver {
     /// @notice ERC-1271 sentinel returned for an invalid signature.
     bytes4 internal constant ERC1271_INVALID = 0xffffffff;
 
-    /// @notice The caller is neither the account itself nor a live, operational Keystore actor.
+    /// @notice The caller is neither the account itself nor a live, operational k1 actor.
     error UnauthorizedCaller();
 
     /// @notice Deploys the account implementation bound to an Keystore instance.
@@ -121,7 +122,7 @@ contract DefaultAccount is Receiver {
     ///
     /// @param caller Address to check.
     ///
-    /// @return True if `caller` is the account itself or a live, operational Keystore actor.
+    /// @return True if `caller` is the account itself or a live, operational k1 actor.
     function isAuthorizedCaller(address caller) external view returns (bool) {
         return _isAuthorizedCaller(caller);
     }
@@ -130,18 +131,22 @@ contract DefaultAccount is Receiver {
     //  INTERNALS
     // ══════════════════════════════════════════════
 
-    /// @dev Authorized if `caller` is the account itself, or is a live actor with operational authority. The
-    ///      `authenticator != address(0)` liveness check must run before the scope check: {Keystore.getActorConfig}
-    ///      zeroes any unknown/revoked/expired actor (so expiry is already enforced there), and {Scopes.isOperator}
-    ///      treats scope 0 as the unrestricted admin, so gating on scope alone would authorize every unregistered
-    ///      caller. Scope: driving execution requires operational authority ({Scopes.isOperator}), i.e. the
-    ///      unrestricted admin (scope == 0x00) or an OPERATOR actor; a POLICY-only actor is not operational and must
-    ///      route every call through its manager. Sharing {Scopes.isOperator} keeps the execution and signing
-    ///      (ERC-1271) authorization surfaces aligned.
+    /// @dev Authorized if `caller` is the account itself, or a live k1 actor with operational authority. The
+    ///      authenticator must be the k1 sentinel. Direct execution authorizes on `msg.sender` matching the actor's
+    ///      address, which is sound only when that address IS the authenticating principal: true for k1 (an
+    ///      EOA/contract whose actorId is its own address), but not for authenticators whose address actorId is a
+    ///      proxy for other authorization logic. A {DelegateAuthenticator} actor, for instance, keys on a delegate
+    ///      account's address yet authorizes only via that account's admin signature; letting it drive execution by
+    ///      being `msg.sender` would skip that check (any operator of the delegate account could then drive this
+    ///      one). Restricting to k1 forces every other authenticator through its signature path, and also subsumes
+    ///      liveness ({Keystore.getActorConfig} zeroes an unknown/revoked/expired actor to authenticator address(0),
+    ///      which is not k1). Operational authority ({Scopes.isOperator}) is still required: the unrestricted admin
+    ///      (scope == 0x00) or an OPERATOR actor; a POLICY-only actor is not operational. Sharing {Scopes.isOperator}
+    ///      keeps the execution and signing (ERC-1271) authorization surfaces aligned.
     function _isAuthorizedCaller(address caller) internal view virtual returns (bool) {
         if (caller == address(this)) return true;
         Keystore.ActorConfig memory config = KEYSTORE.getActorConfig(address(this), ActorId.fromAddress(caller));
-        if (config.authenticator == address(0)) return false;
+        if (config.authenticator != KEYSTORE.K1_AUTHENTICATOR()) return false;
         return Scopes.isOperator(config.scope);
     }
 }

--- a/src/accounts/DefaultAccount.sol
+++ b/src/accounts/DefaultAccount.sol
@@ -25,9 +25,7 @@ struct Call {
 ///         Caller authorization:
 ///           - address(this) is always authorized (hardcoded), covering 8130 self-call batches
 ///           - a live, operational k1 actor (admin scope 0x00, or an OPERATOR actor) may drive execution directly
-///             by matching `msg.sender`: an owner EOA, or a contract such as a PolicyManager, relayer, or EntryPoint
-///             registered as an operational k1 actor. Non-k1 actors (e.g. delegate, passkey) must use their
-///             signature path and cannot drive execution merely by being `msg.sender`
+///             by matching `msg.sender`, e.g. an owner EOA or a contract registered as an operational k1 actor
 ///
 /// @dev Not a deployment target. This describes the default EOA behavior applied natively on an EIP-8130 chain; it
 ///      is intentionally minimal and is NOT ERC-4337 compatible. An account that wants smart-account features (for
@@ -131,18 +129,10 @@ contract DefaultAccount is Receiver {
     //  INTERNALS
     // ══════════════════════════════════════════════
 
-    /// @dev Authorized if `caller` is the account itself, or a live k1 actor with operational authority. The
-    ///      authenticator must be the k1 sentinel. Direct execution authorizes on `msg.sender` matching the actor's
-    ///      address, which is sound only when that address IS the authenticating principal: true for k1 (an
-    ///      EOA/contract whose actorId is its own address), but not for authenticators whose address actorId is a
-    ///      proxy for other authorization logic. A {DelegateAuthenticator} actor, for instance, keys on a delegate
-    ///      account's address yet authorizes only via that account's admin signature; letting it drive execution by
-    ///      being `msg.sender` would skip that check (any operator of the delegate account could then drive this
-    ///      one). Restricting to k1 forces every other authenticator through its signature path, and also subsumes
-    ///      liveness ({Keystore.getActorConfig} zeroes an unknown/revoked/expired actor to authenticator address(0),
-    ///      which is not k1). Operational authority ({Scopes.isOperator}) is still required: the unrestricted admin
-    ///      (scope == 0x00) or an OPERATOR actor; a POLICY-only actor is not operational. Sharing {Scopes.isOperator}
-    ///      keeps the execution and signing (ERC-1271) authorization surfaces aligned.
+    /// @dev Authorized if `caller` is the account itself, or a live, operational k1 actor. The direct-call path is
+    ///      restricted to the k1 authenticator; the same check enforces liveness ({Keystore.getActorConfig} zeroes a
+    ///      non-live actor to authenticator address(0)). Operational authority ({Scopes.isOperator}) is the
+    ///      unrestricted admin (scope == 0x00) or an OPERATOR actor.
     function _isAuthorizedCaller(address caller) internal view virtual returns (bool) {
         if (caller == address(this)) return true;
         Keystore.ActorConfig memory config = KEYSTORE.getActorConfig(address(this), ActorId.fromAddress(caller));

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -96,6 +96,25 @@ contract DefaultAccountTest is KeystoreTest {
             .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (1))));
     }
 
+    /// @notice An operational actor with a non-k1 authenticator (e.g. delegate) cannot drive executeBatch directly.
+    /// @dev Direct execution is restricted to k1, where the actorId-address is the authenticating principal. A
+    ///      delegate actor keys on an address but authorizes only via that account's admin signature, so it must not
+    ///      drive execution merely by being msg.sender; the k1 guard fails closed with UnauthorizedCaller.
+    function test_executeBatch_revert_nonK1ActorCaller(uint256 execSeed) public {
+        (address account,) = _createK1Account(ACTOR_PK);
+
+        address actor = address(uint160(bound(execSeed, 10, type(uint160).max)));
+        vm.assume(actor != account && actor != vm.addr(ACTOR_PK));
+
+        // Operational (admin-scope) actor authenticated via the delegate authenticator, not k1.
+        _authorizeActor(account, ACTOR_PK, bytes32(uint256(uint160(actor))), address(delegateAuthenticator));
+
+        vm.prank(actor);
+        vm.expectRevert(DefaultAccount.UnauthorizedCaller.selector);
+        DefaultAccount(payable(account))
+            .executeBatch(_singleCall(address(target), 0, abi.encodeCall(MockTarget.setValue, (1))));
+    }
+
     /// @notice A failing inner call aborts the whole batch, bubbling the inner revert reason verbatim.
     /// @dev Exercises the failure leg of the low-level call; fuzzes the ETH value carried by the failing call.
     function test_executeBatch_revert_bubblesInnerRevert(uint256 value) public {
@@ -489,6 +508,21 @@ contract DefaultAccountTest is KeystoreTest {
         vm.assume(actor != account && actor != vm.addr(ACTOR_PK));
 
         _authorizeActorWithScope(account, ACTOR_PK, bytes32(uint256(uint160(actor))), k1Authenticator, SCOPE_SELF_PAYER);
+
+        assertFalse(DefaultAccount(payable(account)).isAuthorizedCaller(actor));
+    }
+
+    /// @notice A registered operational actor with a non-k1 authenticator (e.g. delegate) is not an authorized caller.
+    /// @dev Locks in the k1 restriction: only k1 actors (address == principal) may drive execution directly. A
+    ///      delegate actor is operational and address-keyed but authorizes via its account's admin signature, so the
+    ///      direct-call path must reject it.
+    function test_isAuthorizedCaller_success_nonK1ActorNotAuthorized(uint256 execSeed) public {
+        (address account,) = _createK1Account(ACTOR_PK);
+
+        address actor = address(uint160(bound(execSeed, 10, type(uint160).max)));
+        vm.assume(actor != account && actor != vm.addr(ACTOR_PK));
+
+        _authorizeActor(account, ACTOR_PK, bytes32(uint256(uint160(actor))), address(delegateAuthenticator));
 
         assertFalse(DefaultAccount(payable(account)).isAuthorizedCaller(actor));
     }

--- a/test/unit/accounts/DefaultAccount.t.sol
+++ b/test/unit/accounts/DefaultAccount.t.sol
@@ -97,9 +97,7 @@ contract DefaultAccountTest is KeystoreTest {
     }
 
     /// @notice An operational actor with a non-k1 authenticator (e.g. delegate) cannot drive executeBatch directly.
-    /// @dev Direct execution is restricted to k1, where the actorId-address is the authenticating principal. A
-    ///      delegate actor keys on an address but authorizes only via that account's admin signature, so it must not
-    ///      drive execution merely by being msg.sender; the k1 guard fails closed with UnauthorizedCaller.
+    /// @dev The direct-call path is k1-only, so a non-k1 operational actor reverts UnauthorizedCaller.
     function test_executeBatch_revert_nonK1ActorCaller(uint256 execSeed) public {
         (address account,) = _createK1Account(ACTOR_PK);
 
@@ -513,9 +511,7 @@ contract DefaultAccountTest is KeystoreTest {
     }
 
     /// @notice A registered operational actor with a non-k1 authenticator (e.g. delegate) is not an authorized caller.
-    /// @dev Locks in the k1 restriction: only k1 actors (address == principal) may drive execution directly. A
-    ///      delegate actor is operational and address-keyed but authorizes via its account's admin signature, so the
-    ///      direct-call path must reject it.
+    /// @dev Locks in the k1-only restriction on the direct-call path.
     function test_isAuthorizedCaller_success_nonK1ActorNotAuthorized(uint256 execSeed) public {
         (address account,) = _createK1Account(ACTOR_PK);
 


### PR DESCRIPTION
## Summary

Follow-up to #101. `DefaultAccount._isAuthorizedCaller` gated the direct-call path on **any**
non-zero authenticator + operational scope. That's unsafe for authenticators whose address
`actorId` is a *proxy* for other authorization logic. The concrete case is the
**DelegateAuthenticator**: a delegate actor keys on a delegate account B's address, but
authenticates only via **B's admin signature** (`nestedScope == 0`). Since a delegate actor's
`actorId` is `fromAddress(B)` and non-zero, it passed the `!= address(0)` guard, so B could drive
the account directly as `msg.sender`, skipping the admin-signature check. And because
`B.executeBatch` is callable by **B's operators**, any operator of B could then drive this
account — a privilege escalation (B's admin was supposed to be required).

## Fix

Gate the direct-call path on `authenticator == KEYSTORE.K1_AUTHENTICATOR()`:
```solidity
if (config.authenticator != KEYSTORE.K1_AUTHENTICATOR()) return false;
return Scopes.isOperator(config.scope);
```
k1 is the only authenticator where the `actorId`-address **is** the authenticating principal
(`msg.sender` == the key holder), so a direct call is equivalent to that principal acting. Every
other authenticator (delegate, passkey, any future address-keyed scheme) must go through its
signature path, where its real checks run. The k1 check also subsumes the liveness guard (an
unknown/revoked/expired actor resolves to `authenticator == address(0)`, which is not k1).

The direct-call path never invokes the authenticator, so it can't see *which* actor on B drove
the call (only `msg.sender == B`) — no delegate-scope redesign can make it safe; the path is only
sound for k1. This keeps the DelegateAuthenticator's admin-only semantics intact without any
Keystore trust-model change.

## Compatibility

Contracts intended as direct executors are registered as **k1** actors and are unaffected. Only
non-k1 address-keyed actors (delegate) lose the direct-call path — which is the bug.

## Testing

`forge test`: 418 passed / 0 failed. `forge fmt` clean. Adds regression tests that a delegate
(non-k1) operational actor is rejected on both `isAuthorizedCaller` and `executeBatch`.
